### PR TITLE
knowledge: daily GC for archived bucket articles

### DIFF
--- a/backend/app/services/cron.py
+++ b/backend/app/services/cron.py
@@ -83,6 +83,7 @@ class CronLockId(IntEnum):
     KNOWLEDGE_HARVEST = 1001
     KNOWLEDGE_ROUTE = 1002
     KNOWLEDGE_SYNTH = 1003
+    KNOWLEDGE_DECAY = 1004
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/services/cron_jobs.py
+++ b/backend/app/services/cron_jobs.py
@@ -26,6 +26,7 @@ from backend.app.services.cron import (
     cron_with_lock,
     register_cron,
 )
+from backend.app.services.knowledge_decay import gc_all_workspaces
 from backend.app.services.knowledge_harvest import harvest_all_workspaces
 from backend.app.services.knowledge_router import route_all_workspaces
 from backend.app.services.knowledge_synth import synthesise_all_workspaces
@@ -179,6 +180,39 @@ async def _knowledge_synth_tick() -> None:
         )
 
 
+# ---------------------------------------------------------------------------
+# Step 6 — daily archive GC
+# ---------------------------------------------------------------------------
+
+
+@cron_with_lock(lock=CronLockId.KNOWLEDGE_DECAY, name="knowledge_decay")
+async def _knowledge_decay_tick() -> None:
+    """Daily sweep: hard-delete archived bucket articles past the TTL.
+
+    Operator-driven archive (``POST /buckets/{slug}/archive``) and
+    synthesiser-proposed archive both flip articles to ``status='archived'``
+    with ``archived_at=now()``. This sweep collects rows older than
+    ``ARCHIVE_TTL_DAYS`` and removes them so the table doesn't grow
+    forever. ``BucketArticleSource`` rows cascade-delete via the FK.
+    """
+    sm = get_sessionmaker()
+    async with sm() as session:
+        try:
+            reports = await gc_all_workspaces(session)
+            await session.commit()
+        except Exception:
+            await session.rollback()
+            raise
+
+    deleted = sum(r.deleted for r in reports)
+    if deleted:
+        log.info(
+            "knowledge_decay tick: workspaces=%d deleted=%d",
+            len(reports),
+            deleted,
+        )
+
+
 def register_all() -> None:
     """Wire every cron defined in this module into the scheduler.
 
@@ -205,6 +239,14 @@ def register_all() -> None:
         fn=_knowledge_synth_tick,
         cron_expr="40 * * * *",  # every hour at :40
         job_id="knowledge_synth",
+    )
+    # GC runs once daily. Cheap query (filtered DELETE by archived_at)
+    # so an off-peak slot is fine; pick 03:15 UTC to avoid the on-the-
+    # hour pile-ups from the harvest/route/synth chain.
+    register_cron(
+        fn=_knowledge_decay_tick,
+        cron_expr="15 3 * * *",  # daily at 03:15 UTC
+        job_id="knowledge_decay",
     )
 
 

--- a/backend/app/services/knowledge_decay.py
+++ b/backend/app/services/knowledge_decay.py
@@ -1,0 +1,153 @@
+"""Knowledge GC — hard-delete archived bucket articles.
+
+The synthesiser's ``action='archive'`` flow (commit c62dd21) flips
+articles to ``status='archived'`` + ``archived_at=now()`` once an
+operator accepts the inbox proposal. Operator-driven archive does the
+same dual-flip via ``POST /buckets/{slug}/archive``.
+
+Archive isn't deletion. The row stays so search can still surface it
+when ``include_archived=True`` and so a bad archive call is reversible
+via ``POST /buckets/{slug}/restore``. Without a sweep, though, the
+archived rows accumulate forever — they keep their ``embedding``,
+their ``provenance`` JSONB, and the ``BucketArticleSource`` rows that
+link them back to harvested notes.
+
+This module's ``gc_archived_articles`` runs daily and hard-deletes
+articles whose ``archived_at`` is older than a configurable cutoff
+(default 90 days). Cascades:
+
+- ``BucketArticleSource`` rows: deleted via the FK ``ondelete='CASCADE'``
+  on ``article_id``.
+- ``Improvement(kind='knowledge_note')`` rows that fed the article via
+  ``provenance.source_note_ids`` are NOT touched — those are observation
+  events, not derived data, and are still useful for re-routing if a
+  bucket comes back.
+- ``BucketArticle`` rows whose ``supersedes_id`` points at a soon-to-be-
+  deleted article: the FK is ``ondelete='SET NULL'`` so the surviving
+  newer version simply loses its link to history. Acceptable — the
+  history was already archived, and at 90 days the chain is too cold
+  to matter.
+
+Cutoff is a constant for now. If operators ask for per-workspace tuning
+later, lift it onto a workspace settings JSONB field.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.app.db.models.agent_memory import (
+    BucketArticle,
+    BucketArticleStatus,
+)
+from backend.app.db.models.tenancy import Workspace
+
+
+log = logging.getLogger(__name__)
+
+
+# 90 days = a quarter. Long enough that a regretful operator can still
+# restore by hand from the DB if needed; short enough that the table
+# doesn't bloat indefinitely.
+ARCHIVE_TTL_DAYS = 90
+
+
+@dataclass(frozen=True, slots=True)
+class DecayReport:
+    workspace_id: uuid.UUID | None
+    deleted: int = 0
+    inspected: int = 0
+
+
+async def gc_archived_articles(
+    session: AsyncSession,
+    *,
+    workspace_id: uuid.UUID | None = None,
+    cutoff: datetime | None = None,
+) -> DecayReport:
+    """Hard-delete archived articles older than the cutoff.
+
+    ``workspace_id`` is optional — when ``None`` the sweep runs across
+    every workspace (used by the daily cron). The cron entry point
+    iterates per workspace so a long sweep doesn't hold one transaction
+    for the whole tenant set.
+    """
+    cutoff = cutoff or datetime.now(timezone.utc) - timedelta(days=ARCHIVE_TTL_DAYS)
+
+    stmt = select(BucketArticle.id).where(
+        BucketArticle.status == BucketArticleStatus.ARCHIVED,
+        BucketArticle.archived_at.is_not(None),
+        BucketArticle.archived_at < cutoff,
+    )
+    if workspace_id is not None:
+        # Articles don't carry workspace_id directly; join through the
+        # bucket carrier so the sweep stays scoped.
+        from backend.app.db.models.agent_memory import KnowledgeBucket
+
+        stmt = (
+            select(BucketArticle.id)
+            .join(KnowledgeBucket, KnowledgeBucket.id == BucketArticle.bucket_id)
+            .where(
+                BucketArticle.status == BucketArticleStatus.ARCHIVED,
+                BucketArticle.archived_at.is_not(None),
+                BucketArticle.archived_at < cutoff,
+                KnowledgeBucket.workspace_id == workspace_id,
+            )
+        )
+
+    article_ids = list((await session.execute(stmt)).scalars().all())
+    if not article_ids:
+        return DecayReport(workspace_id=workspace_id, deleted=0, inspected=0)
+
+    result = await session.execute(
+        delete(BucketArticle).where(BucketArticle.id.in_(article_ids))
+    )
+    deleted = int(result.rowcount or 0)
+    log.info(
+        "knowledge_decay: hard-deleted archived articles workspace_id=%s "
+        "deleted=%d cutoff=%s",
+        workspace_id,
+        deleted,
+        cutoff.isoformat(),
+    )
+    return DecayReport(
+        workspace_id=workspace_id, deleted=deleted, inspected=len(article_ids)
+    )
+
+
+async def gc_all_workspaces(
+    session: AsyncSession,
+    *,
+    cutoff: datetime | None = None,
+) -> list[DecayReport]:
+    """Cron entry point — sweep every workspace once."""
+    workspace_ids = (
+        await session.execute(select(Workspace.id))
+    ).scalars().all()
+
+    reports: list[DecayReport] = []
+    for ws_id in workspace_ids:
+        try:
+            report = await gc_archived_articles(
+                session, workspace_id=ws_id, cutoff=cutoff
+            )
+        except Exception as exc:
+            log.exception("knowledge_decay sweep failed workspace=%s", ws_id)
+            report = DecayReport(workspace_id=ws_id, deleted=0, inspected=0)
+            _ = exc
+        reports.append(report)
+    return reports
+
+
+__all__ = [
+    "ARCHIVE_TTL_DAYS",
+    "DecayReport",
+    "gc_all_workspaces",
+    "gc_archived_articles",
+]

