### PR TITLE
knowledge: consolidate recommended buckets 10 → 6

### DIFF
--- a/backend/app/services/knowledge_reseed.py
+++ b/backend/app/services/knowledge_reseed.py
@@ -42,14 +42,6 @@ class RecommendedBucket:
 
 RECOMMENDED_BUCKETS: tuple[RecommendedBucket, ...] = (
     RecommendedBucket(
-        slug="project-map",
-        name="Project Map",
-        description="Repository structure, service ownership, and where important files live.",
-        bucket_type="Project Map",
-        purpose="Use for where/which repo/which folder/ownership/project structure questions.",
-        authority="High-confidence reference",
-    ),
-    RecommendedBucket(
         slug="architecture-decisions",
         name="Architecture Decisions",
         description="ADRs, design docs, trade-offs, and why the system is designed this way.",
@@ -76,35 +68,10 @@ RECOMMENDED_BUCKETS: tuple[RecommendedBucket, ...] = (
     RecommendedBucket(
         slug="product-knowledge",
         name="Product Knowledge",
-        description="Product behavior, customer-facing concepts, roadmap context, and UX decisions.",
+        description="Product behavior, customer-facing concepts, roadmap context, UX decisions, and the data/domain vocabulary the team shares.",
         bucket_type="Product Knowledge",
-        purpose="Use for product semantics, customer promises, and user-facing workflows.",
+        purpose="Use for product semantics, customer promises, user-facing workflows, and entity / metric / glossary definitions.",
         authority="High-confidence reference",
-    ),
-    RecommendedBucket(
-        slug="source-intelligence",
-        name="Source Intelligence",
-        description="Ship-generated codebase understanding, code maps, and repository analysis.",
-        bucket_type="Source Intelligence",
-        purpose="Use for generated code intelligence that Ship owns in the database.",
-        authority="Generated / low-authority",
-    ),
-    RecommendedBucket(
-        slug="generated-assets",
-        name="Generated Assets",
-        description="Agent-generated artifacts, summaries, and useful derived knowledge.",
-        bucket_type="Generated Assets",
-        purpose="Use for generated outputs that should remain discoverable but low authority.",
-        authority="Generated / low-authority",
-    ),
-    RecommendedBucket(
-        slug="security-access",
-        name="Security & Access",
-        description="Security practices, access model, secrets handling, and production permissions.",
-        bucket_type="Security",
-        purpose="Use for security controls, access decisions, secrets, and restricted operational knowledge.",
-        authority="Source of truth",
-        access_level="Restricted",
     ),
     RecommendedBucket(
         slug="integration-playbooks",
@@ -115,13 +82,29 @@ RECOMMENDED_BUCKETS: tuple[RecommendedBucket, ...] = (
         authority="High-confidence reference",
     ),
     RecommendedBucket(
-        slug="data-domain-glossary",
-        name="Data & Domain Glossary",
-        description="Domain terms, core entities, data definitions, metrics, and business vocabulary.",
-        bucket_type="Data Glossary",
-        purpose="Use for definitions, entity meaning, metrics, and shared vocabulary.",
+        slug="security-access",
+        name="Security & Access",
+        description="Security practices, access model, secrets handling, and production permissions.",
+        bucket_type="Security",
+        purpose="Use for security controls, access decisions, secrets, and restricted operational knowledge.",
         authority="Source of truth",
+        access_level="Restricted",
     ),
+)
+
+
+# Buckets retired in the 10 → 6 consolidation. Migration 0053 archives
+# any per-workspace rows under these slugs; new workspaces never seed
+# them. ``project-map`` / ``source-intelligence`` lose to the runtime
+# code-exploration tools planned for Step 7 (no static articles to
+# keep fresh). ``generated-assets`` was a sweep-bucket nobody could
+# describe, and ``data-domain-glossary`` collapses into
+# ``product-knowledge`` — vocabulary is a section, not a bucket.
+RETIRED_BUCKET_SLUGS: tuple[str, ...] = (
+    "project-map",
+    "source-intelligence",
+    "generated-assets",
+    "data-domain-glossary",
 )
 
 

--- a/backend/app/services/repo_intel.py
+++ b/backend/app/services/repo_intel.py
@@ -1273,14 +1273,19 @@ async def _get_workspace_bucket_for_intel_article(
     session: AsyncSession, *, repo: WorkspaceRepo, article_slug: str
 ) -> KnowledgeBucket:
     workspace_id = repo.workspace_id
+    # The 10 → 6 consolidation retired ``project-map`` and
+    # ``source-intelligence``; repo overview / generic source-intel rows
+    # fall back to ``product-knowledge`` (closest semantic neighbour for
+    # "what is this repo / what's in it"). The mapping otherwise stays
+    # tied to the per-section author intent.
     preferred = {
-        "overview": "project-map",
+        "overview": "product-knowledge",
         "dev-environment": "engineering-standards",
         "architecture": "architecture-decisions",
         "workflow": "runbooks-operations",
         "visual-style": "product-knowledge",
         "rules": "security-access",
-    }.get(article_slug, "source-intelligence")
+    }.get(article_slug, "product-knowledge")
     bucket = (
         await session.execute(
             select(KnowledgeBucket).where(
@@ -1315,9 +1320,9 @@ async def _get_workspace_bucket_for_intel_article(
         workspace_id=workspace_id,
         scope_kind=BucketScope.WORKSPACE,
         source_kind=BucketSource.REPO_CONTEXT,
-        slug="source-intelligence",
-        name="Source Intelligence",
-        description="Ship-generated source and repository intelligence.",
+        slug="product-knowledge",
+        name="Product Knowledge",
+        description="Product behavior, customer-facing concepts, roadmap context, UX decisions, and the data/domain vocabulary the team shares.",
         source_ref={
             "repo_id": str(repo.id),
             "repo_full_name": repo.full_name,

--- a/backend/migrations/versions/0053_consolidate_buckets.py
+++ b/backend/migrations/versions/0053_consolidate_buckets.py
@@ -1,0 +1,163 @@
+"""archive retired starter buckets — 10 → 6 consolidation
+
+The recommended-buckets list is collapsing to six (architecture-decisions,
+engineering-standards, runbooks-operations, product-knowledge,
+integration-playbooks, security-access). The four retired slugs lose
+their reason to exist:
+
+- ``project-map`` / ``source-intelligence`` — replaced by runtime
+  code-exploration tools (Step 7); static articles for them go stale
+  the moment the repo moves.
+- ``generated-assets`` — sweep bucket nobody could describe; routing
+  into it stopped being meaningful.
+- ``data-domain-glossary`` — vocabulary is a section of
+  ``product-knowledge``, not a bucket of its own.
+
+This migration:
+
+1. Archives any workspace bucket whose slug is in the retired set
+   (``archived_at = now()`` if not already archived).
+2. Archives any non-archived ``BucketArticle`` under those buckets so
+   ``GET /buckets/{slug}/articles`` stops returning them by default.
+3. Cancels any unrouted ``Improvement(kind='knowledge_note')`` rows
+   that the harvester pinned to a retired bucket — sets
+   ``context.routed_bucket_id = NULL`` so the next router tick can
+   re-route them into a live bucket.
+
+The rows are preserved (no DELETE) — operators can resurrect content
+manually if a piece turns out to be load-bearing. Down-migration
+clears ``archived_at`` for both buckets and articles. The unrouted
+notes carry a ``rerouted_from_retired`` flag so the down-migration
+can put them back; we don't try to perfectly invert the route flip
+because the router will pick a fresh target on the next tick anyway.
+
+Revision ID: 0053_consolidate_buckets
+Revises: 0052_drop_pipeline_c
+Create Date: 2026-05-04
+"""
+
+from __future__ import annotations
+
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "0053_consolidate_buckets"
+down_revision: Union[str, None] = "0052_drop_pipeline_c"
+branch_labels: Union[str, tuple[str, ...], None] = None
+depends_on: Union[str, tuple[str, ...], None] = None
+
+
+RETIRED_SLUGS = (
+    "project-map",
+    "source-intelligence",
+    "generated-assets",
+    "data-domain-glossary",
+)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+
+    bind.execute(
+        sa.text(
+            """
+            UPDATE bucket_articles ba
+               SET status = 'archived',
+                   archived_at = COALESCE(ba.archived_at, now())
+              FROM knowledge_buckets kb
+             WHERE ba.bucket_id = kb.id
+               AND kb.slug = ANY(:slugs)
+               AND ba.archived_at IS NULL
+            """
+        ),
+        {"slugs": list(RETIRED_SLUGS)},
+    )
+
+    bind.execute(
+        sa.text(
+            """
+            UPDATE knowledge_buckets
+               SET archived_at = now()
+             WHERE slug = ANY(:slugs)
+               AND archived_at IS NULL
+            """
+        ),
+        {"slugs": list(RETIRED_SLUGS)},
+    )
+
+    # Recycle unrouted knowledge-notes that the router previously pinned
+    # to a now-retired bucket. JSONB update sets ``routed_bucket_id`` =
+    # null and adds a marker so the down-migration can find them.
+    bind.execute(
+        sa.text(
+            """
+            UPDATE improvements i
+               SET context = jsonb_set(
+                       jsonb_set(
+                           i.context,
+                           '{routed_bucket_id}',
+                           'null'::jsonb,
+                           true
+                       ),
+                       '{rerouted_from_retired}',
+                       to_jsonb(kb.slug),
+                       true
+                   )
+              FROM knowledge_buckets kb
+             WHERE i.kind = 'knowledge_note'
+               AND kb.slug = ANY(:slugs)
+               AND (i.context->>'routed_bucket_id')::uuid = kb.id
+            """
+        ),
+        {"slugs": list(RETIRED_SLUGS)},
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+
+    bind.execute(
+        sa.text(
+            """
+            UPDATE knowledge_buckets
+               SET archived_at = NULL
+             WHERE slug = ANY(:slugs)
+            """
+        ),
+        {"slugs": list(RETIRED_SLUGS)},
+    )
+
+    bind.execute(
+        sa.text(
+            """
+            UPDATE bucket_articles ba
+               SET status = 'published',
+                   archived_at = NULL
+              FROM knowledge_buckets kb
+             WHERE ba.bucket_id = kb.id
+               AND kb.slug = ANY(:slugs)
+            """
+        ),
+        {"slugs": list(RETIRED_SLUGS)},
+    )
+
+    bind.execute(
+        sa.text(
+            """
+            UPDATE improvements i
+               SET context = jsonb_set(
+                       i.context - 'rerouted_from_retired',
+                       '{routed_bucket_id}',
+                       to_jsonb(kb.id::text),
+                       true
+                   )
+              FROM knowledge_buckets kb
+             WHERE i.kind = 'knowledge_note'
+               AND i.context ? 'rerouted_from_retired'
+               AND i.context->>'rerouted_from_retired' = kb.slug
+            """
+        )
+    )

--- a/console/src/app/knowledge/knowledge-control-center.tsx
+++ b/console/src/app/knowledge/knowledge-control-center.tsx
@@ -80,16 +80,12 @@ type Props = {
 type Tab = "buckets" | "search" | "sources" | "settings";
 
 const STARTER_BUCKETS = [
-  "Project Map",
   "Architecture Decisions",
   "Engineering Standards",
   "Runbooks & Operations",
   "Product Knowledge",
-  "Source Intelligence",
-  "Generated Assets",
-  "Security & Access",
   "Integration Playbooks",
-  "Data & Domain Glossary",
+  "Security & Access",
 ];
 
 export function KnowledgeControlCenter({


### PR DESCRIPTION
## Summary

Step 4 of the knowledge refactor. Workspaces ship with six well-defined buckets instead of ten. Tighter set → router picks decisively among six descriptions; search stays focused; retired surfaces (``project-map`` / ``source-intelligence``) get out of the way of the runtime code-exploration tools planned for Step 7.

**Final set:** ``architecture-decisions``, ``engineering-standards``, ``runbooks-operations``, ``product-knowledge`` (absorbs ``data-domain-glossary``), ``integration-playbooks``, ``security-access``.

**Retired:** ``project-map`` / ``source-intelligence`` (replaced by runtime tools in Step 7), ``generated-assets`` (sweep bucket nobody could describe), ``data-domain-glossary`` (now a section of product-knowledge).

- Backend: ``RECOMMENDED_BUCKETS`` cut to 6 + new ``RETIRED_BUCKET_SLUGS`` constant. ``repo_intel._get_workspace_bucket_for_intel_article`` re-points ``overview``/fallback from ``source-intelligence`` → ``product-knowledge``.
- Migration ``0053_consolidate_buckets`` archives bucket rows + their articles for the 4 retired slugs per workspace, and clears ``routed_bucket_id`` on unrouted knowledge-notes pinned to them so the router re-targets next tick. Down-migration restores all three flips.
- Console: ``STARTER_BUCKETS`` mirrors the new six.

Net diff: 4 files, **197 insertions, 50 deletions** (mostly the migration).

## Test plan

- [x] ``RECOMMENDED_BUCKETS`` length is 6; ``RETIRED_BUCKET_SLUGS`` lists the 4 drops.
- [x] ``tsc --noEmit`` in console → clean.
- [x] Backend imports clean.
- [ ] CI: full backend suite.
- [ ] Apply 0053 in staging → verify retired buckets archived, articles archived, unrouted notes recycled.
- [ ] New onboarding flow seeds 6 buckets only (smoke test create_workspace).

## Stack order

#84 ✅ → #85 ✅ → #86 ✅ → this PR. No file overlap with #86 (just-merged).