### PR TITLE
E14 T01: server-side routine dispatch (Cursor Cloud)

### DIFF
--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -48,6 +48,7 @@ from backend.app.api.v1.routes import (
     repo_home,
     repo_secrets,
     repos,
+    routine_callbacks,
     routines,
     tracker_binding,
     waitlist,
@@ -97,6 +98,11 @@ api_router.include_router(repos.router)
 # prompt, and hands work off to Cursor Cloud Agent. Owns the routine-run
 # loop end-to-end so the customer-side cron tick can stay a thin wake-up.
 api_router.include_router(routines.router)
+# Public callback endpoints that Cursor-Cloud-launched agents hit with
+# their per-run JWT. Comment / transition / inbox-item write back to
+# Ship using the workspace's existing OAuth, so the agent never holds a
+# Linear or GitHub credential.
+api_router.include_router(routine_callbacks.router)
 # GitHub App OAuth + webhooks (pilot WOW-onboarding flow). Webhook route
 # is public; install start/callback do their own auth.
 api_router.include_router(github_app.router)

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -48,6 +48,7 @@ from backend.app.api.v1.routes import (
     repo_home,
     repo_secrets,
     repos,
+    routines,
     tracker_binding,
     waitlist,
     workspaces,
@@ -91,6 +92,11 @@ api_router.include_router(inbox.router)
 # Lives next to artifact_repos but is keyed off GitHub App installations
 # instead of paste-URL clones.
 api_router.include_router(repos.router)
+# E14 — server-side routine dispatch. ``POST /v1/.../routines/{id}/dispatch``
+# resolves the pattern, picks a tracker ticket if applicable, packages the
+# prompt, and hands work off to Cursor Cloud Agent. Owns the routine-run
+# loop end-to-end so the customer-side cron tick can stay a thin wake-up.
+api_router.include_router(routines.router)
 # GitHub App OAuth + webhooks (pilot WOW-onboarding flow). Webhook route
 # is public; install start/callback do their own auth.
 api_router.include_router(github_app.router)

--- a/backend/app/api/v1/routes/routine_callbacks.py
+++ b/backend/app/api/v1/routes/routine_callbacks.py
@@ -1,0 +1,288 @@
+"""Public callback endpoints for Cursor-Cloud-launched agents.
+
+A routine run hands the agent a short-lived bearer (see
+:mod:`backend.app.services.routine_run_token`) plus a small set of
+``curl`` recipes. The agent calls these endpoints to write back into
+Ship — comment on the bound ticket, transition the FSM stage, drop
+items into the workspace inbox — without ever holding a Linear or
+GitHub credential. Ship server uses the workspace's existing OAuth
+integration to do the actual write through :class:`TrackerGateway`.
+
+All endpoints here are **session-less**: auth is the routine-run JWT
+in ``Authorization: Bearer <token>``. They live under ``/v1/`` (not
+``/v1/workspaces/{ws}/...``) so the caller doesn't need to know the
+workspace UUID — it's encoded in the bearer.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from fastapi import APIRouter, Depends, Header, HTTPException, status
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.app.core.config import Settings, get_settings
+from backend.app.db.models.inbox import InboxItem
+from backend.app.db.models.integrations import GitHubInstallation, WorkspaceRepo
+from backend.app.db.models.tenancy import AuditLog, Integration
+from backend.app.db.session import get_session
+from backend.app.integrations.gateway.tracker import TicketRef, TrackerGateway
+from backend.app.integrations.github.issues_tracker import GitHubIssuesTracker
+from backend.app.integrations.linear.tracker_adapter import LinearTracker
+from backend.app.services.routine_run_token import RoutineRunClaims, decode
+
+
+router = APIRouter(prefix="/routine-callbacks", tags=["routine-callbacks"])
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Auth dependency
+# ---------------------------------------------------------------------------
+
+
+async def _claims(
+    authorization: str | None = Header(default=None),
+    settings: Settings = Depends(get_settings),
+) -> RoutineRunClaims:
+    if not authorization or not authorization.lower().startswith("bearer "):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="missing routine bearer token",
+        )
+    token = authorization.split(None, 1)[1].strip()
+    return decode(token=token, settings=settings)
+
+
+# ---------------------------------------------------------------------------
+# Tracker gateway resolution
+# ---------------------------------------------------------------------------
+
+
+async def _resolve_tracker(
+    *,
+    session: AsyncSession,
+    settings: Settings,
+    claims: RoutineRunClaims,
+) -> tuple[TrackerGateway, str]:
+    """Pick the tracker the agent should write to.
+
+    Preference order: Linear (workspace-level OAuth) → GitHub Issues
+    (the bound code host on the repo). Mirrors the routine dispatch
+    side of E14 — we resolve the same way at write-back time.
+    """
+    from backend.app.api.v1.routes.integrations import decrypt  # lazy
+
+    # 1. Linear.
+    linear_row = (
+        await session.execute(
+            select(Integration).where(
+                Integration.workspace_id == claims.workspace_id,
+                Integration.kind == "linear",
+                Integration.repo_id.is_(None),
+            )
+        )
+    ).scalars().first()
+    if linear_row is not None and linear_row.secret_ciphertext:
+        try:
+            token = decrypt(linear_row.secret_ciphertext)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("linear token unreadable: %s", exc)
+        else:
+            return LinearTracker(token), "linear"
+
+    # 2. GitHub Issues for the bound repo.
+    repo_row = await session.get(WorkspaceRepo, claims.repo_id)
+    if repo_row is None or repo_row.workspace_id != claims.workspace_id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="repo not bound to workspace",
+        )
+    install = await session.get(GitHubInstallation, repo_row.installation_id)
+    if install is None:
+        raise HTTPException(
+            status_code=status.HTTP_412_PRECONDITION_FAILED,
+            detail="github installation missing",
+        )
+    owner, _, name = (repo_row.full_name or "").partition("/")
+    if not owner or not name:
+        raise HTTPException(
+            status_code=500, detail="invalid full_name"
+        )
+    return (
+        GitHubIssuesTracker(
+            installation_id=install.installation_id,
+            owner=owner,
+            repo=name,
+            settings=settings,
+        ),
+        "github_issues",
+    )
+
+
+def _ticket_ref(claims: RoutineRunClaims, override: str | None) -> TicketRef:
+    raw = override or claims.ticket_id
+    if not raw:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="no ticket bound to this run; pass ticket_id explicitly",
+        )
+    # Format we use: ``owner/repo#N`` for github, ``ENG-12`` for Linear.
+    kind = "github_issues" if "#" in raw and "/" in raw else "linear"
+    return TicketRef(kind=kind, raw=raw)
+
+
+# ---------------------------------------------------------------------------
+# Schemas
+# ---------------------------------------------------------------------------
+
+
+class CommentIn(BaseModel):
+    body: str = Field(min_length=1, max_length=8000)
+    # Optional override; default = the ticket bound to the run.
+    ticket_id: str | None = None
+
+
+class TransitionIn(BaseModel):
+    to_state: str = Field(min_length=1, max_length=64)
+    ticket_id: str | None = None
+
+
+class InboxItemIn(BaseModel):
+    type: str = Field(default="improvement", min_length=1, max_length=32)
+    title: str = Field(min_length=1, max_length=300)
+    summary: str | None = Field(default=None, max_length=2000)
+    payload: dict[str, Any] = Field(default_factory=dict)
+
+
+class CallbackOut(BaseModel):
+    ok: bool = True
+    provider: str | None = None
+    note: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.post("/comment", response_model=CallbackOut)
+async def post_comment(
+    payload: CommentIn,
+    claims: RoutineRunClaims = Depends(_claims),
+    session: AsyncSession = Depends(get_session),
+    settings: Settings = Depends(get_settings),
+) -> CallbackOut:
+    gateway, provider = await _resolve_tracker(
+        session=session, settings=settings, claims=claims
+    )
+    ref = _ticket_ref(claims, payload.ticket_id)
+    await gateway.comment(ref, body=payload.body)
+    session.add(
+        AuditLog(
+            workspace_id=claims.workspace_id,
+            actor_user_id=None,
+            actor_token_id=None,
+            action="routine_callback.comment",
+            target_kind="ticket",
+            target_id=ref.raw,
+            payload={
+                "routine_id": claims.routine_id,
+                "pattern": claims.pattern,
+                "agent_id": claims.agent_id,
+                "provider": provider,
+                "body_chars": len(payload.body),
+            },
+        )
+    )
+    await session.flush()
+    return CallbackOut(ok=True, provider=provider)
+
+
+@router.post("/transition", response_model=CallbackOut)
+async def post_transition(
+    payload: TransitionIn,
+    claims: RoutineRunClaims = Depends(_claims),
+    session: AsyncSession = Depends(get_session),
+    settings: Settings = Depends(get_settings),
+) -> CallbackOut:
+    gateway, provider = await _resolve_tracker(
+        session=session, settings=settings, claims=claims
+    )
+    ref = _ticket_ref(claims, payload.ticket_id)
+    await gateway.transition(ref, to_state=payload.to_state)
+    session.add(
+        AuditLog(
+            workspace_id=claims.workspace_id,
+            actor_user_id=None,
+            actor_token_id=None,
+            action="routine_callback.transition",
+            target_kind="ticket",
+            target_id=ref.raw,
+            payload={
+                "routine_id": claims.routine_id,
+                "pattern": claims.pattern,
+                "agent_id": claims.agent_id,
+                "provider": provider,
+                "to_state": payload.to_state,
+            },
+        )
+    )
+    await session.flush()
+    return CallbackOut(ok=True, provider=provider)
+
+
+@router.post("/inbox-item", response_model=CallbackOut)
+async def post_inbox_item(
+    payload: InboxItemIn,
+    claims: RoutineRunClaims = Depends(_claims),
+    session: AsyncSession = Depends(get_session),
+) -> CallbackOut:
+    """Drop a free-form item into the workspace inbox.
+
+    Used by context-free routines (daily digest, learning capture)
+    that don't transition tickets — they leave their output as an
+    operator-facing inbox row.
+    """
+    item = InboxItem(
+        workspace_id=claims.workspace_id,
+        repo_id=claims.repo_id,
+        type=payload.type,
+        title=payload.title[:300],
+        summary=(payload.summary or "")[:2000] or None,
+        payload={
+            **payload.payload,
+            "routine_id": claims.routine_id,
+            "pattern": claims.pattern,
+            "agent_id": claims.agent_id,
+            "produced_at": datetime.now(timezone.utc).isoformat(),
+        },
+        status="new",
+        intake_handle=None,
+        intake_reason=f"routine:{claims.routine_id}",
+    )
+    session.add(item)
+    session.add(
+        AuditLog(
+            workspace_id=claims.workspace_id,
+            actor_user_id=None,
+            actor_token_id=None,
+            action="routine_callback.inbox_item",
+            target_kind="inbox_item",
+            target_id=None,
+            payload={
+                "routine_id": claims.routine_id,
+                "pattern": claims.pattern,
+                "agent_id": claims.agent_id,
+                "type": payload.type,
+                "title": payload.title[:300],
+            },
+        )
+    )
+    await session.flush()
+    return CallbackOut(ok=True, note=f"inbox item created (type={payload.type})")

--- a/backend/app/api/v1/routes/routines.py
+++ b/backend/app/api/v1/routes/routines.py
@@ -1,0 +1,479 @@
+"""E14 — server-side routine dispatch.
+
+Handler that owns the routine-run loop end-to-end. Customer-side cron
+(``ship-trigger-schedule.yml``) only wakes this up; the server figures
+out which pattern is due, picks a ticket from the bound tracker, packs
+the prompt, and hands the work off to the agent runtime (Cursor Cloud
+today; pluggable later).
+
+Tonight's MVP scope:
+
+- Single endpoint ``POST /v1/workspaces/{ws}/repos/{repo_id}/routines/{routine_id}/dispatch``
+- Reads the pattern body from ``artifacts/patterns/<id>/ARTIFACT.md`` on
+  the server image (no DB cache yet — the bundle ships with the image).
+- For tracker-driven roles (``role-intake``, ``role-ba``,
+  ``role-developer``) — picks the next open GitHub issue that doesn't
+  already have a ``[Ship SDLC:<role>]`` comment. Quick-and-dirty FSM:
+  intake = no labels; ba = ``stage:intake`` label; developer =
+  ``ready:developer`` label.
+- For context-free flows (``flow-daily-retro``) — no ticket pull; just
+  dispatch with a workspace-level digest prompt.
+- Hands off to Cursor Cloud via :mod:`backend.app.services.cursor_cloud`.
+- Returns ``{ status, agent_id, ticket_id?, branch_name?, ... }``.
+
+What this is **not** yet:
+
+- No FSM transitions / labels written by the server. The agent does that
+  via ``gh`` CLI from inside its run.
+- No ``output_schema`` validation on the way back. Cursor doesn't post
+  a structured callback today; the agent's effect is the GitHub state
+  it leaves behind.
+- No idempotency layer on top of "did this routine already fire in this
+  window?". Caller (the cron tick handler) is responsible for that.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import time
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.app.api.v1.deps import AuthContext, get_current_auth
+from backend.app.api.v1.routes.workspaces import (
+    ROLES_ADMIN,
+    _require_membership,
+)
+from backend.app.core.config import Settings, get_settings
+from backend.app.db.models.integrations import GitHubInstallation, WorkspaceRepo
+from backend.app.db.models.tenancy import AuditLog
+from backend.app.db.session import get_session
+from backend.app.integrations.github.issues_tracker import GitHubIssuesTracker
+from backend.app.services.cursor_cloud import (
+    CursorCloudError,
+    LaunchedAgent,
+    launch_agent,
+)
+
+
+router = APIRouter(
+    prefix="/workspaces/{workspace_id}/repos/{repo_id}/routines",
+    tags=["routines"],
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ``artifacts/patterns/`` lives at the repo root. The Bunny image copies
+# the artifacts tree alongside ``backend/`` so resolving from ``__file__``
+# walks up enough parents to land on the same root. Pinned here so a
+# single rename doesn't silently degrade dispatch to "pattern not found"
+# at runtime.
+_PATTERNS_DIR = Path(__file__).resolve().parents[5] / "artifacts" / "patterns"
+
+
+# Quick-and-dirty FSM mapping. The full version (declared in pattern
+# frontmatter as ``fsm_stage`` + ``output_schema``) lands in T02; this
+# table is the bridge until then so dispatch works tonight.
+_ROLE_PICK: dict[str, dict[str, Any]] = {
+    "role-intake": {
+        "label": None,  # any open issue
+        "comment_marker": "[Ship SDLC:role-intake]",
+    },
+    "role-ba": {
+        "label": "stage:intake",
+        "comment_marker": "[Ship SDLC:role-ba]",
+    },
+    "role-developer": {
+        "label": "ready:developer",
+        "comment_marker": "[Ship SDLC:role-developer]",
+    },
+}
+
+# Context-free patterns: no ticket pull, just one prompt per dispatch.
+_CONTEXT_FREE: frozenset[str] = frozenset(
+    {"flow-daily-retro", "flow-learning-capture"}
+)
+
+
+# ---------------------------------------------------------------------------
+# Schemas
+# ---------------------------------------------------------------------------
+
+
+class DispatchIn(BaseModel):
+    """Override knobs for the dispatch — most callers post ``{}``."""
+
+    # Which pattern to render. If absent the server will try to look up
+    # the routine in the repo's ``.ship/config.yml`` (a future cache
+    # column on ``workspace_repos``). For tonight: the caller passes the
+    # pattern id explicitly so the route doesn't need that cache yet.
+    pattern: str | None = None
+    # Specific issue number to target (skip the pick step). Useful for
+    # the manual-launch path, e.g. operator clicks "run on this ticket".
+    issue_number: int | None = None
+    # Override Cursor branch name; default derives from role + issue.
+    branch_name: str | None = None
+    # Force ``autoCreatePr`` on the Cursor target. Developers usually
+    # leave it false because the prompt opens a deliberate PR.
+    auto_create_pr: bool = False
+    # Override the GitHub ref the agent checks out. Defaults to the
+    # repo's tracked default branch.
+    ref: str | None = None
+
+
+class DispatchOut(BaseModel):
+    """Result of a single dispatch — one agent kicked off, or a no-op."""
+
+    status: str  # ``dispatched`` | ``noop`` | ``error``
+    routine_id: str
+    pattern: str
+    role: str
+    reason: str | None = None
+    agent_id: str | None = None
+    branch_name: str | None = None
+    cursor_url: str | None = None
+    ticket: dict[str, Any] | None = None
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _read_pattern_body(pattern_id: str) -> str:
+    """Read the body (post-frontmatter) of an ``artifacts/patterns/`` entry."""
+    p = _PATTERNS_DIR / pattern_id / "ARTIFACT.md"
+    if not p.exists():
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={
+                "code": "pattern_not_found",
+                "message": f"No pattern at {p.relative_to(_PATTERNS_DIR.parent.parent)}",
+            },
+        )
+    raw = p.read_text(encoding="utf-8")
+    # Body starts after the second ``---`` line. Defensive: if the file
+    # has no frontmatter, treat the whole thing as body.
+    if raw.startswith("---"):
+        # find the closing ``---`` after the opening one
+        m = re.search(r"^---\s*$", raw[4:], flags=re.MULTILINE)
+        if m:
+            return raw[4 + m.end() :].lstrip("\n").rstrip()
+    return raw.rstrip()
+
+
+def _read_base() -> str:
+    return _read_pattern_body("common-base")
+
+
+def _render_prompt(
+    *,
+    pattern_body: str,
+    role: str,
+    owner: str,
+    repo: str,
+    issue: dict[str, Any] | None,
+) -> str:
+    base_body = _read_base()
+    base = (
+        base_body
+        .replace("{{SKILLS_CONTEXT}}", "(skills directory unavailable in this run)")
+        .replace("{{ROLE}}", role)
+        .replace(
+            "{{ISSUE}}",
+            f"#{issue.get('number')}" if issue else "(no ticket)",
+        )
+    )
+    body = pattern_body.replace("{{BASE}}", base)
+    if issue:
+        body = (
+            body
+            .replace("{{ISSUE}}", f"#{issue.get('number')}")
+            .replace("{{TITLE}}", str(issue.get("title") or "")[:500])
+            .replace("{{DESCRIPTION}}", str(issue.get("body") or "")[:8000])
+        )
+    else:
+        body = (
+            body
+            .replace("{{ISSUE}}", "(no ticket)")
+            .replace("{{TITLE}}", "")
+            .replace("{{DESCRIPTION}}", "")
+        )
+
+    issue_ref = (
+        f"#{issue.get('number')} on {owner}/{repo}" if issue else "(context-free run)"
+    )
+    issue_n = issue.get("number") if issue else None
+    gh_preamble = (
+        "## How to act on GitHub (this repo uses GitHub Issues, not Linear)\n\n"
+        f"The single human-facing channel for this run is the GitHub issue {issue_ref}.\n"
+        "Use the `gh` CLI for everything:\n\n"
+    )
+    if issue_n is not None:
+        gh_preamble += (
+            f"- Read latest state: `gh issue view {issue_n} --repo {owner}/{repo} "
+            "--json title,body,labels,state,comments`\n"
+            f"- Comment: `gh issue comment {issue_n} --repo {owner}/{repo} --body \"...\"`\n"
+            f"- Label: `gh issue edit {issue_n} --repo {owner}/{repo} --add-label \"ready\"`"
+            f" / `--remove-label \"needs-info\"`\n"
+            f"- Close: `gh issue close {issue_n} --repo {owner}/{repo}` (only if this role"
+            " is the right one to close)\n\n"
+        )
+    gh_preamble += (
+        f"End every comment with the marker line `[Ship SDLC:{role}]` (one comment per run, "
+        "not multiple).\n\n"
+        f"If a comment with `[Ship SDLC:{role}]` already reflects the current state — "
+        "exit without re-commenting.\n\n"
+    )
+    return gh_preamble + body
+
+
+async def _pick_issue(
+    *,
+    tracker: GitHubIssuesTracker,
+    role: str,
+    owner: str,
+    repo: str,
+) -> dict[str, Any] | None:
+    """Find the next open GitHub issue this role should work on.
+
+    Tonight's heuristic — see ``_ROLE_PICK``. The full version (driven
+    by pattern frontmatter ``fsm_stage``) lands in T02.
+    """
+    spec = _ROLE_PICK.get(role)
+    if spec is None:
+        return None  # role we don't know — caller decides what to do
+    # GitHub /search/issues lets us filter by label and exclude PRs in one query.
+    # Build the q string. We can't filter by "no comment with marker X" in the
+    # query, so we list candidates and check each.
+    q_parts = [f"repo:{owner}/{repo}", "is:issue", "is:open", "sort:updated-asc"]
+    if spec["label"]:
+        q_parts.append(f'label:"{spec["label"]}"')
+    q = " ".join(q_parts)
+
+    candidates = await tracker.list_tickets(state="open", limit=20, query=q)
+    if not candidates:
+        return None
+    marker = spec["comment_marker"]
+
+    # Hydrate each candidate with body+labels (the listing only returns a thin
+    # subset). Stop at the first one that hasn't yet had this role's marker.
+    for row in candidates:
+        # row['id'] looks like 'owner/repo#N'
+        n = int(str(row["id"]).rsplit("#", 1)[-1])
+        full = await tracker._request(
+            "GET",
+            f"/repos/{owner}/{repo}/issues/{n}",
+            params={"per_page": 100},
+        )
+        full_body = full.json() or {}
+        # Comments (separate endpoint).
+        c = await tracker._request(
+            "GET",
+            f"/repos/{owner}/{repo}/issues/{n}/comments",
+            params={"per_page": 100},
+        )
+        comments = c.json() or []
+        already = any(marker in (cm.get("body") or "") for cm in comments)
+        if already:
+            continue
+        return {
+            "number": n,
+            "title": full_body.get("title"),
+            "body": full_body.get("body") or "",
+            "url": full_body.get("html_url"),
+            "labels": [lab.get("name") for lab in full_body.get("labels") or []],
+            "state": full_body.get("state"),
+        }
+    return None
+
+
+def _branch_name(role: str, issue_number: int | None) -> str:
+    suffix = format(int(time.time() * 1000), "x")
+    if role == "role-developer" and issue_number is not None:
+        return f"fix/ship-{issue_number}-auto"
+    if issue_number is not None:
+        return f"cursor/ship-{role}-issue-{issue_number}-{suffix}"
+    return f"cursor/ship-{role}-{suffix}"
+
+
+# ---------------------------------------------------------------------------
+# Endpoint
+# ---------------------------------------------------------------------------
+
+
+@router.post("/{routine_id}/dispatch", response_model=DispatchOut)
+async def dispatch_routine(
+    workspace_id: uuid.UUID,
+    repo_id: uuid.UUID,
+    routine_id: str,
+    payload: DispatchIn = DispatchIn(),
+    auth: AuthContext = Depends(get_current_auth),
+    session: AsyncSession = Depends(get_session),
+    settings: Settings = Depends(get_settings),
+) -> DispatchOut:
+    await _require_membership(session, workspace_id, auth.user.id, ROLES_ADMIN)
+
+    repo_row = (
+        await session.execute(
+            select(WorkspaceRepo).where(
+                WorkspaceRepo.id == repo_id,
+                WorkspaceRepo.workspace_id == workspace_id,
+            )
+        )
+    ).scalars().first()
+    if repo_row is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="repo not activated"
+        )
+
+    install_row = (
+        await session.execute(
+            select(GitHubInstallation).where(
+                GitHubInstallation.id == repo_row.installation_id
+            )
+        )
+    ).scalars().first()
+    if install_row is None:
+        raise HTTPException(
+            status_code=status.HTTP_412_PRECONDITION_FAILED,
+            detail={"code": "github_app_missing"},
+        )
+
+    pattern_id = (payload.pattern or routine_id).strip()
+    pattern_body = _read_pattern_body(pattern_id)
+
+    # Pull the role from the routine: the pattern id is the role for
+    # tonight's MVP. ``role-intake`` → ``role-intake``.
+    role = pattern_id
+
+    owner, _, repo_name = repo_row.full_name.partition("/")
+    if not owner or not repo_name:
+        raise HTTPException(
+            status_code=500, detail=f"invalid full_name: {repo_row.full_name!r}"
+        )
+
+    issue: dict[str, Any] | None = None
+    if pattern_id not in _CONTEXT_FREE:
+        tracker = GitHubIssuesTracker(
+            installation_id=install_row.installation_id,
+            owner=owner,
+            repo=repo_name,
+            settings=settings,
+        )
+        if payload.issue_number is not None:
+            full = await tracker._request(
+                "GET",
+                f"/repos/{owner}/{repo_name}/issues/{payload.issue_number}",
+            )
+            ib = full.json() or {}
+            issue = {
+                "number": payload.issue_number,
+                "title": ib.get("title"),
+                "body": ib.get("body") or "",
+                "url": ib.get("html_url"),
+                "labels": [lab.get("name") for lab in ib.get("labels") or []],
+                "state": ib.get("state"),
+            }
+        else:
+            issue = await _pick_issue(
+                tracker=tracker, role=role, owner=owner, repo=repo_name
+            )
+        if issue is None:
+            return DispatchOut(
+                status="noop",
+                routine_id=routine_id,
+                pattern=pattern_id,
+                role=role,
+                reason="no_eligible_ticket",
+            )
+
+    prompt = _render_prompt(
+        pattern_body=pattern_body,
+        role=role,
+        owner=owner,
+        repo=repo_name,
+        issue=issue,
+    )
+
+    branch_name = payload.branch_name or _branch_name(
+        role, issue.get("number") if issue else None
+    )
+    ref = payload.ref or repo_row.default_branch or "main"
+    repo_url = f"https://github.com/{repo_row.full_name}"
+
+    api_key = (os.getenv("CURSOR_API_KEY") or "").strip()
+    if not api_key:
+        raise HTTPException(
+            status_code=status.HTTP_412_PRECONDITION_FAILED,
+            detail={
+                "code": "cursor_api_key_missing",
+                "message": "CURSOR_API_KEY is not configured on the Ship server.",
+            },
+        )
+
+    try:
+        launched: LaunchedAgent = await launch_agent(
+            api_key=api_key,
+            prompt=prompt,
+            repo_url=repo_url,
+            branch_name=branch_name,
+            ref=ref,
+            auto_create_pr=payload.auto_create_pr,
+        )
+    except CursorCloudError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail={
+                "code": "cursor_launch_failed",
+                "upstream_status": exc.status,
+                "body": str(exc.body)[:500],
+            },
+        ) from exc
+
+    cursor_url = (
+        launched.raw.get("target", {}).get("url")
+        or f"https://cursor.com/agents/{launched.agent_id}"
+    )
+
+    session.add(
+        AuditLog(
+            workspace_id=workspace_id,
+            actor_user_id=auth.user.id,
+            actor_token_id=auth.token.id if auth.token else None,
+            action="routine.dispatch",
+            target_kind="workspace_repo",
+            target_id=str(repo_row.id),
+            payload={
+                "routine_id": routine_id,
+                "pattern": pattern_id,
+                "role": role,
+                "issue_number": issue.get("number") if issue else None,
+                "branch_name": launched.branch_name,
+                "agent_id": launched.agent_id,
+                "ref": ref,
+            },
+        )
+    )
+    await session.flush()
+
+    return DispatchOut(
+        status="dispatched",
+        routine_id=routine_id,
+        pattern=pattern_id,
+        role=role,
+        agent_id=launched.agent_id,
+        branch_name=launched.branch_name,
+        cursor_url=cursor_url,
+        ticket=issue,
+    )

