### PR TITLE
E14: stage-aware Linear filter (entry + previous-stage gating)

### DIFF
--- a/artifacts/patterns/role-intake/ARTIFACT.md
+++ b/artifacts/patterns/role-intake/ARTIFACT.md
@@ -6,7 +6,7 @@ version: 1.0.0
 channel: stable
 min_shipctl: 0.3.0
 updated_at: "2026-04-07T20:41:22+03:00"
-content_sha256: f2d5e8576db9fa96dd6a19d78d3c5aa0f6ed3220840c0a81e5be37d5d91d67c4
+content_sha256: b60ebe88fc61755c51ee6c9dc2dea56d647d72d80fa0a75883d649fef5c7bd7a
 deprecated: false
 replaced_by: null
 yanked: false
@@ -25,7 +25,9 @@ spec:
   include: [common-base]
   # E14: tracker stage this pattern operates on. ``shipctl agent-run``
   # uses this to pick the next eligible ticket via ``GET /tracker/next``.
-  fsm_stage: triage
+  # Aligns with ``services/linear_provisioner.SHIP_FSM_STAGES`` so the
+  # adapter can translate to a Linear filter without an extra map.
+  fsm_stage: task_intake
   inbox:
     profile: role_reviewer
     overrides:

--- a/backend/app/integrations/linear/tracker_adapter.py
+++ b/backend/app/integrations/linear/tracker_adapter.py
@@ -196,36 +196,45 @@ class LinearTracker:
     def _fsm_filter(self, stage: str) -> list[dict[str, Any]]:
         """Translate a Ship FSM stage name into Linear filter parts.
 
-        The convention: every FSM stage maps to a Linear workflow
-        state name (``Todo`` / ``In Progress`` / ``Review``) and a
-        ``stage:<fsm>`` label. The entry stage is special — it has no
-        stage label yet, so we filter by *absence* of every other
-        stage label rather than presence of an entry-stage label. (We
-        could add ``stage:task_intake`` after intake runs; the entry
-        check needs to keep working in either case.)
+        Convention (one label namespace, ``stage:<fsm>``):
+
+        * ``stage:<X>`` is added when role X has finished its work on the
+          ticket. The label is "this role is done", not "this role is
+          assigned".
+        * To pick a ticket for stage X:
+            - Linear state matches ``FSM_TO_LINEAR_STATE[X]``.
+            - The ``stage:<previous>`` label is present (previous role
+              has produced its output) — except for the entry stage,
+              which has no previous.
+            - The ``stage:<X>`` label is **not** present (this role
+              hasn't run on this ticket yet) — guarantees idempotency.
+
+        ``self_heal`` is intentionally not in ``FSM_STAGE_ORDER``; it
+        runs out-of-band against any open ticket and falls back to the
+        coarse "open" filter via ``list_tickets(state="open")``.
         """
+        from backend.app.services.linear_provisioner import previous_stage
+
         parts: list[dict[str, Any]] = []
         target_state_name = self._fsm_to_linear_state.get(stage)
         if target_state_name and target_state_name in self._state_id_by_name:
             parts.append(
                 {"state": {"id": {"eq": self._state_id_by_name[target_state_name]}}}
             )
-        # Entry stage = task_intake = "no stage label yet". Anything else
-        # filters on the matching label-id.
-        if stage == "task_intake":
-            other_label_ids = [
-                lid
-                for s, lid in self._label_id_by_stage.items()
-                if s != stage
-            ]
-            if other_label_ids:
+
+        # "this role hasn't finished yet" — never re-pick.
+        own_label = self._label_id_by_stage.get(stage)
+        if own_label:
+            parts.append({"labels": {"id": {"nin": [own_label]}}})
+
+        # "previous role is done" — for non-entry stages.
+        prev = previous_stage(stage)
+        if prev:
+            prev_label = self._label_id_by_stage.get(prev)
+            if prev_label:
                 parts.append(
-                    {"labels": {"id": {"nin": other_label_ids}}}
+                    {"labels": {"some": {"id": {"eq": prev_label}}}}
                 )
-        else:
-            label_id = self._label_id_by_stage.get(stage)
-            if label_id:
-                parts.append({"labels": {"id": {"eq": label_id}}})
         return parts
 
     async def transition(self, ticket: TicketRef, *, to_state: str) -> None:

--- a/backend/app/services/linear_provisioner.py
+++ b/backend/app/services/linear_provisioner.py
@@ -30,7 +30,8 @@ logger = logging.getLogger(__name__)
 
 
 # Ship FSM stages that need a label on Linear. Add new stages here
-# when patterns declare them in ``spec.fsm_stage``.
+# when patterns declare them in ``spec.fsm_stage``. Order matters —
+# the adapter uses adjacency to compute "previous stage done" filters.
 SHIP_FSM_STAGES: tuple[str, ...] = (
     "task_intake",
     "ba_requirements",
@@ -40,6 +41,30 @@ SHIP_FSM_STAGES: tuple[str, ...] = (
     "pr_review",
     "self_heal",
 )
+
+
+# Linear order of the SDLC stages. Self-heal is parallel to the main
+# pipeline (any open ticket) so it stays out of the chain.
+FSM_STAGE_ORDER: tuple[str, ...] = (
+    "task_intake",
+    "ba_requirements",
+    "tech_arch_plan",
+    "dev_implementation",
+    "qa_manual",
+    "pr_review",
+)
+
+
+def previous_stage(stage: str) -> str | None:
+    """Return the SDLC stage immediately before ``stage``, or ``None``
+    when ``stage`` is the entry / runs out-of-band.
+    """
+    if stage not in FSM_STAGE_ORDER:
+        return None
+    idx = FSM_STAGE_ORDER.index(stage)
+    if idx == 0:
+        return None
+    return FSM_STAGE_ORDER[idx - 1]
 
 
 # Ship FSM stage → Linear workflow state name. Keys here drive label


### PR DESCRIPTION
Single `stage:<fsm>` namespace. Filter for stage X: Linear state matches map AND has `stage:<previous>` (non-entry) AND lacks `stage:<X>`. `role-intake` frontmatter now `fsm_stage: task_intake`. `linear_provisioner` exports `FSM_STAGE_ORDER` + `previous_stage()` as the chain source-of-truth.