### PR TITLE
console: instant navigation via loading.tsx skeletons

### DIFF
--- a/console/src/app/audit/loading.tsx
+++ b/console/src/app/audit/loading.tsx
@@ -1,0 +1,9 @@
+import { LoadingShell, SkeletonRows } from "@/components/loading-shell";
+
+export default function Loading() {
+  return (
+    <LoadingShell>
+      <SkeletonRows rows={8} />
+    </LoadingShell>
+  );
+}

--- a/console/src/app/chat/loading.tsx
+++ b/console/src/app/chat/loading.tsx
@@ -1,0 +1,9 @@
+import { LoadingShell, SkeletonRows } from "@/components/loading-shell";
+
+export default function Loading() {
+  return (
+    <LoadingShell>
+      <SkeletonRows rows={4} />
+    </LoadingShell>
+  );
+}

--- a/console/src/app/inbox/loading.tsx
+++ b/console/src/app/inbox/loading.tsx
@@ -1,0 +1,19 @@
+import { LoadingShell, SkeletonRows } from "@/components/loading-shell";
+
+export default function Loading() {
+  return (
+    <LoadingShell>
+      <div className="space-y-4">
+        <div className="flex flex-wrap gap-2">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <div
+              key={i}
+              className="h-7 w-20 animate-pulse rounded-full bg-white/[0.06]"
+            />
+          ))}
+        </div>
+        <SkeletonRows rows={6} />
+      </div>
+    </LoadingShell>
+  );
+}

--- a/console/src/app/knowledge/loading.tsx
+++ b/console/src/app/knowledge/loading.tsx
@@ -1,0 +1,12 @@
+import { LoadingShell, SkeletonRows } from "@/components/loading-shell";
+
+export default function Loading() {
+  return (
+    <LoadingShell>
+      <div className="space-y-4">
+        <div className="h-12 w-full animate-pulse rounded-xl border border-white/10 bg-white/[0.04]" />
+        <SkeletonRows rows={5} />
+      </div>
+    </LoadingShell>
+  );
+}

--- a/console/src/app/loading.tsx
+++ b/console/src/app/loading.tsx
@@ -1,0 +1,5 @@
+import { LoadingShell } from "@/components/loading-shell";
+
+export default function Loading() {
+  return <LoadingShell rows={4} />;
+}

--- a/console/src/app/process/loading.tsx
+++ b/console/src/app/process/loading.tsx
@@ -1,0 +1,16 @@
+import { LoadingShell } from "@/components/loading-shell";
+
+export default function Loading() {
+  return (
+    <LoadingShell>
+      <div className="space-y-4">
+        <div className="h-64 animate-pulse rounded-2xl border border-white/10 bg-white/[0.04]" />
+        <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+          <div className="h-40 animate-pulse rounded-2xl border border-white/10 bg-white/[0.04]" />
+          <div className="h-40 animate-pulse rounded-2xl border border-white/10 bg-white/[0.04]" />
+          <div className="h-40 animate-pulse rounded-2xl border border-white/10 bg-white/[0.04]" />
+        </div>
+      </div>
+    </LoadingShell>
+  );
+}

--- a/console/src/app/r/[owner]/[repo]/loading.tsx
+++ b/console/src/app/r/[owner]/[repo]/loading.tsx
@@ -1,0 +1,9 @@
+import { LoadingShell, SkeletonRows } from "@/components/loading-shell";
+
+export default function Loading() {
+  return (
+    <LoadingShell>
+      <SkeletonRows rows={4} />
+    </LoadingShell>
+  );
+}

--- a/console/src/app/settings/loading.tsx
+++ b/console/src/app/settings/loading.tsx
@@ -1,0 +1,22 @@
+import { LoadingShell } from "@/components/loading-shell";
+
+export default function Loading() {
+  return (
+    <LoadingShell>
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-[16rem_minmax(0,1fr)]">
+        <nav className="space-y-1">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <div
+              key={i}
+              className="h-8 w-full animate-pulse rounded-md bg-white/[0.06]"
+            />
+          ))}
+        </nav>
+        <div className="space-y-4">
+          <div className="h-32 animate-pulse rounded-2xl border border-white/10 bg-white/[0.04]" />
+          <div className="h-48 animate-pulse rounded-2xl border border-white/10 bg-white/[0.04]" />
+        </div>
+      </div>
+    </LoadingShell>
+  );
+}

