### PR TITLE
console: fix double-sidebar flash on (authed) loading states

### DIFF
--- a/console/src/app/(authed)/audit/loading.tsx
+++ b/console/src/app/(authed)/audit/loading.tsx
@@ -1,9 +1,9 @@
-import { LoadingShell, SkeletonRows } from "@/components/loading-shell";
+import { LoadingBody, SkeletonRows } from "@/components/loading-shell";
 
 export default function Loading() {
   return (
-    <LoadingShell>
+    <LoadingBody>
       <SkeletonRows rows={8} />
-    </LoadingShell>
+    </LoadingBody>
   );
 }

--- a/console/src/app/(authed)/chat/loading.tsx
+++ b/console/src/app/(authed)/chat/loading.tsx
@@ -1,9 +1,9 @@
-import { LoadingShell, SkeletonRows } from "@/components/loading-shell";
+import { LoadingBody, SkeletonRows } from "@/components/loading-shell";
 
 export default function Loading() {
   return (
-    <LoadingShell>
+    <LoadingBody>
       <SkeletonRows rows={4} />
-    </LoadingShell>
+    </LoadingBody>
   );
 }

--- a/console/src/app/(authed)/inbox/loading.tsx
+++ b/console/src/app/(authed)/inbox/loading.tsx
@@ -1,8 +1,8 @@
-import { LoadingShell, SkeletonRows } from "@/components/loading-shell";
+import { LoadingBody, SkeletonRows } from "@/components/loading-shell";
 
 export default function Loading() {
   return (
-    <LoadingShell>
+    <LoadingBody>
       <div className="space-y-4">
         <div className="flex flex-wrap gap-2">
           {Array.from({ length: 5 }).map((_, i) => (
@@ -14,6 +14,6 @@ export default function Loading() {
         </div>
         <SkeletonRows rows={6} />
       </div>
-    </LoadingShell>
+    </LoadingBody>
   );
 }

--- a/console/src/app/(authed)/knowledge/loading.tsx
+++ b/console/src/app/(authed)/knowledge/loading.tsx
@@ -1,12 +1,12 @@
-import { LoadingShell, SkeletonRows } from "@/components/loading-shell";
+import { LoadingBody, SkeletonRows } from "@/components/loading-shell";
 
 export default function Loading() {
   return (
-    <LoadingShell>
+    <LoadingBody>
       <div className="space-y-4">
         <div className="h-12 w-full animate-pulse rounded-xl border border-white/10 bg-white/[0.04]" />
         <SkeletonRows rows={5} />
       </div>
-    </LoadingShell>
+    </LoadingBody>
   );
 }

--- a/console/src/app/(authed)/loading.tsx
+++ b/console/src/app/(authed)/loading.tsx
@@ -1,0 +1,11 @@
+import { LoadingBody } from "@/components/loading-shell";
+
+/**
+ * Fallback loading state for any (authed) route that does not ship its
+ * own loading.tsx (e.g. /repos/[id]/secrets, /chat/archived). Renders
+ * inside the layout's already-mounted AppShellChrome — must NOT paint
+ * its own sidebar, or we get the double-chrome glitch.
+ */
+export default function Loading() {
+  return <LoadingBody />;
+}

--- a/console/src/app/(authed)/process/loading.tsx
+++ b/console/src/app/(authed)/process/loading.tsx
@@ -1,8 +1,8 @@
-import { LoadingShell } from "@/components/loading-shell";
+import { LoadingBody } from "@/components/loading-shell";
 
 export default function Loading() {
   return (
-    <LoadingShell>
+    <LoadingBody>
       <div className="space-y-4">
         <div className="h-64 animate-pulse rounded-2xl border border-white/10 bg-white/[0.04]" />
         <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
@@ -11,6 +11,6 @@ export default function Loading() {
           <div className="h-40 animate-pulse rounded-2xl border border-white/10 bg-white/[0.04]" />
         </div>
       </div>
-    </LoadingShell>
+    </LoadingBody>
   );
 }

--- a/console/src/app/(authed)/settings/loading.tsx
+++ b/console/src/app/(authed)/settings/loading.tsx
@@ -1,8 +1,8 @@
-import { LoadingShell } from "@/components/loading-shell";
+import { LoadingBody } from "@/components/loading-shell";
 
 export default function Loading() {
   return (
-    <LoadingShell>
+    <LoadingBody>
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-[16rem_minmax(0,1fr)]">
         <nav className="space-y-1">
           {Array.from({ length: 8 }).map((_, i) => (
@@ -17,6 +17,6 @@ export default function Loading() {
           <div className="h-48 animate-pulse rounded-2xl border border-white/10 bg-white/[0.04]" />
         </div>
       </div>
-    </LoadingShell>
+    </LoadingBody>
   );
 }

--- a/console/src/components/loading-shell.tsx
+++ b/console/src/components/loading-shell.tsx
@@ -91,3 +91,33 @@ export function SkeletonRows({
     </div>
   );
 }
+
+/**
+ * Skeleton body for routes that render INSIDE the `(authed)/layout.tsx`
+ * chrome — the layout already provides the sidebar + top-bar, so
+ * `loading.tsx` here must NOT use {@link LoadingShell} (that paints a
+ * second sidebar). Renders just a sticky header placeholder and a body.
+ */
+export function LoadingBody({
+  children,
+  rows = 3,
+}: {
+  children?: ReactNode;
+  rows?: number;
+}) {
+  return (
+    <>
+      <header className="sticky top-0 z-40 border-b border-white/10 bg-ink/80 backdrop-blur-xl">
+        <div className="flex items-center gap-3 px-6 py-4 lg:px-8">
+          <div className="min-w-0 flex-1 space-y-2">
+            <div className="h-3 w-24 animate-pulse rounded bg-white/[0.06]" />
+            <div className="h-6 w-64 animate-pulse rounded bg-white/[0.08]" />
+          </div>
+        </div>
+      </header>
+      <div className="px-6 pb-16 pt-6 lg:px-8 lg:pb-20 lg:pt-8">
+        {children ?? <SkeletonRows rows={rows} />}
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
After PR #95 lifted the chrome into \`(authed)/layout.tsx\`, the per-route \`loading.tsx\` files from PR #92 (which still render \`<LoadingShell>\` with its own sidebar) painted **two stacked sidebars** during navigation — one from the layout's chrome, one from the loading skeleton.

Fix:
- Add \`<LoadingBody>\` (sticky header skeleton + body padding, no chrome).
- Switch every \`(authed)\`-internal \`loading.tsx\` (inbox, knowledge, settings, chat, audit, process) to \`<LoadingBody>\`.
- Add \`(authed)/loading.tsx\` as a body-only fallback for routes that don't ship their own (e.g. \`/repos/[id]/secrets\`, \`/chat/archived\`), so they render inside the existing chrome instead of bubbling up to root \`/loading.tsx\`.
- Keep \`/loading.tsx\` and \`/r/[owner]/[repo]/loading.tsx\` with \`<LoadingShell>\` — those cover surfaces not wrapped by \`(authed)\`.

## Test plan
- [ ] Click between /inbox, /knowledge, /chat, /audit, /process, /settings — no second sidebar appears during loading; the existing sidebar stays mounted and only the body skeleton swaps.
- [ ] Cold visit to /inbox (URL bar) — single chrome appears, no flash.
- [ ] Navigate to /repos/[id]/secrets and /chat/archived — body-only loading fallback fires.
- [ ] /, /r/[owner]/[repo]/* still get full \`<LoadingShell>\` (they don't have shared chrome).