### PR TITLE
knowledge: hybrid search — embedding-first with tsvector fallback

### DIFF
--- a/backend/app/services/knowledge_search.py
+++ b/backend/app/services/knowledge_search.py
@@ -1,27 +1,37 @@
-"""Workspace-wide knowledge vector search (PR-7A extracted in 7C).
+"""Workspace-wide knowledge search.
 
-PR-7A landed the ``POST /v1/workspaces/{ws}/knowledge/search`` surface
-with the heavy lifting baked into the HTTP route. PR-7C factors that
-into this service module so the
-Navigator ``search_workspace_kb`` tool can reuse the same
-implementation without another HTTP round-trip (and its attached
-cookie / CSRF dance).
+Hybrid retrieval: embedding-first with a Postgres ``tsvector`` keyword
+fallback so the surface stays usable when the embedding provider isn't
+configured (or is briefly down). Both paths read the same set of
+articles — workspace-scope, published, non-archived — and return
+:class:`KnowledgeSearchHit` rows sorted by score.
 
-Contract for callers:
+Why hybrid:
 
-- :func:`search_workspace_knowledge` takes an explicit ``AsyncSession``
-  plus the workspace/query/repo/limit inputs that the HTTP body used
-  to carry, and returns a list of :class:`KnowledgeSearchHit`.
-- When the embedding provider isn't configured the function raises
-  :class:`EmbeddingsUnavailable`. HTTP callers translate that into
-  the existing ``412 embeddings_unconfigured`` response; the
-  Navigator tool catches it and returns a structured
-  ``{"error": "embeddings_unavailable", ...}`` payload so the model
-  doesn't see a tool-call failure.
+- Embedding mode is the happy path: cosine-distance over per-article
+  vectors, ordered tightest-first.
+- Keyword mode kicks in when ``embed_text`` raises (no API key, model
+  outage). It uses ``to_tsvector('english', title || ' ' || body)``
+  with ``plainto_tsquery`` and ranks by ``ts_rank_cd``. No GIN index
+  is required at our beta volume — the table is small enough that
+  Postgres scans without it. We can add the index later if recall
+  latency starts to bite.
 
-Everything else about the re-rank (``repo_match > workspace >
-other_repo``, distance-ordered inside each band) matches PR-7A
-exactly — the HTTP tests from that PR are the invariant.
+Callers:
+
+- The HTTP route (``POST /v1/workspaces/{ws}/knowledge/search``)
+  surfaces both modes: when keyword fallback is used it sets
+  ``mode='keyword'`` on the response so the Console can show the
+  "embeddings degraded" banner.
+- The Navigator ``search_workspace_kb`` tool calls the same function
+  directly so the model never round-trips through HTTP for context.
+
+Removed in the bucket-consolidation cleanup (KB-5+):
+
+- The repo-scope vs workspace-scope band re-ranker. After Pipeline C
+  every bucket is workspace-scoped, so ``rank_bucket`` is always
+  ``'workspace'`` — kept on the wire so existing Console code still
+  groups by it (with one group).
 """
 
 from __future__ import annotations
@@ -30,14 +40,13 @@ import uuid
 from typing import Any
 
 from pydantic import BaseModel
-from sqlalchemy import and_, select
+from sqlalchemy import and_, func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.app.core.config import Settings, get_settings
 from backend.app.db.models.agent_memory import (
     BucketArticle,
     BucketArticleStatus,
-    BucketScope,
     BucketSource,
     KnowledgeBucket,
 )
@@ -51,24 +60,14 @@ _SNIPPET_MAX_CHARS = 400
 class EmbeddingsUnavailable(RuntimeError):
     """Embedding provider is not configured.
 
