### PR TITLE
fix: methodology indexer uses pgvector ORM (fixes /search empty)

### DIFF
--- a/backend/app/db/models/__init__.py
+++ b/backend/app/db/models/__init__.py
@@ -41,6 +41,7 @@ from backend.app.db.models.integrations import (
 )
 from backend.app.db.models.knowledge_promotion import KnowledgePromotionCandidate
 from backend.app.db.models.lanes import Lane
+from backend.app.db.models.methodology import MethodologyChunk
 from backend.app.db.models.notifications import WorkspaceNotification
 from backend.app.db.models.pipelines import (
     AgentRequest,
@@ -98,6 +99,7 @@ __all__ = [
     "KnowledgeSourceItem",
     "KnowledgePromotionCandidate",
     "Lane",
+    "MethodologyChunk",
     "MemberGroup",
     "MemberGroupMember",
     "NativeIntegrationAuditEvent",

--- a/backend/app/db/models/methodology.py
+++ b/backend/app/db/models/methodology.py
@@ -1,0 +1,100 @@
+"""ORM model for the ``methodology_chunks`` table (E13 — Chroma → pgvector).
+
+Lives in its own module so the legacy methodology API (``/search``, ``/fetch``)
+can keep its single dependency surface (this model + the indexer service in
+``backend.app.services.methodology_index``) without coupling to the cloud
+platform's bucket models.
+
+Why an ORM model and not raw SQL: pgvector + asyncpg in this codebase always
+goes through ``pgvector.sqlalchemy.Vector`` so the dialect handles the binary
+``vector(N)`` type properly. The raw ``:q::vector`` cast that the first cut
+of ``methodology_index.py`` used silently fell over on insert under asyncpg —
+the indexer ran on startup, swallowed the error inside the ``lifespan``
+``try/except``, and left ``methodology_chunks`` empty. /search then had
+nothing to query and 500'd when the embedder ran without rows to score.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from pgvector.sqlalchemy import Vector
+from sqlalchemy import CheckConstraint, DateTime, Index, Integer, String, Text, text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from backend.app.db.base import Base
+
+
+# Same dim as ``backend.app.services.agent.embedding.EMBED_DIM``. Keep both in
+# step on any model swap — the migration locks ``vector(1536)``.
+EMBED_DIM = 1536
+
+
+class MethodologyChunk(Base):
+    """One indexable chunk of the methodology corpus.
+
+    Rows are owned by :func:`backend.app.services.methodology_index.reindex_if_stale`,
+    which walks ``documentation/``, ``artifacts/**/ARTIFACT.md``, and
+    ``README.md`` on backend startup and upserts deltas (``content_sha``
+    skip path). Read by the legacy ``/search`` and ``/fetch`` route handlers
+    in ``backend/app/main.py``.
+    """
+
+    __tablename__ = "methodology_chunks"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+
+    # Repo-relative path. For ARTIFACT.md the indexer rewrites this to the
+    # artifact folder so callers can fetch the whole bundle.
+    path: Mapped[str] = mapped_column(Text, nullable=False)
+
+    # 0-indexed offset within ``path``.
+    chunk_idx: Mapped[int] = mapped_column(Integer, nullable=False)
+
+    # The chunk text (post-frontmatter strip for ARTIFACT.md).
+    body: Mapped[str] = mapped_column(Text, nullable=False)
+
+    # SHA-256 of ``body`` — drives idempotent reindex (skip when unchanged).
+    content_sha: Mapped[str] = mapped_column(Text, nullable=False)
+
+    # 1536-d OpenAI embedding. Nullable so a chunk row can exist while
+    # embedding is queued (we don't actually use that path today, but it
+    # keeps the model future-proof for a backfill job).
+    embedding: Mapped[list[float] | None] = mapped_column(
+        Vector(EMBED_DIM), nullable=True
+    )
+
+    # Coarse content classification — drives optional filtered queries.
+    kind: Mapped[str] = mapped_column(String(16), nullable=False)
+
+    # Artifact id when the source is ``artifacts/<plural>/<id>/ARTIFACT.md``.
+    slug: Mapped[str | None] = mapped_column(String(255), nullable=True)
+
+    indexed_at: Mapped["DateTime"] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=text("now()"),
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            "kind IN ('doc', 'artifact', 'readme')",
+            name="ck_methodology_chunks_kind",
+        ),
+        # Match migration 0044 — the unique constraint is named explicitly
+        # there. We declare it via ``Index`` (not ``UniqueConstraint``) so
+        # the naming convention can't auto-generate a different name and
+        # diverge from the migration.
+        Index(
+            "uq_methodology_chunks_path_idx",
+            "path",
+            "chunk_idx",
+            unique=True,
+        ),
+        Index("ix_methodology_chunks_kind", "kind"),
+    )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import os
 import re
 import time
@@ -155,12 +156,30 @@ async def lifespan(_app: FastAPI):
     # Reindex the methodology corpus into pgvector (E13). Idempotent: only
     # chunks whose ``content_sha`` changed get re-embedded, so warm starts
     # add maybe a few requests' latency, not a full corpus walk.
+    #
+    # Best-effort by design — a missing OPENAI_API_KEY or transient DB
+    # blip shouldn't take down ``/patterns``/``/tools``/etc. We do *log*
+    # the failure though (the original silent ``except`` left an empty
+    # ``methodology_chunks`` table for /search to 500 against without
+    # any surface-level signal).
     try:
         from backend.app.services.methodology_index import reindex_if_stale
 
-        await reindex_if_stale()
-    except Exception:  # pragma: no cover — best-effort startup
-        pass
+        result = await reindex_if_stale()
+        log = logging.getLogger("ship.methodology_index")
+        log.info(
+            "methodology reindex: walked=%d seen=%d new=%d unchanged=%d pruned=%d",
+            result.files_walked,
+            result.chunks_seen,
+            result.chunks_new_or_changed,
+            result.chunks_unchanged,
+            result.chunks_pruned,
+        )
+    except Exception:
+        logging.getLogger("ship.methodology_index").exception(
+            "methodology reindex failed at startup; /search will be empty until "
+            "the next successful boot"
+        )
     try:
         yield
     finally:

--- a/backend/app/services/methodology_index.py
+++ b/backend/app/services/methodology_index.py
@@ -17,8 +17,9 @@ This module owns:
 - the **upsert** (idempotent: chunks whose ``content_sha`` already
   matches in the DB are skipped — so a cold restart does not re-embed
   the entire corpus, only the deltas);
-- the **search** (cosine distance over the HNSW index, returning the
-  same JSON shape as the old Chroma path so the released CLI sees no
+- the **search** (cosine distance via
+  ``MethodologyChunk.embedding.cosine_distance``, returning the same
+  JSON shape as the old Chroma path so the released CLI sees no
   contract drift).
 
 The module is independent of FastAPI; ``backend/app/main.py`` calls
@@ -29,17 +30,22 @@ The module is independent of FastAPI; ``backend/app/main.py`` calls
 from __future__ import annotations
 
 import hashlib
+import logging
 import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterable
 
-from sqlalchemy import select, text
+from sqlalchemy import delete, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from backend.app.db.models.methodology import EMBED_DIM, MethodologyChunk
 from backend.app.db.session import get_engine
-from backend.app.services.agent.embedding import EMBED_DIM, embed_texts
+from backend.app.services.agent.embedding import embed_texts
+
+
+log = logging.getLogger(__name__)
 
 
 APP_ROOT = Path(__file__).resolve().parents[3]
@@ -94,7 +100,7 @@ def _index_path_for(path: Path) -> str:
 def _kind_for(path: Path) -> str:
     if path.name == "ARTIFACT.md":
         return "artifact"
-    if path.relative_to(APP_ROOT).parts[0] == "README.md".lower() or path.name == "README.md":
+    if path.name == "README.md":
         return "readme"
     return "doc"
 
@@ -216,11 +222,13 @@ async def _existing_index(
     session: AsyncSession,
 ) -> dict[tuple[str, int], str]:
     rows = await session.execute(
-        text(
-            "SELECT path, chunk_idx, content_sha FROM methodology_chunks"
+        select(
+            MethodologyChunk.path,
+            MethodologyChunk.chunk_idx,
+            MethodologyChunk.content_sha,
         )
     )
-    return {(row[0], row[1]): row[2] for row in rows.all()}
+    return {(r[0], r[1]): r[2] for r in rows.all()}
 
 
 async def _upsert_chunks(
@@ -228,63 +236,66 @@ async def _upsert_chunks(
     chunks: list[_Chunk],
     embeddings: list[list[float]],
 ) -> None:
+    """ON CONFLICT-aware bulk insert via the Postgres dialect.
+
+    Going through the dialect-level ``insert(...).on_conflict_do_update``
+    keeps the path/chunk_idx unique-index conflict resolution server-side
+    and lets the ``Vector`` type adapter serialize the embedding properly
+    on asyncpg. The earlier raw-SQL ``::vector`` cast fell over silently
+    here.
+    """
     if not chunks:
         return
     if len(chunks) != len(embeddings):  # pragma: no cover — defensive
         raise RuntimeError(
             f"embedder returned {len(embeddings)} vectors for {len(chunks)} chunks"
         )
+    rows = []
     for c, e in zip(chunks, embeddings, strict=True):
         if len(e) != EMBED_DIM:  # pragma: no cover — defensive
             raise RuntimeError(
                 f"embedder returned {len(e)}-d vector; expected {EMBED_DIM}"
             )
-        await session.execute(
-            text(
-                "INSERT INTO methodology_chunks "
-                "(path, chunk_idx, body, content_sha, embedding, kind, slug) "
-                "VALUES (:path, :chunk_idx, :body, :content_sha, "
-                "        :embedding::vector, :kind, :slug) "
-                "ON CONFLICT (path, chunk_idx) DO UPDATE SET "
-                "    body = EXCLUDED.body, "
-                "    content_sha = EXCLUDED.content_sha, "
-                "    embedding = EXCLUDED.embedding, "
-                "    kind = EXCLUDED.kind, "
-                "    slug = EXCLUDED.slug, "
-                "    indexed_at = now()"
-            ),
+        rows.append(
             {
                 "path": c.path,
                 "chunk_idx": c.chunk_idx,
                 "body": c.body,
                 "content_sha": c.content_sha,
-                # pgvector accepts the canonical "[0.1,0.2,…]" string form;
-                # asyncpg won't auto-cast a Python list to vector otherwise.
-                "embedding": "[" + ",".join(repr(float(x)) for x in e) + "]",
+                "embedding": e,
                 "kind": c.kind,
                 "slug": c.slug,
-            },
+            }
         )
+    stmt = pg_insert(MethodologyChunk).values(rows)
+    stmt = stmt.on_conflict_do_update(
+        index_elements=["path", "chunk_idx"],
+        set_={
+            "body": stmt.excluded.body,
+            "content_sha": stmt.excluded.content_sha,
+            "embedding": stmt.excluded.embedding,
+            "kind": stmt.excluded.kind,
+            "slug": stmt.excluded.slug,
+        },
+    )
+    await session.execute(stmt)
 
 
 async def _prune_missing(
     session: AsyncSession, seen_keys: set[tuple[str, int]]
 ) -> int:
     rows = await session.execute(
-        text("SELECT path, chunk_idx FROM methodology_chunks")
+        select(MethodologyChunk.path, MethodologyChunk.chunk_idx)
     )
-    to_delete = [
-        (row[0], row[1]) for row in rows.all() if (row[0], row[1]) not in seen_keys
-    ]
+    to_delete = [(r[0], r[1]) for r in rows.all() if (r[0], r[1]) not in seen_keys]
     if not to_delete:
         return 0
     for path, chunk_idx in to_delete:
         await session.execute(
-            text(
-                "DELETE FROM methodology_chunks "
-                "WHERE path = :path AND chunk_idx = :chunk_idx"
-            ),
-            {"path": path, "chunk_idx": chunk_idx},
+            delete(MethodologyChunk).where(
+                MethodologyChunk.path == path,
+                MethodologyChunk.chunk_idx == chunk_idx,
+            )
         )
     return len(to_delete)
 
@@ -304,18 +315,22 @@ async def search(query: str, top_k: int = 10) -> list[dict[str, Any]]:
     if not query.strip():
         return []
     [embedding] = await embed_texts([query])
-    embedding_lit = "[" + ",".join(repr(float(x)) for x in embedding) + "]"
     engine = get_engine()
     async with AsyncSession(engine) as session:
+        dist_col = MethodologyChunk.embedding.cosine_distance(embedding).label("dist")
         rows = await session.execute(
-            text(
-                "SELECT id, path, chunk_idx, body, kind, slug, "
-                "       embedding <=> :q::vector AS distance "
-                "FROM methodology_chunks "
-                "ORDER BY embedding <=> :q::vector "
-                "LIMIT :top_k"
-            ),
-            {"q": embedding_lit, "top_k": top_k},
+            select(
+                MethodologyChunk.id,
+                MethodologyChunk.path,
+                MethodologyChunk.chunk_idx,
+                MethodologyChunk.body,
+                MethodologyChunk.kind,
+                MethodologyChunk.slug,
+                dist_col,
+            )
+            .where(MethodologyChunk.embedding.isnot(None))
+            .order_by(dist_col)
+            .limit(top_k)
         )
         out: list[dict[str, Any]] = []
         for row in rows.all():


### PR DESCRIPTION
## /search 500'd after #54

Backend started cleanly but ``POST /search`` returned 500. Inspecting the prod Neon DB:

- ``alembic_version`` = ``0046_waitlist_submissions`` (✅ migrations applied)
- ``methodology_chunks`` table exists, **0 rows** ❌

The startup reindex ran but every insert was silently dropped, then the lifespan ``try/except`` swallowed the error with no log.

## Root cause

The first cut of ``methodology_index.py`` used raw SQL with ``:embedding::vector`` casts. Under asyncpg the cast doesn't actually serialize the embedding payload — the param gets bound but never reaches Postgres as a vector. INSERT silently fails, lifespan eats the error, ``/search`` runs against 0 rows.

The existing cloud-platform code already solved this by going through ``pgvector.sqlalchemy.Vector`` + ``cosine_distance`` ORM. Bring the methodology indexer onto the same path.

## Changes

- New ORM model ``MethodologyChunk`` (``backend/app/db/models/methodology.py``) declared with ``Vector(1536)`` — mirrors migration 0044.
- ``methodology_index.py`` rewritten to use the ORM:
  - Bulk upsert via ``insert(...).on_conflict_do_update`` keyed on ``(path, chunk_idx)``
  - Search via ``MethodologyChunk.embedding.cosine_distance(qvec)`` (identical to ``services/agent/tools.py``)
- ``main.py`` lifespan now **logs** the reindex outcome (chunk counts on success, traceback on failure). The original silent ``except`` is what hid this bug — future startup failures will be visible.

## Verified

- ``py_compile`` clean for all changed files.
- Prod Neon DB schema is already at 0046 with the table and indexes in place — no migration changes needed.

## Test plan

- [ ] CI green
- [ ] Merge → Bunny rollout completes → backend logs ``methodology reindex: walked=N seen=M new=K …``
- [ ] ``curl https://api.ship.elmundi.com/search -X POST -H 'Content-Type: application/json' -d '{"query":"policies"}'`` returns ``{"query":"policies","results":[…]}`` with at least one hit
- [ ] ``npx @elmundi/ship-cli search "policies"`` returns the same shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)