### PR TITLE
fix: drop unresolved GENERAL_LIMITER import from waitlist route

### DIFF
--- a/backend/app/api/v1/routes/waitlist.py
+++ b/backend/app/api/v1/routes/waitlist.py
@@ -17,7 +17,11 @@ from fastapi import APIRouter, Depends, status
 
 from backend.app.db.models.tenancy import WaitlistSubmission
 from backend.app.db.session import get_session
-from backend.app.security.rate_limit import rate_limit, GENERAL_LIMITER
+
+# NB: no rate limiter on this public endpoint yet — sized for the closed-beta
+# trickle. ``backend/app/security/rate_limit.py`` exposes LOGIN/SIGNUP/
+# TOKEN_MINT limiters; add a WAITLIST_LIMITER and ``Depends(rate_limit(...))``
+# on the route below if traffic warrants it post-beta.
 
 
 router = APIRouter(
@@ -56,8 +60,6 @@ async def submit_waitlist(
     Accepts email (required) and optional fields: role, tracker, agent, note.
     Always returns ``{ ok: true }`` even on duplicate emails (idempotent UX).
 
-    Rate-limited per IP using GENERAL_LIMITER.
-
     Args:
         form: Waitlist submission data
         session: Database session
@@ -65,9 +67,6 @@ async def submit_waitlist(
     Returns:
         Success response with ok=true
     """
-    # Apply rate limit (future: configure per-IP limits if needed)
-    # TODO: Implement rate limiting based on client IP if GENERAL_LIMITER is available
-
     # Normalize email to lowercase for consistency
     email = form.email.lower()
 


### PR DESCRIPTION
## Bunny still crash-looping after #52 + #53

Container moved past both DB migration errors and now trips on Python module load:

\`\`\`
File \"/app/backend/app/api/v1/routes/waitlist.py\", line 20, in <module>
    from backend.app.security.rate_limit import rate_limit, GENERAL_LIMITER
ImportError: cannot import name 'GENERAL_LIMITER' from 'backend.app.security.rate_limit'
\`\`\`

## Why

The waitlist route added in #51 (E08 T05) imported \`GENERAL_LIMITER\` but \`security/rate_limit.py\` only exports \`LOGIN_LIMITER\`, \`SIGNUP_LIMITER\`, \`TOKEN_MINT_LIMITER\`. The name didn't exist — the route handler never even used it (the body had a TODO for "future rate limiting").

\`ImportError\` fires at module-load time, before any of the previous fixes' code paths run, which is why this was masked by the migration errors in #52 and #53.

## Fix

Drop the broken import. Left a NB comment pointing at the existing limiter constants so a future PR can wire one in five lines if traffic warrants it post-beta.

## Test plan

- [ ] CI green
- [ ] Merge → Bunny rollout finally completes
- [ ] \`curl https://api.ship.elmundi.com/v1/health\` returns JSON 200
- [ ] \`curl https://api.ship.elmundi.com/v1/public/beta-capacity\` returns \`{accepted: 0, cap: 50, full: false}\`
- [ ] \`POST /v1/public/waitlist\` accepts a valid form (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)