### PR TITLE
Align local and network environment setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,10 +57,12 @@ SNYK_TOKEN=
 # --- Ship cloud platform — backend (RFC-0006) ---
 # Used by docker-compose (`docker compose up`) and by `ship-server` / `ship-worker`
 # directly. The same shape works against a local Postgres+pgvector container,
-# a self-hosted Postgres in your org, or Neon in our SaaS.
+# a self-hosted Postgres in your org, or Neon in our SaaS. If DATABASE_URL is
+# set, Compose uses it instead of the bundled Postgres service, so local and
+# network setup share the same database contract.
 #
 # DATABASE_URL=postgresql+asyncpg://ship:ship@localhost:5433/ship
-# ALEMBIC_DATABASE_URL=                # Optional: override sync URL for migrations
+# ALEMBIC_DATABASE_URL=postgresql+psycopg://ship:ship@localhost:5433/ship
 # REDIS_URL=redis://localhost:6380/0   # Only required for `docker compose --profile worker up`
 # S3_ENDPOINT_URL=http://localhost:9000   # Leave empty when using real AWS S3
 # S3_BUCKET=ship-documents
@@ -72,6 +74,8 @@ SNYK_TOKEN=
 # JWT_TTL_SECONDS=43200
 # ENCRYPTION_KEY=                       # 32-byte urlsafe base64; required to store integration secrets
 # SHIP_PUBLIC_URL=http://localhost:8100
+# SHIP_CONSOLE_URL=http://localhost:3001
+# SHIP_API_URL=http://localhost:8100     # Console server -> backend API; Compose overrides to http://ship-server:8100
 # SHIP_AUTH_MODE=local                  # local (dev) | auth0 (prod). flip to auth0 once AUTH0_* are set
 
 # --- Production overlay (Caddy + HTTPS on a single VPS) ---
@@ -109,6 +113,7 @@ SNYK_TOKEN=
 # NEXT_PUBLIC_SENTRY_ENVIRONMENT=local
 # NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE=0.0
 # SHIP_VERSION=                            # tagged onto every Sentry release
+# NEXT_PUBLIC_SHIP_VERSION=                # browser release tag; defaults to SHIP_VERSION in Compose
 
 # --- Email (Twilio SendGrid) ---
 # Transactional email used for team invites and the navigator's
@@ -132,7 +137,7 @@ SNYK_TOKEN=
 # (Next.js) acts as the OIDC client; backend validates the resulting access
 # token via the tenant JWKS. Run scripts/bootstrap.sh --auth0 ... to fill these.
 # AUTH0_DOMAIN=your-tenant.eu.auth0.com
-# AUTH0_AUDIENCE=https://api.ship.local      # API identifier in Auth0
+# AUTH0_AUDIENCE=https://api.ship.local      # API identifier in Auth0; often matches SHIP_PUBLIC_URL
 # AUTH0_CLIENT_ID=
 # AUTH0_CLIENT_SECRET=
 # AUTH0_SESSION_SECRET=                       # 32-byte hex; used by @auth0/nextjs-auth0 cookie

--- a/backend/README.md
+++ b/backend/README.md
@@ -39,9 +39,14 @@ The API version is reported by `GET /openapi.json` and matches the canonical Shi
 The lean backend stack (Postgres+pgvector, MinIO, API server, console) lives behind a single `docker-compose.yml` at the repo root.
 
 ```bash
-cp .env.example .env       # defaults are fine for local
+cp .env.example .env       # defaults are fine for bundled local services
 docker compose up --build
 ```
+
+The same `.env` keys are used for bundled local services and shared
+infrastructure. By default Compose fills `DATABASE_URL`, `ALEMBIC_DATABASE_URL`,
+and S3 with the in-network Postgres/MinIO service URLs; set those keys in
+`.env` to point the same containers at Neon/S3 instead.
 
 The ARQ worker + Redis are behind a `worker` profile so the default `up` matches the cloud SaaS topology (no worker, no Redis). Spin them up locally only when you need background jobs:
 
@@ -64,13 +69,13 @@ The first boot runs Alembic migrations against the empty database; subsequent bo
 pip install -r requirements-backend.txt
 
 # Migrations (Postgres must already be reachable at DATABASE_URL)
-alembic -c backend/alembic.ini upgrade head
+node scripts/run-with-dotenv.mjs -- .venv/bin/alembic -c backend/alembic.ini upgrade head
 
 # API
-uvicorn backend.app.main:app --reload --host 127.0.0.1 --port 8100
+node scripts/run-with-dotenv.mjs -- .venv/bin/uvicorn backend.app.main:app --reload --host 127.0.0.1 --port 8100
 
 # Worker (separate shell)
