### PR TITLE
backend: closed-beta gate accepts active workspace invites

### DIFF
--- a/backend/app/security/auth0.py
+++ b/backend/app/security/auth0.py
@@ -34,7 +34,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.app.core.config import Settings, get_settings
-from backend.app.db.models.tenancy import PlatformInvite, User
+from backend.app.db.models.tenancy import PlatformInvite, User, WorkspaceInvite
 
 
 log = logging.getLogger(__name__)
@@ -284,10 +284,22 @@ async def user_from_claims(
     # email has an open ``platform_invites`` row. Email-pending sentinels
     # skip the gate here; the real check fires after /complete-profile
     # patches the user's email in.
+    #
+    # An active ``workspace_invites`` row is also accepted as proof that a
+    # workspace admin already vetted this user. Without this fallback, an
+    # admin who invites a brand-new email gets surfaced as a misleading
+    # "wrong email" error on the accept page (the closed-beta 403 is
+    # indistinguishable from the email-mismatch 403 to the console). The
+    # workspace invite is *not* consumed here — the dedicated accept flow
+    # owns that.
     invite: PlatformInvite | None = None
     if not email.endswith("@no-email.local"):
         invite = await _consume_open_invite(session, email)
-        if invite is None and get_settings().invite_only:
+        if (
+            invite is None
+            and get_settings().invite_only
+            and not await _has_open_workspace_invite(session, email)
+        ):
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail=(
@@ -334,6 +346,27 @@ async def user_from_claims(
         # have an audit trail of who burned which invite.
         invite.accepted_by_user_id = user.id
     return user
+
+
+async def _has_open_workspace_invite(
+    session: AsyncSession, email: str
+) -> bool:
+    """Return ``True`` if any live ``workspace_invites`` row targets ``email``.
+
+    A workspace admin issuing an invite is itself a vetting signal, so we
+    let the invitee through the closed-beta gate even without a matching
+    ``platform_invites`` row. We do not consume or mutate the invite —
+    redemption is a separate, explicit step on ``/invite``.
+    """
+    stmt = (
+        select(WorkspaceInvite.id)
+        .where(WorkspaceInvite.email == email.lower())
+        .where(WorkspaceInvite.accepted_at.is_(None))
+        .where(WorkspaceInvite.revoked_at.is_(None))
+        .where(WorkspaceInvite.expires_at > func.now())
+        .limit(1)
+    )
+    return (await session.execute(stmt)).scalar_one_or_none() is not None
 
 
 async def _consume_open_invite(

--- a/backend/tests/test_auth0.py
+++ b/backend/tests/test_auth0.py
@@ -644,6 +644,117 @@ async def test_jit_rejects_with_expired_invite(db_session, monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
+async def test_jit_admits_user_with_open_workspace_invite(
+    db_session, monkeypatch
+) -> None:
+    """An active workspace_invite for the email satisfies the gate.
+
+    Workspace admins issuing invites is itself a vetting signal, so we
+    let the invitee through even without a separate ``platform_invites``
+    row. The workspace invite must remain unconsumed — redemption is an
+    explicit user action on ``/invite``.
+    """
+    import uuid as _uuid
+    from datetime import datetime, timedelta, timezone
+
+    from sqlalchemy import select
+
+    from backend.app.core.config import get_settings
+    from backend.app.db.models.tenancy import Org, Workspace, WorkspaceInvite
+
+    monkeypatch.setenv("SHIP_INVITE_ONLY", "true")
+    get_settings.cache_clear()
+    try:
+        org = Org(slug=f"acme-{_uuid.uuid4().hex[:6]}", name="Acme")
+        db_session.add(org)
+        await db_session.flush()
+        workspace = Workspace(
+            org_id=org.id, slug=f"ws-{_uuid.uuid4().hex[:6]}", name="Acme"
+        )
+        db_session.add(workspace)
+        await db_session.flush()
+        ws_invite = WorkspaceInvite(
+            workspace_id=workspace.id,
+            email="invitee@example.com",
+            role="member",
+            token_hash=b"\x00" * 32,
+            expires_at=datetime.now(timezone.utc) + timedelta(days=7),
+        )
+        db_session.add(ws_invite)
+        await db_session.flush()
+
+        user = await auth0.user_from_claims(
+            {
+                "sub": "auth0|invitee-fresh",
+                "email": "invitee@example.com",
+                "name": "Invitee",
+            },
+            db_session,
+        )
+        await db_session.flush()
+
+        assert user.email == "invitee@example.com"
+        assert user.external_subject == "auth0|invitee-fresh"
+        # The workspace invite must NOT have been auto-accepted — that
+        # is the dedicated /v1/invites/{token}/accept flow's job.
+        refreshed = (
+            await db_session.execute(
+                select(WorkspaceInvite).where(WorkspaceInvite.id == ws_invite.id)
+            )
+        ).scalar_one()
+        assert refreshed.accepted_at is None
+        assert refreshed.accepted_by_user_id is None
+    finally:
+        get_settings.cache_clear()
+
+
+@pytest.mark.asyncio
+async def test_jit_rejects_with_revoked_workspace_invite(
+    db_session, monkeypatch
+) -> None:
+    """A revoked workspace invite does not satisfy the gate."""
+    import uuid as _uuid
+    from datetime import datetime, timedelta, timezone
+
+    from backend.app.core.config import get_settings
+    from backend.app.db.models.tenancy import Org, Workspace, WorkspaceInvite
+
+    monkeypatch.setenv("SHIP_INVITE_ONLY", "true")
+    get_settings.cache_clear()
+    try:
+        org = Org(slug=f"acme-{_uuid.uuid4().hex[:6]}", name="Acme")
+        db_session.add(org)
+        await db_session.flush()
+        workspace = Workspace(
+            org_id=org.id, slug=f"ws-{_uuid.uuid4().hex[:6]}", name="Acme"
+        )
+        db_session.add(workspace)
+        await db_session.flush()
+        ws_invite = WorkspaceInvite(
+            workspace_id=workspace.id,
+            email="revoked-ws@example.com",
+            role="member",
+            token_hash=b"\x01" * 32,
+            expires_at=datetime.now(timezone.utc) + timedelta(days=7),
+            revoked_at=datetime.now(timezone.utc),
+        )
+        db_session.add(ws_invite)
+        await db_session.flush()
+
+        with pytest.raises(HTTPException) as exc:
+            await auth0.user_from_claims(
+                {
+                    "sub": "auth0|revoked-ws",
+                    "email": "revoked-ws@example.com",
+                },
+                db_session,
+            )
+        assert exc.value.status_code == 403
+    finally:
+        get_settings.cache_clear()
+
+
+@pytest.mark.asyncio
 async def test_jit_skips_gate_for_returning_user(db_session, monkeypatch) -> None:
     """Returning users (already have ``external_subject``) bypass the gate."""
     from backend.app.core.config import get_settings


### PR DESCRIPTION
## Summary

- Workspace admins issuing a `workspace_invites` row is itself a vetting signal, but until now the closed-beta gate (E08) only consulted `platform_invites` — so a brand-new email would 403 on first `/v1/auth/me` even with a live workspace invite waiting.
- The console maps any 403 from accept-invite to "wrong email" copy on `/invite`, so the symptom users see is "This invite was issued to a different email" — even though the invite is correct and the gate, not email-mismatch, is what blocked them.
- `user_from_claims` now lets the email through if either a `platform_invites` row exists (consumed as before) or an active `workspace_invites` row for the same email exists (not consumed; redemption is still the explicit `/v1/invites/{token}/accept` step).

Concrete user this fixes: `kaciallaurynovich@gmail.com` had a fresh workspace admin invite, no `platform_invites` row, hit closed-beta 403, saw misleading "wrong email" copy. Worked around in prod by manually issuing a platform invite — this PR removes the need for that workaround.

## Test plan

- [x] `pytest backend/tests/test_auth0.py` — 23 passing, including two new tests:
  - `test_jit_admits_user_with_open_workspace_invite` — fresh user with active workspace invite passes the gate; workspace invite is NOT auto-consumed.
  - `test_jit_rejects_with_revoked_workspace_invite` — revoked workspace invite does not satisfy the gate.
- [x] `pytest backend/tests/test_v1_invites.py backend/tests/test_v1_platform_invites.py` — 14 passing, no regressions.
- [ ] Smoke after deploy: invite a brand-new email → click accept → expect successful workspace join (no manual platform-invite required).