### PR TITLE
spread daily routines across 24h UTC + bundle 0.9

### DIFF
--- a/.ship/config.yml
+++ b/.ship/config.yml
@@ -82,30 +82,12 @@ process:
   - from: qa_manual
     to: pr_review
   routines:
-    daily_architecture_tests_review:
-      name: Daily Architecture Tests Review
-      enabled: true
-      trigger:
-        type: schedule
-        cron: 0 8 * * *
-        window: 30m
-        catchup: latest
-      pattern: role-qa-architect
-    daily_technical_architecture_review:
-      name: Daily Technical Architecture Review
-      enabled: true
-      trigger:
-        type: schedule
-        cron: 0 8 * * *
-        window: 30m
-        catchup: latest
-      pattern: role-tech-architect
     daily_security_review:
       name: Daily Security Review
       enabled: true
       trigger:
         type: schedule
-        cron: 0 8 * * *
+        cron: 0 6 * * *
         window: 30m
         catchup: latest
       pattern: role-security-officer
@@ -118,12 +100,30 @@ process:
         window: 30m
         catchup: latest
       pattern: flow-daily-retro
+    daily_technical_architecture_review:
+      name: Daily Technical Architecture Review
+      enabled: true
+      trigger:
+        type: schedule
+        cron: 0 12 * * *
+        window: 30m
+        catchup: latest
+      pattern: role-tech-architect
+    daily_architecture_tests_review:
+      name: Daily Architecture Tests Review
+      enabled: true
+      trigger:
+        type: schedule
+        cron: 0 15 * * *
+        window: 30m
+        catchup: latest
+      pattern: role-qa-architect
     daily_retro:
       name: Daily Retro
       enabled: true
       trigger:
         type: schedule
-        cron: 0 17 * * *
+        cron: 0 18 * * *
         window: 30m
         catchup: latest
       pattern: flow-learning-capture

--- a/backend/app/services/lane_recipes.py
+++ b/backend/app/services/lane_recipes.py
@@ -97,30 +97,33 @@ operator.
 
 
 DEFAULT_SEED_LANES: Final[dict[str, dict[str, object]]] = {
-    # Daily repo-level review lanes.
-    "daily_architecture_tests_review": {
-        "kind": "schedule",
-        "cron": "0 8 * * *",
-        "pattern": "role-qa-architect",
-    },
-    "daily_technical_architecture_review": {
-        "kind": "schedule",
-        "cron": "0 8 * * *",
-        "pattern": "role-tech-architect",
-    },
+    # Daily reviews — spread every 3h across 24h UTC so the operator
+    # doesn't see 3-4 agents stacked on the same hour in the dashboard.
+    # Order: security → daily digest → tech-debt → tests-coverage →
+    # learning retro. Pre-PR-77 they all stacked at 08:00/09:00/17:00.
     "daily_security_review": {
         "kind": "schedule",
-        "cron": "0 8 * * *",
+        "cron": "0 6 * * *",   # 06:00 UTC
         "pattern": "role-security-officer",
     },
     "daily_digest": {
         "kind": "schedule",
-        "cron": "0 9 * * *",
+        "cron": "0 9 * * *",   # 09:00 UTC — morning summary
         "pattern": "flow-daily-retro",
+    },
+    "daily_technical_architecture_review": {
+        "kind": "schedule",
+        "cron": "0 12 * * *",  # 12:00 UTC — tech-debt sweep
+        "pattern": "role-tech-architect",
+    },
+    "daily_architecture_tests_review": {
+        "kind": "schedule",
+        "cron": "0 15 * * *",  # 15:00 UTC — test coverage review
+        "pattern": "role-qa-architect",
     },
     "daily_retro": {
         "kind": "schedule",
-        "cron": "0 17 * * *",
+        "cron": "0 18 * * *",  # 18:00 UTC — end-of-day retro
         "pattern": "flow-learning-capture",
     },
     # SDLC cadence lanes. GitHub only ticks the clock; Ship decides which

--- a/backend/app/services/seed_bundle.py
+++ b/backend/app/services/seed_bundle.py
@@ -90,7 +90,11 @@ from backend.app.services.tracker_fsm import (
 #         server-side. ``seed_default_knowledge`` finally wired into the
 #         JIT + explicit workspace-create paths (was dead code through
 #         0.7).
-BUNDLE_VERSION: str = "0.8"
+# ``0.9`` → daily review crons spread every 3h across 24h UTC instead
+#         of stacking at 08:00 / 09:00 / 17:00. Order: security 06:00,
+#         digest 09:00, tech-debt 12:00, test-coverage 15:00, retro
+#         18:00.
+BUNDLE_VERSION: str = "0.9"
 
 
 # Default knowledge starters for PR 1. Empty by design: generated knowledge is


### PR DESCRIPTION
Dashboard had 3 daily reviews stacked at 08:00 UTC + digest at 09:00. Spread every 3h: security 06:00 / digest 09:00 / tech-debt 12:00 / test-coverage 15:00 / retro 18:00. Per-ticket FSM agents (`*/15`) + `self_heal` (hourly) unchanged. Updates `lane_recipes.py` (source of truth for new seeds), Ship-on-Ship's live `.ship/config.yml`, and bumps `BUNDLE_VERSION` to 0.9.