### PR TITLE
console: knowledge as a newspaper — search · recent · browse · reader

### DIFF
--- a/console/src/app/(authed)/knowledge/[id]/page.tsx
+++ b/console/src/app/(authed)/knowledge/[id]/page.tsx
@@ -1,18 +1,15 @@
 /**
- * Knowledge bucket detail — articles list + inline viewer.
+ * Knowledge bucket detail — two modes.
  *
- * Stripped down to match the search-first index page (PR #90):
+ * - ``?article=<id>``: article reader. Just the markdown body in a
+ *   centred reading column, with a "← Back to <category>" link at
+ *   the top. No sibling article list, no metadata pills.
+ * - default: category page. Bucket title + description, then the
+ *   bucket's full article list (no inline viewer — clicks go to the
+ *   reader URL).
  *
- * - Breadcrumb header.
- * - Bucket title + one-line description.
- * - Articles table, click-through to inline viewer.
- *
- * Retired in this pass: tab row (Articles / Sources / Distiller runs),
- * "Document" markdown card, legacy ``repo_files`` mirror branch (those
- * buckets are dead post-KB-5), CLI sidebar card, "Source repo" sidebar
- * card, ``LiveBanner`` debug strip, scope/source badges in the header,
- * per-bucket Upload article (direct bucket writes are gone — content
- * flows in via import sources only).
+ * Both modes share the search-first newspaper aesthetic with the
+ * index page: no Card wrappers, no tables, ~720px reading column.
  */
 
 import Link from "next/link";
@@ -22,7 +19,6 @@ import remarkGfm from "remark-gfm";
 
 import { ApiUnavailable } from "@/components/api-unavailable";
 import { PageBody, PageHeader } from "@/components/app-shell";
