### PR TITLE
E14 T01-T03: server tracker write surface + shipctl agent-run pipeline

### DIFF
--- a/artifacts/patterns/common-base/ARTIFACT.md
+++ b/artifacts/patterns/common-base/ARTIFACT.md
@@ -6,7 +6,7 @@ version: 1.0.0
 channel: stable
 min_shipctl: 0.3.0
 updated_at: "2026-04-07T20:41:22+03:00"
-content_sha256: 41b590c88218ec8f92c6ec9e029b2f20afc5887ae3c8f1cfd3492dd09baab3bf
+content_sha256: 418a943f30f266780db2ad07f81598d8392903db15498abc64e4d7689c1bc2a9
 deprecated: false
 replaced_by: null
 yanked: false

--- a/artifacts/patterns/common-base/ARTIFACT.md
+++ b/artifacts/patterns/common-base/ARTIFACT.md
@@ -25,18 +25,37 @@ spec:
   template: true
 ---
 
-## Global rules (Cursor Cloud Agent — GitHub SDLC)
+## Global rules (E14 routine run)
 
-- **SDLC queue:** GitHub pick scripts only take tickets in **Todo** and in the Linear project configured by **`LINEAR_SDLC_PROJECT_ID`** or **`LINEAR_SDLC_PROJECT_NAME`**. **Backlog** is for manual triage — automation does not pick it up until you move the card to Todo.
-- **Linear:** The single channel with humans is **comments on the ticket** in Linear. Do not spam: one substantive comment per pass; end with `[GitHub SDLC:{{ROLE}}]`.
-- **IDEMPOTENCY:** Before making changes, re-read the ticket (and latest comments). If work for this role is already done (required labels/description/status), **exit without changes and without a comment**.
-- **GitHub schedule:** The same ticket can re-enter pick after ~2h. If the latest comment with `[GitHub SDLC:{{ROLE}}]` already reflects the current state and there are no new inputs — **do not duplicate** updates or comments.
-- Do not merge PRs. Do not move to Done without explicit human approval.
-- **LINEAR_API_KEY:** Must be available to the agent (Cursor Cloud → Secrets / env for the repository). Update Linear via API or the official client. If the key is missing — one comment `[LINEAR-DRAFT]` with JSON/text of what to apply manually.
-- **Skills:** Context from `.cursor/skills` appears below — follow it for Bunny, deploy, self-heal, etc., when the task touches those areas.
-- **One ticket — one open PR from SDLC:** branch **`fix/{{ISSUE}}-auto`** (issue key from the ticket, e.g. `ENG-12` → `fix/ENG-12-auto`; see `runtime/scripts/cloud-agent-launch.mjs`). Do not create a parallel **`feature/…-auto`** branch for the same ticket — that duplicates work; if two PRs already exist, do not merge both: keep the current one and close the other.
-- **Dev / prod / deploy:** org-specific hosts, runbooks, and workflow names live in **repository settings** and **documentation/examples** (reference deployment). Follow your team’s documented pre-release and promote process — do not assume a particular domain or image name.
-- **Daily audit roles** (`tech-architect`, `qa-architect`, `security-officer`): do not create tickets without verifiable facts; dedupe against open issues in target Linear projects. Comment marker: `[GitHub SDLC daily-audit:…]` (see `documentation/examples` / operator docs when present).
+- **You are running inside Ship's E14 routine pipeline.** A single
+  routine slot picked you a task. When you finish (or hit a wall),
+  you commit `.ship/run-state.json` on this branch and stop. Ship
+  CLI reads that file and writes back to the tracker / inbox using
+  the workspace's existing OAuth — you never hold credentials and
+  you never call a tracker API directly.
+- **No direct tracker writes.** Do **not** run `gh issue comment`,
+  `linear-cli`, `curl https://api.linear.app/...`, or any other
+  vendor API by hand. Encode all writes into `.ship/run-state.json`.
+- **Single comment per pass.** Whatever your role decides, summarise
+  it in one substantive markdown block (the `comment` field of the
+  state file). End the comment with `[Ship SDLC:{{ROLE}}]` so we can
+  detect "already done" on a re-pick.
+- **IDEMPOTENCY.** Before doing work, re-read the ticket. If a
+  comment with `[Ship SDLC:{{ROLE}}]` already reflects the current
+  state and there are no new inputs, exit with `state=ready_next_step`
+  and an empty `comment` (or skip the comment entirely) so the run
+  doesn't double-fire.
+- **Do not merge PRs.** Do not move tickets to Done without an
+  explicit human approval signal — that's a `human_validation`
+  state, not `ready_next_step`.
+- **One ticket → one open PR.** Branch name is set by Ship CLI at
+  launch (`fix/<ticket>-auto` for developer roles); don't create
+  parallel branches for the same ticket. If two PRs already exist
+  for the same ticket, leave the older one open and exit with a
+  `blocked` state describing the conflict.
+- **Skills:** any context from `.cursor/skills` appears below.
+  Follow it where applicable; if absent, continue with what you
+  have.
 
 ## Relevant skills
 

--- a/artifacts/patterns/role-intake/ARTIFACT.md
+++ b/artifacts/patterns/role-intake/ARTIFACT.md
@@ -23,6 +23,9 @@ spec:
   category: role
   modes: [lane, request]
   include: [common-base]
+  # E14: tracker stage this pattern operates on. ``shipctl agent-run``
+  # uses this to pick the next eligible ticket via ``GET /tracker/next``.
+  fsm_stage: triage
   inbox:
     profile: role_reviewer
     overrides:

--- a/artifacts/patterns/role-intake/ARTIFACT.md
+++ b/artifacts/patterns/role-intake/ARTIFACT.md
@@ -6,7 +6,7 @@ version: 1.0.0
 channel: stable
 min_shipctl: 0.3.0
 updated_at: "2026-04-07T20:41:22+03:00"