--- a/backend/app/api/v1/routes/routines.py
+++ b/backend/app/api/v1/routes/routines.py
@@ -63,6 +63,7 @@ from backend.app.services.cursor_cloud import (
     LaunchedAgent,
     launch_agent,
 )
+from backend.app.services.routine_run_token import RoutineRunClaims, mint as mint_run_token
 
 
 router = APIRouter(
@@ -183,6 +184,8 @@ def _render_prompt(
     owner: str,
     repo: str,
     issue: dict[str, Any] | None,
+    run_token: str | None = None,
+    callbacks_base: str = "",
 ) -> str:
     base_body = _read_base()
     base = (
@@ -214,28 +217,60 @@ def _render_prompt(
         f"#{issue.get('number')} on {owner}/{repo}" if issue else "(context-free run)"
     )
     issue_n = issue.get("number") if issue else None
-    gh_preamble = (
-        "## How to act on GitHub (this repo uses GitHub Issues, not Linear)\n\n"
-        f"The single human-facing channel for this run is the GitHub issue {issue_ref}.\n"
-        "Use the `gh` CLI for everything:\n\n"
+    ticket_id_for_callback = (
+        f"{owner}/{repo}#{issue_n}" if issue_n is not None else ""
     )
-    if issue_n is not None:
-        gh_preamble += (
-            f"- Read latest state: `gh issue view {issue_n} --repo {owner}/{repo} "
-            "--json title,body,labels,state,comments`\n"
-            f"- Comment: `gh issue comment {issue_n} --repo {owner}/{repo} --body \"...\"`\n"
-            f"- Label: `gh issue edit {issue_n} --repo {owner}/{repo} --add-label \"ready\"`"
-            f" / `--remove-label \"needs-info\"`\n"
-            f"- Close: `gh issue close {issue_n} --repo {owner}/{repo}` (only if this role"
-            " is the right one to close)\n\n"
+
+    # Cursor agents do not hold Linear / GitHub credentials. The Ship server
+    # owns the workspace's OAuth tokens and exposes a tiny set of callbacks the
+    # agent hits with the per-run JWT below. The token is short-lived (1h) and
+    # bound to this workspace + repo + ticket, so leaks are bounded.
+    callback_block = ""
+    if run_token and callbacks_base:
+        comment_curl = (
+            f"curl -sS -X POST '{callbacks_base}/v1/routine-callbacks/comment' \\\n"
+            f"  -H 'Authorization: Bearer {run_token}' \\\n"
+            "  -H 'Content-Type: application/json' \\\n"
+            "  -d '{\"body\":\"Your comment text here. [Ship SDLC:" + role + "]\"}'"
         )
-    gh_preamble += (
-        f"End every comment with the marker line `[Ship SDLC:{role}]` (one comment per run, "
-        "not multiple).\n\n"
-        f"If a comment with `[Ship SDLC:{role}]` already reflects the current state — "
-        "exit without re-commenting.\n\n"
-    )
-    return gh_preamble + body
+        inbox_curl = (
+            f"curl -sS -X POST '{callbacks_base}/v1/routine-callbacks/inbox-item' \\\n"
+            f"  -H 'Authorization: Bearer {run_token}' \\\n"
+            "  -H 'Content-Type: application/json' \\\n"
+            "  -d '{\"type\":\"improvement\",\"title\":\"...\",\"summary\":\"...\"}'"
+        )
+        transition_curl = (
+            f"curl -sS -X POST '{callbacks_base}/v1/routine-callbacks/transition' \\\n"
+            f"  -H 'Authorization: Bearer {run_token}' \\\n"
+            "  -H 'Content-Type: application/json' \\\n"
+            "  -d '{\"to_state\":\"in_progress\"}'"
+        )
+        ticket_line = (
+            f"This run is bound to ticket `{ticket_id_for_callback}` — the callbacks below"
+            " act on that ticket by default.\n\n"
+            if ticket_id_for_callback
+            else "This run is context-free (no specific ticket bound).\n\n"
+        )
+        callback_block = (
+            "## How to write back into Ship\n\n"
+            "You DO NOT have direct Linear / GitHub credentials. Ship server owns those.\n"
+            "Instead, hit Ship's per-run callback endpoints with the bearer token below.\n\n"
+            f"Bearer token (for this run only, expires in 1h):\n```\n{run_token}\n```\n\n"
+            f"{ticket_line}"
+            "### Comment on the bound ticket\n\n```bash\n"
+            + comment_curl + "\n```\n\n"
+            "### Drop a free-form item in the workspace inbox\n\n```bash\n"
+            + inbox_curl + "\n```\n\n"
+            "### Transition the FSM stage of the bound ticket\n\n```bash\n"
+            + transition_curl + "\n```\n\n"
+            f"End every Ship-side comment with the marker `[Ship SDLC:{role}]`.\n"
+            f"If a comment with `[Ship SDLC:{role}]` already reflects the current state, "
+            "exit without re-commenting.\n\n"
+            "Do NOT use `gh issue comment`, `linear-cli`, or any other direct API. "
+            "All tracker writes must go through the curl callbacks above so Ship server "
+            "stays the single source of audit truth.\n\n"
+        )
+    return callback_block + body
 
 
 async def _pick_issue(
@@ -398,12 +433,36 @@ async def dispatch_routine(
                 reason="no_eligible_ticket",
             )
 
+    # Mint the routine-run JWT before launching so we can embed it in
+    # the prompt the agent receives. Bound to (workspace, repo, routine,
+    # pattern, ticket) — agent_id is not in the token because we don't
+    # know it until Cursor responds (acceptable: token is short-lived
+    # and the ticket binding already scopes the blast radius).
+    ticket_id_for_token = (
+        f"{owner}/{repo_name}#{issue.get('number')}"
+        if issue and issue.get("number") is not None
+        else None
+    )
+    run_token = mint_run_token(
+        claims=RoutineRunClaims(
+            workspace_id=workspace_id,
+            repo_id=repo_id,
+            routine_id=routine_id,
+            pattern=pattern_id,
+            ticket_id=ticket_id_for_token,
+        ),
+        settings=settings,
+    )
+    callbacks_base = settings.public_url.rstrip("/") if settings.public_url else ""
+
     prompt = _render_prompt(
         pattern_body=pattern_body,
         role=role,
         owner=owner,
         repo=repo_name,
         issue=issue,
+        run_token=run_token,
+        callbacks_base=callbacks_base,
     )
 
     branch_name = payload.branch_name or _branch_name(

--- a/backend/app/services/cursor_cloud.py
+++ b/backend/app/services/cursor_cloud.py
@@ -1,0 +1,127 @@
+"""Cursor Cloud Agent API wrapper.
+
+Single-shot dispatch: ``launch_agent(prompt, repo_url, branch_name, …)``
+posts to ``https://api.cursor.com/v0/agents`` and returns the agent
+metadata. Mirrors what
+``tools/linear-agent/scripts/cloud-agent-launch.mjs`` does in the
+ElMundi sibling repo.
+
+Lives in ``services/`` (not ``integrations/``) because Cursor Cloud is
+the **agent runtime** — the thing the routine handler hands the prompt
+off to — not a tracker or a code host. There's no FSM or polling here.
+The agent writes back to its own outputs (PRs, issue comments) using
+its own tools; the Ship server just kicks the work off and returns.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+
+logger = logging.getLogger(__name__)
+
+
+CURSOR_API_BASE = "https://api.cursor.com"
+
+
+class CursorCloudError(RuntimeError):
+    """Raised when the Cursor Cloud API rejects a launch request.
+
+    Carries the upstream HTTP status + body so the caller can choose
+    between mapping to a specific user-facing error (4xx) or treating
+    it as a transient infra fault (5xx).
+    """
+
+    def __init__(self, status: int, body: Any) -> None:
+        super().__init__(f"Cursor Cloud API returned {status}: {body!r}")
+        self.status = status
+        self.body = body
+
+
+@dataclass(frozen=True)
+class LaunchedAgent:
+    """Agent metadata returned by the Cursor Cloud launch."""
+
+    agent_id: str
+    branch_name: str
+    raw: dict[str, Any]
+
+
+async def launch_agent(
+    *,
+    api_key: str,
+    prompt: str,
+    repo_url: str,
+    branch_name: str,
+    ref: str = "main",
+    auto_create_pr: bool = False,
+    open_as_cursor_github_app: bool = False,
+    client: httpx.AsyncClient | None = None,
+    timeout: float = 30.0,
+) -> LaunchedAgent:
+    """Kick off a single Cursor Cloud agent run.
+
+    The agent checks out ``repo_url`` at ``ref``, creates ``branch_name``,
+    and runs ``prompt``. If ``auto_create_pr`` is true the runtime opens a
+    PR back to ``ref`` as soon as the branch has a commit; otherwise the
+    prompt is responsible for opening the PR itself (developer roles in
+    practice — they want to write the PR title/body deliberately).
+    """
+    if not api_key:
+        raise CursorCloudError(0, "missing CURSOR_API_KEY")
+
+    auth = "Basic " + base64.b64encode(f"{api_key}:".encode("utf-8")).decode("ascii")
+    body = {
+        "prompt": {"text": prompt},
+        "source": {"repository": repo_url, "ref": ref},
+        "target": {
+            "branchName": branch_name,
+            "autoCreatePr": auto_create_pr,
+            "openAsCursorGithubApp": open_as_cursor_github_app,
+        },
+    }
+
+    async def _post(c: httpx.AsyncClient) -> httpx.Response:
+        return await c.post(
+            f"{CURSOR_API_BASE}/v0/agents",
+            json=body,
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": auth,
+            },
+            timeout=timeout,
+        )
+
+    if client is None:
+        async with httpx.AsyncClient() as fresh:
+            res = await _post(fresh)
+    else:
+        res = await _post(client)
+
+    text = res.text
+    if not res.is_success:
+        # Don't try to JSON-decode an error response — Cursor's 4xx/5xx
+        # bodies are sometimes plain strings.
+        raise CursorCloudError(res.status_code, text)
+
+    try:
+        data = res.json()
+    except Exception as exc:  # pragma: no cover — non-JSON 200 is unexpected
+        raise CursorCloudError(res.status_code, text) from exc
+
+    agent_id = (
+        data.get("id")
+        or data.get("agentId")
+        or data.get("agent_id")
+        or ""
+    )
+    return LaunchedAgent(
+        agent_id=str(agent_id),
+        branch_name=branch_name,
+        raw=data,
+    )

--- a/backend/app/services/routine_run_token.py
+++ b/backend/app/services/routine_run_token.py
@@ -1,0 +1,100 @@
+"""Mint and verify per-routine-run JWTs.
+
+A routine run hands a Cursor Cloud agent a short-lived bearer that lets
+it talk back to Ship — comment on tickets, drop inbox items, etc. —
+without ever holding a Linear/GitHub credential. The token is
+HS256-signed with ``settings.jwt_secret`` and carries enough claims
+(workspace, repo, ticket, agent) for the callback handler to know
+*who* is acting and *where* it is allowed to write.
+
+Mirrors the ``_mint_run_token`` helper in
+:mod:`backend.app.api.v1.routes.pipelines` but with a distinct subject
+and richer claims so a pipeline-callback bearer can't be replayed
+against a routine-callback handler (and vice versa).
+"""
+
+from __future__ import annotations
+
+import secrets
+import time
+import uuid
+from typing import Final
+
+from fastapi import HTTPException, status
+from jose import JWTError, jwt
+from pydantic import BaseModel, Field
+
+from backend.app.core.config import Settings
+
+
+_SUBJECT: Final[str] = "ship.routine.run"
+_TTL_SECONDS: Final[int] = 60 * 60  # 1 hour — Cursor agents typically finish in <30 min
+
+
+class RoutineRunClaims(BaseModel):
+    """Decoded claims from a routine-run bearer."""
+
+    workspace_id: uuid.UUID
+    repo_id: uuid.UUID
+    routine_id: str
+    pattern: str
+    agent_id: str | None = None
+    # Optional ticket the run is bound to. ``None`` for context-free
+    # routines (daily digest, learning capture). When set, callbacks
+    # that mutate a tracker MUST target this ticket.
+    ticket_id: str | None = None
+    issued_at: int = Field(default_factory=lambda: int(time.time()))
+
+
+def mint(*, claims: RoutineRunClaims, settings: Settings) -> str:
+    issued = int(time.time())
+    payload: dict = {
+        "sub": _SUBJECT,
+        "iat": issued,
+        "exp": issued + _TTL_SECONDS,
+        "nonce": secrets.token_urlsafe(8),
+        "ws": str(claims.workspace_id),
+        "repo": str(claims.repo_id),
+        "routine": claims.routine_id,
+        "pattern": claims.pattern,
+    }
+    if claims.agent_id:
+        payload["agent"] = claims.agent_id
+    if claims.ticket_id:
+        payload["ticket"] = claims.ticket_id
+    return jwt.encode(payload, settings.jwt_secret, algorithm="HS256")
+
+
+def decode(*, token: str, settings: Settings) -> RoutineRunClaims:
+    try:
+        decoded = jwt.decode(
+            token,
+            settings.jwt_secret,
+            algorithms=["HS256"],
+            options={"require": ["exp", "iat", "sub"]},
+        )
+    except JWTError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="routine token invalid or expired",
+        ) from exc
+    if decoded.get("sub") != _SUBJECT:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="routine token has wrong subject",
+        )
+    try:
+        return RoutineRunClaims(
+            workspace_id=uuid.UUID(str(decoded["ws"])),
+            repo_id=uuid.UUID(str(decoded["repo"])),
+            routine_id=str(decoded["routine"]),
+            pattern=str(decoded["pattern"]),
+            agent_id=decoded.get("agent"),
+            ticket_id=decoded.get("ticket"),
+            issued_at=int(decoded.get("iat", 0)),
+        )
+    except (KeyError, ValueError) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=f"routine token malformed: {exc}",
+        ) from exc

--- a/e2e/scripts/bind-github-tracker.mjs
+++ b/e2e/scripts/bind-github-tracker.mjs
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+/**
+ * Bind GitHub Issues as the tracker for ElMundiUA/ship in the active workspace.
+ * Reuses the saved Auth0 session.
+ */
+
+import { chromium } from "playwright";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const STORAGE = path.resolve(__dirname, "..", ".auth", "user.json");
+const BASE = "https://app.ship.elmundi.com";
+const WORKSPACE_ID = "d591af28-225e-477e-8448-7a4b9b06fbfc";
+const REPO_ID = "0f01d965-d4d7-46c9-bcdd-930b9efdd3b6"; // ElMundiUA/ship
+
+async function main() {
+  const browser = await chromium.launch({ headless: true });
+  const ctx = await browser.newContext({ storageState: STORAGE });
+  const page = await ctx.newPage();
+
+  // Land on console so iron-session cookies attach.
+  await page.goto(BASE + "/", { waitUntil: "domcontentloaded", timeout: 30000 });
+
+  // PUT /api/workspaces/{ws}/repos/{repo}/tracker is rewritten to
+  // backend's /v1/.../tracker. The console's session cookie is exchanged
+  // server-side into the backend bearer.
+  const url = `${BASE}/api/workspaces/${WORKSPACE_ID}/repos/${REPO_ID}/tracker`;
+  console.log(">> PUT", url);
+  const res = await page.evaluate(async (u) => {
+    const r = await fetch(u, {
+      method: "PUT",
+      credentials: "include",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ kind: "github", config: {} }),
+    });
+    return { status: r.status, body: await r.text() };
+  }, url);
+  console.log("status=", res.status);
+  console.log("body:", res.body.slice(0, 500));
+
+  await browser.close();
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/e2e/scripts/launch-cursor-agent.mjs
+++ b/e2e/scripts/launch-cursor-agent.mjs
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+/**
+ * Manual single-shot launcher for a Cursor Cloud agent against a Ship
+ * pattern + GitHub issue. Mirrors `tools/linear-agent/scripts/cloud-agent-launch.mjs`
+ * from the ElMundi sibling repo, adapted to:
+ *
+ *   - Ship pattern frontmatter (artifacts/patterns/<role>/ARTIFACT.md)
+ *   - GitHub Issues as the tracker (instead of Linear)
+ *
+ * Usage:
+ *   CURSOR_API_KEY=… node e2e/scripts/launch-cursor-agent.mjs \
+ *     --role role-intake --owner ElMundiUA --repo ship --issue 66
+ *
+ * Reads the pattern body, substitutes {{ISSUE}}, {{TITLE}}, {{DESCRIPTION}},
+ * {{BASE}}, posts the prompt to the Cursor Cloud Agent API. The agent
+ * is responsible for talking back to GitHub via `gh` CLI / GH App.
+ *
+ * This is the manual-iteration path before the server endpoint
+ * (E14 T01) takes over.
+ */
+
+import { readFileSync, existsSync } from "node:fs";
+import { resolve, dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { execFileSync } from "node:child_process";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, "..", "..");
+const ARTIFACTS = join(REPO_ROOT, "artifacts", "patterns");
+
+function parseArgs() {
+  const out = { role: "", owner: "", repo: "", issue: "", branch: "", autoCreatePr: false };
+  const args = process.argv.slice(2);
+  for (let i = 0; i < args.length; i += 1) {
+    const a = args[i];
+    if (a === "--role") out.role = args[++i];
+    else if (a === "--owner") out.owner = args[++i];
+    else if (a === "--repo") out.repo = args[++i];
+    else if (a === "--issue") out.issue = String(args[++i]);
+    else if (a === "--branch") out.branch = args[++i];
+    else if (a === "--auto-create-pr") out.autoCreatePr = true;
+  }
+  return out;
+}
+
+function readPatternBody(role) {
+  const p = join(ARTIFACTS, role, "ARTIFACT.md");
+  if (!existsSync(p)) throw new Error(`Pattern not found: ${p}`);
+  const raw = readFileSync(p, "utf8");
+  // Strip frontmatter — body starts after the second "---".
+  const idx = raw.indexOf("\n---\n", 4);
+  const body = idx >= 0 ? raw.slice(idx + 5) : raw;
+  return body.trim();
+}
+
+function readBase() {
+  const p = join(ARTIFACTS, "common-base", "ARTIFACT.md");
+  if (!existsSync(p)) return "";
+  const raw = readFileSync(p, "utf8");
+  const idx = raw.indexOf("\n---\n", 4);
+  return idx >= 0 ? raw.slice(idx + 5).trim() : raw;
+}
+
+function ghIssue(owner, repo, n) {
+  const buf = execFileSync(
+    "gh",
+    ["issue", "view", n, "--repo", `${owner}/${repo}`, "--json", "number,title,body,url,labels,state"],
+    { encoding: "utf8", maxBuffer: 8 * 1024 * 1024 },
+  );
+  return JSON.parse(buf);
+}
+
+async function main() {
+  const opts = parseArgs();
+  if (!opts.role || !opts.owner || !opts.repo || !opts.issue) {
+    console.error("Usage: --role <pattern-id> --owner <gh-owner> --repo <gh-repo> --issue <number>");
+    process.exit(1);
+  }
+  const apiKey = process.env.CURSOR_API_KEY;
+  if (!apiKey) {
+    console.error("CURSOR_API_KEY required");
+    process.exit(1);
+  }
+
+  const issue = ghIssue(opts.owner, opts.repo, opts.issue);
+  const baseBody = readBase()
+    .replace(/\{\{SKILLS_CONTEXT\}\}/g, "(no skills directory in this repo)")
+    .replace(/\{\{ROLE\}\}/g, opts.role)
+    .replace(/\{\{ISSUE\}\}/g, `#${issue.number}`);
+
+  const body = readPatternBody(opts.role);
+  const issueRef = `#${issue.number}`;
+  const prompt = body
+    .replace(/\{\{BASE\}\}/g, baseBody)
+    .replace(/\{\{ISSUE\}\}/g, issueRef)
+    .replace(/\{\{TITLE\}\}/g, (issue.title || "").slice(0, 500))
+    .replace(/\{\{DESCRIPTION\}\}/g, (issue.body || "").slice(0, 8000));
+
+  // Override + clarify: this is a GitHub Issues workflow, not Linear.
+  const ghPreamble = `
+## How to act on GitHub (this repo uses GitHub Issues, not Linear)
+
+The single human-facing channel for this ticket is the GitHub issue ${issueRef} on ${opts.owner}/${opts.repo}.
+Use the \`gh\` CLI for everything:
+
+- Read latest state: \`gh issue view ${opts.issue} --repo ${opts.owner}/${opts.repo} --json title,body,labels,state,comments\`
+- Comment: \`gh issue comment ${opts.issue} --repo ${opts.owner}/${opts.repo} --body "..."\`
+- Label: \`gh issue edit ${opts.issue} --repo ${opts.owner}/${opts.repo} --add-label "ready"\` / \`--remove-label "needs-info"\`
+- Close: \`gh issue close ${opts.issue} --repo ${opts.owner}/${opts.repo}\` (only when role is the right one to close)
+
+End every comment with the marker line \`[Ship SDLC:${opts.role}]\` (one comment per run, not multiple).
+
+If a comment with \`[Ship SDLC:${opts.role}]\` already reflects the current state — exit without re-commenting.
+
+`;
+
+  const fullPrompt = ghPreamble + prompt;
+
+  const branchName = opts.branch || `cursor/ship-${opts.role}-issue-${issue.number}-${Date.now().toString(36)}`;
+  const repoUrl = `https://github.com/${opts.owner}/${opts.repo}`;
+
+  const reqBody = JSON.stringify({
+    prompt: { text: fullPrompt },
+    source: { repository: repoUrl, ref: "main" },
+    target: {
+      branchName,
+      autoCreatePr: opts.autoCreatePr,
+      openAsCursorGithubApp: false,
+    },
+  });
+
+  console.log("== prompt preview (first 500 chars) ==");
+  console.log(fullPrompt.slice(0, 500));
+  console.log("== POST https://api.cursor.com/v0/agents ==");
+
+  const res = await fetch("https://api.cursor.com/v0/agents", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: "Basic " + Buffer.from(`${apiKey}:`).toString("base64"),
+    },
+    body: reqBody,
+  });
+  const text = await res.text();
+  if (!res.ok) {
+    console.error("Cursor API failed:", res.status, text.slice(0, 1000));
+    process.exit(1);
+  }
+  let data;
+  try { data = JSON.parse(text); } catch { data = text; }
+  console.log("OK:", JSON.stringify(data, null, 2));
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary

First piece of E14 (now in-beta scope per #65). Single endpoint that owns the routine-run loop end-to-end:

\`POST /v1/workspaces/{ws}/repos/{repo_id}/routines/{routine_id}/dispatch\`

Server picks the pattern, picks a tracker ticket if applicable, packages the prompt, and hands work off to **Cursor Cloud Agent** via \`POST https://api.cursor.com/v0/agents\`. Mirrors the launch pattern from the ElMundi sibling repo's \`tools/linear-agent/scripts/cloud-agent-launch.mjs\`, adapted to:
- Ship pattern frontmatter (\`artifacts/patterns/<id>/ARTIFACT.md\`)
- GitHub Issues as the tracker (instead of Linear)

## Tonight's MVP scope

- Reads pattern body from the artifacts tree shipped in the image (no DB cache yet — \`config_yaml\` cache lands in T05).
- For tracker-driven roles (\`role-intake\`, \`role-ba\`, \`role-developer\`) — picks the next open GitHub issue without an \`[Ship SDLC:<role>]\` comment, with a label-gate FSM bridge until pattern frontmatter \`fsm_stage\` lands (T02).
- For context-free patterns (\`flow-daily-retro\`, \`flow-learning-capture\`) — no ticket pull; just dispatch.
- Audit-logs every dispatch with routine + pattern + role + ticket + agent_id + branch_name.
- Returns \`{ status: dispatched|noop|error, agent_id?, ticket?, ... }\`.

## Out of scope tonight

- \`output_schema\` validation. Cursor doesn't post a structured callback today; the agent's effect is the GitHub state it leaves behind.
- Server-side idempotency window (\"did this routine fire in this slot?\").
- FSM transitions written by the server. The agent does that via \`gh\` CLI from inside its run.

## Required env

\`CURSOR_API_KEY\` must be set on the Ship-API Bunny container template (Bunny dashboard → Ship-API → Environment variables). The endpoint 412s with \`cursor_api_key_missing\` if absent.

## Test plan

- [x] \`pytest backend/tests/ -k "router"\` — green (router still imports cleanly with the new \`routines\` module).
- [ ] Add \`CURSOR_API_KEY\` to the Bunny Ship-API container env (manual).
- [ ] After deploy: dispatch \`role-intake\` against \`ElMundiUA/ship\` and confirm a Cursor agent run is launched.
- [ ] Confirm the agent posts back to the GitHub issue (or open follow-up to refine the prompt — see B-list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)