### PR TITLE
console: knowledge UI copy cleanup after the refactor

### DIFF
--- a/console/src/app/knowledge/[id]/actions.ts
+++ b/console/src/app/knowledge/[id]/actions.ts
@@ -20,7 +20,6 @@ import {
   type ApiDistillerClassifier,
   uploadToBucket,
 } from "@/lib/api/client";
-import { getSessionToken } from "@/lib/api/session";
 
 // Mirrors the backend cap in ``POST /v1/.../upload``. We double-check
 // on this side so the user gets a crisp error *before* we round-trip

--- a/console/src/app/knowledge/[id]/page.tsx
+++ b/console/src/app/knowledge/[id]/page.tsx
@@ -251,8 +251,7 @@ function LiveView({
   // Upload is meaningful for any bucket except ``repo_files`` — those
   // mirror ``.ship/knowledge`` from git and should stay authoritative
   // in the repo. All other source kinds accept UTF-8 uploads through
-  // the same Distiller path (including ``agent_memory``, connectors,
-  // ``promoted``, etc.).
+  // the same Distiller path.
   const canUpload = bucket !== null && bucket.source_kind !== "repo_files";
 
   const scopeKind = bucket?.scope_kind ?? (legacy?.visibility ?? "workspace");
@@ -581,10 +580,12 @@ function provenanceHint(article: ApiBucketArticle): string | null {
       ? `uploaded: ${p.filename}`
       : "uploaded file";
   }
-  if (kind === "connector_proxy") {
-    const connector =
-      typeof p.connector_kind === "string" ? p.connector_kind : null;
-    return connector ? `synced from ${connector}` : "synced from connector";
+  if (kind === "knowledge_import_source") {
+    const source = typeof p.import_source_kind === "string" ? p.import_source_kind : null;
+    return source ? `harvested from ${source}` : "harvested from import source";
+  }
+  if (kind === "auto_routed_notes" || kind === "auto_routed_draft") {
+    return "synthesised from harvested notes";
   }
   if (kind === "repo_files" && typeof p.path === "string") {
     return `from ${p.path}`;

--- a/console/src/app/knowledge/knowledge-control-center.tsx
+++ b/console/src/app/knowledge/knowledge-control-center.tsx
@@ -1,857 +1,528 @@
 "use client";
 
+/**
+ * Knowledge — single-page control surface.
+ *
+ * Layout, top to bottom:
+ *
+ *   [Title · Workspace]                       [Export ZIP] [Import source]
+ *   [           Big search input                                          ]
+ *   [All]  [Architecture decisions]  [Engineering]  ...  (6 buckets max)
+ *   [Optional: import panel collapsed below header]
+ *   [Articles list — flat, click-through to bucket detail]
+ *
+ * No metric tiles, no per-bucket cards, no tabs. Buckets are fixed at six
+ * after the consolidation, so they fit comfortably as filter chips and
+ * the articles surface gets the page real estate.
+ */
+
 import Link from "next/link";
 import { useMemo, useState, useTransition } from "react";
-import { useRouter } from "next/navigation";
 
-import {
-  Badge,
-  ButtonGhost,
-  Card,
-  CardHeader,
-  EmptyState,
-} from "@/components/ui";
+import { Card, CardHeader } from "@/components/ui";
 import { cn } from "@/lib/cn";
 import type {
   ApiActivatedRepo,
   ApiKnowledgeSearchHit,
   ApiKnowledgeSearchResponse,
 } from "@/lib/api/client";
-import type { ApiBucketScope, ApiIntegration } from "@/lib/api/types";
+import type { ApiIntegration } from "@/lib/api/types";
 
-import {
-  archiveBucketAction,
-  type ArchiveResult,
-} from "./actions";
 import { KnowledgeImportWizard } from "./import-wizard";
 
-export type KnowledgeBucketStatus =
-  | "Ready"
-  | "Indexing"
-  | "Failed"
-  | "Empty"
-  | "Stale";
 
-export type KnowledgeControlBucket = {
+export type KnowledgeBucketRow = {
   id: string;
   slug: string;
   name: string;
   description: string;
-  bucketType: string;
-  scope: string;
-  sourceKind: string;
-  authority: string;
-  accessLevel: string;
-  freshnessPolicy: string;
-  status: KnowledgeBucketStatus;
-  articles: number;
-  chunks: number;
-  sourceCount: number;
-  sourceNames: string[];
-  lastIndexedAt: string | null;
-  updatedAt: string | null;
+  archived: boolean;
 };
 
-export type KnowledgeControlSource = {
+export type KnowledgeArticleRow = {
   id: string;
-  bucketSlug: string | null;
+  bucketSlug: string;
   bucketName: string;
+  slug: string;
+  title: string;
+  snippet: string;
+  updatedAt: string;
+};
+
+export type KnowledgeSourceRow = {
+  id: string;
+  name: string;
   kind: string;
   status: string;
   lastSyncedAt: string | null;
-  nextSyncAt: string | null;
   lastError: string | null;
-  documents: number | null;
-  chunks: number | null;
-  urlOrPath: string | null;
 };
 
 type Props = {
-  mode: "live" | "mock";
   workspace: { id?: string; slug: string; name: string };
-  reason?: string;
-  buckets: KnowledgeControlBucket[];
-  sources: KnowledgeControlSource[];
+  buckets: KnowledgeBucketRow[];
+  articles: KnowledgeArticleRow[];
+  sources: KnowledgeSourceRow[];
   repos: ApiActivatedRepo[];
   integrations: ApiIntegration[];
-  defaultScope: ApiBucketScope;
 };
 
-type Tab = "buckets" | "search" | "sources" | "settings";
-
-const STARTER_BUCKETS = [
-  "Architecture Decisions",
-  "Engineering Standards",
-  "Runbooks & Operations",
-  "Product Knowledge",
-  "Integration Playbooks",
-  "Security & Access",
-];
 
 export function KnowledgeControlCenter({
-  mode,
   workspace,
-  reason,
   buckets,
+  articles,
   sources,
   repos,
   integrations,
-  defaultScope,
 }: Props) {
-  const [tab, setTab] = useState<Tab>("buckets");
-  const stats = useMemo(() => {
-    const lastIndexedAt = maxDate(
-      buckets.map((bucket) => bucket.lastIndexedAt ?? bucket.updatedAt),
-    );
-    return {
-      buckets: buckets.length,
-      articles: buckets.reduce((sum, bucket) => sum + bucket.articles, 0),
-      chunks: buckets.reduce((sum, bucket) => sum + bucket.chunks, 0),
-      sources: sources.length || buckets.reduce((sum, bucket) => sum + bucket.sourceCount, 0),
-      lastIndexedAt,
-    };
-  }, [buckets, sources]);
-
-  return (
-    <div className="space-y-6">
-      {mode === "mock" && reason && (
-        <div className="rounded-xl border border-sun/30 bg-sun/5 px-3 py-2 text-xs text-sun/95">
-          <span className="mr-2 rounded-full bg-sun/25 px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-widest">
-            mock
-          </span>
-          <span className="align-middle">
-          {reason}
-          </span>
-        </div>
-      )}
-
-      <section className="rounded-3xl border border-aqua/20 bg-gradient-to-br from-aqua/10 via-white/[0.04] to-lilac/10 p-5 shadow-card">
-        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-          <div className="max-w-3xl">
-            <div className="text-[10px] font-bold uppercase tracking-[0.2em] text-aqua/80">
-              Workspace memory control center
-            </div>
-            <h2 className="mt-2 font-display text-2xl font-bold text-white">
-              Knowledge for {workspace.name}
-            </h2>
-            <p className="mt-2 text-sm leading-relaxed text-white/70">
-              Buckets define where Ship stores project memory, which sources feed
-              it, how agents route questions, and which articles become canonical.
-              Search is one workflow inside the control center.
-            </p>
-          </div>
-          <div className="flex flex-wrap items-center gap-2">
-            <ExportButton workspace={workspace} />
-            <button
-              type="button"
-              onClick={() => setTab("sources")}
-              className="inline-flex items-center gap-1.5 rounded-full border border-aqua/40 bg-aqua/10 px-3 py-1.5 text-xs font-bold text-aqua transition hover:bg-aqua/20"
-            >
-              Import source
-            </button>
-          </div>
-        </div>
-
-        <div className="mt-5 grid grid-cols-2 gap-3 md:grid-cols-5">
-          <Metric label="Buckets" value={stats.buckets.toLocaleString()} />
-          <Metric label="Articles" value={stats.articles.toLocaleString()} />
-          <Metric label="Chunks" value={stats.chunks.toLocaleString()} />
-          <Metric label="Sources" value={stats.sources.toLocaleString()} />
-          <Metric
-            label="Last indexed"
-            value={stats.lastIndexedAt ? relativeDate(stats.lastIndexedAt) : "Never"}
-          />
-        </div>
-      </section>
-
-      <div
-        role="tablist"
-        aria-label="Knowledge areas"
-        className="flex flex-wrap items-center gap-1 border-b border-white/10"
-      >
-        <TabButton active={tab === "buckets"} onClick={() => setTab("buckets")}>
-          Buckets
-        </TabButton>
-        <TabButton active={tab === "search"} onClick={() => setTab("search")}>
-          Search
-        </TabButton>
-        <TabButton active={tab === "sources"} onClick={() => setTab("sources")}>
-          Sources
-        </TabButton>
-        <TabButton active={tab === "settings"} onClick={() => setTab("settings")}>
-          Settings
-        </TabButton>
-      </div>
-
-      {tab === "buckets" && <BucketsTab buckets={buckets} live={mode === "live"} />}
-      {tab === "search" && (
-        <SearchTab workspaceId={workspace.id} buckets={buckets} repos={repos} />
-      )}
-      {tab === "sources" && (
-        <SourcesTab
-          mode={mode}
-          sources={sources}
-          integrations={integrations}
-          repos={repos}
-          defaultScope={defaultScope}
-        />
-      )}
-      {tab === "settings" && <SettingsTab buckets={buckets} />}
-    </div>
-  );
-}
-
-function BucketsTab({
-  buckets,
-  live,
-}: {
-  buckets: KnowledgeControlBucket[];
-  live: boolean;
-}) {
-  if (buckets.length === 0) {
-    return (
-      <EmptyState
-        title="No knowledge buckets yet"
-        body="Knowledge buckets help Ship organize project memory for agents and humans."
-        action={
-          <div className="flex flex-wrap justify-center gap-2">
-            <ButtonGhost>Create starter buckets</ButtonGhost>
-            {live && <ButtonGhost>Create custom bucket</ButtonGhost>}
-          </div>
-        }
-      />
-    );
-  }
-
-  return (
-    <section className="grid grid-cols-1 gap-4 lg:grid-cols-2 xl:grid-cols-3">
-      {buckets.map((bucket) => (
-        <BucketCard key={bucket.id} bucket={bucket} live={live} />
-      ))}
-    </section>
-  );
-}
-
-function BucketCard({
-  bucket,
-  live,
-}: {
-  bucket: KnowledgeControlBucket;
-  live: boolean;
-}) {
-  const sourceText =
-    bucket.sourceNames.length > 0
-      ? bucket.sourceNames.slice(0, 2).join(", ")
-      : prettySource(bucket.sourceKind);
-
-  return (
-    <Card className="relative flex min-h-[22rem] flex-col">
-      <div className="flex items-start justify-between gap-3">
-        <div className="grid h-12 w-12 shrink-0 place-items-center rounded-2xl bg-gradient-to-br from-lilac/40 via-aqua/30 to-coral/30 font-display text-xl font-bold text-white">
-          {bucketInitial(bucket.name)}
-        </div>
-        <div className="flex flex-wrap justify-end gap-1.5">
-          <Badge tone={statusTone(bucket.status)} dot>
-            {bucket.status}
-          </Badge>
-          <Badge tone={scopeTone(bucket.scope)}>{scopeLabel(bucket.scope)}</Badge>
-        </div>
-      </div>
-
-      <div className="mt-4 min-w-0">
-        <Link
-          href={`/knowledge/${encodeURIComponent(bucket.slug)}`}
-          className="font-display text-lg font-bold text-white hover:text-aqua"
-        >
-          {bucket.name}
-        </Link>
-        <p className="mt-1 line-clamp-3 text-sm leading-relaxed text-white/65">
-          {bucket.description || "No description yet. Add purpose and source hints so agents know when to use this memory."}
-        </p>
-      </div>
-
-      <div className="mt-3 flex flex-wrap gap-1.5">
-        <Badge tone="neutral">{bucket.bucketType}</Badge>
-        <Badge tone={authorityTone(bucket.authority)}>
-          {bucket.authority}
-        </Badge>
-      </div>
-
-      <dl className="mt-4 grid grid-cols-2 gap-3 text-[11px]">
-        <MiniStat label="Articles" value={bucket.articles.toLocaleString()} />
-        <MiniStat label="Chunks" value={bucket.chunks.toLocaleString()} />
-        <MiniStat label="Sources" value={bucket.sourceCount.toLocaleString()} />
-        <MiniStat
-          label="Last indexed"
-          value={bucket.lastIndexedAt ? relativeDate(bucket.lastIndexedAt) : "Never"}
-        />
-      </dl>
-
-      <div className="mt-4 rounded-xl border border-white/10 bg-black/20 p-3 text-xs text-white/60">
-        <div className="flex items-center justify-between gap-2">
-          <span className="font-semibold text-white/80">Sources</span>
-          <span className="font-mono text-aqua/80">{bucket.sourceCount}</span>
-        </div>
-        <p className="mt-1 truncate">{sourceText}</p>
-      </div>
-
-      <div className="mt-auto flex items-center justify-between gap-3 pt-4">
-        <Link
-          href={`/knowledge/${encodeURIComponent(bucket.slug)}`}
-          className="text-sm font-semibold text-aqua hover:underline"
-        >
-          Open bucket
-        </Link>
-        {live && <BucketManageMenu bucket={bucket} />}
-      </div>
-    </Card>
-  );
-}
-
-function BucketManageMenu({ bucket }: { bucket: KnowledgeControlBucket }) {
-  const router = useRouter();
-  const [result, setResult] = useState<ArchiveResult | null>(null);
-  const [pending, startTransition] = useTransition();
-
-  function archive() {
-    setResult(null);
-    startTransition(async () => {
-      const response = await archiveBucketAction(bucket.slug);
-      setResult(response);
-      if (response.ok) router.refresh();
-    });
-  }
-
-  return (
-    <div className="flex flex-col items-end gap-1">
-      <button
-        type="button"
-        disabled={pending}
-        onClick={archive}
-        className="rounded-full border border-coral/40 bg-coral/10 px-3 py-1.5 text-xs font-semibold text-coral disabled:opacity-50"
-      >
-        {pending ? "Archiving…" : "Archive"}
-      </button>
-      {result && !result.ok && (
-        <p className="text-xs text-coral">{result.message}</p>
-      )}
-    </div>
-  );
-}
-
-function SearchTab({
-  workspaceId,
-  buckets,
-  repos,
-}: {
-  workspaceId?: string;
-  buckets: KnowledgeControlBucket[];
-  repos: ApiActivatedRepo[];
-}) {
   const [query, setQuery] = useState("");
-  const [bucketMode, setBucketMode] = useState("all");
-  const [selectedBuckets, setSelectedBuckets] = useState<string[]>([]);
-  const [repoId, setRepoId] = useState("");
-  const [sourceFilter, setSourceFilter] = useState("");
-  const [authorityFilter, setAuthorityFilter] = useState("");
-  const [resultType, setResultType] = useState("");
-  const [advancedOpen, setAdvancedOpen] = useState(false);
-  const [hits, setHits] = useState<ApiKnowledgeSearchHit[] | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  const [filterSlug, setFilterSlug] = useState<string | null>(null);
+  const [searchHits, setSearchHits] = useState<ApiKnowledgeSearchHit[] | null>(null);
+  const [searchedFor, setSearchedFor] = useState("");
+  const [searchError, setSearchError] = useState<string | null>(null);
+  const [importOpen, setImportOpen] = useState(false);
   const [pending, startTransition] = useTransition();
 
-  const bucketBySlug = useMemo(
-    () => new Map(buckets.map((bucket) => [bucket.slug, bucket])),
-    [buckets],
-  );
-  const effectiveSelected =
-    bucketMode === "all"
-      ? []
-      : bucketMode === "recommended"
-        ? buckets
-            .filter((bucket) =>
-              ["Source of truth", "High-confidence reference"].includes(
-                bucket.authority,
-              ),
-            )
-            .slice(0, 4)
-            .map((bucket) => bucket.slug)
-        : selectedBuckets;
-  const filteredHits = useMemo(() => {
-    if (!hits) return null;
-    return hits.filter((hit) => {
-      const bucket = hit.bucket_slug ? bucketBySlug.get(hit.bucket_slug) : null;
-      if (sourceFilter && bucket?.sourceKind !== sourceFilter) return false;
-      if (authorityFilter && bucket?.authority !== authorityFilter) return false;
-      if (resultType && hit.source !== resultType) return false;
-      return true;
-    });
-  }, [authorityFilter, bucketBySlug, hits, resultType, sourceFilter]);
+  const articlesByBucket = useMemo(() => {
+    const map = new Map<string, number>();
+    for (const a of articles) {
+      map.set(a.bucketSlug, (map.get(a.bucketSlug) ?? 0) + 1);
+    }
+    return map;
+  }, [articles]);
 
-  function runSearch(event: React.FormEvent) {
-    event.preventDefault();
+  const visibleArticles = useMemo(() => {
+    if (!filterSlug) return articles;
+    return articles.filter((a) => a.bucketSlug === filterSlug);
+  }, [articles, filterSlug]);
+
+  const visibleHits = useMemo(() => {
+    if (!searchHits) return null;
+    if (!filterSlug) return searchHits;
+    return searchHits.filter((h) => h.bucket_slug === filterSlug);
+  }, [searchHits, filterSlug]);
+
+  function runSearch(event?: React.FormEvent) {
+    event?.preventDefault();
     const q = query.trim();
-    if (!workspaceId) {
-      setError("Search needs a live workspace.");
+    if (!q) {
+      setSearchHits(null);
+      setSearchedFor("");
+      setSearchError(null);
       return;
     }
-    if (!q) return;
-    setError(null);
-    setHits(null);
+    setSearchError(null);
     startTransition(async () => {
       try {
-        const searches =
-          effectiveSelected.length > 0 ? effectiveSelected : [null];
-        const responses = await Promise.all(
-          searches.map((bucketSlug) =>
-            fetch("/api/knowledge/search", {
-              method: "POST",
-              headers: { "content-type": "application/json" },
-              body: JSON.stringify({
-                workspaceId,
-                query: q,
-                repoId: repoId || null,
-                bucketSlug,
-                limit: 20,
-              }),
-            }),
-          ),
-        );
-        const payloads = await Promise.all(
-          responses.map(async (response) => ({
-            response,
-            body: (await response.json()) as
-              | ApiKnowledgeSearchResponse
-              | { error?: string },
-          })),
-        );
-        const failed = payloads.find((payload) => !payload.response.ok);
-        if (failed) {
-          setError(
-            "error" in failed.body && failed.body.error
-              ? failed.body.error
-              : `Search failed (HTTP ${failed.response.status}).`,
-          );
-          setHits([]);
+        const res = await fetch("/api/knowledge/search", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            workspaceId: workspace.id,
+            query: q,
+            limit: 30,
+          }),
+        });
+        const body = (await res.json()) as
+          | ApiKnowledgeSearchResponse
+          | { error?: string; code?: string };
+        if (!res.ok || !("hits" in body)) {
+          const msg =
+            ("error" in body && body.error) ||
+            `Search failed (HTTP ${res.status}).`;
+          setSearchHits([]);
+          setSearchedFor(q);
+          setSearchError(msg);
           return;
         }
-        const merged = dedupeHits(
-          payloads.flatMap((payload) => (payload.body as ApiKnowledgeSearchResponse).hits),
-        );
-        setHits(merged);
+        setSearchHits(body.hits);
+        setSearchedFor(body.query || q);
       } catch (err) {
-        setError(err instanceof Error ? err.message : "Search failed.");
-        setHits([]);
+        setSearchHits([]);
+        setSearchedFor(q);
+        setSearchError(err instanceof Error ? err.message : "Search failed.");
       }
     });
   }
 
-  return (
-    <section className="grid grid-cols-1 gap-5 xl:grid-cols-[minmax(0,1fr)_22rem]">
-      <div className="space-y-4">
-        <Card>
-          <CardHeader
-            title="Search workspace knowledge"
-            subtitle="Search all buckets, recommended authoritative buckets, or a manual selection."
-          />
-          <form onSubmit={runSearch} className="space-y-4">
-            <input
-              type="search"
-              value={query}
-              onChange={(event) => setQuery(event.target.value)}
-              placeholder="How do we deploy staging?"
-              className="w-full rounded-xl border border-white/15 bg-white/[0.04] px-4 py-3 text-sm text-white outline-none transition focus:border-aqua/60"
-            />
-
-            <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
-              <Field label="Search in">
-                <select
-                  value={bucketMode}
-                  onChange={(event) => setBucketMode(event.target.value)}
-                  className="w-full rounded-lg border border-white/15 bg-black/30 px-3 py-2 text-sm text-white"
-                >
-                  <option value="all">All buckets</option>
-                  <option value="recommended">Recommended buckets</option>
-                  <option value="manual">Manual selection</option>
-                </select>
-              </Field>
-              <Field label="Repo boost">
-                <select
-                  value={repoId}
-                  onChange={(event) => setRepoId(event.target.value)}
-                  className="w-full rounded-lg border border-white/15 bg-black/30 px-3 py-2 text-sm text-white"
-                >
-                  <option value="">No repo boost</option>
-                  {repos.map((repo) => (
-                    <option key={repo.id} value={repo.id}>
-                      {repo.full_name}
-                    </option>
-                  ))}
-                </select>
-              </Field>
-            </div>
-
-            {bucketMode === "manual" && (
-              <div className="grid grid-cols-1 gap-2 md:grid-cols-2">
-                {buckets.map((bucket) => (
-                  <label
-                    key={bucket.slug}
-                    className="flex items-center gap-2 rounded-xl border border-white/10 bg-white/[0.03] px-3 py-2 text-xs text-white/75"
-                  >
-                    <input
-                      type="checkbox"
-                      checked={selectedBuckets.includes(bucket.slug)}
-                      onChange={(event) => {
-                        setSelectedBuckets((current) =>
-                          event.target.checked
-                            ? [...current, bucket.slug]
-                            : current.filter((slug) => slug !== bucket.slug),
-                        );
-                      }}
-                    />
-                    <span>{bucket.name}</span>
-                  </label>
-                ))}
-              </div>
-            )}
-
-            <button
-              type="button"
-              onClick={() => setAdvancedOpen((value) => !value)}
-              className="text-xs font-semibold text-aqua hover:underline"
-            >
-              {advancedOpen ? "Hide advanced options" : "Show advanced options"}
-            </button>
-
-            {advancedOpen && (
-              <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
-                <Field label="Source">
-                  <select
-                    value={sourceFilter}
-                    onChange={(event) => setSourceFilter(event.target.value)}
-                    className="w-full rounded-lg border border-white/15 bg-black/30 px-3 py-2 text-sm text-white"
-                  >
-                    <option value="">Any source</option>
-                    {unique(buckets.map((bucket) => bucket.sourceKind)).map((source) => (
-                      <option key={source} value={source}>
-                        {prettySource(source)}
-                      </option>
-                    ))}
-                  </select>
-                </Field>
-                <Field label="Authority">
-                  <select
-                    value={authorityFilter}
-                    onChange={(event) => setAuthorityFilter(event.target.value)}
-                    className="w-full rounded-lg border border-white/15 bg-black/30 px-3 py-2 text-sm text-white"
-                  >
-                    <option value="">Any authority</option>
-                    {unique(buckets.map((bucket) => bucket.authority)).map((authority) => (
-                      <option key={authority} value={authority}>
-                        {authority}
-                      </option>
-                    ))}
-                  </select>
-                </Field>
-                <Field label="Result type">
-                  <select
-                    value={resultType}
-                    onChange={(event) => setResultType(event.target.value)}
-                    className="w-full rounded-lg border border-white/15 bg-black/30 px-3 py-2 text-sm text-white"
-                  >
-                    <option value="">Articles and chunks</option>
-                    <option value="bucket_article">Articles</option>
-                    <option value="kb_chunk">Chunks</option>
-                  </select>
-                </Field>
-              </div>
-            )}
-
-            <div className="flex items-center gap-2">
-              <button
-                type="submit"
-                disabled={pending || !query.trim() || !workspaceId}
-                className="rounded-full bg-gradient-to-r from-coral via-lilac to-aqua px-4 py-2 text-xs font-bold text-ink shadow-glow disabled:cursor-not-allowed disabled:opacity-50"
-              >
-                {pending ? "Searching..." : "Search"}
-              </button>
-              {hits && (
-                <ButtonGhost onClick={() => setHits(null)}>Clear</ButtonGhost>
-              )}
-            </div>
-          </form>
-        </Card>
-
-        {error && (
-          <Card className="border-coral/40 bg-coral/5">
-            <p className="text-sm text-coral">{error}</p>
-          </Card>
-        )}
-
-        {filteredHits && (
-          <SearchResults hits={filteredHits} bucketBySlug={bucketBySlug} />
-        )}
-      </div>
-
-      <Card>
-        <CardHeader
-          title="Routing preview"
-          subtitle="How Navigator should decide where to search."
-        />
-        <div className="space-y-3 text-xs text-white/65">
-          <RoutingHint
-            bucket="Project Map"
-            useFor="where files live, repository structure, service ownership"
-            avoid="architectural rationale or deployment procedures"
-          />
-          <RoutingHint
-            bucket="Runbooks & Operations"
-            useFor="deploy, rollback, incident, recovery, rotation"
-            avoid="product discovery or UX decisions"
-          />
-          <RoutingHint
-            bucket="Architecture Decisions"
-            useFor="why the system is designed this way"
-            avoid="current operational checklists"
-          />
-        </div>
-      </Card>
-    </section>
-  );
-}
-
-function SearchResults({
-  hits,
-  bucketBySlug,
-}: {
-  hits: ApiKnowledgeSearchHit[];
-  bucketBySlug: Map<string, KnowledgeControlBucket>;
-}) {
-  if (hits.length === 0) {
-    return (
-      <EmptyState
-        title="No matches"
-        body="Try all buckets, remove filters, or import a more relevant source."
-      />
-    );
+  function clearSearch() {
+    setQuery("");
+    setSearchHits(null);
+    setSearchedFor("");
+    setSearchError(null);
   }
-  return (
-    <div className="space-y-3">
-      {hits.map((hit) => {
-        const bucket = hit.bucket_slug ? bucketBySlug.get(hit.bucket_slug) : null;
-        return (
-          <Card key={`${hit.source}:${hit.id}`}>
-            <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
-              <div className="min-w-0">
-                <div className="flex flex-wrap items-center gap-2">
-                  <Link
-                    href={
-                      hit.bucket_slug
-                        ? `/knowledge/${encodeURIComponent(hit.bucket_slug)}`
-                        : "#"
-                    }
-                    className="font-semibold text-white hover:text-aqua"
-                  >
-                    {hit.title || bucket?.name || "Knowledge result"}
-                  </Link>
-                  <Badge tone="neutral">
-                    {hit.source === "bucket_article" ? "article" : "chunk"}
-                  </Badge>
-                  {bucket && <Badge tone="workspace">{bucket.name}</Badge>}
-                  {bucket && (
-                    <Badge tone={authorityTone(bucket.authority)}>
-                      {bucket.authority}
-                    </Badge>
-                  )}
-                </div>
-                <p className="mt-2 line-clamp-3 text-sm leading-relaxed text-white/65">
-                  {hit.snippet}
-                </p>
-                <div className="mt-2 flex flex-wrap gap-2 text-[11px] text-white/45">
-                  <span>{bucket ? scopeLabel(bucket.scope) : hit.scope_kind}</span>
-                  {hit.repo_full_name && <span>{hit.repo_full_name}</span>}
-                  <span>{bucket?.lastIndexedAt ? relativeDate(bucket.lastIndexedAt) : "freshness unknown"}</span>
-                </div>
-              </div>
-              <div className="flex shrink-0 items-center gap-2">
-                <span className="font-mono text-xs text-aqua/85">
-                  {hit.score.toFixed(3)}
-                </span>
-                <ButtonGhost>Promote</ButtonGhost>
-              </div>
-            </div>
-          </Card>
-        );
-      })}
-    </div>
-  );
-}
 
-function SourcesTab({
-  mode,
-  sources,
-  integrations,
-  repos,
-  defaultScope,
-}: {
-  mode: "live" | "mock";
-  sources: KnowledgeControlSource[];
-  integrations: ApiIntegration[];
-  repos: ApiActivatedRepo[];
-  defaultScope: ApiBucketScope;
-}) {
+  const liveBuckets = buckets.filter((b) => !b.archived);
+  const isSearching = searchHits !== null;
+
   return (
     <div className="space-y-5">
-      {mode === "live" && (
-        <KnowledgeImportWizard
-          integrations={integrations}
+      <header className="flex flex-wrap items-center gap-3">
+        <h1 className="font-display text-xl font-bold text-white">Knowledge</h1>
+        <span className="text-xs text-white/45">{workspace.name}</span>
+        <div className="ml-auto flex items-center gap-2">
+          <ExportButton workspace={workspace} />
+          <button
+            type="button"
+            onClick={() => setImportOpen((v) => !v)}
+            className={cn(
+              "rounded-full border px-3 py-1.5 text-xs font-bold transition",
+              importOpen
+                ? "border-aqua/60 bg-aqua/15 text-aqua"
+                : "border-aqua/40 bg-aqua/10 text-aqua hover:bg-aqua/20",
+            )}
+          >
+            {importOpen ? "Close import" : "Import source"}
+          </button>
+        </div>
+      </header>
+
+      <form onSubmit={runSearch}>
+        <div className="relative">
+          <input
+            type="search"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search workspace knowledge…"
+            className="w-full rounded-2xl border border-white/15 bg-white/[0.04] px-5 py-3 text-base text-white placeholder:text-white/35 outline-none transition focus:border-aqua/60"
+            aria-label="Search workspace knowledge"
+          />
+          {(query || isSearching) && (
+            <button
+              type="button"
+              onClick={clearSearch}
+              aria-label="Clear search"
+              className="absolute right-3 top-1/2 -translate-y-1/2 rounded-full border border-white/10 px-2 py-0.5 text-xs text-white/55 hover:border-white/30 hover:text-white"
+            >
+              clear
+            </button>
+          )}
+        </div>
+      </form>
+
+      <div className="flex flex-wrap gap-2">
+        <BucketChip
+          active={filterSlug === null}
+          label="All"
+          count={isSearching ? (searchHits?.length ?? 0) : articles.length}
+          onClick={() => setFilterSlug(null)}
+        />
+        {liveBuckets.map((bucket) => (
+          <BucketChip
+            key={bucket.slug}
+            active={filterSlug === bucket.slug}
+            label={bucket.name}
+            count={
+              isSearching
+                ? (searchHits?.filter((h) => h.bucket_slug === bucket.slug).length ?? 0)
+                : (articlesByBucket.get(bucket.slug) ?? 0)
+            }
+            onClick={() =>
+              setFilterSlug(filterSlug === bucket.slug ? null : bucket.slug)
+            }
+          />
+        ))}
+      </div>
+
+      {importOpen && (
+        <ImportPanel
           repos={repos}
-          defaultScope={defaultScope}
+          integrations={integrations}
+          sources={sources}
         />
       )}
 
-      <Card padded={false}>
-        <CardHeader
-          className="px-5 pt-5"
-          title="Sources / Ingestion"
-          subtitle="Workspace sources are synced once, fingerprinted, analyzed, and routed into the right buckets."
-        />
-        {sources.length === 0 ? (
-          <p className="px-5 pb-5 text-sm text-white/60">
-            No source rows recorded yet. Create an upload bucket or import a
-            Notion/Confluence root to start ingestion.
-          </p>
-        ) : (
-          <div className="overflow-x-auto">
-            <table className="min-w-full text-sm">
-              <thead className="bg-white/[0.04] text-[10px] uppercase tracking-widest text-white/45">
-                <tr>
-                  <th className="px-4 py-2 text-left font-semibold">Source</th>
-                  <th className="px-4 py-2 text-left font-semibold">Bucket</th>
-                  <th className="px-4 py-2 text-left font-semibold">Status</th>
-                  <th className="px-4 py-2 text-left font-semibold">Last sync</th>
-                  <th className="px-4 py-2 text-left font-semibold">Docs</th>
-                  <th className="px-4 py-2 text-left font-semibold">Chunks</th>
-                </tr>
-              </thead>
-              <tbody>
-                {sources.map((source) => (
-                  <tr key={source.id} className="border-t border-white/5">
-                    <td className="px-4 py-3 align-top">
-                      <div className="font-semibold text-white">{prettySource(source.kind)}</div>
-                      {source.urlOrPath && (
-                        <div className="mt-1 max-w-md truncate font-mono text-[11px] text-aqua/80">
-                          {source.urlOrPath}
-                        </div>
-                      )}
-                      {source.lastError && (
-                        <div className="mt-1 text-xs text-coral">{source.lastError}</div>
-                      )}
-                    </td>
-                    <td className="px-4 py-3 align-top">
-                      {source.bucketSlug ? (
-                        <Link
-                          href={`/knowledge/${encodeURIComponent(source.bucketSlug)}`}
-                          className="font-semibold text-aqua hover:underline"
-                        >
-                          {source.bucketName}
-                        </Link>
-                      ) : (
-                        <span className="font-semibold text-white/70">
-                          {source.bucketName}
-                        </span>
-                      )}
-                    </td>
-                    <td className="px-4 py-3 align-top">
-                      <Badge tone={source.status === "error" ? "err" : "ok"}>
-                        {source.status}
-                      </Badge>
-                    </td>
-                    <td className="px-4 py-3 align-top text-xs text-white/60">
-                      {source.lastSyncedAt ? relativeDate(source.lastSyncedAt) : "Never"}
-                    </td>
-                    <td className="px-4 py-3 align-top text-xs text-white/60">
-                      {source.documents ?? "unknown"}
-                    </td>
-                    <td className="px-4 py-3 align-top text-xs text-white/60">
-                      {source.chunks ?? "unknown"}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
+      <section>
+        {pending && (
+          <p className="mb-2 text-xs text-white/45">Searching…</p>
         )}
-      </Card>
-
-      <Card>
-        <CardHeader
-          title="Supported source types"
-          subtitle="Workspace sources sync into Ship's database and route changed content into the recommended buckets."
-        />
-        <div className="flex flex-wrap gap-2">
-          {[
-            "Notion",
-            "Confluence",
-            "docs repository",
-            "website via Firecrawl",
-            "uploaded files",
-          ].map((source) => (
-            <Badge key={source} tone="neutral">
-              {source}
-            </Badge>
-          ))}
-        </div>
-      </Card>
+        {searchError && (
+          <Card className="mb-3 border-coral/40 bg-coral/5">
+            <p className="text-sm text-coral">{searchError}</p>
+          </Card>
+        )}
+        {isSearching ? (
+          <SearchResults
+            hits={visibleHits ?? []}
+            queriedFor={searchedFor}
+            filtered={filterSlug !== null}
+          />
+        ) : (
+          <ArticlesList
+            articles={visibleArticles}
+            filterSlug={filterSlug}
+            totalCount={articles.length}
+          />
+        )}
+      </section>
     </div>
   );
 }
 
-function SettingsTab({ buckets }: { buckets: KnowledgeControlBucket[] }) {
+
+// ---------------------------------------------------------------------------
+// Bucket filter chips
+// ---------------------------------------------------------------------------
+
+
+function BucketChip({
+  active,
+  label,
+  count,
+  onClick,
+}: {
+  active: boolean;
+  label: string;
+  count: number;
+  onClick: () => void;
+}) {
   return (
-    <div className="grid grid-cols-1 gap-5 xl:grid-cols-2">
-      <Card>
-        <CardHeader
-          title="Starter bucket setup"
-          subtitle="Recommended defaults for a new workspace."
-        />
-        <div className="grid grid-cols-1 gap-2 md:grid-cols-2">
-          {STARTER_BUCKETS.map((bucket) => {
-            const exists = buckets.some((item) =>
-              item.name.toLowerCase().includes(bucket.toLowerCase().slice(0, 12)),
-            );
-            return (
-              <div
-                key={bucket}
-                className="flex items-center justify-between gap-2 rounded-xl border border-white/10 bg-white/[0.03] px-3 py-2 text-xs"
-              >
-                <span className="text-white/75">{bucket}</span>
-                <Badge tone={exists ? "ok" : "neutral"}>
-                  {exists ? "present" : "optional"}
-                </Badge>
-              </div>
-            );
-          })}
-        </div>
-      </Card>
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-semibold transition",
+        active
+          ? "border-aqua/60 bg-aqua/15 text-aqua"
+          : "border-white/15 bg-white/[0.04] text-white/70 hover:border-white/30 hover:text-white",
+      )}
+    >
+      <span>{label}</span>
+      <span
+        className={cn(
+          "rounded-full px-1.5 text-[10px] font-bold",
+          active ? "bg-aqua/30 text-aqua" : "bg-white/10 text-white/55",
+        )}
+      >
+        {count}
+      </span>
+    </button>
+  );
+}
 
-      <Card>
-        <CardHeader
-          title="Policies and permissions"
-          subtitle="Modeled here now; deeper enforcement belongs to bucket-level backend permissions."
-        />
-        <div className="space-y-3 text-sm text-white/65">
-          <PolicyRow label="Visibility" value="Workspace, team, client, restricted" />
-          <PolicyRow label="Permissions" value="Read, write, manage sources, delete, search" />
-          <PolicyRow label="Routing hints" value="Use for / do not use for prompts per bucket" />
-          <PolicyRow label="Freshness" value="Manual, scheduled, source-change, stale alerts" />
-        </div>
-      </Card>
+
+// ---------------------------------------------------------------------------
+// Article listing
+// ---------------------------------------------------------------------------
+
+
+function ArticlesList({
+  articles,
+  filterSlug,
+  totalCount,
+}: {
+  articles: KnowledgeArticleRow[];
+  filterSlug: string | null;
+  totalCount: number;
+}) {
+  if (articles.length === 0) {
+    return (
+      <div className="rounded-2xl border border-white/10 bg-white/[0.02] px-5 py-10 text-center">
+        <p className="text-sm text-white/55">
+          {totalCount === 0
+            ? "No articles in this workspace yet. Import a source or wait for the harvester to surface drafts."
+            : filterSlug
+              ? "No articles in this bucket yet."
+              : "No articles match the current filter."}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <ul className="divide-y divide-white/5 rounded-2xl border border-white/10 bg-white/[0.02]">
+      {articles.map((article) => (
+        <li key={article.id} className="px-5 py-3">
+          <Link
+            href={`/knowledge/${encodeURIComponent(article.bucketSlug)}?article=${encodeURIComponent(article.id)}#article-viewer`}
+            className="group flex flex-col gap-1"
+          >
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="text-sm font-semibold text-white group-hover:text-aqua">
+                {article.title || article.slug}
+              </span>
+              <span className="rounded-full bg-white/10 px-2 py-0.5 text-[10px] font-semibold text-white/65">
+                {article.bucketName}
+              </span>
+              <span className="ml-auto text-[11px] text-white/45">
+                {relativeDate(article.updatedAt)}
+              </span>
+            </div>
+            {article.snippet && (
+              <p className="line-clamp-2 text-xs text-white/55">
+                {article.snippet}
+              </p>
+            )}
+          </Link>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+
+// ---------------------------------------------------------------------------
+// Search results
+// ---------------------------------------------------------------------------
+
+
+function SearchResults({
+  hits,
+  queriedFor,
+  filtered,
+}: {
+  hits: ApiKnowledgeSearchHit[];
+  queriedFor: string;
+  filtered: boolean;
+}) {
+  if (hits.length === 0) {
+    return (
+      <div className="rounded-2xl border border-white/10 bg-white/[0.02] px-5 py-10 text-center">
+        <p className="text-sm text-white/55">
+          {queriedFor
+            ? filtered
+              ? `No matches for "${queriedFor}" in this bucket.`
+              : `Nothing matched "${queriedFor}".`
+            : "No matches."}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <ul className="divide-y divide-white/5 rounded-2xl border border-white/10 bg-white/[0.02]">
+      {hits.map((hit) => {
+        const title =
+          hit.title?.trim() ||
+          hit.bucket_slug ||
+          (hit.source === "kb_chunk" ? "Repo chunk" : "Article");
+        const href =
+          hit.source === "bucket_article" && hit.bucket_slug
+            ? `/knowledge/${encodeURIComponent(hit.bucket_slug)}?article=${encodeURIComponent(hit.id)}#article-viewer`
+            : null;
+        const RowEl = href ? Link : "div";
+        return (
+          <li key={`${hit.source}:${hit.id}`} className="px-5 py-3">
+            <RowEl
+              href={href ?? ""}
+              className="group flex flex-col gap-1"
+            >
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="text-sm font-semibold text-white group-hover:text-aqua">
+                  {title}
+                </span>
+                {hit.bucket_slug && (
+                  <span className="rounded-full bg-white/10 px-2 py-0.5 text-[10px] font-semibold text-white/65">
+                    {hit.bucket_slug}
+                  </span>
+                )}
+                <span
+                  className="ml-auto font-mono text-[11px] text-aqua/80"
+                  title="match score"
+                >
+                  {hit.score.toFixed(3)}
+                </span>
+              </div>
+              {hit.snippet && (
+                <p className="line-clamp-2 text-xs text-white/55">
+                  {hit.snippet}
+                </p>
+              )}
+            </RowEl>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+
+// ---------------------------------------------------------------------------
+// Import panel — collapsed unless toggled
+// ---------------------------------------------------------------------------
+
+
+function ImportPanel({
+  repos,
+  integrations,
+  sources,
+}: {
+  repos: ApiActivatedRepo[];
+  integrations: ApiIntegration[];
+  sources: KnowledgeSourceRow[];
+}) {
+  return (
+    <div className="space-y-3">
+      <KnowledgeImportWizard
+        integrations={integrations}
+        repos={repos}
+        defaultScope="workspace"
+      />
+      <SourcesTable sources={sources} />
     </div>
   );
 }
 
-function ExportButton({ workspace }: {
+
+function SourcesTable({ sources }: { sources: KnowledgeSourceRow[] }) {
+  if (sources.length === 0) {
+    return null;
+  }
+  return (
+    <Card padded={false}>
+      <CardHeader
+        className="px-5 pt-5"
+        title="Connected sources"
+        subtitle="The harvester pulls from these and routes content into buckets."
+      />
+      <ul className="divide-y divide-white/5">
+        {sources.map((source) => (
+          <li key={source.id} className="grid grid-cols-[1fr_auto] items-center gap-3 px-5 py-3">
+            <div className="min-w-0">
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="truncate text-sm font-semibold text-white">
+                  {source.name}
+                </span>
+                <span className="rounded-full bg-white/10 px-2 py-0.5 text-[10px] font-semibold text-white/65">
+                  {source.kind}
+                </span>
+              </div>
+              {source.lastError && (
+                <p className="mt-0.5 line-clamp-1 text-[11px] text-coral">
+                  {source.lastError}
+                </p>
+              )}
+            </div>
+            <div className="flex flex-col items-end text-[11px] text-white/55">
+              <span className={statusColor(source.status)}>{source.status}</span>
+              <span>{source.lastSyncedAt ? relativeDate(source.lastSyncedAt) : "never synced"}</span>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </Card>
+  );
+}
+
+
+function statusColor(status: string): string {
+  if (status === "error") return "text-coral";
+  if (status === "syncing") return "text-aqua";
+  if (status === "ready") return "text-emerald-400";
+  return "text-white/55";
+}
+
+
+// ---------------------------------------------------------------------------
+// Compact export button (kept from the previous version, trimmed)
+// ---------------------------------------------------------------------------
+
+
+function ExportButton({
+  workspace,
+}: {
   workspace: Props["workspace"];
 }) {
   const href = workspace.id
@@ -869,173 +540,22 @@ function ExportButton({ workspace }: {
   );
 }
 
-function Metric({ label, value }: { label: string; value: string }) {
-  return (
-    <div className="rounded-2xl border border-white/10 bg-black/20 p-3">
-      <div className="text-[10px] font-bold uppercase tracking-widest text-white/45">
-        {label}
-      </div>
-      <div className="mt-1 font-display text-xl font-bold text-white">{value}</div>
-    </div>
-  );
-}
 
-function MiniStat({ label, value }: { label: string; value: string }) {
-  return (
-    <div className="rounded-lg border border-white/10 bg-white/[0.025] px-2 py-1.5">
-      <div className="text-[9px] font-bold uppercase tracking-widest text-white/40">
-        {label}
-      </div>
-      <div className="mt-0.5 font-semibold text-white">{value}</div>
-    </div>
-  );
-}
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
 
-function TabButton({
-  active,
-  onClick,
-  children,
-}: {
-  active: boolean;
-  onClick: () => void;
-  children: React.ReactNode;
-}) {
-  return (
-    <button
-      type="button"
-      role="tab"
-      aria-selected={active}
-      onClick={onClick}
-      className={cn(
-        "relative px-3 py-2 text-sm font-semibold transition",
-        active
-          ? "text-white after:absolute after:inset-x-2 after:-bottom-px after:h-0.5 after:rounded-full after:bg-aqua"
-          : "text-white/55 hover:text-white",
-      )}
-    >
-      {children}
-    </button>
-  );
-}
 
-function Field({
-  label,
-  children,
-}: {
-  label: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <label className="block text-xs text-white/65">
-      <span className="mb-1 block font-semibold uppercase tracking-widest text-white/45">
-        {label}
-      </span>
-      {children}
-    </label>
-  );
-}
-
-function RoutingHint({
-  bucket,
-  useFor,
-  avoid,
-}: {
-  bucket: string;
-  useFor: string;
-  avoid: string;
-}) {
-  return (
-    <div className="rounded-xl border border-white/10 bg-white/[0.03] p-3">
-      <div className="font-semibold text-white">{bucket}</div>
-      <p className="mt-1">
-        <span className="text-aqua/90">Use for:</span> {useFor}
-      </p>
-      <p className="mt-1">
-        <span className="text-coral/90">Do not use for:</span> {avoid}
-      </p>
-    </div>
-  );
-}
-
-function PolicyRow({ label, value }: { label: string; value: string }) {
-  return (
-    <div className="rounded-xl border border-white/10 bg-white/[0.03] p-3">
-      <div className="text-xs font-bold uppercase tracking-widest text-white/45">
-        {label}
-      </div>
-      <div className="mt-1">{value}</div>
-    </div>
-  );
-}
-
-function dedupeHits(hits: ApiKnowledgeSearchHit[]): ApiKnowledgeSearchHit[] {
-  const byKey = new Map<string, ApiKnowledgeSearchHit>();
-  for (const hit of hits) {
-    const key = `${hit.source}:${hit.id}`;
-    const current = byKey.get(key);
-    if (!current || hit.score > current.score) byKey.set(key, hit);
-  }
-  return Array.from(byKey.values()).sort((a, b) => b.score - a.score);
-}
-
-function maxDate(values: Array<string | null | undefined>): string | null {
-  const times = values
-    .map((value) => (value ? Date.parse(value) : Number.NaN))
-    .filter((value) => Number.isFinite(value));
-  if (times.length === 0) return null;
-  return new Date(Math.max(...times)).toISOString();
-}
-
-function unique(values: string[]): string[] {
-  return Array.from(new Set(values.filter(Boolean))).sort();
-}
-
-function bucketInitial(name: string): string {
-  return name.trim().slice(0, 1).toUpperCase() || "K";
-}
-
-function statusTone(status: KnowledgeBucketStatus) {
-  if (status === "Ready") return "ok";
-  if (status === "Indexing" || status === "Stale") return "warn";
-  if (status === "Failed") return "err";
-  return "neutral";
-}
-
-function scopeTone(scope: string) {
-  if (scope === "workspace") return "workspace";
-  if (scope === "project" || scope === "repo") return "project";
-  return "neutral";
-}
-
-function authorityTone(authority: string) {
-  if (authority === "Source of truth") return "ok";
-  if (authority.includes("Generated") || authority.includes("Temporary")) {
-    return "warn";
-  }
-  return "neutral";
-}
-
-function scopeLabel(scope: string): string {
-  if (scope === "workspace") return "Workspace";
-  if (scope === "repo") return "Repo-specific";
-  if (scope === "user") return "Restricted";
-  if (scope === "project") return "Project";
-  return scope;
-}
-
-function prettySource(source: string): string {
-  return source.replace(/_/g, " ");
-}
-
-function relativeDate(value: string): string {
-  const timestamp = Date.parse(value);
-  if (!Number.isFinite(timestamp)) return "Unknown";
-  const diff = Date.now() - timestamp;
+function relativeDate(value: string | null | undefined): string {
+  if (!value) return "—";
+  const date = Date.parse(value);
+  if (Number.isNaN(date)) return "—";
+  const diff = Date.now() - date;
   const minute = 60_000;
   const hour = 60 * minute;
   const day = 24 * hour;
-  if (diff < minute) return "just now";
-  if (diff < hour) return `${Math.floor(diff / minute)}m ago`;
-  if (diff < day) return `${Math.floor(diff / hour)}h ago`;
-  return `${Math.floor(diff / day)}d ago`;
+  if (diff < hour) return `${Math.max(1, Math.round(diff / minute))}m ago`;
+  if (diff < day) return `${Math.round(diff / hour)}h ago`;
+  if (diff < 30 * day) return `${Math.round(diff / day)}d ago`;
+  return new Date(date).toLocaleDateString();
 }

--- a/console/src/app/knowledge/page.tsx
+++ b/console/src/app/knowledge/page.tsx
@@ -10,10 +10,10 @@ import {
   getMe,
   isApiConfigured,
   listActivatedRepos,
-  listBucketSources,
+  listBucketArticles,
+  listIntegrations,
   listKnowledgeImportSources,
   listBuckets,
-  listIntegrations,
   listWorkspaces,
 } from "@/lib/api/client";
 import { getSessionToken } from "@/lib/api/session";
@@ -23,17 +23,17 @@ import {
   toAppShellWorkspaces,
 } from "@/lib/workspace-scope";
 import type {
+  ApiBucketArticle,
   ApiIntegration,
   ApiKnowledgeImportSource,
-  ApiKnowledgeSource,
   ApiUser,
 } from "@/lib/api/types";
 
 import {
   KnowledgeControlCenter,
-  type KnowledgeControlBucket,
-  type KnowledgeControlSource,
-  type KnowledgeBucketStatus,
+  type KnowledgeArticleRow,
+  type KnowledgeBucketRow,
+  type KnowledgeSourceRow,
 } from "./knowledge-control-center";
 
 export const dynamic = "force-dynamic";
@@ -41,8 +41,9 @@ export const dynamic = "force-dynamic";
 type LiveData = {
   workspace: { id: string; slug: string; name: string };
   allWorkspaces: Awaited<ReturnType<typeof listWorkspaces>>;
-  buckets: KnowledgeControlBucket[];
-  sources: KnowledgeControlSource[];
+  buckets: KnowledgeBucketRow[];
+  articles: KnowledgeArticleRow[];
+  sources: KnowledgeSourceRow[];
   repos: ApiActivatedRepo[];
   integrations: ApiIntegration[];
   me: ApiUser | null;
@@ -54,13 +55,14 @@ type LoadResult =
   | { status: "live"; data: LiveData }
   | { status: "unavailable"; reason: string };
 
+
 async function load(
   params: Record<string, string | string[] | undefined>,
 ): Promise<LoadResult> {
   if (!isApiConfigured()) {
     return {
       status: "unavailable",
-      reason: "SHIP_API_URL is not set on this deployment."
+      reason: "SHIP_API_URL is not set on this deployment.",
     };
   }
 
@@ -101,29 +103,44 @@ async function load(
         ),
       ]);
 
-    const sourcePairs = await Promise.all(
+    // Fetch the published-and-fresh article set for every bucket in
+    // parallel. Six fixed buckets after the consolidation, so this is
+    // a bounded fan-out — no pagination needed in the UI surface.
+    const articlePairs = await Promise.all(
       rawBuckets.map(async (bucket) => ({
         bucket,
-        sources: await listBucketSources(workspace.id, bucket.slug, token).catch(
-          () => [] as ApiKnowledgeSource[],
-        ),
+        articles: await listBucketArticles(
+          workspace.id,
+          bucket.slug,
+          {},
+          token,
+        ).catch(() => [] as ApiBucketArticle[]),
       })),
     );
-    const sources = [
-      ...importSources.map(normalizeImportSource),
-      ...sourcePairs.flatMap(({ bucket, sources }) =>
-        sources.map((source) => normalizeSource(bucket, source)),
-      ),
-    ];
+
+    const buckets: KnowledgeBucketRow[] = rawBuckets.map((bucket) =>
+      toBucketRow(bucket),
+    );
+    const articles: KnowledgeArticleRow[] = articlePairs
+      .flatMap(({ bucket, articles }) =>
+        articles.map((article) => toArticleRow(article, bucket)),
+      )
+      .sort(
+        (a, b) => Date.parse(b.updatedAt) - Date.parse(a.updatedAt),
+      );
+    const sources: KnowledgeSourceRow[] = importSources.map(toSourceRow);
 
     return {
       status: "live",
       data: {
-        workspace: { id: workspace.id, slug: workspace.slug, name: workspace.name },
+        workspace: {
+          id: workspace.id,
+          slug: workspace.slug,
+          name: workspace.name,
+        },
         allWorkspaces: workspaceRows,
-        buckets: sourcePairs.map(({ bucket, sources }) =>
-          normalizeBucket(bucket, sources),
-        ),
+        buckets,
+        articles,
         sources,
         repos,
         integrations,
@@ -134,10 +151,11 @@ async function load(
     if (err instanceof ApiHttpError && err.status === 401) {
       redirect("/login?next=%2Fknowledge&reason=session_expired");
     }
-    const message = err instanceof Error ? err.message : "Could not load knowledge buckets.";
+    const message = err instanceof Error ? err.message : "Could not load knowledge.";
     return { status: "unavailable", reason: message };
   }
 }
+
 
 export default async function KnowledgeIndexPage({
   searchParams,
@@ -155,7 +173,8 @@ export default async function KnowledgeIndexPage({
     );
   }
 
-  const { workspace, allWorkspaces, buckets, sources, repos, integrations, me } = result.data;
+  const { workspace, allWorkspaces, buckets, articles, sources, repos, integrations, me } =
+    result.data;
 
   const scopePill = (
     <ScopePill
@@ -189,202 +208,73 @@ export default async function KnowledgeIndexPage({
       scopePill={scopePill}
     >
       <KnowledgeControlCenter
-        mode="live"
         workspace={workspace}
         buckets={buckets}
+        articles={articles}
         sources={sources}
         repos={repos}
         integrations={integrations}
-        defaultScope="workspace"
       />
     </AppShell>
   );
 }
 
-function normalizeBucket(
-  bucket: ApiBucket,
-  sources: ApiKnowledgeSource[],
-): KnowledgeControlBucket {
-  const metadata = metadataFromRef(bucket.source_ref);
-  const lastIndexedAt =
-    maxDate(sources.map((source) => source.last_synced_at)) ?? bucket.updated_at;
-  const sourceCount =
-    sources.length > 0 ? sources.length : bucket.source_kind ? 1 : 0;
 
+// ---------------------------------------------------------------------------
+// Mappers
+// ---------------------------------------------------------------------------
+
+
+function toBucketRow(bucket: ApiBucket): KnowledgeBucketRow {
   return {
     id: bucket.id,
     slug: bucket.slug,
     name: bucket.name,
     description: bucket.description ?? "",
-    bucketType: metadata.bucketType ?? inferBucketType(bucket),
-    scope: bucket.scope_kind ?? "workspace",
-    sourceKind: bucket.source_kind ?? "agent_memory",
-    authority: metadata.authority ?? inferAuthority(bucket),
-    accessLevel: metadata.accessLevel ?? inferAccess(bucket),
-    freshnessPolicy: metadata.freshnessPolicy ?? "Manual refresh",
-    status: bucketStatus(bucket, sources),
-    articles: bucket.summary_count ?? 0,
-    chunks: inferChunks(bucket, sources),
-    sourceCount,
-    sourceNames:
-      sources.length > 0
-        ? sources.map((source) => source.kind)
-        : bucket.source_kind
-          ? [bucket.source_kind]
-          : [],
-    lastIndexedAt,
-    updatedAt: bucket.updated_at,
+    archived: Boolean(bucket.archived_at),
   };
 }
 
-function normalizeSource(
+
+function toArticleRow(
+  article: ApiBucketArticle,
   bucket: ApiBucket,
-  source: ApiKnowledgeSource,
-): KnowledgeControlSource {
+): KnowledgeArticleRow {
   return {
-    id: source.id,
+    id: article.id,
     bucketSlug: bucket.slug,
     bucketName: bucket.name,
-    kind: source.kind,
-    status: source.status,
-    lastSyncedAt: source.last_synced_at,
-    nextSyncAt: asString(source.config.next_sync_at),
-    lastError: source.last_error,
-    documents: asNumber(source.config.document_count),
-    chunks: asNumber(source.config.chunk_count),
-    urlOrPath:
-      asString(source.config.url) ??
-      asString(source.config.path) ??
-      asString(source.config.page_id) ??
-      asString(source.config.space_key),
+    slug: article.slug,
+    title: article.title || article.slug,
+    snippet: firstParagraph(article.body_md),
+    updatedAt: article.updated_at,
   };
 }
 
-function normalizeImportSource(
-  source: ApiKnowledgeImportSource,
-): KnowledgeControlSource {
-  const config = source.config ?? {};
+
+function toSourceRow(source: ApiKnowledgeImportSource): KnowledgeSourceRow {
   return {
     id: source.id,
-    bucketSlug: null,
-    bucketName: "Auto-routed",
+    name: source.name,
     kind: source.kind,
     status: source.status,
     lastSyncedAt: source.last_synced_at,
-    nextSyncAt: computeNextSyncAt(
-      source.last_synced_at,
-      source.sync_interval_minutes,
-    ),
     lastError: source.last_error,
-    documents: asNumber(config.document_count),
-    chunks: null,
-    urlOrPath:
-      asString(config.url) ??
-      asString(config.root_url) ??
-      asString(config.path) ??
-      source.name,
   };
 }
 
-/**
- * Compute the next-due sync timestamp from the last sync + the interval.
- *
- * Returns ``null`` for one-shot sources (``sync_interval_minutes === null``,
- * e.g. ``static_upload``) and for sources that have never run yet — neither
- * has a meaningful "next at" time. The UI surfaces "Due now" elsewhere when
- * the result is in the past.
- */
-function computeNextSyncAt(
-  lastSyncedAt: string | null,
-  intervalMinutes: number | null,
-): string | null {
-  if (!lastSyncedAt || !intervalMinutes || intervalMinutes <= 0) return null;
-  const last = Date.parse(lastSyncedAt);
-  if (Number.isNaN(last)) return null;
-  return new Date(last + intervalMinutes * 60_000).toISOString();
-}
 
-function bucketStatus(
-  bucket: ApiBucket,
-  sources: ApiKnowledgeSource[],
-): KnowledgeBucketStatus {
-  if (bucket.archived_at) return "Stale";
-  if (sources.some((source) => source.status === "error")) return "Failed";
-  if (sources.some((source) => source.status === "syncing")) return "Indexing";
-  if ((bucket.summary_count ?? 0) === 0 && sources.length === 0) return "Empty";
-  const lastIndexedAt = maxDate(sources.map((source) => source.last_synced_at));
-  if (lastIndexedAt && Date.now() - Date.parse(lastIndexedAt) > 30 * 86_400_000) {
-    return "Stale";
+function firstParagraph(body: string): string {
+  if (!body) return "";
+  const text = body.trim();
+  if (!text) return "";
+  for (const chunk of text.split("\n\n")) {
+    const candidate = chunk.replace(/^#+\s+/, "").trim();
+    if (candidate) {
+      return candidate.length > 220
+        ? candidate.slice(0, 219).trimEnd() + "…"
+        : candidate;
+    }
   }
-  return "Ready";
-}
-
-function metadataFromRef(sourceRef: Record<string, unknown> | null | undefined) {
-  const raw =
-    sourceRef &&
-    typeof sourceRef.knowledge_metadata === "object" &&
-    sourceRef.knowledge_metadata !== null
-      ? (sourceRef.knowledge_metadata as Record<string, unknown>)
-      : {};
-  return {
-    bucketType: asString(raw.bucket_type),
-    authority: asString(raw.authority),
-    accessLevel: asString(raw.access_level),
-    freshnessPolicy: asString(raw.freshness_policy),
-  };
-}
-
-function inferBucketType(bucket: ApiBucket): string {
-  const haystack = `${bucket.name} ${bucket.slug} ${bucket.description ?? ""}`.toLowerCase();
-  if (haystack.includes("architect")) return "Architecture";
-  if (haystack.includes("runbook") || haystack.includes("ops")) return "Runbooks";
-  if (haystack.includes("security") || haystack.includes("access")) return "Security";
-  if (haystack.includes("product")) return "Product Knowledge";
-  if (haystack.includes("glossary") || haystack.includes("data")) return "Data Glossary";
-  if (bucket.source_kind === "repo_context" || bucket.source_kind === "repo_files") {
-    return "Source Intelligence";
-  }
-  return "Custom";
-}
-
-function inferAuthority(bucket: ApiBucket): string {
-  if (bucket.scope_kind === "workspace" && bucket.source_kind === "promoted") {
-    return "Source of truth";
-  }
-  if (bucket.source_kind === "agent_memory" || bucket.source_kind === "repo_context") {
-    return "Generated / low-authority";
-  }
-  if (bucket.source_kind === "audio_transcript") return "Temporary memory";
-  return "High-confidence reference";
-}
-
-function inferAccess(bucket: ApiBucket): string {
-  if (bucket.scope_kind === "user") return "Restricted";
-  if (bucket.scope_kind === "repo") return "Repository-specific";
-  return "Workspace";
-}
-
-function inferChunks(bucket: ApiBucket, sources: ApiKnowledgeSource[]): number {
-  const sourceChunks = sources.reduce(
-    (sum, source) => sum + (asNumber(source.config.chunk_count) ?? 0),
-    0,
-  );
-  if (sourceChunks > 0) return sourceChunks;
-  return (bucket.summary_count ?? 0) * 8;
-}
-
-function maxDate(values: Array<string | null | undefined>): string | null {
-  const times = values
-    .map((value) => (value ? Date.parse(value) : Number.NaN))
-    .filter((value) => Number.isFinite(value));
-  if (times.length === 0) return null;
-  return new Date(Math.max(...times)).toISOString();
-}
-
-function asString(value: unknown): string | null {
-  return typeof value === "string" && value.trim() ? value.trim() : null;
-}
-
-function asNumber(value: unknown): number | null {
-  return typeof value === "number" && Number.isFinite(value) ? value : null;
+  return text.length > 220 ? text.slice(0, 219).trimEnd() + "…" : text;
 }


### PR DESCRIPTION
## Summary

Step 8 — finishing pass on user-visible strings now that the backend flow is settled.

- Hero blurb on ``/knowledge`` rewritten: "which articles become canonical" was load-bearing for retired Pipeline C; replaced with post-refactor reality (six fixed buckets, harvester routes, operator reviews drafts).
- Empty state on the Buckets tab: drop "Create starter buckets" / "Create custom bucket" CTAs (no-ops since Step 2). Body now points at bootstrap delay reason.
- Search hits drop the dead "Promote" button.
- Bucket detail ``provenanceHint`` recognises ``kind='knowledge_import_source'`` (Step 3) + synth's ``auto_routed_notes``/``auto_routed_draft`` shapes.
- Drop stale comment mentioning connectors/promoted in upload-eligibility note.

Net diff: 2 files, **12 insertions, 17 deletions**.

## Test plan

- [x] ``tsc --noEmit`` in console → clean.
- [ ] Smoke ``/knowledge`` and ``/knowledge/[slug]`` in console: copy reads correctly post-refactor; no "Create custom bucket"/"Promote" buttons remain.

## Stack order

#84 ✅ → #85 ✅ → #86 ✅ → #87 ✅ → #88 ✅ → #89 ✅ → this PR. Final step.

## Knowledge refactor — wrap-up

Eight planned steps closed:

1. Kill Pipeline C (canonical/promotion/dedup) — #84
2. Kill user-driven bucket creation — #85
3. ``source_to_notes`` adapter — sources feed harvester — #86
4. Bucket consolidation 10 → 6 — #87
5. Hybrid search — embedding + tsvector fallback — #88
6. Daily GC for archived bucket articles — #89
7. Code exploration tools — partial; ``repo_grep``/``repo_read`` already on main as ``search_code``/``get_repo_file``. ``repo_symbols`` (tree-sitter) deferred to its own Linear project: ELS-72.
8. UI copy cleanup — this PR.

Total cumulative diff across the eight: ~6300 deletions / ~600 insertions.