--- a/console/src/components/loading-shell.tsx
+++ b/console/src/components/loading-shell.tsx
@@ -1,0 +1,93 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/cn";
+
+/**
+ * Static skeleton that mirrors `AppShell`'s sidebar + top-bar geometry so
+ * `loading.tsx` files can render a usable shape the moment a navigation
+ * starts, before the route's server component finishes its data fetch.
+ *
+ * Intentionally not wired to any data: this is a pure layout placeholder
+ * and must stay synchronous so Next can stream it instantly. Pages that
+ * want a richer body skeleton pass `children`; the default body is a
+ * trio of pulsing cards.
+ */
+export function LoadingShell({
+  children,
+  rows = 3,
+}: {
+  children?: ReactNode;
+  rows?: number;
+}) {
+  const navRows = 6;
+  return (
+    <div className="min-h-screen bg-ink text-mist">
+      <div className="flex w-full gap-0">
+        <aside className="sticky top-0 hidden h-screen w-64 shrink-0 flex-col border-r border-white/10 bg-black/30 backdrop-blur-xl lg:flex">
+          <div className="border-b border-white/10 px-4 py-5">
+            <div className="font-display text-base font-bold tracking-tight text-white">
+              Ship<span className="text-aqua">.</span>
+              <span className="ml-1 rounded-md border border-aqua/40 bg-aqua/10 px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-widest text-aqua/90">
+                cloud
+              </span>
+            </div>
+          </div>
+          <div className="border-b border-white/10 px-3 py-3">
+            <div className="h-10 w-full animate-pulse rounded-xl bg-white/[0.06]" />
+          </div>
+          <nav className="flex-1 overflow-y-auto px-2 py-3">
+            <div className="px-3 pb-1.5 text-[10px] font-bold uppercase tracking-[0.18em] text-white/35">
+              Workspace
+            </div>
+            <ul className="space-y-1">
+              {Array.from({ length: navRows }).map((_, i) => (
+                <li key={i} className="px-3 py-1.5">
+                  <div
+                    className="h-3 animate-pulse rounded bg-white/[0.06]"
+                    style={{ width: `${60 + ((i * 13) % 30)}%` }}
+                  />
+                </li>
+              ))}
+            </ul>
+          </nav>
+          <div className="border-t border-white/10 p-3">
+            <div className="h-9 w-full animate-pulse rounded-md bg-white/[0.06]" />
+          </div>
+        </aside>
+
+        <div className="flex min-w-0 flex-1 flex-col">
+          <header className="sticky top-0 z-40 border-b border-white/10 bg-ink/80 backdrop-blur-xl">
+            <div className="flex items-center gap-3 px-6 py-4 lg:px-8">
+              <div className="min-w-0 flex-1 space-y-2">
+                <div className="h-3 w-24 animate-pulse rounded bg-white/[0.06]" />
+                <div className="h-6 w-64 animate-pulse rounded bg-white/[0.08]" />
+              </div>
+            </div>
+          </header>
+          <main className="px-6 pb-16 pt-6 lg:px-8 lg:pb-20 lg:pt-8">
+            {children ?? <SkeletonRows rows={rows} />}
+          </main>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function SkeletonRows({
+  rows = 3,
+  className,
+}: {
+  rows?: number;
+  className?: string;
+}) {
+  return (
+    <div className={cn("space-y-4", className)}>
+      {Array.from({ length: rows }).map((_, i) => (
+        <div
+          key={i}
+          className="h-24 animate-pulse rounded-2xl border border-white/10 bg-white/[0.04]"
+        />
+      ))}
+    </div>
+  );
+}

--- a/console/src/lib/api/session-cache.server.ts
+++ b/console/src/lib/api/session-cache.server.ts
@@ -1,0 +1,41 @@
+import "server-only";
+
+import { cache } from "react";
+
+import { getMe, listWorkspaces } from "@/lib/api/client";
+import type { ApiUser, ApiWorkspace } from "@/lib/api/types";
+import { getSessionToken } from "@/lib/api/session";
+
+/**
+ * React.cache()-wrapped session helpers. Within a single server render
+ * (one navigation, one RSC payload), repeat calls return the same
+ * promise instead of hitting the API again.
+ *
+ * Use these from layouts AND pages — when a shared layout fetches
+ * workspaces and the page needs them too, only one network round-trip
+ * happens. Note: cache lifetime is per-request only; cross-navigation
+ * deduplication needs Next data cache (revalidate) or layout-level
+ * partial rendering.
+ */
+
+export const getCachedSessionToken = cache(
+  async (): Promise<string | null> => getSessionToken(),
+);
+
+export const getCachedWorkspaces = cache(
+  async (): Promise<ApiWorkspace[]> => {
+    const token = await getCachedSessionToken();
+    if (!token) return [];
+    return listWorkspaces(token);
+  },
+);
+
+export const getCachedMe = cache(async (): Promise<ApiUser | null> => {
+  const token = await getCachedSessionToken();
+  if (!token) return null;
+  try {
+    return await getMe(token);
+  } catch {
+    return null;
+  }
+});


### PR DESCRIPTION
## Summary
- Add per-route `loading.tsx` skeletons so URL changes feel instant — Next App Router was blocking every navigation on the new page's full server-side data fetch with no fallback.
- Introduce `LoadingShell` that mirrors `AppShell` geometry (sidebar + sticky top bar) so the skeleton shape-matches the page that's about to render.
- Wrap `getSessionToken` / `listWorkspaces` / `getMe` with `React.cache` in `session-cache.server.ts` so a future shared `(authed)` layout can prefetch these without duplicating the call from each page in the same render.

This is Phase 1 of a perf cleanup. Phase 2 (lifting workspace fetch + AppShell into a shared `(authed)` layout to actually skip per-navigation fetches) lands separately.

## Test plan
- [ ] Click between /inbox, /knowledge, /settings, /chat — URL changes immediately, skeleton appears, then page resolves.
- [ ] No console errors on any of the touched routes.
- [ ] Type-check + lint clean (verified locally).