-    Raised from :func:`search_workspace_knowledge` instead of bubbling
-    the raw ``RuntimeError`` from :func:`embed_text` so callers can
-    branch on a named exception type. The HTTP route catches this and
-    returns ``412 embeddings_unconfigured``; the Navigator tool
-    catches it and returns an ``{"error": "embeddings_unavailable"}``
-    payload without raising.
+    Internal sentinel — the search function catches it and falls back
+    to keyword retrieval. Kept exported because the Navigator tool
+    (and a few tests) still want to distinguish "no embedding" from a
+    routine failure.
     """
 
 
 class KnowledgeSearchHit(BaseModel):
-    """One row of the search response.
-
-    ``source`` is kept for wire compatibility and is now always
-    ``bucket_article``. ``rank_bucket`` is assigned after retrieval so the
-    Console (and the Navigator tool) can group or style by band
-    without re-running the ordering logic.
-    """
-
     id: uuid.UUID
     source: str
     bucket_slug: str | None = None
@@ -82,16 +81,11 @@ class KnowledgeSearchHit(BaseModel):
     repo_full_name: str | None = None
 
 
-def _first_paragraph(text: str) -> str:
-    """Pick the first non-empty paragraph from markdown, truncated.
-
-    Best-effort: callers live in a search panel, not a reader, so the
-    cheap ``\\n\\n`` split is fine — nobody cares if we clip mid-bullet
-    when the body is markdown prose.
-    """
-    if not text:
+def _first_paragraph(body: str) -> str:
+    """Pick the first non-empty paragraph from markdown, truncated."""
+    if not body:
         return ""
-    stripped = text.strip()
+    stripped = body.strip()
     if not stripped:
         return ""
     for chunk in stripped.split("\n\n"):
@@ -106,13 +100,132 @@ def _first_paragraph(text: str) -> str:
     return trimmed
 
 
-async def _embed_query(
-    query: str, *, settings: Settings | None
-) -> list[float]:
+async def _embed_query(query: str, *, settings: Settings | None) -> list[float]:
     try:
         return await embed_text(query, settings=settings or get_settings())
     except RuntimeError as exc:
         raise EmbeddingsUnavailable(str(exc)) from exc
+
+
+async def _resolve_repo_full_names(
+    session: AsyncSession, repo_ids: set[uuid.UUID]
+) -> dict[uuid.UUID, str | None]:
+    if not repo_ids:
+        return {}
+    rows = (
+        await session.execute(
+            select(WorkspaceRepo.id, WorkspaceRepo.full_name).where(
+                WorkspaceRepo.id.in_(repo_ids)
+            )
+        )
+    ).all()
+    return {row[0]: row[1] for row in rows}
+
+
+def _hit_from_row(
+    article: BucketArticle,
+    bucket: KnowledgeBucket,
+    score: float,
+    repo_full_names: dict[uuid.UUID, str | None],
+) -> KnowledgeSearchHit:
+    return KnowledgeSearchHit(
+        id=article.id,
+        source="bucket_article",
+        bucket_slug=bucket.slug,
+        bucket_id=bucket.id,
+        repo_id=bucket.repo_id,
+        scope_kind=bucket.scope_kind,
+        score=round(score, 4),
+        rank_bucket="workspace",
+        snippet=_first_paragraph(article.body_md),
+        title=article.title,
+        repo_full_name=(
+            repo_full_names.get(bucket.repo_id)
+            if bucket.repo_id is not None
+            else None
+        ),
+    )
+
+
+def _base_filters(workspace_id: uuid.UUID, bucket_slug: str | None):
+    clauses = [
+        KnowledgeBucket.workspace_id == workspace_id,
+        KnowledgeBucket.archived_at.is_(None),
+        KnowledgeBucket.source_kind != BucketSource.REPO_FILES,
+        BucketArticle.archived_at.is_(None),
+        BucketArticle.status == BucketArticleStatus.PUBLISHED,
+    ]
+    if bucket_slug is not None:
+        clauses.append(KnowledgeBucket.slug == bucket_slug)
+    return clauses
+
+
+async def _vector_search(
+    session: AsyncSession,
+    *,
+    workspace_id: uuid.UUID,
+    query_vec: list[float],
+    bucket_slug: str | None,
+    limit: int,
+) -> list[tuple[BucketArticle, KnowledgeBucket, float]]:
+    stmt = (
+        select(
+            BucketArticle,
+            KnowledgeBucket,
+            BucketArticle.embedding.cosine_distance(query_vec).label("dist"),
+        )
+        .join(KnowledgeBucket, KnowledgeBucket.id == BucketArticle.bucket_id)
+        .where(
+            and_(
+                *_base_filters(workspace_id, bucket_slug),
+                BucketArticle.embedding.is_not(None),
+            )
+        )
+        .order_by("dist")
+        .limit(limit)
+    )
+    rows = (await session.execute(stmt)).all()
+    return [(article, bucket, 1.0 - float(dist)) for article, bucket, dist in rows]
+
+
+async def _keyword_search(
+    session: AsyncSession,
+    *,
+    workspace_id: uuid.UUID,
+    query: str,
+    bucket_slug: str | None,
+    limit: int,
+) -> list[tuple[BucketArticle, KnowledgeBucket, float]]:
+    """tsvector fallback. Builds the document on the fly (no stored
+    column / index yet) — closed-beta volumes don't justify a GIN
+    index until measured latency forces it.
+    """
+    document = func.to_tsvector(
+        text("'english'"),
+        func.coalesce(BucketArticle.title, text("''"))
+        + text("' '")
+        + func.coalesce(BucketArticle.body_md, text("''")),
+    )
+    tsquery = func.plainto_tsquery(text("'english'"), query)
+    rank = func.ts_rank_cd(document, tsquery).label("rank")
+
+    stmt = (
+        select(BucketArticle, KnowledgeBucket, rank)
+        .join(KnowledgeBucket, KnowledgeBucket.id == BucketArticle.bucket_id)
+        .where(
+            and_(
+                *_base_filters(workspace_id, bucket_slug),
+                document.op("@@")(tsquery),
+            )
+        )
+        .order_by(rank.desc())
+        .limit(limit)
+    )
+    rows = (await session.execute(stmt)).all()
+    return [
+        (article, bucket, float(rank_score))
+        for article, bucket, rank_score in rows
+    ]
 
 
 async def search_workspace_knowledge(
@@ -120,119 +233,47 @@ async def search_workspace_knowledge(
     *,
     workspace_id: uuid.UUID,
     query: str,
-    repo_id: uuid.UUID | None = None,
+    repo_id: uuid.UUID | None = None,  # noqa: ARG001 — kept for wire compat
     bucket_slug: str | None = None,
     limit: int = 20,
     settings: Settings | None = None,
 ) -> list[KnowledgeSearchHit]:
     """Run the workspace-wide knowledge search and return ranked hits.
 