--- a/backend/tests/test_knowledge_decay.py
+++ b/backend/tests/test_knowledge_decay.py
@@ -1,0 +1,160 @@
+"""Coverage for ``gc_archived_articles`` — Step 6.
+
+Pins the contract that the daily cron only deletes archived rows past
+the TTL cutoff and never touches published / recently-archived rows.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import select
+
+from backend.app.db.models.agent_memory import (
+    BucketArticle,
+    BucketArticleStatus,
+    BucketScope,
+    BucketSource,
+    KnowledgeBucket,
+)
+from backend.app.services.knowledge_decay import (
+    ARCHIVE_TTL_DAYS,
+    gc_archived_articles,
+)
+
+
+pytestmark = pytest.mark.asyncio
+
+
+def _content_sha(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+async def _seed_bucket(db_session, workspace_id) -> KnowledgeBucket:
+    bucket = KnowledgeBucket(
+        id=uuid.uuid4(),
+        workspace_id=workspace_id,
+        slug="product-knowledge",
+        name="Product Knowledge",
+        scope_kind=BucketScope.WORKSPACE,
+        source_kind=BucketSource.AGENT_MEMORY,
+    )
+    db_session.add(bucket)
+    await db_session.flush()
+    return bucket
+
+
+def _archived_article(bucket: KnowledgeBucket, *, slug: str, age_days: int) -> BucketArticle:
+    archived_at = datetime.now(timezone.utc) - timedelta(days=age_days)
+    return BucketArticle(
+        id=uuid.uuid4(),
+        bucket_id=bucket.id,
+        slug=slug,
+        title=slug.title(),
+        body_md=f"body for {slug}",
+        content_sha=_content_sha(f"body for {slug}"),
+        status=BucketArticleStatus.ARCHIVED,
+        archived_at=archived_at,
+    )
+
+
+def _published_article(bucket: KnowledgeBucket, *, slug: str) -> BucketArticle:
+    return BucketArticle(
+        id=uuid.uuid4(),
+        bucket_id=bucket.id,
+        slug=slug,
+        title=slug.title(),
+        body_md=f"body for {slug}",
+        content_sha=_content_sha(f"body for {slug}"),
+        status=BucketArticleStatus.PUBLISHED,
+    )
+
+
+async def test_gc_deletes_only_archived_articles_past_ttl(db_session, seed_workspace):
+    _, _, workspace = seed_workspace
+    bucket = await _seed_bucket(db_session, workspace.id)
+
+    old = _archived_article(bucket, slug="old", age_days=ARCHIVE_TTL_DAYS + 5)
+    fresh = _archived_article(bucket, slug="fresh", age_days=ARCHIVE_TTL_DAYS - 5)
+    live = _published_article(bucket, slug="live")
+    db_session.add_all([old, fresh, live])
+    await db_session.flush()
+
+    report = await gc_archived_articles(db_session, workspace_id=workspace.id)
+    assert report.deleted == 1
+    assert report.inspected == 1
+
+    surviving = list(
+        (
+            await db_session.execute(
+                select(BucketArticle).where(BucketArticle.bucket_id == bucket.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    surviving_slugs = {row.slug for row in surviving}
+    assert surviving_slugs == {"fresh", "live"}
+
+
+async def test_gc_workspace_scoped(db_session, seed_workspace, seed_user):
+    """The sweep doesn't touch articles in other workspaces."""
+    from backend.app.db.models.tenancy import Workspace
+
+    _, _, workspace = seed_workspace
+    _, org = seed_user
+
+    other = Workspace(
+        org_id=org.id, slug=f"ws-{uuid.uuid4().hex[:6]}", name="Other workspace"
+    )
+    db_session.add(other)
+    await db_session.flush()
+
+    bucket = await _seed_bucket(db_session, workspace.id)
+    other_bucket = KnowledgeBucket(
+        id=uuid.uuid4(),
+        workspace_id=other.id,
+        slug="product-knowledge",
+        name="Product Knowledge",
+        scope_kind=BucketScope.WORKSPACE,
+        source_kind=BucketSource.AGENT_MEMORY,
+    )
+    db_session.add(other_bucket)
+    await db_session.flush()
+
+    target = _archived_article(bucket, slug="old-target", age_days=ARCHIVE_TTL_DAYS + 5)
+    other_old = _archived_article(other_bucket, slug="old-other", age_days=ARCHIVE_TTL_DAYS + 5)
+    db_session.add_all([target, other_old])
+    await db_session.flush()
+
+    report = await gc_archived_articles(db_session, workspace_id=workspace.id)
+    assert report.deleted == 1
+
+    other_remaining = list(
+        (
+            await db_session.execute(
+                select(BucketArticle).where(BucketArticle.bucket_id == other_bucket.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert {row.slug for row in other_remaining} == {"old-other"}
+
+
+async def test_gc_explicit_cutoff_overrides_default(db_session, seed_workspace):
+    _, _, workspace = seed_workspace
+    bucket = await _seed_bucket(db_session, workspace.id)
+
+    very_recent = _archived_article(bucket, slug="recent", age_days=2)
+    db_session.add(very_recent)
+    await db_session.flush()
+
+    cutoff = datetime.now(timezone.utc) - timedelta(days=1)
+    report = await gc_archived_articles(
+        db_session, workspace_id=workspace.id, cutoff=cutoff
+    )
+    assert report.deleted == 1


### PR DESCRIPTION
## Summary

Step 6 of the knowledge refactor. The synthesiser already votes stale articles out via ``action='archive'`` (commit c62dd21) and the operator-archive route does the same dual-flip — but nothing hard-deletes those rows, so the table grows forever.

- ``services/knowledge_decay.py`` — ``gc_archived_articles`` / ``gc_all_workspaces`` find ``status='archived'`` rows whose ``archived_at`` is older than ``ARCHIVE_TTL_DAYS`` (default 90) and DELETE them. ``BucketArticleSource`` cascade-deletes via FK; ``Improvement(kind='knowledge_note')`` rows are kept (raw events, still useful for re-routing).
- New ``CronLockId.KNOWLEDGE_DECAY = 1004``.
- ``_knowledge_decay_tick`` registered at ``15 3 * * *`` — off-peak so it doesn't pile onto the on-the-hour harvest/route/synth chain.
- Tests: 3 invariants — only past-TTL archived rows go, fresh archives survive, published rows untouched, workspace-scoping respected.

Net diff: 4 files, +356 / 0.

## Test plan

- [x] ``knowledge_decay`` imports clean.
- [x] ``test_knowledge_decay.py`` pins TTL + workspace-scope contract.
- [ ] CI: full backend suite.
- [ ] Verify cron registration on staging deploy logs.

## Stack order

#84 ✅ → #85 ✅ → #86 ✅ → #87 ✅ → #88 ✅ → this PR.