-arq backend.app.workers.main.WorkerSettings
+node scripts/run-with-dotenv.mjs -- .venv/bin/arq backend.app.workers.main.WorkerSettings
 ```
 
 ## Run against shared dev infrastructure

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -77,6 +77,28 @@ def test_cloud_mode_accepts_real_hostnames() -> None:
     assert settings.console_url.startswith("https://")
 
 
+def test_neon_style_database_urls_normalize_for_runtime_and_migrations() -> None:
+    """Neon/libpq DSNs use the same env keys in local and network setups."""
+    settings = Settings(
+        DATABASE_URL=(
+            "postgresql://ship:secret@ep-test.us-east-1.aws.neon.tech/ship"
+            "?sslmode=require&channel_binding=require"
+        ),
+        ALEMBIC_DATABASE_URL=(
+            "postgresql://ship:secret@ep-test.us-east-1.aws.neon.tech/ship"
+            "?sslmode=require"
+        ),
+    )
+
+    assert settings.async_database_url == (
+        "postgresql+asyncpg://ship:secret@ep-test.us-east-1.aws.neon.tech/ship"
+    )
+    assert settings.sync_database_url == (
+        "postgresql+psycopg://ship:secret@ep-test.us-east-1.aws.neon.tech/ship"
+        "?sslmode=require"
+    )
+
+
 def test_anthropic_vendor_swaps_default_openai_model_ids() -> None:
     """Anthropic + key + default ``gpt-*`` env → Claude ids (avoids 404 model)."""
     settings = Settings(

--- a/console/src/lib/auth0.ts
+++ b/console/src/lib/auth0.ts
@@ -37,10 +37,7 @@ export const auth0 = isAuth0Mode
       domain: process.env.AUTH0_DOMAIN ?? "",
       clientId: process.env.AUTH0_CLIENT_ID ?? "",
       clientSecret: process.env.AUTH0_CLIENT_SECRET ?? "",
-      appBaseUrl:
-        process.env.APP_BASE_URL ??
-        process.env.AUTH0_BASE_URL ??
-        "http://localhost:3001",
+      appBaseUrl: process.env.APP_BASE_URL ?? "http://localhost:3001",
       secret: process.env.AUTH0_SESSION_SECRET ?? "",
       authorizationParameters: {
         audience: process.env.AUTH0_AUDIENCE,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,9 +92,9 @@ services:
       minio:
         condition: service_healthy
     environment:
-      DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER:-ship}:${POSTGRES_PASSWORD:-ship}@postgres:5432/${POSTGRES_DB:-ship}
-      ALEMBIC_DATABASE_URL: postgresql+psycopg://${POSTGRES_USER:-ship}:${POSTGRES_PASSWORD:-ship}@postgres:5432/${POSTGRES_DB:-ship}
-      S3_ENDPOINT_URL: http://minio:9000
+      DATABASE_URL: ${DATABASE_URL:-postgresql+asyncpg://${POSTGRES_USER:-ship}:${POSTGRES_PASSWORD:-ship}@postgres:5432/${POSTGRES_DB:-ship}}
+      ALEMBIC_DATABASE_URL: ${ALEMBIC_DATABASE_URL:-postgresql+psycopg://${POSTGRES_USER:-ship}:${POSTGRES_PASSWORD:-ship}@postgres:5432/${POSTGRES_DB:-ship}}
+      S3_ENDPOINT_URL: ${S3_ENDPOINT_URL:-http://minio:9000}
       S3_BUCKET: ${S3_BUCKET:-ship-documents}
       S3_ACCESS_KEY: ${S3_ACCESS_KEY:-shipminio}
       S3_SECRET_KEY: ${S3_SECRET_KEY:-shipminio}
@@ -150,9 +150,9 @@ services:
         # the mock banner for no good reason.
         condition: service_healthy
     environment:
-      # Console talks to ship-server over the internal compose network.
-      # next.config.ts proxies /api/* -> ${SHIP_API_URL}/v1/* when set.
-      SHIP_API_URL: http://ship-server:8100
+      # Console talks to ship-server over the internal compose network by
+      # default. Set SHIP_API_URL to point the same image at shared infra.
+      SHIP_API_URL: ${SHIP_API_URL:-http://ship-server:8100}
       PORT: "3001"
       SHIP_AUTH_MODE: ${SHIP_AUTH_MODE:-local}
       # Auth0 (used when SHIP_AUTH_MODE=auth0). The SDK reads these from
@@ -173,6 +173,7 @@ services:
       NEXT_PUBLIC_SENTRY_ENVIRONMENT: ${NEXT_PUBLIC_SENTRY_ENVIRONMENT:-${SENTRY_ENVIRONMENT:-local}}
       NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE: ${NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE:-${SENTRY_TRACES_SAMPLE_RATE:-0.0}}
       SHIP_VERSION: ${SHIP_VERSION:-}
+      NEXT_PUBLIC_SHIP_VERSION: ${NEXT_PUBLIC_SHIP_VERSION:-${SHIP_VERSION:-}}
     ports:
       - "${SHIP_CONSOLE_PORT:-3001}:3001"
     healthcheck:
@@ -217,9 +218,9 @@ services:
     environment:
       # Server runs migrations; worker should not race on them.
       SHIP_SKIP_MIGRATIONS: "1"
-      DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER:-ship}:${POSTGRES_PASSWORD:-ship}@postgres:5432/${POSTGRES_DB:-ship}
+      DATABASE_URL: ${DATABASE_URL:-postgresql+asyncpg://${POSTGRES_USER:-ship}:${POSTGRES_PASSWORD:-ship}@postgres:5432/${POSTGRES_DB:-ship}}
       REDIS_URL: redis://redis:6379/0
-      S3_ENDPOINT_URL: http://minio:9000
+      S3_ENDPOINT_URL: ${S3_ENDPOINT_URL:-http://minio:9000}
       S3_BUCKET: ${S3_BUCKET:-ship-documents}
       S3_ACCESS_KEY: ${S3_ACCESS_KEY:-shipminio}
       S3_SECRET_KEY: ${S3_SECRET_KEY:-shipminio}

--- a/documentation/auth0-setup.md
+++ b/documentation/auth0-setup.md
@@ -81,7 +81,17 @@ public URL of the Console:
 ```bash
 SHIP_AUTH_MODE=auth0
 APP_BASE_URL=https://ship.example.com   # http://localhost:3001 for laptop