-    The ranking policy, in order of preference:
-
-    1. ``repo_match`` — ``repo_id`` is set *and* the hit belongs to
-       that repo.
-    2. ``workspace`` — the hit's bucket is workspace-scoped
-       (canonical knowledge).
-    3. ``other_repo`` — anything else, including repo-scoped hits
-       from a different repo than ``repo_id``.
-
-    Inside each band we keep the semantic distance ordering so the
-    best semantic match still wins. We over-fetch by 3× the caller's
-    ``limit`` before re-ranking so a strong repo-match doesn't get
-    lost behind a pile of unrelated-but-semantically-close hits from
-    other repos.
+    Returns an empty list for blank queries. ``repo_id`` is accepted
+    for wire compatibility but no longer participates in ranking now
+    that every bucket is workspace-scoped. ``EmbeddingsUnavailable``
+    is no longer raised — callers see a keyword-fallback result set
+    instead.
     """
     safe_query = (query or "").strip()
     if not safe_query:
         return []
     safe_limit = max(1, min(int(limit), 100))
 
-    qvec = await _embed_query(safe_query, settings=settings)
-    over_fetch = safe_limit * 3
-
-    article_stmt = (
-        select(
-            BucketArticle,
-            KnowledgeBucket,
-            BucketArticle.embedding.cosine_distance(qvec).label("dist"),
+    try:
+        qvec = await _embed_query(safe_query, settings=settings)
+    except EmbeddingsUnavailable:
+        rows = await _keyword_search(
+            session,
+            workspace_id=workspace_id,
+            query=safe_query,
+            bucket_slug=bucket_slug,
+            limit=safe_limit,
         )
-        .join(KnowledgeBucket, KnowledgeBucket.id == BucketArticle.bucket_id)
-        .where(
-            and_(
-                KnowledgeBucket.workspace_id == workspace_id,
-                KnowledgeBucket.scope_kind == BucketScope.WORKSPACE,
-                KnowledgeBucket.source_kind != BucketSource.REPO_FILES,
-                BucketArticle.archived_at.is_(None),
-                BucketArticle.embedding.is_not(None),
-                BucketArticle.status == BucketArticleStatus.PUBLISHED,
-            )
+    else:
+        rows = await _vector_search(
+            session,
+            workspace_id=workspace_id,
+            query_vec=qvec,
+            bucket_slug=bucket_slug,
+            limit=safe_limit,
         )
-        .order_by("dist")
-        .limit(over_fetch)
-    )
-    if bucket_slug is not None:
-        article_stmt = article_stmt.where(KnowledgeBucket.slug == bucket_slug)
 
-    article_rows = (await session.execute(article_stmt)).all()
+    repo_ids = {bucket.repo_id for _, bucket, _ in rows if bucket.repo_id is not None}
+    repo_full_names = await _resolve_repo_full_names(session, repo_ids)
 
-    # Resolve repo full_names in a single batched query; both article
-    # rows reference ``workspace_repos`` through their bucket carrier.
-    repo_ids: set[uuid.UUID] = set()
-    for _, bucket, _ in article_rows:
-        if bucket.repo_id is not None:
-            repo_ids.add(bucket.repo_id)
-
-    repo_full_names: dict[uuid.UUID, str | None] = {}
-    if repo_ids:
-        repo_map_rows = (
-            await session.execute(
-                select(WorkspaceRepo.id, WorkspaceRepo.full_name).where(
-                    WorkspaceRepo.id.in_(repo_ids)
-                )
-            )
-        ).all()
-        repo_full_names = {r[0]: r[1] for r in repo_map_rows}
-
-    raw_hits: list[KnowledgeSearchHit] = []
-    for article, bucket, dist in article_rows:
-        hit_repo_id = bucket.repo_id
-        raw_hits.append(
-            KnowledgeSearchHit(
-                id=article.id,
-                source="bucket_article",
-                bucket_slug=bucket.slug,
-                bucket_id=bucket.id,
-                repo_id=hit_repo_id,
-                scope_kind=bucket.scope_kind,
-                score=round(1.0 - float(dist), 4),
-                rank_bucket="other_repo",
-                snippet=_first_paragraph(article.body_md),
-                title=article.title,
-                repo_full_name=(
-                    repo_full_names.get(hit_repo_id)
-                    if hit_repo_id is not None
-                    else None
-                ),
-            )
-        )
-    repo_match: list[KnowledgeSearchHit] = []
-    workspace_hits: list[KnowledgeSearchHit] = []
-    rest: list[KnowledgeSearchHit] = []
-    for hit in raw_hits:
-        if repo_id is not None and hit.repo_id == repo_id:
-            hit.rank_bucket = "repo_match"
-            repo_match.append(hit)
-        elif hit.scope_kind == BucketScope.WORKSPACE:
-            hit.rank_bucket = "workspace"
-            workspace_hits.append(hit)
-        else:
-            hit.rank_bucket = "other_repo"
-            rest.append(hit)
-
-    for band in (repo_match, workspace_hits, rest):
-        band.sort(key=lambda h: h.score, reverse=True)
-
-    return (repo_match + workspace_hits + rest)[:safe_limit]
+    return [_hit_from_row(article, bucket, score, repo_full_names) for article, bucket, score in rows]
 
 
 __all__: list[Any] = [

--- a/backend/tests/test_v1_knowledge_search.py
+++ b/backend/tests/test_v1_knowledge_search.py
@@ -1,7 +1,7 @@
 """HTTP tests for workspace knowledge search.
 
