### PR TITLE
fix: invalid CREATE INDEX syntax in migration 0045 partial index

### DIFF
--- a/backend/migrations/versions/0045_platform_invites.py
+++ b/backend/migrations/versions/0045_platform_invites.py
@@ -121,11 +121,14 @@ def upgrade() -> None:
         unique=True,
     )
 
-    # Partial index for "open invites" query: (accepted_at IS NULL, expires_at).
+    # Partial index for "open invites" query — the WHERE clause already
+    # filters down to ``accepted_at IS NULL``, so we just sort by expiry.
+    # (Postgres rejects ``accepted_at IS NULL DESC`` as an index expression
+    # — that's a boolean predicate, not a sortable value.)
     op.execute(
         "CREATE INDEX ix_platform_invites_open "
-        "ON platform_invites (accepted_at IS NULL DESC, expires_at) "
-        "WHERE accepted_at IS NULL"
+        "ON platform_invites (expires_at) "
+        "WHERE accepted_at IS NULL AND revoked_at IS NULL"
     )
 
 


### PR DESCRIPTION
## Bunny still crashing after #52

Container moved past the duplicate-index error fixed in #52 and now trips on the third statement of migration 0045:

```
sqlalchemy.exc.ProgrammingError: (psycopg.errors.SyntaxError)
syntax error at or near "IS"
LINE 1: ...orm_invites_open ON platform_invites (accepted_at IS NULL DE...
[SQL: CREATE INDEX ix_platform_invites_open
 ON platform_invites (accepted_at IS NULL DESC, expires_at)
 WHERE accepted_at IS NULL]
```

## Why

Postgres rejects ``accepted_at IS NULL DESC`` as an index expression because a boolean predicate isn't a sortable value (it'd need ``::int``or a ``CASE``). The intent was a partial index for "open invites" — but the ``WHERE accepted_at IS NULL`` already filters to that subset, so the expression part is redundant.

## Fix

- Sort by ``expires_at`` alone in the index expression
- Also tighten the WHERE filter to exclude revoked invites — open-invites queries shouldn't see those either

## Verified

- Prod Neon DB still at ``alembic_version = 0043_knowledge_import_sources`` — none of 0044/0045/0046 applied. Fix lands before any partial state.

## Test plan

- [ ] CI green on this PR
- [ ] Merge → Bunny rollout proceeds → migration 0044 + fixed 0045 + 0046 all apply
- [ ] ``curl https://api.ship.elmundi.com/v1/health`` returns JSON 200
- [ ] ``curl https://api.ship.elmundi.com/v1/public/beta-capacity`` returns ``{accepted: 0, cap: 50, full: false}``

🤖 Generated with [Claude Code](https://claude.com/claude-code)