-content_sha256: 72b435b7bfc4ed650ccab102ea2779c718af880d08d9d1d8fa1143aadf927b17
+content_sha256: f2d5e8576db9fa96dd6a19d78d3c5aa0f6ed3220840c0a81e5be37d5d91d67c4
 deprecated: false
 replaced_by: null
 yanked: false

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -15,6 +15,7 @@ from fastapi import APIRouter
 
 from backend.app.api.v1.routes import (
     admin_invites,
+    agent_runs,
     agent_secrets,
     artifact_repos,
     audit,
@@ -91,6 +92,11 @@ api_router.include_router(inbox.router)
 # Lives next to artifact_repos but is keyed off GitHub App installations
 # instead of paste-URL clones.
 api_router.include_router(repos.router)
+# E14 — write-side surface that ``shipctl run`` calls during a routine
+# run. Workspace-scoped (admin auth), vendor-agnostic ``ticket_ref``.
+# Server resolves the right TrackerGateway adapter so the CLI doesn't
+# need per-vendor logic.
+api_router.include_router(agent_runs.router)
 # GitHub App OAuth + webhooks (pilot WOW-onboarding flow). Webhook route
 # is public; install start/callback do their own auth.
 api_router.include_router(github_app.router)

--- a/backend/app/api/v1/routes/agent_runs.py
+++ b/backend/app/api/v1/routes/agent_runs.py
@@ -1,0 +1,357 @@
+"""Agent-run helpers: the read-and-write surface ``shipctl`` calls
+during a routine run.
+
+E14 architecture (locked 2026-04-30):
+
+- Customer's GitHub Actions cron fires ``shipctl run --routine X``.
+- ``shipctl`` reads the routine's pattern, asks Ship server for a
+  task (a single ticket in the routine's FSM stage, if applicable),
+  hands the prompt to a Cursor Cloud agent, polls until the agent
+  finishes, reads the agent's structured state from
+  ``.ship/run-state.json``, and dispatches to the right write call:
+
+  - ``ready_next_step``  → ``POST /tracker/transition``
+  - ``human_validation`` → ``POST /tracker/comment`` + ``POST /inbox/items``
+  - ``blocked``          → ``POST /inbox/items``
+
+The endpoints in this module are the write side of that contract.
+``shipctl`` runs in the customer's runner with a workspace API
+token; the server uses the workspace's existing Linear / GitHub
+OAuth integrations to do the actual mutation. The CLI never holds
+the tracker credential.
+
+These routes intentionally take a vendor-agnostic ``ticket_ref``
+string — Ship server picks the right adapter via
+:func:`backend.app.services.tracker_resolver.resolve_for_repo` and
+hands it to :class:`TrackerGateway`. CLI doesn't have to know
+whether the workspace runs Linear or GitHub Issues.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Literal
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel, Field
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.app.api.v1.deps import AuthContext, get_current_auth
+from backend.app.api.v1.routes.workspaces import (
+    ROLES_ADMIN,
+    _require_membership,
+)
+from backend.app.core.config import Settings, get_settings
+from backend.app.db.models.inbox import InboxItem
+from backend.app.db.models.tenancy import AuditLog
+from backend.app.db.session import get_session
+from backend.app.integrations.gateway.tracker import TicketRef
+from backend.app.services.tracker_resolver import resolve_for_repo
+
+
+router = APIRouter(
+    prefix="/workspaces/{workspace_id}",
+    tags=["agent-runs"],
+)
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Schemas
+# ---------------------------------------------------------------------------
+
+
+class TaskTicketOut(BaseModel):
+    """A single task the agent will work on, shaped for prompt rendering."""
+
+    ticket_ref: str  # vendor-agnostic id the CLI passes back on writes
+    kind: str  # tracker provider — informational, not load-bearing
+    title: str
+    body: str | None = None
+    url: str | None = None
+    labels: list[str] = Field(default_factory=list)
+    state: str | None = None
+    fsm_stage: str | None = None  # echo of the requested stage
+
+
+class TaskResponseOut(BaseModel):
+    """``GET /tracker/next`` response. ``ticket=None`` → no eligible task."""
+
+    ticket: TaskTicketOut | None = None
+    fsm_stage: str
+    tracker_kind: str | None = None
+
+
+class TransitionIn(BaseModel):
+    ticket_ref: str = Field(min_length=1, max_length=512)
+    to_state: str = Field(min_length=1, max_length=64)
+    # Optional sanity check: refuse the call if the ticket isn't in this
+    # stage on Ship's side. CLI passes its own knowledge of "I just
+    # picked this from <stage>" — server uses it to short-circuit a
+    # double-fire.
+    from_state: str | None = None
+    comment: str | None = None  # leave a trail before/with the transition
+
+
+class CommentIn(BaseModel):
+    ticket_ref: str = Field(min_length=1, max_length=512)
+    body: str = Field(min_length=1, max_length=8000)
+
+
+class InboxItemIn(BaseModel):
+    type: Literal["clarification", "improvement", "blocker", "approval"] = "improvement"
+    title: str = Field(min_length=1, max_length=300)
+    summary: str | None = Field(default=None, max_length=2000)
+    payload: dict[str, Any] = Field(default_factory=dict)
+    ticket_ref: str | None = None
+
+
+class WriteOut(BaseModel):
+    ok: bool = True
+    tracker_kind: str | None = None
+    note: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _vendor_kind_to_ticket_kind(vendor_kind: str) -> Literal[
+    "github_issues", "linear", "notion", "jira"
+]:
+    if vendor_kind == "linear":
+        return "linear"
+    if vendor_kind == "github_issues":
+        return "github_issues"
+    if vendor_kind == "jira":
+        return "jira"
+    return "github_issues"  # safe default for the pilot
+
+
+def _ticket_ref_from(vendor_kind: str, raw: str) -> TicketRef:
+    """Hydrate a vendor-agnostic ``ticket_ref`` string into a typed
+    :class:`TicketRef` for adapter calls.
+
+    The string format we standardise on:
+
+    - ``linear``        → display id, e.g. ``ENG-42`` (the adapter
+      resolves to UUID at call time).
+    - ``github_issues`` → ``owner/repo#42``.
+    """
+    return TicketRef(
+        kind=_vendor_kind_to_ticket_kind(vendor_kind),
+        workspace_hint=None,
+        id=raw,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/repos/{repo_id}/tracker/next",
+    response_model=TaskResponseOut,
+)
+async def get_next_task(
+    workspace_id: uuid.UUID,
+    repo_id: uuid.UUID,
+    state: str = Query(..., min_length=1, max_length=64, alias="state"),
+    auth: AuthContext = Depends(get_current_auth),
+    session: AsyncSession = Depends(get_session),
+    settings: Settings = Depends(get_settings),
+) -> TaskResponseOut:
+    """Return the next ticket the agent should work on for ``state``."""
+    await _require_membership(session, workspace_id, auth.user.id, ROLES_ADMIN)
+
+    resolved = await resolve_for_repo(
+        session=session,
+        settings=settings,
+        workspace_id=workspace_id,
+        repo_id=repo_id,
+    )
+    if resolved is None:
+        return TaskResponseOut(ticket=None, fsm_stage=state, tracker_kind=None)
+
+    rows = await resolved.gateway.list_tickets(state=state, limit=10)
+    if not rows:
+        return TaskResponseOut(
+            ticket=None, fsm_stage=state, tracker_kind=resolved.kind
+        )
+
+    pick = rows[0]
+    return TaskResponseOut(
+        fsm_stage=state,
+        tracker_kind=resolved.kind,
+        ticket=TaskTicketOut(
+            ticket_ref=str(pick.get("id") or ""),
+            kind=resolved.kind,
+            title=str(pick.get("title") or ""),
+            body=pick.get("body") if isinstance(pick.get("body"), str) else None,
+            url=str(pick["url"]) if pick.get("url") else None,
+            labels=list(pick.get("labels") or []),
+            state=str(pick.get("status") or "") or None,
+            fsm_stage=state,
+        ),
+    )
+
+
+@router.post(
+    "/repos/{repo_id}/tracker/transition",
+    response_model=WriteOut,
+)
+async def transition_ticket(
+    workspace_id: uuid.UUID,
+    repo_id: uuid.UUID,
+    payload: TransitionIn,
+    auth: AuthContext = Depends(get_current_auth),
+    session: AsyncSession = Depends(get_session),
+    settings: Settings = Depends(get_settings),
+) -> WriteOut:
+    """Move ``payload.ticket_ref`` to ``payload.to_state`` (FSM stage).
+
+    The vendor adapter knows how to map the abstract Ship FSM stage
+    (``ba_requirements`` etc.) to its native state — Linear status,
+    GitHub Issues label, etc. This is the only place that mapping
+    happens, so CLI doesn't need to grow per-vendor logic.
+    """
+    await _require_membership(session, workspace_id, auth.user.id, ROLES_ADMIN)
+
+    resolved = await resolve_for_repo(
+        session=session,
+        settings=settings,
+        workspace_id=workspace_id,
+        repo_id=repo_id,
+    )
+    if resolved is None:
+        raise HTTPException(
+            status_code=status.HTTP_412_PRECONDITION_FAILED,
+            detail={"code": "no_tracker_bound"},
+        )
+
+    ref = _ticket_ref_from(resolved.kind, payload.ticket_ref)
+    if payload.comment:
+        await resolved.gateway.comment(ref, body=payload.comment)
+    await resolved.gateway.transition(ref, to_state=payload.to_state)
+
+    session.add(
+        AuditLog(
+            workspace_id=workspace_id,
+            actor_user_id=auth.user.id,
+            actor_token_id=auth.token.id if auth.token else None,
+            action="agent_run.transition",
+            target_kind="ticket",
+            target_id=payload.ticket_ref,
+            payload={
+                "tracker_kind": resolved.kind,
+                "from_state": payload.from_state,
+                "to_state": payload.to_state,
+                "had_comment": bool(payload.comment),
+            },
+        )
+    )
+    await session.flush()
+    return WriteOut(ok=True, tracker_kind=resolved.kind)
+
+
+@router.post(
+    "/repos/{repo_id}/tracker/comment",
+    response_model=WriteOut,
+)
+async def comment_ticket(
+    workspace_id: uuid.UUID,
+    repo_id: uuid.UUID,
+    payload: CommentIn,
+    auth: AuthContext = Depends(get_current_auth),
+    session: AsyncSession = Depends(get_session),
+    settings: Settings = Depends(get_settings),
+) -> WriteOut:
+    await _require_membership(session, workspace_id, auth.user.id, ROLES_ADMIN)
+
+    resolved = await resolve_for_repo(
+        session=session,
+        settings=settings,
+        workspace_id=workspace_id,
+        repo_id=repo_id,
+    )
+    if resolved is None:
+        raise HTTPException(
+            status_code=status.HTTP_412_PRECONDITION_FAILED,
+            detail={"code": "no_tracker_bound"},
+        )
+    ref = _ticket_ref_from(resolved.kind, payload.ticket_ref)
+    await resolved.gateway.comment(ref, body=payload.body)
+
+    session.add(
+        AuditLog(
+            workspace_id=workspace_id,
+            actor_user_id=auth.user.id,
+            actor_token_id=auth.token.id if auth.token else None,
+            action="agent_run.comment",
+            target_kind="ticket",
+            target_id=payload.ticket_ref,
+            payload={
+                "tracker_kind": resolved.kind,
+                "body_chars": len(payload.body),
+            },
+        )
+    )
+    await session.flush()
+    return WriteOut(ok=True, tracker_kind=resolved.kind)
+
+
+@router.post("/inbox/items", response_model=WriteOut)
+async def post_inbox_item(
+    workspace_id: uuid.UUID,
+    payload: InboxItemIn,
+    auth: AuthContext = Depends(get_current_auth),
+    session: AsyncSession = Depends(get_session),
+) -> WriteOut:
+    """Drop a free-form item into the workspace inbox.
+
+    Used by:
+      - context-free routines (daily digest, learning capture) that
+        don't transition tickets — they leave their output as an
+        operator-facing inbox row.
+      - ``shipctl run`` when the agent's state is ``blocked`` or
+        ``human_validation`` — captures the question or the missing
+        prerequisite as an inbox item the operator can act on.
+    """
+    await _require_membership(session, workspace_id, auth.user.id, ROLES_ADMIN)
+    item = InboxItem(
+        workspace_id=workspace_id,
+        repo_id=None,
+        type=payload.type,
+        title=payload.title[:300],
+        summary=(payload.summary or "")[:2000] or None,
+        payload={
+            **payload.payload,
+            "ticket_ref": payload.ticket_ref,
+            "produced_at": datetime.now(timezone.utc).isoformat(),
+        },
+        status="new",
+        intake_handle=None,
+        intake_reason="agent_run",
+    )
+    session.add(item)
+    session.add(
+        AuditLog(
+            workspace_id=workspace_id,
+            actor_user_id=auth.user.id,
+            actor_token_id=auth.token.id if auth.token else None,
+            action="agent_run.inbox_item",
+            target_kind="inbox_item",
+            target_id=None,
+            payload={
+                "type": payload.type,
+                "title": payload.title[:300],
+                "ticket_ref": payload.ticket_ref,
+            },
+        )
+    )
+    await session.flush()
+    return WriteOut(ok=True, note=f"inbox item created (type={payload.type})")

--- a/backend/app/api/v1/routes/agent_runs.py
+++ b/backend/app/api/v1/routes/agent_runs.py
@@ -3,6 +3,13 @@ during a routine run.
 
 E14 architecture (locked 2026-04-30):
 
+- A workspace **is** a project. There is exactly **one** tracker
+  per workspace (Linear team / Jira project / etc.); the workspace
+  may host several repos but they all share the same backlog. The
+  endpoints in this module are therefore workspace-scoped — repo
+  context is only needed at the agent-runtime level (which checkout
+  to spawn), not for tracker resolution.
+
 - Customer's GitHub Actions cron fires ``shipctl run --routine X``.
 - ``shipctl`` reads the routine's pattern, asks Ship server for a
   task (a single ticket in the routine's FSM stage, if applicable),
@@ -14,17 +21,11 @@ E14 architecture (locked 2026-04-30):
   - ``human_validation`` → ``POST /tracker/comment`` + ``POST /inbox/items``
   - ``blocked``          → ``POST /inbox/items``
 
-The endpoints in this module are the write side of that contract.
 ``shipctl`` runs in the customer's runner with a workspace API
-token; the server uses the workspace's existing Linear / GitHub
-OAuth integrations to do the actual mutation. The CLI never holds
-the tracker credential.
-
-These routes intentionally take a vendor-agnostic ``ticket_ref``
-string — Ship server picks the right adapter via
-:func:`backend.app.services.tracker_resolver.resolve_for_repo` and
-hands it to :class:`TrackerGateway`. CLI doesn't have to know
-whether the workspace runs Linear or GitHub Issues.
+token; the server uses the workspace's Linear OAuth integration
+to do the actual mutation. The CLI never holds the tracker
+credential and never has to think about per-vendor differences —
+it just passes a ``ticket_ref`` string back.
 """
 
 from __future__ import annotations
@@ -48,7 +49,7 @@ from backend.app.db.models.inbox import InboxItem
 from backend.app.db.models.tenancy import AuditLog
 from backend.app.db.session import get_session
 from backend.app.integrations.gateway.tracker import TicketRef
-from backend.app.services.tracker_resolver import resolve_for_repo
+from backend.app.services.tracker_resolver import resolve_for_workspace
 
 
 router = APIRouter(
@@ -154,12 +155,11 @@ def _ticket_ref_from(vendor_kind: str, raw: str) -> TicketRef:
 
 
 @router.get(
-    "/repos/{repo_id}/tracker/next",
+    "/tracker/next",
     response_model=TaskResponseOut,
 )
 async def get_next_task(
     workspace_id: uuid.UUID,
-    repo_id: uuid.UUID,
     state: str = Query(..., min_length=1, max_length=64, alias="state"),
     auth: AuthContext = Depends(get_current_auth),
     session: AsyncSession = Depends(get_session),
@@ -168,11 +168,10 @@ async def get_next_task(
     """Return the next ticket the agent should work on for ``state``."""
     await _require_membership(session, workspace_id, auth.user.id, ROLES_ADMIN)
 
-    resolved = await resolve_for_repo(
+    resolved = await resolve_for_workspace(
         session=session,
         settings=settings,
         workspace_id=workspace_id,
-        repo_id=repo_id,
     )
     if resolved is None:
         return TaskResponseOut(ticket=None, fsm_stage=state, tracker_kind=None)
@@ -200,13 +199,9 @@ async def get_next_task(
     )
 
 
-@router.post(
-    "/repos/{repo_id}/tracker/transition",
-    response_model=WriteOut,
-)
+@router.post("/tracker/transition", response_model=WriteOut)
 async def transition_ticket(
     workspace_id: uuid.UUID,
-    repo_id: uuid.UUID,
     payload: TransitionIn,
     auth: AuthContext = Depends(get_current_auth),
     session: AsyncSession = Depends(get_session),
@@ -215,17 +210,16 @@ async def transition_ticket(
     """Move ``payload.ticket_ref`` to ``payload.to_state`` (FSM stage).
 
     The vendor adapter knows how to map the abstract Ship FSM stage
-    (``ba_requirements`` etc.) to its native state — Linear status,
-    GitHub Issues label, etc. This is the only place that mapping
-    happens, so CLI doesn't need to grow per-vendor logic.
+    (``ba_requirements`` etc.) to its native state — Linear status
+    name, etc. This is the only place that mapping happens, so CLI
+    doesn't need to grow per-vendor logic.
     """
     await _require_membership(session, workspace_id, auth.user.id, ROLES_ADMIN)
 
-    resolved = await resolve_for_repo(
+    resolved = await resolve_for_workspace(
         session=session,
         settings=settings,
         workspace_id=workspace_id,
-        repo_id=repo_id,
     )
     if resolved is None:
         raise HTTPException(
@@ -258,13 +252,9 @@ async def transition_ticket(
     return WriteOut(ok=True, tracker_kind=resolved.kind)
 
 
-@router.post(
-    "/repos/{repo_id}/tracker/comment",
-    response_model=WriteOut,
-)
+@router.post("/tracker/comment", response_model=WriteOut)
 async def comment_ticket(
     workspace_id: uuid.UUID,
-    repo_id: uuid.UUID,
     payload: CommentIn,
     auth: AuthContext = Depends(get_current_auth),
     session: AsyncSession = Depends(get_session),
@@ -272,11 +262,10 @@ async def comment_ticket(
 ) -> WriteOut:
     await _require_membership(session, workspace_id, auth.user.id, ROLES_ADMIN)
 
-    resolved = await resolve_for_repo(
+    resolved = await resolve_for_workspace(
         session=session,
         settings=settings,
         workspace_id=workspace_id,
-        repo_id=repo_id,
     )
     if resolved is None:
         raise HTTPException(

--- a/backend/app/services/tracker_resolver.py
+++ b/backend/app/services/tracker_resolver.py
@@ -1,0 +1,145 @@
+"""Pick a single :class:`TrackerGateway` for a (workspace, repo) pair.
+
+E14 puts the FSM mapping on the server side: the CLI sends abstract
+"transition this ticket from X to Y" calls, the server picks the right
+adapter and translates. This helper centralises that pick so every
+write-side route resolves the same way.
+
+Preference order:
+    1. Per-repo ``Integration`` row (``kind=linear|github|jira``,
+       ``repo_id`` set). The wizard binds this when the operator picks
+       a tracker for the specific repo.
+    2. Workspace-level Linear OAuth row.
+    3. GitHub Issues via the App installation on the repo.
+
+Returns ``None`` if no tracker is available — callers map that to a
+4xx so the agent can surface ``blocked`` cleanly.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from dataclasses import dataclass
+from typing import Literal
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.app.core.config import Settings
+from backend.app.db.models.integrations import GitHubInstallation, WorkspaceRepo
+from backend.app.db.models.tenancy import Integration
+from backend.app.integrations.gateway.tracker import TrackerGateway
+from backend.app.integrations.github.issues_tracker import GitHubIssuesTracker
+from backend.app.integrations.linear.tracker_adapter import LinearTracker
+
+
+logger = logging.getLogger(__name__)
+
+
+TrackerKind = Literal["linear", "github_issues", "jira"]
+
+
+@dataclass(frozen=True)
+class ResolvedTracker:
+    kind: TrackerKind
+    gateway: TrackerGateway
+    # Vendor-specific scope hint (Linear team key, GH ``owner/repo``).
+    # Adapters fall back to "the only available scope" when unset.
+    scope_hint: str | None
+
+
+async def resolve_for_repo(
+    *,
+    session: AsyncSession,
+    settings: Settings,
+    workspace_id: uuid.UUID,
+    repo_id: uuid.UUID,
+) -> ResolvedTracker | None:
+    """Pick the tracker the agent should read/write for this repo.
+
+    Per-repo binding wins; workspace Linear comes second; the GitHub
+    App installation is the last fallback.
+    """
+    from backend.app.api.v1.routes.integrations import decrypt  # lazy
+
+    # 1. Per-repo binding row. Carries kind + optional scope hint in
+    #    config (e.g. ``{team_key: "ENG"}`` for Linear).
+    per_repo = (
+        await session.execute(
+            select(Integration).where(
+                Integration.workspace_id == workspace_id,
+                Integration.repo_id == repo_id,
+                Integration.kind.in_(("linear", "github", "jira")),
+            )
+            .order_by(Integration.updated_at.desc())
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+
+    if per_repo and per_repo.kind == "linear":
+        token = await _decrypt_linear_token(per_repo, decrypt)
+        if token is None:
+            return None
+        scope = (per_repo.config or {}).get("team_key")
+        return ResolvedTracker(
+            kind="linear", gateway=LinearTracker(token), scope_hint=scope
+        )
+
+    # 2. Workspace-level Linear (the OAuth-installed tracker). Used when
+    #    no per-repo binding exists or the per-repo row picks ``github``.
+    workspace_linear = (
+        await session.execute(
+            select(Integration).where(
+                Integration.workspace_id == workspace_id,
+                Integration.repo_id.is_(None),
+                Integration.kind == "linear",
+            )
+            .order_by(Integration.updated_at.desc())
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+
+    if per_repo is None and workspace_linear is not None:
+        # No per-repo row and we have workspace Linear → use it.
+        token = await _decrypt_linear_token(workspace_linear, decrypt)
+        if token is not None:
+            scope = (workspace_linear.config or {}).get("team_key")
+            return ResolvedTracker(
+                kind="linear", gateway=LinearTracker(token), scope_hint=scope
+            )
+
+    # 3. GitHub Issues via the repo's Ship App installation.
+    repo_row = await session.get(WorkspaceRepo, repo_id)
+    if repo_row is None or repo_row.workspace_id != workspace_id:
+        return None
+    install = (
+        await session.get(GitHubInstallation, repo_row.installation_id)
+        if repo_row.installation_id
+        else None
+    )
+    if install is None:
+        return None
+    owner, _, name = (repo_row.full_name or "").partition("/")
+    if not owner or not name:
+        return None
+    return ResolvedTracker(
+        kind="github_issues",
+        gateway=GitHubIssuesTracker(
+            installation_id=install.installation_id,
+            owner=owner,
+            repo=name,
+            settings=settings,
+        ),
+        scope_hint=f"{owner}/{name}",
+    )
+
+
+async def _decrypt_linear_token(row: Integration, decrypt) -> str | None:
+    if not row.secret_ciphertext:
+        return None
+    try:
+        return decrypt(row.secret_ciphertext)
+    except Exception:  # noqa: BLE001 — log + degrade
+        logger.warning("linear token unreadable for integration=%s", row.id)
+        return None

--- a/backend/app/services/tracker_resolver.py
+++ b/backend/app/services/tracker_resolver.py
@@ -1,19 +1,18 @@
-"""Pick a single :class:`TrackerGateway` for a (workspace, repo) pair.
+"""Pick a single :class:`TrackerGateway` for a workspace.
 
-E14 puts the FSM mapping on the server side: the CLI sends abstract
-"transition this ticket from X to Y" calls, the server picks the right
-adapter and translates. This helper centralises that pick so every
-write-side route resolves the same way.
+E14 model (locked 2026-04-30): a workspace is the project, so the
+tracker is workspace-scoped — exactly one per workspace, regardless
+of how many repos the workspace hosts. The CLI sends abstract
+"transition this ticket from X to Y" calls; this helper centralises
+the lookup of the bound tracker so every write-side route resolves
+the same way.
 
-Preference order:
-    1. Per-repo ``Integration`` row (``kind=linear|github|jira``,
-       ``repo_id`` set). The wizard binds this when the operator picks
-       a tracker for the specific repo.
-    2. Workspace-level Linear OAuth row.
-    3. GitHub Issues via the App installation on the repo.
+Today's catalog:
+- ``linear``  — workspace-level Linear OAuth row.
+- ``jira``    — same shape, deferred until needed.
 
-Returns ``None`` if no tracker is available — callers map that to a
-4xx so the agent can surface ``blocked`` cleanly.
+Returns ``None`` when no tracker is bound — callers map that to
+``no_tracker_bound`` and the agent surfaces ``blocked`` cleanly.
 """
 
 from __future__ import annotations
@@ -27,119 +26,68 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.app.core.config import Settings
-from backend.app.db.models.integrations import GitHubInstallation, WorkspaceRepo
 from backend.app.db.models.tenancy import Integration
 from backend.app.integrations.gateway.tracker import TrackerGateway
-from backend.app.integrations.github.issues_tracker import GitHubIssuesTracker
 from backend.app.integrations.linear.tracker_adapter import LinearTracker
 
 
 logger = logging.getLogger(__name__)
 
 
-TrackerKind = Literal["linear", "github_issues", "jira"]
+TrackerKind = Literal["linear", "jira"]
 
 
 @dataclass(frozen=True)
 class ResolvedTracker:
     kind: TrackerKind
     gateway: TrackerGateway
-    # Vendor-specific scope hint (Linear team key, GH ``owner/repo``).
+    # Vendor-specific scope hint (Linear team key, Jira project key).
     # Adapters fall back to "the only available scope" when unset.
     scope_hint: str | None
 
 
-async def resolve_for_repo(
+async def resolve_for_workspace(
     *,
     session: AsyncSession,
     settings: Settings,
     workspace_id: uuid.UUID,
-    repo_id: uuid.UUID,
 ) -> ResolvedTracker | None:
-    """Pick the tracker the agent should read/write for this repo.
-
-    Per-repo binding wins; workspace Linear comes second; the GitHub
-    App installation is the last fallback.
-    """
+    """Return the workspace's bound tracker, if any."""
     from backend.app.api.v1.routes.integrations import decrypt  # lazy
 
-    # 1. Per-repo binding row. Carries kind + optional scope hint in
-    #    config (e.g. ``{team_key: "ENG"}`` for Linear).
-    per_repo = (
-        await session.execute(
-            select(Integration).where(
-                Integration.workspace_id == workspace_id,
-                Integration.repo_id == repo_id,
-                Integration.kind.in_(("linear", "github", "jira")),
-            )
-            .order_by(Integration.updated_at.desc())
-            .limit(1)
-        )
-    ).scalar_one_or_none()
-
-    if per_repo and per_repo.kind == "linear":
-        token = await _decrypt_linear_token(per_repo, decrypt)
-        if token is None:
-            return None
-        scope = (per_repo.config or {}).get("team_key")
-        return ResolvedTracker(
-            kind="linear", gateway=LinearTracker(token), scope_hint=scope
-        )
-
-    # 2. Workspace-level Linear (the OAuth-installed tracker). Used when
-    #    no per-repo binding exists or the per-repo row picks ``github``.
-    workspace_linear = (
+    row = (
         await session.execute(
             select(Integration).where(
                 Integration.workspace_id == workspace_id,
                 Integration.repo_id.is_(None),
-                Integration.kind == "linear",
+                Integration.kind.in_(("linear", "jira")),
             )
             .order_by(Integration.updated_at.desc())
             .limit(1)
         )
     ).scalar_one_or_none()
-
-    if per_repo is None and workspace_linear is not None:
-        # No per-repo row and we have workspace Linear → use it.
-        token = await _decrypt_linear_token(workspace_linear, decrypt)
-        if token is not None:
-            scope = (workspace_linear.config or {}).get("team_key")
-            return ResolvedTracker(
-                kind="linear", gateway=LinearTracker(token), scope_hint=scope
-            )
-
-    # 3. GitHub Issues via the repo's Ship App installation.
-    repo_row = await session.get(WorkspaceRepo, repo_id)
-    if repo_row is None or repo_row.workspace_id != workspace_id:
+    if row is None:
         return None
-    install = (
-        await session.get(GitHubInstallation, repo_row.installation_id)
-        if repo_row.installation_id
-        else None
-    )
-    if install is None:
-        return None
-    owner, _, name = (repo_row.full_name or "").partition("/")
-    if not owner or not name:
-        return None
-    return ResolvedTracker(
-        kind="github_issues",
-        gateway=GitHubIssuesTracker(
-            installation_id=install.installation_id,
-            owner=owner,
-            repo=name,
-            settings=settings,
-        ),
-        scope_hint=f"{owner}/{name}",
-    )
+
+    if row.kind == "linear":
+        token = await _decrypt_token(row, decrypt)
+        if token is None:
+            return None
+        scope = (row.config or {}).get("team_key")
+        return ResolvedTracker(
+            kind="linear", gateway=LinearTracker(token), scope_hint=scope
+        )
+
+    # Jira / others — wire when needed.
+    logger.warning("workspace %s has tracker kind=%s, not yet wired", workspace_id, row.kind)
+    return None
 
 
-async def _decrypt_linear_token(row: Integration, decrypt) -> str | None:
+async def _decrypt_token(row: Integration, decrypt) -> str | None:
     if not row.secret_ciphertext:
         return None
     try:
         return decrypt(row.secret_ciphertext)
-    except Exception:  # noqa: BLE001 — log + degrade
-        logger.warning("linear token unreadable for integration=%s", row.id)
+    except Exception:  # noqa: BLE001
+        logger.warning("tracker token unreadable for integration=%s", row.id)
         return None

--- a/cli/bin/shipctl.mjs
+++ b/cli/bin/shipctl.mjs
@@ -158,6 +158,12 @@ try {
     process.exit(0);
   }
 
+  if (cmd === "agent-run") {
+    const { agentRunCommand } = await import("../lib/commands/agent-run.mjs");
+    await agentRunCommand(ctx, rest);
+    process.exit(0);
+  }
+
   /* `lanes` is the protocol-stable name; `automations` is the
    * operator-friendly soft alias. Both dispatch to the same handler
    * indefinitely — we are not deprecating the original. */

--- a/cli/lib/agents/cursor.mjs
+++ b/cli/lib/agents/cursor.mjs
@@ -1,0 +1,141 @@
+/**
+ * Cursor Cloud Agent runtime adapter.
+ *
+ * Wraps the public ``POST https://api.cursor.com/v0/agents`` API the
+ * ElMundi sibling repo uses (``tools/linear-agent/scripts/cloud-agent-launch.mjs``).
+ * The shape Ship needs:
+ *
+ *   1. Launch an agent against ``repo`` at ``ref`` with ``prompt``.
+ *   2. Poll until the agent's status is one of the terminal values
+ *      (``FINISHED`` / ``ERRORED`` / ``CANCELLED``).
+ *   3. Return the branch name + final status so ``shipctl agent-run``
+ *      can read ``.ship/run-state.json`` back from that branch.
+ *
+ * Auth: ``CURSOR_API_KEY`` env var, sent as Basic ``<key>:`` per Cursor's
+ * docs.
+ */
+
+import { Buffer } from "node:buffer";
+
+const BASE = "https://api.cursor.com";
+const TERMINAL_STATUSES = new Set(["FINISHED", "ERRORED", "CANCELLED"]);
+
+
+function authHeader() {
+  const key = (process.env.CURSOR_API_KEY || "").trim();
+  if (!key) {
+    throw new Error("CURSOR_API_KEY is not set");
+  }
+  return "Basic " + Buffer.from(`${key}:`).toString("base64");
+}
+
+
+async function postJson(path, body) {
+  const res = await fetch(`${BASE}${path}`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: authHeader(),
+    },
+    body: JSON.stringify(body),
+  });
+  const text = await res.text();
+  if (!res.ok) {
+    throw new Error(`Cursor API ${path} ${res.status}: ${text.slice(0, 500)}`);
+  }
+  return text ? JSON.parse(text) : {};
+}
+
+
+async function getJson(path) {
+  const res = await fetch(`${BASE}${path}`, {
+    headers: { Authorization: authHeader() },
+  });
+  const text = await res.text();
+  if (!res.ok) {
+    throw new Error(`Cursor API ${path} ${res.status}: ${text.slice(0, 500)}`);
+  }
+  return text ? JSON.parse(text) : {};
+}
+
+
+/**
+ * Launch a single Cursor agent and poll until it terminates.
+ *
+ * @param {object} opts
+ * @param {string} opts.repoUrl       e.g. ``https://github.com/owner/repo``
+ * @param {string} opts.ref           branch the agent checks out (default ``main``)
+ * @param {string} opts.branchName    branch the agent commits onto
+ * @param {string} opts.prompt        full prompt body
+ * @param {boolean} [opts.autoCreatePr] open a PR when done (default false)
+ * @param {number} [opts.pollIntervalMs]   poll cadence (default 15s)
+ * @param {number} [opts.timeoutMs]   total deadline (default 30 min)
+ * @param {(line: string) => void} [opts.onLog] streaming log hook
+ * @returns {Promise<{ agentId: string, branchName: string, status: string, raw: object }>}
+ */
+export async function runCursorAgent({
+  repoUrl,
+  ref = "main",
+  branchName,
+  prompt,
+  autoCreatePr = false,
+  pollIntervalMs = 15_000,
+  timeoutMs = 30 * 60 * 1000,
+  onLog = (l) => console.error(`[cursor] ${l}`),
+} = {}) {
+  if (!repoUrl) throw new Error("runCursorAgent: repoUrl required");
+  if (!branchName) throw new Error("runCursorAgent: branchName required");
+  if (!prompt || typeof prompt !== "string") {
+    throw new Error("runCursorAgent: prompt required");
+  }
+
+  const launch = await postJson("/v0/agents", {
+    prompt: { text: prompt },
+    source: { repository: repoUrl, ref },
+    target: {
+      branchName,
+      autoCreatePr,
+      openAsCursorGithubApp: false,
+    },
+  });
+  const agentId = launch.id || launch.agentId || launch.agent_id;
+  if (!agentId) {
+    throw new Error(`Cursor launch returned no agent id: ${JSON.stringify(launch).slice(0, 300)}`);
+  }
+  onLog(`launched agent=${agentId} branch=${branchName} ref=${ref}`);
+
+  const deadline = Date.now() + timeoutMs;
+  let lastStatus = launch.status || "CREATING";
+  while (Date.now() < deadline) {
+    if (TERMINAL_STATUSES.has(String(lastStatus).toUpperCase())) {
+      onLog(`agent terminal: status=${lastStatus}`);
+      return { agentId, branchName, status: lastStatus, raw: launch };
+    }
+    await sleep(pollIntervalMs);
+    let snapshot;
+    try {
+      snapshot = await getJson(`/v0/agents/${encodeURIComponent(agentId)}`);
+    } catch (err) {
+      onLog(`poll error (continuing): ${err.message}`);
+      continue;
+    }
+    const next = (snapshot.status || "").toString();
+    if (next && next !== lastStatus) {
+      onLog(`status: ${lastStatus} → ${next}`);
+      lastStatus = next;
+    }
+    if (TERMINAL_STATUSES.has(next.toUpperCase())) {
+      return { agentId, branchName, status: next, raw: snapshot };
+    }
+  }
+  throw new Error(
+    `Cursor agent ${agentId} did not reach a terminal state within ${Math.round(
+      timeoutMs / 1000,
+    )}s (last status: ${lastStatus})`,
+  );
+}
+
+
+function sleep(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}

--- a/cli/lib/agents/index.mjs
+++ b/cli/lib/agents/index.mjs
@@ -1,0 +1,51 @@
+/**
+ * Agent runtime dispatcher.
+ *
+ * E14 picks the runtime per ``.ship/config.yml`` ``agent.default.provider``
+ * (and per-routine override under ``agent.overrides.<routine>``). Today
+ * Cursor Cloud is the only one wired in; ``claude`` / ``codex`` slots
+ * exist so adding them later is a single new file plus an entry in
+ * ``RUNTIMES`` here.
+ */
+
+import { runCursorAgent } from "./cursor.mjs";
+
+
+const RUNTIMES = {
+  cursor: runCursorAgent,
+  // claude: runClaudeCodeAgent,   // TODO when we add it
+  // codex:  runCodexAgent,        // TODO when we add it
+};
+
+const DEFAULT_PROVIDER = "cursor";
+
+
+export function resolveProvider(config, routineId) {
+  const override = config?.agent?.overrides?.[routineId]?.provider;
+  if (override) return String(override).toLowerCase();
+  const def = config?.agent?.default?.provider;
+  if (def) return String(def).toLowerCase();
+  return DEFAULT_PROVIDER;
+}
+
+
+/**
+ * Run the configured agent runtime.
+ *
+ * @param {string} provider — one of ``RUNTIMES``' keys.
+ * @param {object} opts — passed straight through to the runtime.
+ * @returns {Promise<{ agentId: string, branchName: string, status: string, raw: object }>}
+ */
+export async function runAgent(provider, opts) {
+  const fn = RUNTIMES[provider];
+  if (!fn) {
+    const known = Object.keys(RUNTIMES).join(", ") || "(none)";
+    throw new Error(
+      `agent runtime '${provider}' is not wired in this build. Known: ${known}`,
+    );
+  }
+  return fn(opts);
+}
+
+
+export const SUPPORTED_PROVIDERS = Object.freeze(Object.keys(RUNTIMES));

--- a/cli/lib/commands/agent-run.mjs
+++ b/cli/lib/commands/agent-run.mjs
@@ -38,11 +38,15 @@
 
 import path from "node:path";
 
+import fs from "node:fs";
+
 import yaml from "yaml";
 
 import { readConfig, findShipRoot } from "../config/io.mjs";
 import { resolveExecutable } from "../runtime/routines.mjs";
 import { fetchArtifact } from "../http.mjs";
+import { readArtifactFile } from "../artifacts/fs-index.mjs";
+import { resolveShipRepoRootForCatalog } from "../find-ship-root.mjs";
 import { resolveProvider, runAgent } from "../agents/index.mjs";
 
 
@@ -92,29 +96,45 @@ export async function agentRunCommand(ctx, rest) {
   }
 
   const fetchBase = methodologyBase(env, config);
-  const { content: rawPatternBody } = await fetchArtifact(fetchBase, "pattern", patternId);
-  const { frontmatter, body: patternBody } = splitFrontmatter(rawPatternBody);
-  const fsmStage = pickFsmStage(frontmatter);
+  const rawPatternBody = await loadPattern({ id: patternId, fetchBase });
+  const { frontmatter, frontmatterRaw, body: patternBody } = splitFrontmatter(rawPatternBody);
+  const fsmStage = pickFsmStage(frontmatter, frontmatterRaw);
 
   // Patterns reference ``{{BASE}}`` to splice in common-base. Fetch it
   // up-front so renderPrompt can do the substitution. ``{{SKILLS_CONTEXT}}``
   // inside common-base is left as "(no skills directory)" for the MVP —
   // skills bundling lands in a follow-up.
-  const baseBody = await fetchCommonBase(fetchBase);
+  const baseRaw = await loadPattern({ id: "common-base", fetchBase, optional: true });
+  const baseBody = baseRaw ? splitFrontmatter(baseRaw).body : "";
 
-  // 2) Resolve task
+  // 2) Resolve task. ``--dry-run`` skips the server call and uses a
+  // synthetic task so the operator can see the prompt shape without
+  // needing the new endpoints deployed.
   let task = null;
   if (fsmStage) {
-    task = await getNextTask({
-      apiBase,
-      apiToken,
-      workspaceId,
-      repoId,
-      state: fsmStage,
-    });
-    if (!task) {
-      emit(args, { status: "noop", routine: args.routine, pattern: patternId, fsm_stage: fsmStage, reason: "no_eligible_ticket" });
-      process.exit(EXIT_NO_TASK);
+    if (args.dryRun || ctx.dryRun) {
+      task = {
+        ticket_ref: "dry-run/sample#1",
+        kind: "dry-run",
+        title: "Sample ticket for dry-run prompt rendering",
+        body: "This is a synthetic ticket body. The real one comes from `GET /tracker/next` when not in dry-run.",
+        url: null,
+        labels: ["sample"],
+        state: "open",
+        fsm_stage: fsmStage,
+      };
+    } else {
+      task = await getNextTask({
+        apiBase,
+        apiToken,
+        workspaceId,
+        repoId,
+        state: fsmStage,
+      });
+      if (!task) {
+        emit(args, { status: "noop", routine: args.routine, pattern: patternId, fsm_stage: fsmStage, reason: "no_eligible_ticket" });
+        process.exit(EXIT_NO_TASK);
+      }
     }
   }
 
@@ -127,6 +147,32 @@ export async function agentRunCommand(ctx, rest) {
     task,
     fsmStage,
   });
+
+  // ``--dry-run`` exits here so the operator can eyeball the rendered
+  // prompt + resolved task without launching an agent or touching any
+  // tracker. Useful when iterating on pattern bodies.
+  if (args.dryRun || ctx.dryRun) {
+    if (args.json) {
+      console.log(JSON.stringify({
+        status: "dry-run",
+        routine: args.routine,
+        pattern: patternId,
+        fsm_stage: fsmStage,
+        task,
+        prompt,
+      }, null, 2));
+    } else {
+      console.error(`# ship: dry-run routine=${args.routine} pattern=${patternId} fsm_stage=${fsmStage || "(context-free)"}`);
+      if (task) {
+        console.error(`# ship: task ticket_ref=${task.ticket_ref} title=${JSON.stringify(task.title || "")}`);
+      } else {
+        console.error("# ship: task=(none)");
+      }
+      console.error("# ---- prompt ----");
+      console.log(prompt);
+    }
+    process.exit(EXIT_OK);
+  }
 
   // 4) Launch agent runtime
   const provider = resolveProvider(config, args.routine);
@@ -252,25 +298,36 @@ function methodologyBase(env, config) {
 
 
 function splitFrontmatter(raw) {
-  if (!raw.startsWith("---")) return { frontmatter: {}, body: raw };
+  if (!raw.startsWith("---")) return { frontmatter: {}, frontmatterRaw: "", body: raw };
   const end = raw.indexOf("\n---\n", 4);
-  if (end < 0) return { frontmatter: {}, body: raw };
-  const headRaw = raw.slice(3, end + 1).trim();
+  if (end < 0) return { frontmatter: {}, frontmatterRaw: "", body: raw };
+  const headRaw = raw.slice(3, end + 1);
   const body = raw.slice(end + 5);
   let parsed = {};
   try {
     parsed = yaml.parse(headRaw) || {};
   } catch {
+    // Some Ship patterns have unquoted ``@elmundi/ship-core`` in
+    // ``authors`` which strict YAML rejects. The CLI doesn't need the
+    // full document — ``pickFsmStage`` falls back to a regex on the
+    // raw frontmatter text in that case.
     parsed = {};
   }
-  return { frontmatter: parsed, body };
+  return { frontmatter: parsed, frontmatterRaw: headRaw, body };
 }
 
 
-function pickFsmStage(frontmatter) {
+function pickFsmStage(frontmatter, frontmatterRaw) {
   const spec = frontmatter?.spec || {};
   const v = spec.fsm_stage ?? spec.fsmStage;
   if (typeof v === "string" && v.trim()) return v.trim();
+  if (frontmatterRaw) {
+    // Strict-YAML-fallback: regex on the raw frontmatter. Matches
+    // ``fsm_stage: triage`` (with optional surrounding whitespace, with
+    // or without quotes) anywhere in the spec block.
+    const m = frontmatterRaw.match(/^\s*fsm_stage:\s*['"]?([\w.-]+)['"]?/m);
+    if (m && m[1]) return m[1].trim();
+  }
   return null;
 }
 
@@ -340,14 +397,29 @@ function renderPrompt({ patternBody, baseBody, role, routineSpec, task, fsmStage
 }
 
 
-async function fetchCommonBase(fetchBase) {
+/**
+ * Load a pattern body. Resolution order:
+ *   1) when running inside the Ship monorepo, read from
+ *      ``artifacts/patterns/<id>/ARTIFACT.md`` on disk — fast and
+ *      always reflects the working tree (good for dry-runs / local
+ *      smoke tests before the server is rebuilt).
+ *   2) otherwise hit the server's ``POST /fetch``.
+ */
+async function loadPattern({ id, fetchBase, optional = false }) {
+  const shipRepo = resolveShipRepoRootForCatalog();
+  if (shipRepo) {
+    const file = readArtifactFile(shipRepo, "pattern", id);
+    if (file && typeof file.content === "string") return file.content;
+  }
   try {
-    const { content } = await fetchArtifact(fetchBase, "pattern", "common-base");
-    return splitFrontmatter(content).body;
+    const { content } = await fetchArtifact(fetchBase, "pattern", id);
+    return content;
   } catch (err) {
-    // common-base is optional — surface a warning but keep going.
-    console.error(`warn: failed to fetch common-base pattern: ${err.message}`);
-    return "";
+    if (optional) {
+      console.error(`warn: failed to fetch pattern '${id}': ${err.message}`);
+      return "";
+    }
+    throw err;
   }
 }
 
@@ -529,12 +601,13 @@ async function applyAgentState({
 
 
 function parseArgs(rest) {
-  const out = { routine: null, cwd: null, json: false, help: false };
+  const out = { routine: null, cwd: null, json: false, help: false, dryRun: false };
   const copy = [...rest];
   while (copy.length) {
     const a = copy[0];
     if (a === "--help" || a === "-h") { out.help = true; copy.shift(); continue; }
     if (a === "--json") { out.json = true; copy.shift(); continue; }
+    if (a === "--dry-run") { out.dryRun = true; copy.shift(); continue; }
     if (a === "--routine" && copy[1] !== undefined) { out.routine = copy[1]; copy.splice(0, 2); continue; }
     if (a === "--cwd" && copy[1] !== undefined) { out.cwd = path.resolve(copy[1]); copy.splice(0, 2); continue; }
     die(EXIT_USAGE, `unknown argument: ${a}`);

--- a/cli/lib/commands/agent-run.mjs
+++ b/cli/lib/commands/agent-run.mjs
@@ -30,10 +30,13 @@
  *   - SHIP_API_BASE         — Ship server, e.g. https://ship.elmundi.com
  *   - SHIP_API_TOKEN        — workspace API token (admin scope)
  *   - SHIP_WORKSPACE_ID     — UUID of the workspace this run belongs to
- *   - SHIP_REPO_ID          — UUID of the WorkspaceRepo row
  *   - CURSOR_API_KEY        — Cursor Cloud agent API key (when provider=cursor)
- *   - GITHUB_REPOSITORY     — owner/repo (used to resolve the agent's branch back)
+ *   - GITHUB_REPOSITORY     — owner/repo (the repo the agent will check out)
  *   - GITHUB_TOKEN          — read-only repo access (to fetch run-state.json)
+ *
+ * Note: there is **no SHIP_REPO_ID** — a workspace is the project, so
+ * the tracker is workspace-scoped. ``GITHUB_REPOSITORY`` only tells the
+ * agent runtime which checkout to spawn for code work.
  */
 
 import path from "node:path";
@@ -87,7 +90,7 @@ export async function agentRunCommand(ctx, rest) {
   }
 
   const env = readEnv();
-  const { apiBase, apiToken, workspaceId, repoId, githubRepo, githubToken } = env;
+  const { apiBase, apiToken, workspaceId, githubRepo, githubToken } = env;
 
   // 1) Resolve pattern
   const patternId = resolved.executable.pattern;
@@ -128,7 +131,6 @@ export async function agentRunCommand(ctx, rest) {
         apiBase,
         apiToken,
         workspaceId,
-        repoId,
         state: fsmStage,
       });
       if (!task) {
@@ -240,7 +242,6 @@ export async function agentRunCommand(ctx, rest) {
     apiBase,
     apiToken,
     workspaceId,
-    repoId,
     routine: args.routine,
     pattern: patternId,
     task,
@@ -273,7 +274,6 @@ function readEnv() {
     apiBase: stripSlash(process.env.SHIP_API_BASE || ""),
     apiToken: process.env.SHIP_API_TOKEN || "",
     workspaceId: process.env.SHIP_WORKSPACE_ID || "",
-    repoId: process.env.SHIP_REPO_ID || "",
     githubRepo: process.env.GITHUB_REPOSITORY || "",
     githubRef: (process.env.GITHUB_REF_NAME || "main").trim(),
     githubToken: process.env.GITHUB_TOKEN || "",
@@ -332,8 +332,8 @@ function pickFsmStage(frontmatter, frontmatterRaw) {
 }
 
 
-async function getNextTask({ apiBase, apiToken, workspaceId, repoId, state }) {
-  const url = `${apiBase}/v1/workspaces/${encodeURIComponent(workspaceId)}/repos/${encodeURIComponent(repoId)}/tracker/next?state=${encodeURIComponent(state)}`;
+async function getNextTask({ apiBase, apiToken, workspaceId, state }) {
+  const url = `${apiBase}/v1/workspaces/${encodeURIComponent(workspaceId)}/tracker/next?state=${encodeURIComponent(state)}`;
   const res = await fetch(url, {
     headers: {
       Accept: "application/json",
@@ -490,7 +490,6 @@ async function applyAgentState({
   apiBase,
   apiToken,
   workspaceId,
-  repoId,
   routine,
   pattern,
   task,
@@ -503,7 +502,6 @@ async function applyAgentState({
     Authorization: `Bearer ${apiToken}`,
   };
   const ws = encodeURIComponent(workspaceId);
-  const repoSeg = encodeURIComponent(repoId);
 
   async function call(method, url, body) {
     const res = await fetch(url, { method, headers, body: body && JSON.stringify(body) });
@@ -523,7 +521,7 @@ async function applyAgentState({
       }
       const r = await call(
         "POST",
-        `${apiBase}/v1/workspaces/${ws}/repos/${repoSeg}/tracker/transition`,
+        `${apiBase}/v1/workspaces/${ws}/tracker/transition`,
         {
           ticket_ref: task.ticket_ref,
           to_state: state.transition_to,
@@ -538,7 +536,7 @@ async function applyAgentState({
       if (task?.ticket_ref && state.comment) {
         const c = await call(
           "POST",
-          `${apiBase}/v1/workspaces/${ws}/repos/${repoSeg}/tracker/comment`,
+          `${apiBase}/v1/workspaces/${ws}/tracker/comment`,
           { ticket_ref: task.ticket_ref, body: state.comment },
         );
         actions.push({ kind: "comment", response: c });
@@ -625,9 +623,8 @@ USAGE
 ENV
   SHIP_API_BASE        Ship server base URL (e.g. https://ship.elmundi.com)
   SHIP_API_TOKEN       workspace API token (admin scope)
-  SHIP_WORKSPACE_ID    UUID of the workspace
-  SHIP_REPO_ID         UUID of the WorkspaceRepo row
-  GITHUB_REPOSITORY    owner/repo (used for Cursor + state read)
+  SHIP_WORKSPACE_ID    UUID of the workspace (a workspace is one project)
+  GITHUB_REPOSITORY    owner/repo (which checkout the agent gets)
   GITHUB_TOKEN         read-only repo token (to fetch .ship/run-state.json)
   CURSOR_API_KEY       Cursor Cloud API key (when agent.default.provider=cursor)
 

--- a/cli/lib/commands/agent-run.mjs
+++ b/cli/lib/commands/agent-run.mjs
@@ -1,0 +1,585 @@
+/**
+ * `shipctl agent-run` — E14 routine entry-point.
+ *
+ * Customer's GH Actions cron fires this once per routine slot. The
+ * pipeline:
+ *
+ *   1. Read the routine from `.ship/config.yml` (pattern_id, optional
+ *      user-authored prompt).
+ *   2. Fetch the pattern body+frontmatter from Ship server
+ *      (`POST /fetch kind=pattern id=<pattern_id>`).
+ *   3. If the pattern declares `spec.fsm_stage`, ask Ship server for
+ *      the next ticket in that FSM stage
+ *      (`GET /v1/.../tracker/next?state=<stage>`). Server picks the
+ *      adapter (Linear / GH Issues / etc.) — CLI doesn't care.
+ *   4. Render the prompt (pattern body + ticket details + hand-off
+ *      instructions for `.ship/run-state.json`).
+ *   5. Launch the configured agent runtime (`cli/lib/agents/`) — Cursor
+ *      Cloud today. Block until the runtime terminates.
+ *   6. Read `.ship/run-state.json` from the agent's branch
+ *      (`{ state, comment?, transition_to?, payload? }`).
+ *   7. Apply via Ship server endpoints:
+ *
+ *        - state=ready_next_step    → POST /tracker/transition
+ *        - state=human_validation   → POST /tracker/comment + /inbox/items
+ *        - state=blocked            → POST /inbox/items
+ *
+ *   8. Exit 0 / non-0 with a structured summary on stdout (`--json`).
+ *
+ * Env contract (typically wired in `ship-trigger-schedule.yml`):
+ *   - SHIP_API_BASE         — Ship server, e.g. https://ship.elmundi.com
+ *   - SHIP_API_TOKEN        — workspace API token (admin scope)
+ *   - SHIP_WORKSPACE_ID     — UUID of the workspace this run belongs to
+ *   - SHIP_REPO_ID          — UUID of the WorkspaceRepo row
+ *   - CURSOR_API_KEY        — Cursor Cloud agent API key (when provider=cursor)
+ *   - GITHUB_REPOSITORY     — owner/repo (used to resolve the agent's branch back)
+ *   - GITHUB_TOKEN          — read-only repo access (to fetch run-state.json)
+ */
+
+import path from "node:path";
+
+import yaml from "yaml";
+
+import { readConfig, findShipRoot } from "../config/io.mjs";
+import { resolveExecutable } from "../runtime/routines.mjs";
+import { fetchArtifact } from "../http.mjs";
+import { resolveProvider, runAgent } from "../agents/index.mjs";
+
+
+const EXIT_OK = 0;
+const EXIT_USAGE = 1;
+const EXIT_NO_TASK = 0; // intentional: no eligible ticket is a clean noop
+const EXIT_BLOCKED = 5;
+const EXIT_HUMAN = 6;
+const EXIT_AGENT_FAIL = 7;
+const EXIT_API_FAIL = 8;
+
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+
+export async function agentRunCommand(ctx, rest) {
+  const args = parseArgs(rest);
+  if (args.help) {
+    printHelp();
+    process.exit(EXIT_OK);
+  }
+  if (!args.routine) {
+    die(EXIT_USAGE, "`--routine <id>` is required.\nRun: shipctl agent-run --help");
+  }
+
+  const cwd = args.cwd || process.cwd();
+  const root = findShipRoot(cwd);
+  if (!root) {
+    die(EXIT_USAGE, `.ship/config.yml not found (searched from ${path.resolve(cwd)} upward).`);
+  }
+
+  const { config } = readConfig(cwd);
+  const resolved = resolveExecutable(config, args.routine);
+  if (!resolved) {
+    die(EXIT_USAGE, `unknown routine '${args.routine}' in .ship/config.yml`);
+  }
+
+  const env = readEnv();
+  const { apiBase, apiToken, workspaceId, repoId, githubRepo, githubToken } = env;
+
+  // 1) Resolve pattern
+  const patternId = resolved.executable.pattern;
+  if (!patternId) {
+    die(EXIT_USAGE, `routine '${args.routine}' has no pattern set`);
+  }
+
+  const fetchBase = methodologyBase(env, config);
+  const { content: rawPatternBody } = await fetchArtifact(fetchBase, "pattern", patternId);
+  const { frontmatter, body: patternBody } = splitFrontmatter(rawPatternBody);
+  const fsmStage = pickFsmStage(frontmatter);
+
+  // Patterns reference ``{{BASE}}`` to splice in common-base. Fetch it
+  // up-front so renderPrompt can do the substitution. ``{{SKILLS_CONTEXT}}``
+  // inside common-base is left as "(no skills directory)" for the MVP —
+  // skills bundling lands in a follow-up.
+  const baseBody = await fetchCommonBase(fetchBase);
+
+  // 2) Resolve task
+  let task = null;
+  if (fsmStage) {
+    task = await getNextTask({
+      apiBase,
+      apiToken,
+      workspaceId,
+      repoId,
+      state: fsmStage,
+    });
+    if (!task) {
+      emit(args, { status: "noop", routine: args.routine, pattern: patternId, fsm_stage: fsmStage, reason: "no_eligible_ticket" });
+      process.exit(EXIT_NO_TASK);
+    }
+  }
+
+  // 3) Render prompt
+  const prompt = renderPrompt({
+    patternBody,
+    baseBody,
+    role: patternId,
+    routineSpec: resolved.executable,
+    task,
+    fsmStage,
+  });
+
+  // 4) Launch agent runtime
+  const provider = resolveProvider(config, args.routine);
+  const branchName = makeBranchName(args.routine, task?.ticket_ref);
+  const repoUrl = githubRepo ? `https://github.com/${githubRepo}` : null;
+  if (!repoUrl) die(EXIT_USAGE, "GITHUB_REPOSITORY env var is required to launch agent");
+
+  let runtime;
+  try {
+    runtime = await runAgent(provider, {
+      repoUrl,
+      ref: env.githubRef || "main",
+      branchName,
+      prompt,
+      autoCreatePr: false,
+    });
+  } catch (err) {
+    emit(args, {
+      status: "error",
+      routine: args.routine,
+      pattern: patternId,
+      stage: "launch_agent",
+      error: err instanceof Error ? err.message : String(err),
+    });
+    process.exit(EXIT_AGENT_FAIL);
+  }
+
+  // 5) Read .ship/run-state.json from agent's branch
+  let stateFile;
+  try {
+    stateFile = await readBranchFile({
+      repo: githubRepo,
+      branch: runtime.branchName,
+      path: ".ship/run-state.json",
+      githubToken,
+    });
+  } catch (err) {
+    emit(args, {
+      status: "error",
+      routine: args.routine,
+      pattern: patternId,
+      stage: "read_state",
+      branch: runtime.branchName,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    process.exit(EXIT_AGENT_FAIL);
+  }
+
+  let agentState;
+  try {
+    agentState = JSON.parse(stateFile);
+  } catch (err) {
+    emit(args, {
+      status: "error",
+      routine: args.routine,
+      pattern: patternId,
+      stage: "parse_state",
+      error: `.ship/run-state.json is not valid JSON: ${err.message}`,
+    });
+    process.exit(EXIT_AGENT_FAIL);
+  }
+
+  // 6) Apply via Ship server
+  const apply = await applyAgentState({
+    apiBase,
+    apiToken,
+    workspaceId,
+    repoId,
+    routine: args.routine,
+    pattern: patternId,
+    task,
+    state: agentState,
+    fsmStage,
+  });
+
+  emit(args, {
+    status: apply.exitCode === EXIT_OK ? "completed" : apply.statusName,
+    routine: args.routine,
+    pattern: patternId,
+    fsm_stage: fsmStage,
+    ticket_ref: task?.ticket_ref || null,
+    agent_id: runtime.agentId,
+    branch: runtime.branchName,
+    state: agentState.state,
+    actions: apply.actions,
+  });
+  process.exit(apply.exitCode);
+}
+
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+
+function readEnv() {
+  return {
+    apiBase: stripSlash(process.env.SHIP_API_BASE || ""),
+    apiToken: process.env.SHIP_API_TOKEN || "",
+    workspaceId: process.env.SHIP_WORKSPACE_ID || "",
+    repoId: process.env.SHIP_REPO_ID || "",
+    githubRepo: process.env.GITHUB_REPOSITORY || "",
+    githubRef: (process.env.GITHUB_REF_NAME || "main").trim(),
+    githubToken: process.env.GITHUB_TOKEN || "",
+  };
+}
+
+
+function stripSlash(s) {
+  return s.replace(/\/+$/, "");
+}
+
+
+function methodologyBase(env, config) {
+  // Server's POST /fetch lives next to /v1, not under /api/methodology.
+  if (env.apiBase) return env.apiBase;
+  const fromConfig = config?.api?.base_url;
+  if (typeof fromConfig === "string" && fromConfig.trim()) {
+    return stripSlash(fromConfig);
+  }
+  throw new Error("SHIP_API_BASE not set and no api.base_url in .ship/config.yml");
+}
+
+
+function splitFrontmatter(raw) {
+  if (!raw.startsWith("---")) return { frontmatter: {}, body: raw };
+  const end = raw.indexOf("\n---\n", 4);
+  if (end < 0) return { frontmatter: {}, body: raw };
+  const headRaw = raw.slice(3, end + 1).trim();
+  const body = raw.slice(end + 5);
+  let parsed = {};
+  try {
+    parsed = yaml.parse(headRaw) || {};
+  } catch {
+    parsed = {};
+  }
+  return { frontmatter: parsed, body };
+}
+
+
+function pickFsmStage(frontmatter) {
+  const spec = frontmatter?.spec || {};
+  const v = spec.fsm_stage ?? spec.fsmStage;
+  if (typeof v === "string" && v.trim()) return v.trim();
+  return null;
+}
+
+
+async function getNextTask({ apiBase, apiToken, workspaceId, repoId, state }) {
+  const url = `${apiBase}/v1/workspaces/${encodeURIComponent(workspaceId)}/repos/${encodeURIComponent(repoId)}/tracker/next?state=${encodeURIComponent(state)}`;
+  const res = await fetch(url, {
+    headers: {
+      Accept: "application/json",
+      Authorization: `Bearer ${apiToken}`,
+    },
+  });
+  if (!res.ok) {
+    throw new Error(`tracker/next ${res.status}: ${(await res.text()).slice(0, 300)}`);
+  }
+  const body = await res.json();
+  return body.ticket || null;
+}
+
+
+function renderPrompt({ patternBody, baseBody, role, routineSpec, task, fsmStage }) {
+  const issueRef = task?.ticket_ref ? task.ticket_ref : "(no ticket)";
+  const title = task?.title || "";
+  const description = task?.body || "";
+
+  // Pattern-template substitution. Order matters: expand {{BASE}} first
+  // so any further {{ROLE}} / {{SKILLS_CONTEXT}} placeholders inside
+  // common-base also get resolved.
+  const baseExpanded = (baseBody || "")
+    .replace(/\{\{ROLE\}\}/g, role)
+    .replace(/\{\{ISSUE\}\}/g, issueRef)
+    .replace(/\{\{SKILLS_CONTEXT\}\}/g, "(no skills directory bundled in this run)");
+
+  const expanded = patternBody
+    .replace(/\{\{BASE\}\}/g, baseExpanded)
+    .replace(/\{\{ROLE\}\}/g, role)
+    .replace(/\{\{ISSUE\}\}/g, issueRef)
+    .replace(/\{\{TITLE\}\}/g, title.slice(0, 500))
+    .replace(/\{\{DESCRIPTION\}\}/g, description.slice(0, 8000));
+
+  const out = [];
+  if (routineSpec.prompt) {
+    out.push("## Routine instructions");
+    out.push(routineSpec.prompt.trim());
+    out.push("");
+  }
+  out.push(expanded.trim());
+  if (task) {
+    out.push("");
+    out.push("## Task");
+    out.push(`- **Ticket:** \`${task.ticket_ref}\` (${task.kind})`);
+    if (task.url) out.push(`- **URL:** ${task.url}`);
+    if (task.title) out.push(`- **Title:** ${task.title}`);
+    if (task.fsm_stage || fsmStage) out.push(`- **FSM stage:** \`${task.fsm_stage || fsmStage}\``);
+    if (Array.isArray(task.labels) && task.labels.length) {
+      out.push(`- **Labels:** ${task.labels.join(", ")}`);
+    }
+    if (task.body) {
+      out.push("");
+      out.push("### Description");
+      out.push(task.body);
+    }
+  }
+  out.push("");
+  out.push(EXIT_PROTOCOL);
+  return out.join("\n");
+}
+
+
+async function fetchCommonBase(fetchBase) {
+  try {
+    const { content } = await fetchArtifact(fetchBase, "pattern", "common-base");
+    return splitFrontmatter(content).body;
+  } catch (err) {
+    // common-base is optional — surface a warning but keep going.
+    console.error(`warn: failed to fetch common-base pattern: ${err.message}`);
+    return "";
+  }
+}
+
+
+const EXIT_PROTOCOL = `## Required exit protocol
+
+When you finish (or determine you cannot proceed), commit a single
+file at \`.ship/run-state.json\` on this branch and stop.
+
+The file MUST be valid JSON with this shape:
+
+\`\`\`json
+{
+  "state": "ready_next_step" | "human_validation" | "blocked",
+  "comment": "Markdown your work-product comment.",
+  "transition_to": "<next FSM stage>",
+  "payload": { "...optional structured details..." }
+}
+\`\`\`
+
+State semantics:
+
+- \`ready_next_step\` — your role is done. Set \`comment\` (what you did),
+  \`transition_to\` (next FSM stage). Ship CLI will move the ticket and
+  post the comment.
+- \`human_validation\` — you need an answer from a human. Set \`comment\`
+  with the question. Ship CLI will leave a comment on the ticket and
+  drop a clarification item in the workspace inbox.
+- \`blocked\` — you cannot proceed (missing secret, broken env). Set
+  \`comment\` with the reason. Ship CLI will drop a blocker item in the
+  inbox; the ticket stays where it is.
+
+Do NOT call any tracker API directly (no \`gh issue comment\`, no
+\`linear-cli\`, no curl to Ship). Ship CLI reads the state file after
+you finish and does the writes through the workspace's existing OAuth.
+`;
+
+
+function makeBranchName(routine, ticketRef) {
+  const stamp = Date.now().toString(36);
+  if (ticketRef) {
+    const safe = String(ticketRef).replace(/[^a-zA-Z0-9_-]/g, "-");
+    return `cursor/ship-${routine}-${safe}-${stamp}`;
+  }
+  return `cursor/ship-${routine}-${stamp}`;
+}
+
+
+async function readBranchFile({ repo, branch, path: filePath, githubToken }) {
+  if (!repo) throw new Error("readBranchFile: GITHUB_REPOSITORY is empty");
+  if (!githubToken) throw new Error("readBranchFile: GITHUB_TOKEN is empty");
+  const url = `https://api.github.com/repos/${repo}/contents/${encodeURIComponent(filePath)}?ref=${encodeURIComponent(branch)}`;
+  const res = await fetch(url, {
+    headers: {
+      Accept: "application/vnd.github.raw",
+      Authorization: `Bearer ${githubToken}`,
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+  });
+  if (!res.ok) {
+    throw new Error(`GET ${filePath}@${branch} ${res.status}: ${(await res.text()).slice(0, 200)}`);
+  }
+  return res.text();
+}
+
+
+async function applyAgentState({
+  apiBase,
+  apiToken,
+  workspaceId,
+  repoId,
+  routine,
+  pattern,
+  task,
+  state,
+  fsmStage,
+}) {
+  const actions = [];
+  const headers = {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${apiToken}`,
+  };
+  const ws = encodeURIComponent(workspaceId);
+  const repoSeg = encodeURIComponent(repoId);
+
+  async function call(method, url, body) {
+    const res = await fetch(url, { method, headers, body: body && JSON.stringify(body) });
+    if (!res.ok) {
+      throw new Error(`${method} ${url} ${res.status}: ${(await res.text()).slice(0, 300)}`);
+    }
+    return res.json().catch(() => ({}));
+  }
+
+  try {
+    if (state.state === "ready_next_step") {
+      if (!task?.ticket_ref) {
+        throw new Error("ready_next_step requires a bound ticket");
+      }
+      if (!state.transition_to) {
+        throw new Error("ready_next_step requires `transition_to`");
+      }
+      const r = await call(
+        "POST",
+        `${apiBase}/v1/workspaces/${ws}/repos/${repoSeg}/tracker/transition`,
+        {
+          ticket_ref: task.ticket_ref,
+          to_state: state.transition_to,
+          from_state: fsmStage || undefined,
+          comment: state.comment || undefined,
+        },
+      );
+      actions.push({ kind: "transition", to_state: state.transition_to, response: r });
+      return { exitCode: EXIT_OK, statusName: "completed", actions };
+    }
+    if (state.state === "human_validation") {
+      if (task?.ticket_ref && state.comment) {
+        const c = await call(
+          "POST",
+          `${apiBase}/v1/workspaces/${ws}/repos/${repoSeg}/tracker/comment`,
+          { ticket_ref: task.ticket_ref, body: state.comment },
+        );
+        actions.push({ kind: "comment", response: c });
+      }
+      const inbox = await call(
+        "POST",
+        `${apiBase}/v1/workspaces/${ws}/inbox/items`,
+        {
+          type: "clarification",
+          title: `[${routine}] ${task?.title || "needs human"}`.slice(0, 300),
+          summary: state.comment || null,
+          ticket_ref: task?.ticket_ref || null,
+          payload: {
+            routine,
+            pattern,
+            agent_state: state.state,
+            ...((state.payload && typeof state.payload === "object") ? state.payload : {}),
+          },
+        },
+      );
+      actions.push({ kind: "inbox", response: inbox });
+      return { exitCode: EXIT_HUMAN, statusName: "human_validation", actions };
+    }
+    if (state.state === "blocked") {
+      const inbox = await call(
+        "POST",
+        `${apiBase}/v1/workspaces/${ws}/inbox/items`,
+        {
+          type: "blocker",
+          title: `[${routine}] blocked: ${task?.title || pattern}`.slice(0, 300),
+          summary: state.comment || null,
+          ticket_ref: task?.ticket_ref || null,
+          payload: {
+            routine,
+            pattern,
+            agent_state: state.state,
+            ...((state.payload && typeof state.payload === "object") ? state.payload : {}),
+          },
+        },
+      );
+      actions.push({ kind: "inbox", response: inbox });
+      return { exitCode: EXIT_BLOCKED, statusName: "blocked", actions };
+    }
+    throw new Error(
+      `Unknown agent state '${state.state}' (expected ready_next_step | human_validation | blocked)`,
+    );
+  } catch (err) {
+    return {
+      exitCode: EXIT_API_FAIL,
+      statusName: "error",
+      actions: [...actions, { kind: "error", error: err instanceof Error ? err.message : String(err) }],
+    };
+  }
+}
+
+
+// ---------------------------------------------------------------------------
+// Argument plumbing
+// ---------------------------------------------------------------------------
+
+
+function parseArgs(rest) {
+  const out = { routine: null, cwd: null, json: false, help: false };
+  const copy = [...rest];
+  while (copy.length) {
+    const a = copy[0];
+    if (a === "--help" || a === "-h") { out.help = true; copy.shift(); continue; }
+    if (a === "--json") { out.json = true; copy.shift(); continue; }
+    if (a === "--routine" && copy[1] !== undefined) { out.routine = copy[1]; copy.splice(0, 2); continue; }
+    if (a === "--cwd" && copy[1] !== undefined) { out.cwd = path.resolve(copy[1]); copy.splice(0, 2); continue; }
+    die(EXIT_USAGE, `unknown argument: ${a}`);
+  }
+  return out;
+}
+
+
+function printHelp() {
+  console.log(`shipctl agent-run — execute one E14 routine end-to-end.
+
+USAGE
+  shipctl agent-run --routine <id> [--json] [--cwd <dir>]
+
+ENV
+  SHIP_API_BASE        Ship server base URL (e.g. https://ship.elmundi.com)
+  SHIP_API_TOKEN       workspace API token (admin scope)
+  SHIP_WORKSPACE_ID    UUID of the workspace
+  SHIP_REPO_ID         UUID of the WorkspaceRepo row
+  GITHUB_REPOSITORY    owner/repo (used for Cursor + state read)
+  GITHUB_TOKEN         read-only repo token (to fetch .ship/run-state.json)
+  CURSOR_API_KEY       Cursor Cloud API key (when agent.default.provider=cursor)
+
+EXIT
+  0  routine completed (or noop: no eligible ticket)
+  1  usage / config error
+  5  agent reported state=blocked
+  6  agent reported state=human_validation
+  7  agent runtime crashed / state file missing
+  8  Ship API write failed
+`);
+}
+
+
+function emit(args, payload) {
+  if (args.json) {
+    console.log(JSON.stringify(payload, null, 2));
+  } else {
+    console.error(`# ship: ${payload.status}${payload.reason ? ` reason=${payload.reason}` : ""}${payload.routine ? ` routine=${payload.routine}` : ""}`);
+    if (payload.error) console.error(`#   error: ${payload.error}`);
+  }
+}
+
+
+function die(code, msg) {
+  console.error(msg);
+  process.exit(code);
+}


### PR DESCRIPTION
## Summary

Lays down the E14 contract: **CLI is the orchestrator, server is the vendor-agnostic write-back surface**. The agent never holds a tracker credential; every write goes through `shipctl` → Ship server → TrackerGateway (Linear OAuth or GitHub App).

End-to-end shape (no server-side cron, no per-run JWT):

\`\`\`
GH Actions cron → shipctl agent-run --routine X
    ├─ load routine from .ship/config.yml
    ├─ POST /fetch kind=pattern id=<pattern_id>      (+ common-base)
    ├─ if pattern.spec.fsm_stage:
    │    GET /v1/.../tracker/next?state=<stage>
    ├─ render prompt (pattern + task + exit-protocol)
    ├─ launch agent runtime per agent.default
    │    (cursor today; claude/codex slots reserved)
    ├─ poll until terminal status
    ├─ read .ship/run-state.json from agent's branch
    └─ apply via Ship server:
          ready_next_step  → /tracker/transition
          human_validation → /tracker/comment + /inbox/items
          blocked          → /inbox/items
\`\`\`

## Server (workspace API token auth)

- \`GET  /v1/workspaces/{ws}/repos/{repo}/tracker/next?state=<fsm>\`
- \`POST /v1/workspaces/{ws}/repos/{repo}/tracker/transition\`
- \`POST /v1/workspaces/{ws}/repos/{repo}/tracker/comment\`
- \`POST /v1/workspaces/{ws}/inbox/items\`

Tracker resolution (\`services/tracker_resolver.py\`): per-repo binding row → workspace Linear OAuth → GitHub App installation. CLI passes a vendor-agnostic \`ticket_ref\`; server picks the adapter.

## CLI

- \`shipctl agent-run --routine X\` (\`cli/lib/commands/agent-run.mjs\`)
- \`cli/lib/agents/cursor.mjs\` — Cursor Cloud launcher + poller
- \`cli/lib/agents/index.mjs\` — runtime dispatcher per \`agent.default.provider\`

## Patterns

- \`role-intake\` declares \`spec.fsm_stage: triage\`.
- \`common-base\` body rewritten runtime-agnostic — drops Linear-specific guidance, points agents at \`.ship/run-state.json\` exit protocol, forbids direct tracker writes.

## Out of scope this PR (next)

- Output-schema validation
- \`RoutineRun\` DB table
- More patterns migrated (role-ba, role-developer, daily flows)
- Server-direct daily without an agent (rejected — daily goes through the agent runtime like everything else)

## Test plan

- [x] \`pytest backend/tests/test_v1_workspaces.py\` — green
- [x] \`shipctl agent-run --help\` — emits the contract docs
- [ ] After deploy: trigger \`shipctl agent-run --routine task_intake\` from the customer cron with valid env, verify Cursor agent is launched, the agent commits \`.ship/run-state.json\`, and Ship server applies the transition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)