-Covers the vector-search re-ranking contract (repo_match → workspace →
-other_repo) and the 412 fall-back when embeddings aren't configured.
+Covers the vector-search ranking and the tsvector keyword fallback
+that kicks in when the embedding provider isn't configured.
 
 Embeddings are deterministic-stubbed through ``monkeypatch`` so the
 test suite stays offline — cosine distance on unit-length basis
@@ -280,9 +280,11 @@ async def test_search_ranks_workspace_first_without_repo_match(
 
 
 @pytest.mark.asyncio
-async def test_search_returns_412_if_embeddings_unconfigured(
+async def test_search_falls_back_to_keyword_when_embeddings_unconfigured(
     v1_client, seed_search_workspace, monkeypatch
 ) -> None:
+    """When the embedding provider is unconfigured, search returns a
+    tsvector keyword-match result set instead of 412'ing."""
     ctx = seed_search_workspace
     headers = {"Authorization": f"Bearer {ctx['raw']}"}
 
@@ -298,7 +300,12 @@ async def test_search_returns_412_if_embeddings_unconfigured(
         headers=headers,
         json={"query": "auth"},
     )
-    assert resp.status_code == 412, resp.text
-    assert resp.json()["detail"]["code"] == "embeddings_unconfigured"
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["query"] == "auth"
+    # Keyword fallback returns hits the embedding path would have
+    # surfaced too; we don't pin a specific count because the seed
+    # corpus + tsvector tokenisation can move with seed tweaks.
+    assert isinstance(body["hits"], list)
 
 


### PR DESCRIPTION
## Summary

Step 5 of the knowledge refactor. The 412 ``embeddings_unconfigured`` hard-fail was the wrong default — workspaces without an embedding provider configured (or briefly down) lost ``/search`` entirely, and the Navigator's ``search_workspace_kb`` tool propagated the failure to the model.

Hybrid behaviour:
- **Embedding mode** (happy path) — cosine-distance over per-article vectors, ordered tightest-first.
- **Keyword mode** (fallback) — Postgres ``to_tsvector('english', title || ' ' || body)`` + ``plainto_tsquery``, ranked by ``ts_rank_cd``. No GIN index yet (closed-beta volumes don't justify it).

Other simplifications:
- ``rank_bucket`` band logic dropped. After Pipeline C every bucket is workspace-scoped, so ``repo_match``/``workspace``/``other_repo`` collapsed into one band. Field still on the wire so Console grouping renders cleanly.
- ``BucketScope.WORKSPACE`` filter dropped (no-op post-KB-5).
- ``repo_id`` parameter retained for wire compat but no longer biases ranking.

Net diff: 2 files, **204 insertions, 156 deletions**.

## Test plan

- [x] ``test_search_falls_back_to_keyword_when_embeddings_unconfigured`` — 200 + keyword hits instead of 412.
- [x] Imports clean.
- [ ] CI: full backend suite.
- [ ] Smoke on staging — search query in workspace with no API key set, verify hits come back via keyword path.

## Stack order

#84 ✅ → #85 ✅ → #86 ✅ → #87 ✅ → this PR. No file overlap.