+SHIP_CONSOLE_URL=https://ship.example.com
+SHIP_PUBLIC_URL=https://api.ship.example.com
 ```
+
+Use the same Auth0 variable names everywhere. The console reads
+`AUTH0_DOMAIN`, `AUTH0_CLIENT_ID`, `AUTH0_CLIENT_SECRET`, `AUTH0_AUDIENCE`,
+`AUTH0_SESSION_SECRET`, and `APP_BASE_URL`; the backend reads
+`AUTH0_DOMAIN`, `AUTH0_AUDIENCE`, `AUTH0_ISSUER`, `SHIP_PUBLIC_URL`, and
+`SHIP_CONSOLE_URL`. `AUTH0_AUDIENCE` must match the API identifier configured
+in Auth0, which is commonly the same string as `SHIP_PUBLIC_URL` but is still
+an Auth0 API setting rather than a browser URL.
 
 `make restart` and you're done. The `/login` page now shows a "Continue
 with Auth0" button instead of the local email/password form.

--- a/documentation/internal/pilot-plan.md
+++ b/documentation/internal/pilot-plan.md
@@ -911,19 +911,21 @@ SENTRY_SERVICE_NAME=ship-server
 ### Console env vars (Bunny `ship-console`)
 
 ```
-NEXT_PUBLIC_SHIP_API_URL=https://api.ship.<your-domain>
-NEXT_PUBLIC_AUTH0_DOMAIN=<tenant>.eu.auth0.com
-NEXT_PUBLIC_AUTH0_CLIENT_ID=<console SPA client id>
-NEXT_PUBLIC_AUTH0_AUDIENCE=https://api.ship.<your-domain>
-AUTH0_SECRET=<openssl rand -hex 32>                     # for cookie encryption (server-side)
-AUTH0_BASE_URL=https://ship.<your-domain>
-AUTH0_ISSUER_BASE_URL=https://<tenant>.eu.auth0.com
+SHIP_API_URL=https://api.ship.<your-domain>
+SHIP_AUTH_MODE=auth0
+APP_BASE_URL=https://ship.<your-domain>
+SHIP_CONSOLE_URL=https://ship.<your-domain>
+AUTH0_DOMAIN=<tenant>.eu.auth0.com
+AUTH0_AUDIENCE=https://api.ship.<your-domain>            # Auth0 API identifier
+AUTH0_SESSION_SECRET=<openssl rand -hex 32>              # for cookie encryption (server-side)
 AUTH0_CLIENT_ID=<console regular web app client id>
 AUTH0_CLIENT_SECRET=<...>
 
 NEXT_PUBLIC_SENTRY_DSN=https://...@sentry.io/...
+NEXT_PUBLIC_SENTRY_ENVIRONMENT=pilot
 SENTRY_ENVIRONMENT=pilot
 SHIP_VERSION=sha-<short>
+NEXT_PUBLIC_SHIP_VERSION=sha-<short>
 SENTRY_SERVICE_NAME=ship-console
 ```
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Make Compose accept the same database, S3, API, Auth0, and Sentry release env contract used by shared Neon/Auth0 deployments.
- Update env examples and setup docs to use the runtime variable names read by backend and console.
- Add backend config coverage for Neon-style DSNs and remove the stale console Auth0 base URL fallback.

### Testing
- `.venv/bin/python -m pytest backend/tests/test_config.py -q`
- `python3 - <<'PY' ... compose YAML contract assertions ... PY`
- `if rg 'NEXT_PUBLIC_SHIP_API_URL|NEXT_PUBLIC_AUTH0_|AUTH0_SECRET|AUTH0_BASE_URL|AUTH0_ISSUER_BASE_URL' ...; then exit 1; else echo 'no stale Auth0/API env names found'; fi`
- `npm run build --prefix console`
- `curl -fsS http://127.0.0.1:8100/v1/health && curl -fsS -o /dev/null -w 'console /login HTTP %{http_code}\n' http://127.0.0.1:3001/login`

### Notes
- `docker compose config` could not run on this VM because Docker is not installed; YAML parsing and explicit environment assertions covered the same config drift checks locally.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-941d76e0-fc7c-4ad6-8685-fb7cc9abc963"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-941d76e0-fc7c-4ad6-8685-fb7cc9abc963"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