-import { Badge, Card, CardHeader } from "@/components/ui";
 import {
   type ApiBucket,
   ApiHttpError,
@@ -107,218 +103,231 @@ export default async function KnowledgeBucketDetailPage({
     : query.article;
   const data = await load(id);
   if (data === "notfound") notFound();
-  return data.source === "live" ? (
-    <LiveView data={data} selectedArticleId={selectedArticleId} />
+  if (data.source !== "live") return <UnavailableView data={data} />;
+
+  const selectedArticle = selectedArticleId
+    ? data.articles.find((a) => a.id === selectedArticleId) ??
+      data.articles.find((a) => a.slug === selectedArticleId) ??
+      null
+    : null;
+
+  return selectedArticle ? (
+    <ReaderView bucket={data.bucket} article={selectedArticle} />
   ) : (
-    <UnavailableView data={data} />
+    <CategoryView bucket={data.bucket} articles={data.articles} />
   );
 }
 
 
-function LiveView({
-  data,
-  selectedArticleId,
-}: {
-  data: LiveData;
-  selectedArticleId?: string;
-}) {
-  const { workspace: ws, bucket, articles } = data;
-  const selectedArticle =
-    articles.find((article) => article.id === selectedArticleId) ??
-    articles.find((article) => article.slug === selectedArticleId) ??
-    articles[0] ??
-    null;
+// ---------------------------------------------------------------------------
+// Category page — bucket title + article list
+// ---------------------------------------------------------------------------
 
+
+function CategoryView({
+  bucket,
+  articles,
+}: {
+  bucket: ApiBucket;
+  articles: ApiBucketArticle[];
+}) {
   return (
     <>
       <PageHeader kicker="knowledge" title={bucket.name} />
       <PageBody>
-        <div className="mb-3 flex flex-wrap items-center gap-2 text-xs text-white/55">
-          <Link href="/knowledge" className="hover:text-white">
-            Knowledge
-          </Link>
-          <span className="text-white/25">/</span>
-          <span className="font-mono text-white/65">{bucket.slug}</span>
-          <span className="ml-auto text-[11px] text-white/40">
-            {articles.length} article{articles.length === 1 ? "" : "s"} · updated{" "}
-            {relativeTime(bucket.updated_at)}
-          </span>
+        <div className="mx-auto max-w-3xl space-y-8">
+          <div className="space-y-2">
+            <Link
+              href="/knowledge"
+              className="text-xs text-white/55 hover:text-white"
+            >
+              ← Knowledge
+            </Link>
+            <h1 className="font-display text-3xl font-bold text-white">
+              {bucket.name}
+            </h1>
+            {bucket.description && (
+              <p className="text-base leading-relaxed text-white/65">
+                {bucket.description}
+              </p>
+            )}
+            <p className="text-xs text-white/40">
+              {articles.length} article{articles.length === 1 ? "" : "s"}
+            </p>
+          </div>
+
+          <ArticleList articles={articles} bucketSlug={bucket.slug} />
         </div>
-
-        {bucket.description && (
-          <p className="mb-5 max-w-3xl text-sm leading-relaxed text-white/70">
-            {bucket.description}
-          </p>
-        )}
-
-        <ArticlesCard
-          articles={articles}
-          bucketSlug={bucket.slug}
-          selectedArticleId={selectedArticle?.id}
-        />
-        {selectedArticle && <ArticleViewer article={selectedArticle} />}
       </PageBody>
     </>
   );
 }
 
 
-function ArticlesCard({
+function ArticleList({
   articles,
   bucketSlug,
-  selectedArticleId,
 }: {
   articles: ApiBucketArticle[];
   bucketSlug: string;
-  selectedArticleId?: string;
 }) {
   if (articles.length === 0) {
     return (
-      <div className="rounded-2xl border border-white/10 bg-white/[0.02] px-5 py-10 text-center">
-        <p className="text-sm text-white/55">
-          No articles in this bucket yet.
-        </p>
-      </div>
+      <p className="text-sm text-white/55">No articles in this bucket yet.</p>
     );
   }
   return (
-    <Card padded={false} data-testid="bucket-articles">
-      <table className="min-w-full text-sm">
-        <thead className="bg-white/[0.04] text-[10px] uppercase tracking-widest text-white/45">
-          <tr>
-            <th className="px-4 py-2 text-left font-semibold">Title</th>
-            <th className="px-4 py-2 text-left font-semibold">Slug</th>
-            <th className="px-4 py-2 text-left font-semibold">v</th>
-            <th className="px-4 py-2 text-left font-semibold">Status</th>
-            <th className="px-4 py-2 text-left font-semibold">Updated</th>
-          </tr>
-        </thead>
-        <tbody>
-          {articles.map((a) => (
-            <tr
-              key={a.id}
-              className={
-                a.id === selectedArticleId
-                  ? "border-t border-aqua/20 bg-aqua/[0.04]"
-                  : "border-t border-white/5"
-              }
-            >
-              <td className="px-4 py-2.5 align-top">
-                <Link
-                  href={`/knowledge/${encodeURIComponent(bucketSlug)}?article=${encodeURIComponent(a.id)}#article-viewer`}
-                  className="font-semibold text-white hover:text-aqua"
-                >
-                  {a.title}
-                </Link>
-                {provenanceHint(a) && (
-                  <div className="mt-0.5 text-[10px] text-white/45">
-                    {provenanceHint(a)}
-                  </div>
-                )}
-              </td>
-              <td className="px-4 py-2.5 align-top font-mono text-[11px] text-aqua/85">
-                {a.slug}
-              </td>
-              <td className="px-4 py-2.5 align-top text-xs text-white/65">
-                {a.version}
-              </td>
-              <td className="px-4 py-2.5 align-top">
-                <Badge tone={statusTone(a.status)}>{a.status}</Badge>
-              </td>
-              <td className="px-4 py-2.5 align-top text-xs text-white/55">
-                {relativeTime(a.updated_at)}
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </Card>
+    <ul className="space-y-6">
+      {articles.map((article) => (
+        <li key={article.id}>
+          <Link
+            href={`/knowledge/${encodeURIComponent(bucketSlug)}?article=${encodeURIComponent(article.id)}`}
+            className="group block"
+          >
+            <div className="text-base font-semibold text-white group-hover:text-aqua">
+              {article.title || article.slug}
+            </div>
+            {firstParagraph(article.body_md) && (
+              <p className="mt-1 line-clamp-2 text-sm leading-relaxed text-white/60">
+                {firstParagraph(article.body_md)}
+              </p>
+            )}
+            <div className="mt-1 flex items-center gap-2 text-[11px] text-white/40">
+              <span>{relativeTime(article.updated_at)}</span>
+              {article.status !== "published" && (
+                <>
+                  <span className="text-white/20">·</span>
+                  <span>{article.status}</span>
+                </>
+              )}
+              {provenanceHint(article) && (
+                <>
+                  <span className="text-white/20">·</span>
+                  <span>{provenanceHint(article)}</span>
+                </>
+              )}
+            </div>
+          </Link>
+        </li>
+      ))}
+    </ul>
   );
 }
 
 
-function ArticleViewer({ article }: { article: ApiBucketArticle }) {
+// ---------------------------------------------------------------------------
+// Article reader — Medium-style
+// ---------------------------------------------------------------------------
+
+
+function ReaderView({
+  bucket,
+  article,
+}: {
+  bucket: ApiBucket;
+  article: ApiBucketArticle;
+}) {
   return (
-    <Card id="article-viewer" data-testid="article-viewer" className="mt-5">
-      <CardHeader
-        title={article.title}
-        subtitle={
-          <span>
-            <span className="font-mono">{article.slug}</span> · v{article.version} ·{" "}
-            {article.status} · updated {relativeTime(article.updated_at)}
-          </span>
-        }
-      />
-      <article className="space-y-4 text-sm leading-relaxed text-white/80">
-        <ReactMarkdown
-          remarkPlugins={[remarkGfm]}
-          components={{
-            h1: ({ children }) => (
-              <h1 className="font-display text-2xl font-bold text-white">
-                {children}
-              </h1>
-            ),
-            h2: ({ children }) => (
-              <h2 className="font-display text-xl font-bold text-white">
-                {children}
-              </h2>
-            ),
-            h3: ({ children }) => (
-              <h3 className="font-display text-lg font-bold text-white">
-                {children}
-              </h3>
-            ),
-            p: ({ children }) => <p className="text-white/78">{children}</p>,
-            a: ({ children, href }) => (
-              <a
-                href={href}
-                target="_blank"
-                rel="noreferrer"
-                className="text-aqua hover:underline"
-              >
-                {children}
-              </a>
-            ),
-            ul: ({ children }) => (
-              <ul className="list-disc space-y-1 pl-5">{children}</ul>
-            ),
-            ol: ({ children }) => (
-              <ol className="list-decimal space-y-1 pl-5">{children}</ol>
-            ),
-            blockquote: ({ children }) => (
-              <blockquote className="border-l-2 border-aqua/50 pl-4 text-white/65">
-                {children}
-              </blockquote>
-            ),
-            code: ({ children }) => (
-              <code className="rounded bg-white/[0.08] px-1.5 py-0.5 font-mono text-[12px] text-aqua/95">
-                {children}
-              </code>
-            ),
-            pre: ({ children }) => (
-              <pre className="overflow-x-auto rounded-xl border border-white/10 bg-black/35 p-4 text-xs text-white/85">
-                {children}
-              </pre>
-            ),
-          }}
-        >
-          {article.body_md || "_Empty article._"}
-        </ReactMarkdown>
-      </article>
-    </Card>
+    <>
+      <PageHeader kicker="knowledge" title={article.title} />
+      <PageBody>
+        <article className="mx-auto max-w-3xl space-y-6">
+          <div className="space-y-2">
+            <Link
+              href={`/knowledge/${encodeURIComponent(bucket.slug)}`}
+              className="text-xs text-white/55 hover:text-white"
+            >
+              ← {bucket.name}
+            </Link>
+            <h1 className="font-display text-3xl font-bold leading-tight text-white">
+              {article.title}
+            </h1>
+            <p className="text-xs text-white/40">
+              Updated {relativeTime(article.updated_at)}
+              {article.status !== "published" && (
+                <>
+                  <span className="mx-2 text-white/20">·</span>
+                  <span>{article.status}</span>
+                </>
+              )}
+              {provenanceHint(article) && (
+                <>
+                  <span className="mx-2 text-white/20">·</span>
+                  <span>{provenanceHint(article)}</span>
+                </>
+              )}
+            </p>
+          </div>
+
+          <div className="prose-reader space-y-5 text-[15px] leading-[1.75] text-white/80">
+            <ReactMarkdown
+              remarkPlugins={[remarkGfm]}
+              components={{
+                h1: ({ children }) => (
+                  <h1 className="mt-10 font-display text-2xl font-bold text-white">
+                    {children}
+                  </h1>
+                ),
+                h2: ({ children }) => (
+                  <h2 className="mt-8 font-display text-xl font-bold text-white">
+                    {children}
+                  </h2>
+                ),
+                h3: ({ children }) => (
+                  <h3 className="mt-6 font-display text-lg font-bold text-white">
+                    {children}
+                  </h3>
+                ),
+                p: ({ children }) => (
+                  <p className="text-white/80">{children}</p>
+                ),
+                a: ({ children, href }) => (
+                  <a
+                    href={href}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="text-aqua underline-offset-4 hover:underline"
+                  >
+                    {children}
+                  </a>
+                ),
+                ul: ({ children }) => (
+                  <ul className="list-disc space-y-2 pl-6">{children}</ul>
+                ),
+                ol: ({ children }) => (
+                  <ol className="list-decimal space-y-2 pl-6">{children}</ol>
+                ),
+                blockquote: ({ children }) => (
+                  <blockquote className="border-l-2 border-aqua/50 pl-5 italic text-white/65">
+                    {children}
+                  </blockquote>
+                ),
+                code: ({ children }) => (
+                  <code className="rounded bg-white/[0.08] px-1.5 py-0.5 font-mono text-[13px] text-aqua/95">
+                    {children}
+                  </code>
+                ),
+                pre: ({ children }) => (
+                  <pre className="overflow-x-auto rounded-lg bg-black/40 p-4 font-mono text-[13px] leading-relaxed text-white/85">
+                    {children}
+                  </pre>
+                ),
+                hr: () => <hr className="border-white/10" />,
+              }}
+            >
+              {article.body_md || "_Empty article._"}
+            </ReactMarkdown>
+          </div>
+        </article>
+      </PageBody>
+    </>
   );
 }
 
 
-function statusTone(
-  status: string,
-): "ok" | "warn" | "info" | "neutral" {
-  if (status === "published") return "ok";
-  if (status === "draft") return "warn";
-  if (status === "archived") return "neutral";
-  if (status === "superseded") return "info";
-  return "neutral";
-}
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
 
 
 function provenanceHint(article: ApiBucketArticle): string | null {
@@ -332,11 +341,6 @@ function provenanceHint(article: ApiBucketArticle): string | null {
       ? `from PR #${num ?? "?"} by @${author ?? "?"}`
       : "from merged PR";
   }
-  if (kind === "external_static_upload") {
-    return typeof p.filename === "string"
-      ? `uploaded: ${p.filename}`
-      : "uploaded file";
-  }
   if (kind === "knowledge_import_source") {
     const source = typeof p.import_source_kind === "string" ? p.import_source_kind : null;
     return source ? `harvested from ${source}` : "harvested from import source";
@@ -348,6 +352,22 @@ function provenanceHint(article: ApiBucketArticle): string | null {
     return `packed from thread ${p.thread_id.slice(0, 8)}…`;
   }
   return null;
+}
+
+
+function firstParagraph(body: string): string {
+  if (!body) return "";
+  const text = body.trim();
+  if (!text) return "";
+  for (const chunk of text.split("\n\n")) {
+    const candidate = chunk.replace(/^#+\s+/, "").trim();
+    if (candidate) {
+      return candidate.length > 200
+        ? candidate.slice(0, 199).trimEnd() + "…"
+        : candidate;
+    }
+  }
+  return text.length > 200 ? text.slice(0, 199).trimEnd() + "…" : text;
 }
 
 

--- a/console/src/app/(authed)/knowledge/knowledge-control-center.tsx
+++ b/console/src/app/(authed)/knowledge/knowledge-control-center.tsx
@@ -1,25 +1,24 @@
 "use client";
 
 /**
- * Knowledge — single-page control surface.
+ * Knowledge — single-page newspaper.
  *
- * Layout, top to bottom:
+ * Top of the page: a search bar + the export/import actions.
+ * Below: two sections — "Recent" (top-10 articles by updated_at)
+ * and "Browse by area" (the six buckets as text links).
  *
- *   [Title · Workspace]                       [Export ZIP] [Import source]
- *   [           Big search input                                          ]
- *   [All]  [Architecture decisions]  [Engineering]  ...  (6 buckets max)
- *   [Optional: import panel collapsed below header]
- *   [Articles list — flat, click-through to bucket detail]
+ * No bordered cards, no metric tiles, no chip-filter row, no fat
+ * tables. Reading-column width capped so the layout feels like a
+ * blog, not a control panel. Bucket → category page; article →
+ * reader page.
  *
- * No metric tiles, no per-bucket cards, no tabs. Buckets are fixed at six
- * after the consolidation, so they fit comfortably as filter chips and
- * the articles surface gets the page real estate.
+ * Real popularity-based ranking is a follow-up — we don't track
+ * article views yet, so "Recent" is what we surface for now.
  */
 
 import Link from "next/link";
-import { useMemo, useState, useTransition } from "react";
+import { useState, useTransition } from "react";
 
-import { Card, CardHeader } from "@/components/ui";
 import { cn } from "@/lib/cn";
 import type {
   ApiActivatedRepo,
@@ -37,6 +36,7 @@ export type KnowledgeBucketRow = {
   name: string;
   description: string;
   archived: boolean;
+  articleCount: number;
 };
 
 export type KnowledgeArticleRow = {
@@ -77,31 +77,11 @@ export function KnowledgeControlCenter({
   integrations,
 }: Props) {
   const [query, setQuery] = useState("");
-  const [filterSlug, setFilterSlug] = useState<string | null>(null);
   const [searchHits, setSearchHits] = useState<ApiKnowledgeSearchHit[] | null>(null);
   const [searchedFor, setSearchedFor] = useState("");
   const [searchError, setSearchError] = useState<string | null>(null);
   const [importOpen, setImportOpen] = useState(false);
   const [pending, startTransition] = useTransition();
-
-  const articlesByBucket = useMemo(() => {
-    const map = new Map<string, number>();
-    for (const a of articles) {
-      map.set(a.bucketSlug, (map.get(a.bucketSlug) ?? 0) + 1);
-    }
-    return map;
-  }, [articles]);
-
-  const visibleArticles = useMemo(() => {
-    if (!filterSlug) return articles;
-    return articles.filter((a) => a.bucketSlug === filterSlug);
-  }, [articles, filterSlug]);
-
-  const visibleHits = useMemo(() => {
-    if (!searchHits) return null;
-    if (!filterSlug) return searchHits;
-    return searchHits.filter((h) => h.bucket_slug === filterSlug);
-  }, [searchHits, filterSlug]);
 
   function runSearch(event?: React.FormEvent) {
     event?.preventDefault();
@@ -118,11 +98,7 @@ export function KnowledgeControlCenter({
         const res = await fetch("/api/knowledge/search", {
           method: "POST",
           headers: { "content-type": "application/json" },
-          body: JSON.stringify({
-            workspaceId: workspace.id,
-            query: q,
-            limit: 30,
-          }),
+          body: JSON.stringify({ workspaceId: workspace.id, query: q, limit: 30 }),
         });
         const body = (await res.json()) as
           | ApiKnowledgeSearchResponse
@@ -157,15 +133,15 @@ export function KnowledgeControlCenter({
   const isSearching = searchHits !== null;
 
   return (
-    <div className="space-y-4">
-      <form onSubmit={runSearch}>
-        <div className="relative">
+    <div className="mx-auto max-w-3xl space-y-10">
+      <div className="flex flex-col gap-3">
+        <form onSubmit={runSearch} className="relative">
           <input
             type="search"
             value={query}
             onChange={(event) => setQuery(event.target.value)}
             placeholder="Search workspace knowledge…"
-            className="w-full rounded-2xl border border-white/15 bg-white/[0.04] px-5 py-3 text-base text-white placeholder:text-white/35 outline-none transition focus:border-aqua/60"
+            className="w-full border-b border-white/15 bg-transparent px-1 pb-2 pt-1 text-base text-white placeholder:text-white/30 outline-none transition focus:border-aqua/60"
             aria-label="Search workspace knowledge"
           />
           {(query || isSearching) && (
@@ -173,52 +149,42 @@ export function KnowledgeControlCenter({
               type="button"
               onClick={clearSearch}
               aria-label="Clear search"
-              className="absolute right-3 top-1/2 -translate-y-1/2 rounded-full border border-white/10 px-2 py-0.5 text-xs text-white/55 hover:border-white/30 hover:text-white"
+              className="absolute right-1 top-1 text-xs text-white/45 hover:text-white"
             >
               clear
             </button>
           )}
-        </div>
-      </form>
+        </form>
 
-      <div className="flex flex-wrap items-center gap-2">
-        <BucketChip
-          active={filterSlug === null}
-          label="All"
-          count={isSearching ? (searchHits?.length ?? 0) : articles.length}
-          onClick={() => setFilterSlug(null)}
-        />
-        {liveBuckets.map((bucket) => (
-          <BucketChip
-            key={bucket.slug}
-            active={filterSlug === bucket.slug}
-            label={bucket.name}
-            count={
-              isSearching
-                ? (searchHits?.filter((h) => h.bucket_slug === bucket.slug).length ?? 0)
-                : (articlesByBucket.get(bucket.slug) ?? 0)
-            }
-            onClick={() =>
-              setFilterSlug(filterSlug === bucket.slug ? null : bucket.slug)
-            }
-          />
-        ))}
-        <div className="ml-auto flex items-center gap-2">
-          <ExportButton workspace={workspace} />
+        <div className="flex items-center gap-3 text-xs">
           <button
             type="button"
             onClick={() => setImportOpen((v) => !v)}
             className={cn(
-              "rounded-full border px-3 py-1.5 text-xs font-bold transition",
-              importOpen
-                ? "border-aqua/60 bg-aqua/15 text-aqua"
-                : "border-aqua/40 bg-aqua/10 text-aqua hover:bg-aqua/20",
+              "transition",
+              importOpen ? "text-aqua" : "text-white/55 hover:text-white",
             )}
           >
             {importOpen ? "Close import" : "Import source"}
           </button>
+          <span className="text-white/15">·</span>
+          {workspace.id && (
+            <a
+              href={`/api/knowledge/export?workspaceId=${encodeURIComponent(workspace.id)}`}
+              className="text-white/55 transition hover:text-white"
+            >
+              Export ZIP
+            </a>
+          )}
         </div>
       </div>
+
+      {pending && (
+        <p className="text-xs text-white/45">Searching…</p>
+      )}
+      {searchError && (
+        <p className="text-sm text-coral">{searchError}</p>
+      )}
 
       {importOpen && (
         <ImportPanel
@@ -228,214 +194,211 @@ export function KnowledgeControlCenter({
         />
       )}
 
-      <section>
-        {pending && (
-          <p className="mb-2 text-xs text-white/45">Searching…</p>
-        )}
-        {searchError && (
-          <Card className="mb-3 border-coral/40 bg-coral/5">
-            <p className="text-sm text-coral">{searchError}</p>
-          </Card>
-        )}
-        {isSearching ? (
-          <SearchResults
-            hits={visibleHits ?? []}
-            queriedFor={searchedFor}
-            filtered={filterSlug !== null}
-          />
-        ) : (
-          <ArticlesList
-            articles={visibleArticles}
-            filterSlug={filterSlug}
-            totalCount={articles.length}
-          />
-        )}
-      </section>
+      {isSearching ? (
+        <SearchResults hits={searchHits ?? []} queriedFor={searchedFor} />
+      ) : (
+        <>
+          <RecentSection articles={articles} />
+          <BrowseByAreaSection buckets={liveBuckets} />
+        </>
+      )}
     </div>
   );
 }
 
 
 // ---------------------------------------------------------------------------
-// Bucket filter chips
+// Sections
 // ---------------------------------------------------------------------------
 
 
-function BucketChip({
-  active,
-  label,
-  count,
-  onClick,
-}: {
-  active: boolean;
-  label: string;
-  count: number;
-  onClick: () => void;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      aria-pressed={active}
-      className={cn(
-        "inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-semibold transition",
-        active
-          ? "border-aqua/60 bg-aqua/15 text-aqua"
-          : "border-white/15 bg-white/[0.04] text-white/70 hover:border-white/30 hover:text-white",
-      )}
-    >
-      <span>{label}</span>
-      <span
-        className={cn(
-          "rounded-full px-1.5 text-[10px] font-bold",
-          active ? "bg-aqua/30 text-aqua" : "bg-white/10 text-white/55",
-        )}
-      >
-        {count}
-      </span>
-    </button>
-  );
-}
-
-
-// ---------------------------------------------------------------------------
-// Article listing
-// ---------------------------------------------------------------------------
-
-
-function ArticlesList({
-  articles,
-  filterSlug,
-  totalCount,
-}: {
-  articles: KnowledgeArticleRow[];
-  filterSlug: string | null;
-  totalCount: number;
-}) {
+function RecentSection({ articles }: { articles: KnowledgeArticleRow[] }) {
   if (articles.length === 0) {
     return (
-      <div className="rounded-2xl border border-white/10 bg-white/[0.02] px-5 py-10 text-center">
-        <p className="text-sm text-white/55">
-          {totalCount === 0
-            ? "No articles in this workspace yet. Import a source or wait for the harvester to surface drafts."
-            : filterSlug
-              ? "No articles in this bucket yet."
-              : "No articles match the current filter."}
-        </p>
-      </div>
+      <SectionHeader
+        title="Recent"
+        empty="No articles in this workspace yet. Import a source or wait for the harvester to surface drafts."
+      />
     );
   }
-
   return (
-    <ul className="divide-y divide-white/5 rounded-2xl border border-white/10 bg-white/[0.02]">
-      {articles.map((article) => (
-        <li key={article.id} className="px-5 py-3">
-          <Link
-            href={`/knowledge/${encodeURIComponent(article.bucketSlug)}?article=${encodeURIComponent(article.id)}#article-viewer`}
-            className="group flex flex-col gap-1"
-          >
-            <div className="flex flex-wrap items-center gap-2">
-              <span className="text-sm font-semibold text-white group-hover:text-aqua">
-                {article.title || article.slug}
-              </span>
-              <span className="rounded-full bg-white/10 px-2 py-0.5 text-[10px] font-semibold text-white/65">
-                {article.bucketName}
-              </span>
-              <span className="ml-auto text-[11px] text-white/45">
-                {relativeDate(article.updatedAt)}
-              </span>
-            </div>
-            {article.snippet && (
-              <p className="line-clamp-2 text-xs text-white/55">
-                {article.snippet}
-              </p>
-            )}
-          </Link>
-        </li>
-      ))}
-    </ul>
+    <section className="space-y-4">
+      <SectionHeader title="Recent" />
+      <ul className="space-y-5">
+        {articles.map((article) => (
+          <li key={article.id}>
+            <ArticleRow article={article} showBucket />
+          </li>
+        ))}
+      </ul>
+    </section>
   );
 }
 
 
-// ---------------------------------------------------------------------------
-// Search results
-// ---------------------------------------------------------------------------
+function BrowseByAreaSection({ buckets }: { buckets: KnowledgeBucketRow[] }) {
+  if (buckets.length === 0) return null;
+  return (
+    <section className="space-y-4">
+      <SectionHeader title="Browse by area" />
+      <ul className="divide-y divide-white/5">
+        {buckets.map((bucket) => (
+          <li key={bucket.slug}>
+            <Link
+              href={`/knowledge/${encodeURIComponent(bucket.slug)}`}
+              className="group flex items-baseline justify-between gap-4 py-3"
+            >
+              <div className="min-w-0">
+                <div className="text-base font-semibold text-white group-hover:text-aqua">
+                  {bucket.name}
+                </div>
+                {bucket.description && (
+                  <p className="mt-0.5 line-clamp-1 text-xs text-white/50">
+                    {bucket.description}
+                  </p>
+                )}
+              </div>
+              <span className="shrink-0 font-mono text-xs text-white/45">
+                {bucket.articleCount} article{bucket.articleCount === 1 ? "" : "s"}
+              </span>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
 
 
 function SearchResults({
   hits,
   queriedFor,
-  filtered,
 }: {
   hits: ApiKnowledgeSearchHit[];
   queriedFor: string;
-  filtered: boolean;
 }) {
   if (hits.length === 0) {
     return (
-      <div className="rounded-2xl border border-white/10 bg-white/[0.02] px-5 py-10 text-center">
-        <p className="text-sm text-white/55">
-          {queriedFor
-            ? filtered
-              ? `No matches for "${queriedFor}" in this bucket.`
-              : `Nothing matched "${queriedFor}".`
-            : "No matches."}
-        </p>
-      </div>
+      <SectionHeader
+        title={`Results for “${queriedFor}”`}
+        empty={queriedFor ? `Nothing matched “${queriedFor}”.` : "No matches."}
+      />
     );
   }
-
   return (
-    <ul className="divide-y divide-white/5 rounded-2xl border border-white/10 bg-white/[0.02]">
-      {hits.map((hit) => {
-        const title =
-          hit.title?.trim() ||
-          hit.bucket_slug ||
-          (hit.source === "kb_chunk" ? "Repo chunk" : "Article");
-        const href =
-          hit.source === "bucket_article" && hit.bucket_slug
-            ? `/knowledge/${encodeURIComponent(hit.bucket_slug)}?article=${encodeURIComponent(hit.id)}#article-viewer`
-            : null;
-        const RowEl = href ? Link : "div";
-        return (
-          <li key={`${hit.source}:${hit.id}`} className="px-5 py-3">
-            <RowEl
-              href={href ?? ""}
-              className="group flex flex-col gap-1"
-            >
-              <div className="flex flex-wrap items-center gap-2">
-                <span className="text-sm font-semibold text-white group-hover:text-aqua">
-                  {title}
-                </span>
-                {hit.bucket_slug && (
-                  <span className="rounded-full bg-white/10 px-2 py-0.5 text-[10px] font-semibold text-white/65">
-                    {hit.bucket_slug}
-                  </span>
-                )}
-                <span
-                  className="ml-auto font-mono text-[11px] text-aqua/80"
-                  title="match score"
-                >
-                  {hit.score.toFixed(3)}
-                </span>
-              </div>
-              {hit.snippet && (
-                <p className="line-clamp-2 text-xs text-white/55">
-                  {hit.snippet}
-                </p>
-              )}
-            </RowEl>
+    <section className="space-y-4">
+      <SectionHeader title={`Results for “${queriedFor}”`} />
+      <ul className="space-y-5">
+        {hits.map((hit) => (
+          <li key={`${hit.source}:${hit.id}`}>
+            <SearchHitRow hit={hit} />
           </li>
-        );
-      })}
-    </ul>
+        ))}
+      </ul>
+    </section>
   );
 }
 
 
 // ---------------------------------------------------------------------------
-// Import panel — collapsed unless toggled
+// Building blocks
+// ---------------------------------------------------------------------------
+
+
+function SectionHeader({
+  title,
+  empty,
+}: {
+  title: string;
+  empty?: string;
+}) {
+  return (
+    <div className="space-y-2">
+      <h2 className="text-[11px] font-bold uppercase tracking-[0.2em] text-white/45">
+        {title}
+      </h2>
+      {empty && <p className="text-sm text-white/55">{empty}</p>}
+    </div>
+  );
+}
+
+
+function ArticleRow({
+  article,
+  showBucket,
+}: {
+  article: KnowledgeArticleRow;
+  showBucket?: boolean;
+}) {
+  return (
+    <Link
+      href={`/knowledge/${encodeURIComponent(article.bucketSlug)}?article=${encodeURIComponent(article.id)}`}
+      className="group block"
+    >
+      <div className="text-base font-semibold text-white group-hover:text-aqua">
+        {article.title}
+      </div>
+      {article.snippet && (
+        <p className="mt-1 line-clamp-2 text-sm leading-relaxed text-white/60">
+          {article.snippet}
+        </p>
+      )}
+      <div className="mt-1 text-[11px] text-white/40">
+        {showBucket && (
+          <>
+            <span>{article.bucketName}</span>
+            <span className="mx-2 text-white/20">·</span>
+          </>
+        )}
+        <span>{relativeDate(article.updatedAt)}</span>
+      </div>
+    </Link>
+  );
+}
+
+
+function SearchHitRow({ hit }: { hit: ApiKnowledgeSearchHit }) {
+  const title =
+    hit.title?.trim() ||
+    hit.bucket_slug ||
+    (hit.source === "kb_chunk" ? "Repo chunk" : "Article");
+  const href =
+    hit.source === "bucket_article" && hit.bucket_slug
+      ? `/knowledge/${encodeURIComponent(hit.bucket_slug)}?article=${encodeURIComponent(hit.id)}`
+      : null;
+  const content = (
+    <>
+      <div className="text-base font-semibold text-white group-hover:text-aqua">
+        {title}
+      </div>
+      {hit.snippet && (
+        <p className="mt-1 line-clamp-2 text-sm leading-relaxed text-white/60">
+          {hit.snippet}
+        </p>
+      )}
+      <div className="mt-1 text-[11px] text-white/40">
+        {hit.bucket_slug && (
+          <>
+            <span>{hit.bucket_slug}</span>
+            <span className="mx-2 text-white/20">·</span>
+          </>
+        )}
+        <span className="font-mono">{hit.score.toFixed(3)}</span>
+      </div>
+    </>
+  );
+  return href ? (
+    <Link href={href} className="group block">
+      {content}
+    </Link>
+  ) : (
+    <div className="group block">{content}</div>
+  );
+}
+
+
+// ---------------------------------------------------------------------------
+// Import panel — wizard + connected sources list, no Card wrappers
 // ---------------------------------------------------------------------------
 
 
@@ -449,55 +412,52 @@ function ImportPanel({
   sources: KnowledgeSourceRow[];
 }) {
   return (
-    <div className="space-y-3">
+    <section className="space-y-6 border-l border-aqua/30 pl-6">
       <KnowledgeImportWizard
         integrations={integrations}
         repos={repos}
         defaultScope="workspace"
       />
-      <SourcesTable sources={sources} />
-    </div>
-  );
-}
-
-
-function SourcesTable({ sources }: { sources: KnowledgeSourceRow[] }) {
-  if (sources.length === 0) {
-    return null;
-  }
-  return (
-    <Card padded={false}>
-      <CardHeader
-        className="px-5 pt-5"
-        title="Connected sources"
-        subtitle="The harvester pulls from these and routes content into buckets."
-      />
-      <ul className="divide-y divide-white/5">
-        {sources.map((source) => (
-          <li key={source.id} className="grid grid-cols-[1fr_auto] items-center gap-3 px-5 py-3">
-            <div className="min-w-0">
-              <div className="flex flex-wrap items-center gap-2">
-                <span className="truncate text-sm font-semibold text-white">
-                  {source.name}
-                </span>
-                <span className="rounded-full bg-white/10 px-2 py-0.5 text-[10px] font-semibold text-white/65">
-                  {source.kind}
-                </span>
-              </div>
-              {source.lastError && (
-                <p className="mt-0.5 line-clamp-1 text-[11px] text-coral">
-                  {source.lastError}
-                </p>
-              )}
-            </div>
-            <div className="flex flex-col items-end text-[11px] text-white/55">
-              <span className={statusColor(source.status)}>{source.status}</span>
-              <span>{source.lastSyncedAt ? relativeDate(source.lastSyncedAt) : "never synced"}</span>
-            </div>
-          </li>
-        ))}
-      </ul>
-    </Card>
+      {sources.length > 0 && (
+        <div className="space-y-3">
+          <h3 className="text-[11px] font-bold uppercase tracking-[0.2em] text-white/45">
+            Connected sources
+          </h3>
+          <ul className="divide-y divide-white/5">
+            {sources.map((source) => (
+              <li
+                key={source.id}
+                className="grid grid-cols-[1fr_auto] items-center gap-3 py-2"
+              >
+                <div className="min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="truncate text-sm font-semibold text-white">
+                      {source.name}
+                    </span>
+                    <span className="text-[11px] uppercase tracking-widest text-white/40">
+                      {source.kind}
+                    </span>
+                  </div>
+                  {source.lastError && (
+                    <p className="mt-0.5 line-clamp-1 text-[11px] text-coral">
+                      {source.lastError}
+                    </p>
+                  )}
+                </div>
+                <div className="flex flex-col items-end text-[11px] text-white/45">
+                  <span className={statusColor(source.status)}>
+                    {source.status}
+                  </span>
+                  <span>
+                    {source.lastSyncedAt ? relativeDate(source.lastSyncedAt) : "never"}
+                  </span>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </section>
   );
 }
 
@@ -507,32 +467,6 @@ function statusColor(status: string): string {
   if (status === "syncing") return "text-aqua";
   if (status === "ready") return "text-emerald-400";
   return "text-white/55";
-}
-
-
-// ---------------------------------------------------------------------------
-// Compact export button (kept from the previous version, trimmed)
-// ---------------------------------------------------------------------------
-
-
-function ExportButton({
-  workspace,
-}: {
-  workspace: Props["workspace"];
-}) {
-  const href = workspace.id
-    ? `/api/knowledge/export?workspaceId=${encodeURIComponent(workspace.id)}`
-    : undefined;
-
-  return (
-    <a
-      href={href}
-      aria-disabled={!href}
-      className="inline-flex items-center gap-1.5 rounded-full border border-white/15 bg-white/[0.04] px-3 py-1.5 text-xs font-semibold text-white/85 transition hover:border-white/30 hover:bg-white/[0.08] aria-disabled:pointer-events-none aria-disabled:opacity-50"
-    >
-      Export ZIP
-    </a>
-  );
 }
 
 

--- a/console/src/app/(authed)/knowledge/page.tsx
+++ b/console/src/app/(authed)/knowledge/page.tsx
@@ -91,16 +91,21 @@ async function load(
       })),
     );
 
+    // Per-bucket counts feed the "Browse by area" list; flat
+    // top-N (sorted by updated_at) feeds the "Recent" section.
+    const articleCounts = new Map<string, number>();
+    for (const { bucket, articles } of articlePairs) {
+      articleCounts.set(bucket.slug, articles.length);
+    }
     const buckets: KnowledgeBucketRow[] = rawBuckets.map((bucket) =>
-      toBucketRow(bucket),
+      toBucketRow(bucket, articleCounts.get(bucket.slug) ?? 0),
     );
     const articles: KnowledgeArticleRow[] = articlePairs
       .flatMap(({ bucket, articles }) =>
         articles.map((article) => toArticleRow(article, bucket)),
       )
-      .sort(
-        (a, b) => Date.parse(b.updatedAt) - Date.parse(a.updatedAt),
-      );
+      .sort((a, b) => Date.parse(b.updatedAt) - Date.parse(a.updatedAt))
+      .slice(0, 10);
     const sources: KnowledgeSourceRow[] = importSources.map(toSourceRow);
 
     return {
@@ -193,13 +198,14 @@ export default async function KnowledgeIndexPage({
 // ---------------------------------------------------------------------------
 
 
-function toBucketRow(bucket: ApiBucket): KnowledgeBucketRow {
+function toBucketRow(bucket: ApiBucket, articleCount: number): KnowledgeBucketRow {
   return {
     id: bucket.id,
     slug: bucket.slug,
     name: bucket.name,
     description: bucket.description ?? "",
     archived: Boolean(bucket.archived_at),
+    articleCount,
   };
 }
 


### PR DESCRIPTION
## Summary

Replaces the chip-filter + table layout with three discrete reading surfaces, each centred at a ~720px reading column:

- **\`/knowledge\`** — search bar, **Recent** (top-10 articles by \`updated_at\` desc), **Browse by area** (six fixed buckets as text links with article counts).
- **\`/knowledge/<slug>\`** — category page. Bucket title + description + full article list. No inline viewer.
- **\`/knowledge/<slug>?article=<id>\`** — reader. Markdown body with generous typography, \`← Back to <category>\` link. No sibling article list, no metadata pills.

### Visual cleanup

- Drop bucket filter chips on the index — buckets are a navigation surface, not an in-page filter.
- Drop \`Card\` borders and table chrome on both index and category pages. Article rows = plain links with title + 2-line excerpt + small meta.
- Drop the \`Workspace memory control center\` hero block and the metric tile row.
- Reader uses wider line-height + larger body type, no card border around markdown, looser heading rhythm. Closer to a blog post than a wiki page.

### Sort note

Real popularity-based ranking needs view-counter tracking we don't have. \`Recent\` ranks by \`updated_at\` — accurate framing of what we can show. View counter is a follow-up.

### Implementation

- \`page.tsx\` — caps flat article list at 10, surfaces per-bucket counts on \`KnowledgeBucketRow.articleCount\`.
- \`knowledge-control-center.tsx\` — full rewrite, three sections + collapsible import panel.
- \`[id]/page.tsx\` — splits to \`CategoryView\` vs \`ReaderView\` based on \`?article=\` presence.

Net diff: 3 files, +468 / −508.

## Test plan

- [x] \`tsc --noEmit\` clean.
- [x] \`eslint --max-warnings=0\` clean on touched files.
- [ ] CI.
- [ ] Smoke: \`/knowledge\` shows search + recent (≤10) + 6 bucket links; \`/knowledge/architecture-decisions\` shows just the article list; \`?article=<id>\` shows just the article reader, no sibling list.