### PR TITLE
console: knowledge multicolumn editorial layout

### DIFF
--- a/console/src/app/(authed)/knowledge/[id]/page.tsx
+++ b/console/src/app/(authed)/knowledge/[id]/page.tsx
@@ -1,15 +1,19 @@
 /**
- * Knowledge bucket detail — two modes.
+ * Knowledge bucket detail — two modes, multi-column.
  *
- * - ``?article=<id>``: article reader. Just the markdown body in a
- *   centred reading column, with a "← Back to <category>" link at
- *   the top. No sibling article list, no metadata pills.
- * - default: category page. Bucket title + description, then the
- *   bucket's full article list (no inline viewer — clicks go to the
- *   reader URL).
+ * Category (no ``?article=``):
+ *   masthead spans 6xl, then a 12-col body — article list 8 cols /
+ *   "Other areas" + "About" sidebar 4 cols. Sidebar collapses below
+ *   the list at < lg.
  *
- * Both modes share the search-first newspaper aesthetic with the
- * index page: no Card wrappers, no tables, ~720px reading column.
+ * Reader (``?article=<id>``):
+ *   3-column grid at xl: left meta rail (UPDATED / STATUS / SOURCE
+ *   stacked, uppercase labels), prose column capped at ~680px in
+ *   the middle, right rail reserved empty for future TOC / related.
+ *   Drops to single column under lg.
+ *
+ * No bordered cards on either surface; section breaks come from
+ * whitespace + a single hairline rule.
  */
 
 import Link from "next/link";
@@ -25,6 +29,7 @@ import {
   getBucket,
   isApiConfigured,
   listBucketArticles,
+  listBuckets,
 } from "@/lib/api/client";
 import {
   getCachedSessionToken,
@@ -36,11 +41,17 @@ import { relativeTime } from "@/lib/format";
 export const dynamic = "force-dynamic";
 
 
+type SiblingBucket = {
+  slug: string;
+  name: string;
+};
+
 type LiveData = {
   source: "live";
   workspace: { id: string; slug: string; name: string };
   bucket: ApiBucket;
   articles: ApiBucketArticle[];
+  siblings: SiblingBucket[];
 };
 
 type UnavailableData = {
@@ -66,21 +77,29 @@ async function load(slug: string): Promise<Loaded | "notfound"> {
     }
     const ws = wss[0];
 
-    const bucket = await getBucket(ws.id, slug, token).catch((err) => {
-      if (err instanceof ApiHttpError && err.status === 404) return null;
-      throw err;
-    });
+    const [bucket, articles, allBuckets] = await Promise.all([
+      getBucket(ws.id, slug, token).catch((err) => {
+        if (err instanceof ApiHttpError && err.status === 404) return null;
+        throw err;
+      }),
+      listBucketArticles(ws.id, slug, {}, token).catch(
+        () => [] as ApiBucketArticle[],
+      ),
+      listBuckets(ws.id, { token }).catch(() => [] as ApiBucket[]),
+    ]);
+
     if (bucket === null) return "notfound";
 
-    const articles = await listBucketArticles(ws.id, slug, {}, token).catch(
-      () => [] as ApiBucketArticle[],
-    );
+    const siblings: SiblingBucket[] = allBuckets
+      .filter((b) => b.slug !== bucket.slug && !b.archived_at)
+      .map((b) => ({ slug: b.slug, name: b.name }));
 
     return {
       source: "live",
       workspace: { id: ws.id, slug: ws.slug, name: ws.name },
       bucket,
       articles,
+      siblings,
     };
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
@@ -114,49 +133,94 @@ export default async function KnowledgeBucketDetailPage({
   return selectedArticle ? (
     <ReaderView bucket={data.bucket} article={selectedArticle} />
   ) : (
-    <CategoryView bucket={data.bucket} articles={data.articles} />
+    <CategoryView
+      bucket={data.bucket}
+      articles={data.articles}
+      siblings={data.siblings}
+    />
   );
 }
 
 
 // ---------------------------------------------------------------------------
-// Category page — bucket title + article list
+// Category view — masthead + (article list | other areas + about)
 // ---------------------------------------------------------------------------
 
 
 function CategoryView({
   bucket,
   articles,
+  siblings,
 }: {
   bucket: ApiBucket;
   articles: ApiBucketArticle[];
+  siblings: SiblingBucket[];
 }) {
   return (
     <>
       <PageHeader kicker="knowledge" title={bucket.name} />
       <PageBody>
-        <div className="mx-auto max-w-3xl space-y-8">
-          <div className="space-y-2">
+        <div className="mx-auto max-w-6xl">
+          <header className="mb-12 space-y-3">
             <Link
               href="/knowledge"
               className="text-xs text-white/55 hover:text-white"
             >
               ← Knowledge
             </Link>
-            <h1 className="font-display text-3xl font-bold text-white">
+            <h1 className="font-display text-4xl font-bold leading-tight text-white">
               {bucket.name}
             </h1>
             {bucket.description && (
-              <p className="text-base leading-relaxed text-white/65">
+              <p className="max-w-2xl text-base leading-relaxed text-white/65">
                 {bucket.description}
               </p>
             )}
-            <p className="text-xs text-white/40">
+            <p className="text-[11px] uppercase tracking-widest text-white/40">
               {articles.length} article{articles.length === 1 ? "" : "s"}
+              <span className="mx-2 text-white/20">·</span>
+              updated {relativeTime(bucket.updated_at)}
             </p>
-          </div>
+          </header>
 
-          <ArticleList articles={articles} bucketSlug={bucket.slug} />
+          <div className="grid grid-cols-1 gap-x-12 gap-y-12 lg:grid-cols-12">
+            <section className="lg:col-span-8">
+              <ArticleList articles={articles} bucketSlug={bucket.slug} />
+            </section>
+
+            <aside className="space-y-10 lg:col-span-4 lg:sticky lg:top-24 lg:self-start">
+              {siblings.length > 0 && (
+                <div className="space-y-4">
+                  <h2 className="text-[11px] font-bold uppercase tracking-[0.22em] text-lilac/75">
+                    Other areas
+                  </h2>
+                  <ul className="divide-y divide-white/5">
+                    {siblings.map((sibling) => (
+                      <li key={sibling.slug}>
+                        <Link
+                          href={`/knowledge/${encodeURIComponent(sibling.slug)}`}
+                          className="block py-3 font-display text-sm font-bold uppercase tracking-wider text-white/65 transition hover:text-lilac"
+                        >
+                          {sibling.name}
+                        </Link>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+
+              <div className="space-y-3">
+                <h2 className="text-[11px] font-bold uppercase tracking-[0.22em] text-white/40">
+                  About
+                </h2>
+                <p className="text-sm leading-relaxed text-white/55">
+                  Articles in this area are drafted by the synthesiser from
+                  harvested notes, then reviewed by an operator before
+                  publishing.
+                </p>
+              </div>
+            </aside>
+          </div>
         </div>
       </PageBody>
     </>
@@ -177,22 +241,22 @@ function ArticleList({
     );
   }
   return (
-    <ul className="space-y-6">
+    <ul className="divide-y divide-white/5">
       {articles.map((article) => (
-        <li key={article.id}>
+        <li key={article.id} className="py-5 first:pt-0">
           <Link
             href={`/knowledge/${encodeURIComponent(bucketSlug)}?article=${encodeURIComponent(article.id)}`}
-            className="group block"
+            className="group block space-y-1.5"
           >
             <div className="text-base font-semibold text-white group-hover:text-aqua">
               {article.title || article.slug}
             </div>
             {firstParagraph(article.body_md) && (
-              <p className="mt-1 line-clamp-2 text-sm leading-relaxed text-white/60">
+              <p className="line-clamp-2 text-sm leading-relaxed text-white/55">
                 {firstParagraph(article.body_md)}
               </p>
             )}
-            <div className="mt-1 flex items-center gap-2 text-[11px] text-white/40">
+            <div className="flex items-center gap-2 text-[11px] text-white/40">
               <span>{relativeTime(article.updated_at)}</span>
               {article.status !== "published" && (
                 <>
@@ -216,7 +280,7 @@ function ArticleList({
 
 
 // ---------------------------------------------------------------------------
-// Article reader — Medium-style
+// Reader — left meta rail + prose + reserved right rail
 // ---------------------------------------------------------------------------
 
 
@@ -227,100 +291,147 @@ function ReaderView({
   bucket: ApiBucket;
   article: ApiBucketArticle;
 }) {
+  const provenance = provenanceHint(article);
   return (
     <>
       <PageHeader kicker="knowledge" title={article.title} />
       <PageBody>
-        <article className="mx-auto max-w-3xl space-y-6">
-          <div className="space-y-2">
+        <div className="mx-auto max-w-6xl">
+          <header className="mb-10 space-y-4">
             <Link
               href={`/knowledge/${encodeURIComponent(bucket.slug)}`}
               className="text-xs text-white/55 hover:text-white"
             >
               ← {bucket.name}
             </Link>
-            <h1 className="font-display text-3xl font-bold leading-tight text-white">
+            <h1 className="font-display text-3xl font-bold leading-tight tracking-tight text-white md:text-4xl">
               {article.title}
             </h1>
-            <p className="text-xs text-white/40">
-              Updated {relativeTime(article.updated_at)}
+            <p className="flex flex-wrap items-center gap-2 text-[11px] uppercase tracking-widest text-white/40">
+              <span>Updated {relativeTime(article.updated_at)}</span>
               {article.status !== "published" && (
                 <>
-                  <span className="mx-2 text-white/20">·</span>
+                  <span className="text-white/20">·</span>
                   <span>{article.status}</span>
                 </>
               )}
-              {provenanceHint(article) && (
+              {provenance && (
                 <>
-                  <span className="mx-2 text-white/20">·</span>
-                  <span>{provenanceHint(article)}</span>
+                  <span className="text-white/20">·</span>
+                  <span>{provenance}</span>
                 </>
               )}
             </p>
-          </div>
+            <div className="border-t border-aqua/30 pt-1" />
+          </header>
 
-          <div className="prose-reader space-y-5 text-[15px] leading-[1.75] text-white/80">
-            <ReactMarkdown
-              remarkPlugins={[remarkGfm]}
-              components={{
-                h1: ({ children }) => (
-                  <h1 className="mt-10 font-display text-2xl font-bold text-white">
-                    {children}
-                  </h1>
-                ),
-                h2: ({ children }) => (
-                  <h2 className="mt-8 font-display text-xl font-bold text-white">
-                    {children}
-                  </h2>
-                ),
-                h3: ({ children }) => (
-                  <h3 className="mt-6 font-display text-lg font-bold text-white">
-                    {children}
-                  </h3>
-                ),
-                p: ({ children }) => (
-                  <p className="text-white/80">{children}</p>
-                ),
-                a: ({ children, href }) => (
-                  <a
-                    href={href}
-                    target="_blank"
-                    rel="noreferrer"
-                    className="text-aqua underline-offset-4 hover:underline"
-                  >
-                    {children}
-                  </a>
-                ),
-                ul: ({ children }) => (
-                  <ul className="list-disc space-y-2 pl-6">{children}</ul>
-                ),
-                ol: ({ children }) => (
-                  <ol className="list-decimal space-y-2 pl-6">{children}</ol>
-                ),
-                blockquote: ({ children }) => (
-                  <blockquote className="border-l-2 border-aqua/50 pl-5 italic text-white/65">
-                    {children}
-                  </blockquote>
-                ),
-                code: ({ children }) => (
-                  <code className="rounded bg-white/[0.08] px-1.5 py-0.5 font-mono text-[13px] text-aqua/95">
-                    {children}
-                  </code>
-                ),
-                pre: ({ children }) => (
-                  <pre className="overflow-x-auto rounded-lg bg-black/40 p-4 font-mono text-[13px] leading-relaxed text-white/85">
-                    {children}
-                  </pre>
-                ),
-                hr: () => <hr className="border-white/10" />,
-              }}
-            >
-              {article.body_md || "_Empty article._"}
-            </ReactMarkdown>
+          <div className="grid grid-cols-1 gap-12 lg:grid-cols-12">
+            <aside className="order-2 space-y-6 lg:order-1 lg:col-span-2">
+              <RailLabel label="Updated" value={relativeTime(article.updated_at)} />
+              <RailLabel label="Status" value={article.status} />
+              {provenance && <RailLabel label="Source" value={provenance} />}
+              <RailLabel label="Slug" value={article.slug} mono />
+              <RailLabel label="Version" value={`v${article.version}`} />
+            </aside>
+
+            <article className="order-1 max-w-[680px] lg:order-2 lg:col-span-7">
+              <div className="space-y-5 text-[16px] leading-[1.8] text-white/82">
+                <ReactMarkdown
+                  remarkPlugins={[remarkGfm]}
+                  components={{
+                    h1: ({ children }) => (
+                      <h2 className="mt-12 font-display text-2xl font-bold text-white">
+                        {children}
+                      </h2>
+                    ),
+                    h2: ({ children }) => (
+                      <h2 className="mt-10 font-display text-xl font-bold text-white">
+                        {children}
+                      </h2>
+                    ),
+                    h3: ({ children }) => (
+                      <h3 className="mt-8 font-display text-lg font-bold text-white">
+                        {children}
+                      </h3>
+                    ),
+                    p: ({ children }) => (
+                      <p className="text-white/82">{children}</p>
+                    ),
+                    a: ({ children, href }) => (
+                      <a
+                        href={href}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="text-aqua underline-offset-4 hover:underline"
+                      >
+                        {children}
+                      </a>
+                    ),
+                    ul: ({ children }) => (
+                      <ul className="list-disc space-y-2 pl-6">{children}</ul>
+                    ),
+                    ol: ({ children }) => (
+                      <ol className="list-decimal space-y-2 pl-6">{children}</ol>
+                    ),
+                    blockquote: ({ children }) => (
+                      <blockquote className="border-l-2 border-aqua/50 pl-5 italic text-white/65">
+                        {children}
+                      </blockquote>
+                    ),
+                    code: ({ children }) => (
+                      <code className="rounded bg-white/[0.08] px-1.5 py-0.5 font-mono text-[13px] text-aqua/95">
+                        {children}
+                      </code>
+                    ),
+                    pre: ({ children }) => (
+                      <pre className="overflow-x-auto rounded-lg bg-black/40 p-4 font-mono text-[13px] leading-relaxed text-white/85 ring-1 ring-white/5">
+                        {children}
+                      </pre>
+                    ),
+                    hr: () => <hr className="border-white/10" />,
+                  }}
+                >
+                  {article.body_md || "_Empty article._"}
+                </ReactMarkdown>
+              </div>
+            </article>
+
+            <aside
+              className="order-3 hidden lg:col-span-3 lg:block"
+              aria-hidden="true"
+            />
           </div>
-        </article>
+        </div>
       </PageBody>
     </>
+  );
+}
+
+
+function RailLabel({
+  label,
+  value,
+  mono,
+}: {
+  label: string;
+  value: string;
+  mono?: boolean;
+}) {
+  return (
+    <div className="space-y-1">
+      <div className="text-[11px] uppercase tracking-widest text-white/45">
+        {label}
+      </div>
+      <div
+        className={
+          mono
+            ? "font-mono text-[12px] text-white/75"
+            : "text-sm text-white/75"
+        }
+      >
+        {value}
+      </div>
+    </div>
   );
 }
 

--- a/console/src/app/(authed)/knowledge/knowledge-control-center.tsx
+++ b/console/src/app/(authed)/knowledge/knowledge-control-center.tsx
@@ -1,19 +1,28 @@
 "use client";
 
 /**
- * Knowledge — single-page newspaper.
+ * Knowledge index — editorial multi-column.
  *
- * Top of the page: a search bar + the export/import actions.
- * Below: two sections — "Recent" (top-10 articles by updated_at)
- * and "Browse by area" (the six buckets as text links).
+ * Layout (≥ lg):
  *
- * No bordered cards, no metric tiles, no chip-filter row, no fat
- * tables. Reading-column width capped so the layout feels like a
- * blog, not a control panel. Bucket → category page; article →
- * reader page.
+ *   ┌──────────────────────────────────────────────────────────┐
+ *   │  Search · Import source · Export ZIP                      │
+ *   ├──────────────────────────────────┬───────────────────────┤
+ *   │  Recent (col-span-8)             │  Browse by area (4)    │
+ *   │    Lede article                  │    Sticky bucket nav   │
+ *   │    Recent rows (divide-y)        │                        │
+ *   ├──────────────────────────────────┴───────────────────────┤
+ *   │  Sources (collapsed)                                      │
+ *   └──────────────────────────────────────────────────────────┘
  *
- * Real popularity-based ranking is a follow-up — we don't track
- * article views yet, so "Recent" is what we surface for now.
+ * Below ``lg``: collapses to a single column with the bucket nav
+ * lifted above Recent (so the IA is visible without scrolling).
+ *
+ * Style cues: Linear changelog rhythm + Stripe Press editorial ledes.
+ * No bordered cards; sections separated by whitespace + a single
+ * hairline rule. ``aqua`` (champagne gold) is reserved for editorial
+ * accents (lede hairline, link hover); ``lilac`` for bucket nav;
+ * ``coral`` for errors only.
  */
 
 import Link from "next/link";
@@ -131,60 +140,24 @@ export function KnowledgeControlCenter({
 
   const liveBuckets = buckets.filter((b) => !b.archived);
   const isSearching = searchHits !== null;
+  const lede = articles[0] ?? null;
+  const rest = articles.slice(1);
 
   return (
-    <div className="mx-auto max-w-3xl space-y-10">
-      <div className="flex flex-col gap-3">
-        <form onSubmit={runSearch} className="relative">
-          <input
-            type="search"
-            value={query}
-            onChange={(event) => setQuery(event.target.value)}
-            placeholder="Search workspace knowledge…"
-            className="w-full border-b border-white/15 bg-transparent px-1 pb-2 pt-1 text-base text-white placeholder:text-white/30 outline-none transition focus:border-aqua/60"
-            aria-label="Search workspace knowledge"
-          />
-          {(query || isSearching) && (
-            <button
-              type="button"
-              onClick={clearSearch}
-              aria-label="Clear search"
-              className="absolute right-1 top-1 text-xs text-white/45 hover:text-white"
-            >
-              clear
-            </button>
-          )}
-        </form>
+    <div className="mx-auto max-w-6xl space-y-12">
+      <SearchHeader
+        query={query}
+        onChange={setQuery}
+        onSubmit={runSearch}
+        onClear={clearSearch}
+        isSearching={isSearching}
+        importOpen={importOpen}
+        onToggleImport={() => setImportOpen((v) => !v)}
+        workspaceId={workspace.id}
+      />
 
-        <div className="flex items-center gap-3 text-xs">
-          <button
-            type="button"
-            onClick={() => setImportOpen((v) => !v)}
-            className={cn(
-              "transition",
-              importOpen ? "text-aqua" : "text-white/55 hover:text-white",
-            )}
-          >
-            {importOpen ? "Close import" : "Import source"}
-          </button>
-          <span className="text-white/15">·</span>
-          {workspace.id && (
-            <a
-              href={`/api/knowledge/export?workspaceId=${encodeURIComponent(workspace.id)}`}
-              className="text-white/55 transition hover:text-white"
-            >
-              Export ZIP
-            </a>
-          )}
-        </div>
-      </div>
-
-      {pending && (
-        <p className="text-xs text-white/45">Searching…</p>
-      )}
-      {searchError && (
-        <p className="text-sm text-coral">{searchError}</p>
-      )}
+      {pending && <p className="text-xs text-white/45">Searching…</p>}
+      {searchError && <p className="text-sm text-coral">{searchError}</p>}
 
       {importOpen && (
         <ImportPanel
@@ -197,10 +170,42 @@ export function KnowledgeControlCenter({
       {isSearching ? (
         <SearchResults hits={searchHits ?? []} queriedFor={searchedFor} />
       ) : (
-        <>
-          <RecentSection articles={articles} />
-          <BrowseByAreaSection buckets={liveBuckets} />
-        </>
+        <div className="grid grid-cols-1 gap-x-12 gap-y-12 lg:grid-cols-12">
+          <section className="space-y-8 lg:col-span-8">
+            <SectionKicker tone="aqua">Recent</SectionKicker>
+            {lede ? (
+              <>
+                <LedeArticle article={lede} />
+                {rest.length > 0 && (
+                  <ul className="divide-y divide-white/5">
+                    {rest.map((article) => (
+                      <li key={article.id} className="py-5 first:pt-6">
+                        <ArticleRow article={article} showBucket />
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </>
+            ) : (
+              <p className="text-sm text-white/55">
+                No articles in this workspace yet. Connect an import source or
+                wait for the harvester to surface drafts.
+              </p>
+            )}
+          </section>
+
+          <aside className="space-y-6 lg:col-span-4 lg:sticky lg:top-24 lg:self-start">
+            <SectionKicker tone="lilac">Browse by area</SectionKicker>
+            <BucketDirectory buckets={liveBuckets} />
+          </aside>
+
+          {sources.length > 0 && (
+            <section className="space-y-3 lg:col-span-12">
+              <SectionKicker tone="muted">Sources</SectionKicker>
+              <ConnectedSources sources={sources} />
+            </section>
+          )}
+        </div>
       )}
     </div>
   );
@@ -208,117 +213,103 @@ export function KnowledgeControlCenter({
 
 
 // ---------------------------------------------------------------------------
-// Sections
+// Header — search + actions
 // ---------------------------------------------------------------------------
 
 
-function RecentSection({ articles }: { articles: KnowledgeArticleRow[] }) {
-  if (articles.length === 0) {
-    return (
-      <SectionHeader
-        title="Recent"
-        empty="No articles in this workspace yet. Import a source or wait for the harvester to surface drafts."
-      />
-    );
-  }
-  return (
-    <section className="space-y-4">
-      <SectionHeader title="Recent" />
-      <ul className="space-y-5">
-        {articles.map((article) => (
-          <li key={article.id}>
-            <ArticleRow article={article} showBucket />
-          </li>
-        ))}
-      </ul>
-    </section>
-  );
-}
-
-
-function BrowseByAreaSection({ buckets }: { buckets: KnowledgeBucketRow[] }) {
-  if (buckets.length === 0) return null;
-  return (
-    <section className="space-y-4">
-      <SectionHeader title="Browse by area" />
-      <ul className="divide-y divide-white/5">
-        {buckets.map((bucket) => (
-          <li key={bucket.slug}>
-            <Link
-              href={`/knowledge/${encodeURIComponent(bucket.slug)}`}
-              className="group flex items-baseline justify-between gap-4 py-3"
-            >
-              <div className="min-w-0">
-                <div className="text-base font-semibold text-white group-hover:text-aqua">
-                  {bucket.name}
-                </div>
-                {bucket.description && (
-                  <p className="mt-0.5 line-clamp-1 text-xs text-white/50">
-                    {bucket.description}
-                  </p>
-                )}
-              </div>
-              <span className="shrink-0 font-mono text-xs text-white/45">
-                {bucket.articleCount} article{bucket.articleCount === 1 ? "" : "s"}
-              </span>
-            </Link>
-          </li>
-        ))}
-      </ul>
-    </section>
-  );
-}
-
-
-function SearchResults({
-  hits,
-  queriedFor,
+function SearchHeader({
+  query,
+  onChange,
+  onSubmit,
+  onClear,
+  isSearching,
+  importOpen,
+  onToggleImport,
+  workspaceId,
 }: {
-  hits: ApiKnowledgeSearchHit[];
-  queriedFor: string;
-}) {
-  if (hits.length === 0) {
-    return (
-      <SectionHeader
-        title={`Results for “${queriedFor}”`}
-        empty={queriedFor ? `Nothing matched “${queriedFor}”.` : "No matches."}
-      />
-    );
-  }
-  return (
-    <section className="space-y-4">
-      <SectionHeader title={`Results for “${queriedFor}”`} />
-      <ul className="space-y-5">
-        {hits.map((hit) => (
-          <li key={`${hit.source}:${hit.id}`}>
-            <SearchHitRow hit={hit} />
-          </li>
-        ))}
-      </ul>
-    </section>
-  );
-}
-
-
-// ---------------------------------------------------------------------------
-// Building blocks
-// ---------------------------------------------------------------------------
-
-
-function SectionHeader({
-  title,
-  empty,
-}: {
-  title: string;
-  empty?: string;
+  query: string;
+  onChange: (v: string) => void;
+  onSubmit: (e?: React.FormEvent) => void;
+  onClear: () => void;
+  isSearching: boolean;
+  importOpen: boolean;
+  onToggleImport: () => void;
+  workspaceId?: string;
 }) {
   return (
-    <div className="space-y-2">
-      <h2 className="text-[11px] font-bold uppercase tracking-[0.2em] text-white/45">
-        {title}
-      </h2>
-      {empty && <p className="text-sm text-white/55">{empty}</p>}
+    <div className="flex flex-col gap-3">
+      <form onSubmit={onSubmit} className="relative">
+        <input
+          type="search"
+          value={query}
+          onChange={(event) => onChange(event.target.value)}
+          placeholder="Search workspace knowledge…"
+          className="w-full border-b border-white/15 bg-transparent px-1 pb-3 pt-1 text-lg text-white placeholder:text-white/30 outline-none transition focus:border-aqua/60"
+          aria-label="Search workspace knowledge"
+        />
+        {(query || isSearching) && (
+          <button
+            type="button"
+            onClick={onClear}
+            aria-label="Clear search"
+            className="absolute right-1 top-2 text-xs text-white/45 hover:text-white"
+          >
+            clear
+          </button>
+        )}
+      </form>
+
+      <div className="flex items-center gap-3 text-xs">
+        <button
+          type="button"
+          onClick={onToggleImport}
+          className={cn(
+            "transition",
+            importOpen ? "text-aqua" : "text-white/55 hover:text-white",
+          )}
+        >
+          {importOpen ? "Close import" : "Import source"}
+        </button>
+        <span className="text-white/15">·</span>
+        {workspaceId && (
+          <a
+            href={`/api/knowledge/export?workspaceId=${encodeURIComponent(workspaceId)}`}
+            className="text-white/55 transition hover:text-white"
+          >
+            Export ZIP
+          </a>
+        )}
+      </div>
     </div>
+  );
+}
+
+
+// ---------------------------------------------------------------------------
+// Recent — lede + rows
+// ---------------------------------------------------------------------------
+
+
+function LedeArticle({ article }: { article: KnowledgeArticleRow }) {
+  return (
+    <Link
+      href={`/knowledge/${encodeURIComponent(article.bucketSlug)}?article=${encodeURIComponent(article.id)}`}
+      className="group block space-y-3 border-b border-aqua/30 pb-8"
+    >
+      <h3 className="font-display text-2xl font-bold leading-tight text-white group-hover:text-aqua md:text-3xl">
+        {article.title}
+      </h3>
+      {article.snippet && (
+        <p className="line-clamp-3 text-base leading-relaxed text-white/65">
+          {article.snippet}
+        </p>
+      )}
+      <p className="flex items-center gap-2 text-[11px] uppercase tracking-widest text-white/40">
+        <span>{article.bucketName}</span>
+        <span className="text-white/20">·</span>
+        <span>{relativeDate(article.updatedAt)}</span>
+      </p>
+    </Link>
   );
 }
 
@@ -333,17 +324,17 @@ function ArticleRow({
   return (
     <Link
       href={`/knowledge/${encodeURIComponent(article.bucketSlug)}?article=${encodeURIComponent(article.id)}`}
-      className="group block"
+      className="group block space-y-1.5"
     >
       <div className="text-base font-semibold text-white group-hover:text-aqua">
         {article.title}
       </div>
       {article.snippet && (
-        <p className="mt-1 line-clamp-2 text-sm leading-relaxed text-white/60">
+        <p className="line-clamp-2 text-sm leading-relaxed text-white/55">
           {article.snippet}
         </p>
       )}
-      <div className="mt-1 text-[11px] text-white/40">
+      <div className="text-[11px] text-white/40">
         {showBucket && (
           <>
             <span>{article.bucketName}</span>
@@ -353,6 +344,77 @@ function ArticleRow({
         <span>{relativeDate(article.updatedAt)}</span>
       </div>
     </Link>
+  );
+}
+
+
+// ---------------------------------------------------------------------------
+// Browse by area — bucket directory
+// ---------------------------------------------------------------------------
+
+
+function BucketDirectory({ buckets }: { buckets: KnowledgeBucketRow[] }) {
+  if (buckets.length === 0) return null;
+  return (
+    <ul className="divide-y divide-white/5">
+      {buckets.map((bucket) => (
+        <li key={bucket.slug}>
+          <Link
+            href={`/knowledge/${encodeURIComponent(bucket.slug)}`}
+            className="group flex items-baseline justify-between gap-3 py-3"
+          >
+            <div className="min-w-0 flex-1">
+              <div className="font-display text-sm font-bold uppercase tracking-wider text-white/85 group-hover:text-lilac">
+                {bucket.name}
+              </div>
+              {bucket.description && (
+                <p className="mt-1 line-clamp-1 text-xs text-white/45">
+                  {bucket.description}
+                </p>
+              )}
+            </div>
+            <span className="shrink-0 font-mono text-xs text-white/35">
+              {bucket.articleCount}
+            </span>
+          </Link>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+
+// ---------------------------------------------------------------------------
+// Search results — same shape as Recent rows, single column inside the grid
+// ---------------------------------------------------------------------------
+
+
+function SearchResults({
+  hits,
+  queriedFor,
+}: {
+  hits: ApiKnowledgeSearchHit[];
+  queriedFor: string;
+}) {
+  return (
+    <section className="space-y-6">
+      <SectionKicker tone="aqua">
+        Results for “{queriedFor}”
+      </SectionKicker>
+      {hits.length === 0 ? (
+        <p className="text-sm text-white/55">
+          {queriedFor ? `Nothing matched “${queriedFor}”.` : "No matches."}
+        </p>
+      ) : (
+        <ul className="divide-y divide-white/5">
+          {hits.map((hit) => (
+            <li key={`${hit.source}:${hit.id}`} className="py-5 first:pt-0">
+              <SearchHitRow hit={hit} />
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
   );
 }
 
@@ -372,15 +434,15 @@ function SearchHitRow({ hit }: { hit: ApiKnowledgeSearchHit }) {
         {title}
       </div>
       {hit.snippet && (
-        <p className="mt-1 line-clamp-2 text-sm leading-relaxed text-white/60">
+        <p className="mt-1 line-clamp-2 text-sm leading-relaxed text-white/55">
           {hit.snippet}
         </p>
       )}
-      <div className="mt-1 text-[11px] text-white/40">
+      <div className="mt-1 flex items-center gap-2 text-[11px] text-white/40">
         {hit.bucket_slug && (
           <>
             <span>{hit.bucket_slug}</span>
-            <span className="mx-2 text-white/20">·</span>
+            <span className="text-white/20">·</span>
           </>
         )}
         <span className="font-mono">{hit.score.toFixed(3)}</span>
@@ -398,7 +460,7 @@ function SearchHitRow({ hit }: { hit: ApiKnowledgeSearchHit }) {
 
 
 // ---------------------------------------------------------------------------
-// Import panel — wizard + connected sources list, no Card wrappers
+// Sources — wizard + connected list, full-width footer
 // ---------------------------------------------------------------------------
 
 
@@ -418,46 +480,45 @@ function ImportPanel({
         repos={repos}
         defaultScope="workspace"
       />
-      {sources.length > 0 && (
-        <div className="space-y-3">
-          <h3 className="text-[11px] font-bold uppercase tracking-[0.2em] text-white/45">
-            Connected sources
-          </h3>
-          <ul className="divide-y divide-white/5">
-            {sources.map((source) => (
-              <li
-                key={source.id}
-                className="grid grid-cols-[1fr_auto] items-center gap-3 py-2"
-              >
-                <div className="min-w-0">
-                  <div className="flex items-center gap-2">
-                    <span className="truncate text-sm font-semibold text-white">
-                      {source.name}
-                    </span>
-                    <span className="text-[11px] uppercase tracking-widest text-white/40">
-                      {source.kind}
-                    </span>
-                  </div>
-                  {source.lastError && (
-                    <p className="mt-0.5 line-clamp-1 text-[11px] text-coral">
-                      {source.lastError}
-                    </p>
-                  )}
-                </div>
-                <div className="flex flex-col items-end text-[11px] text-white/45">
-                  <span className={statusColor(source.status)}>
-                    {source.status}
-                  </span>
-                  <span>
-                    {source.lastSyncedAt ? relativeDate(source.lastSyncedAt) : "never"}
-                  </span>
-                </div>
-              </li>
-            ))}
-          </ul>
-        </div>
-      )}
+      {sources.length > 0 && <ConnectedSources sources={sources} />}
     </section>
+  );
+}
+
+
+function ConnectedSources({ sources }: { sources: KnowledgeSourceRow[] }) {
+  if (sources.length === 0) return null;
+  return (
+    <ul className="divide-y divide-white/5">
+      {sources.map((source) => (
+        <li
+          key={source.id}
+          className="grid grid-cols-[1fr_auto] items-center gap-3 py-3"
+        >
+          <div className="min-w-0">
+            <div className="flex items-center gap-2">
+              <span className="truncate text-sm font-semibold text-white">
+                {source.name}
+              </span>
+              <span className="text-[11px] uppercase tracking-widest text-white/40">
+                {source.kind}
+              </span>
+            </div>
+            {source.lastError && (
+              <p className="mt-0.5 line-clamp-1 text-[11px] text-coral">
+                {source.lastError}
+              </p>
+            )}
+          </div>
+          <div className="flex flex-col items-end text-[11px] text-white/45">
+            <span className={statusColor(source.status)}>{source.status}</span>
+            <span>
+              {source.lastSyncedAt ? relativeDate(source.lastSyncedAt) : "never"}
+            </span>
+          </div>
+        </li>
+      ))}
+    </ul>
   );
 }
 
@@ -473,6 +534,32 @@ function statusColor(status: string): string {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+
+function SectionKicker({
+  children,
+  tone,
+}: {
+  children: React.ReactNode;
+  tone: "aqua" | "lilac" | "muted";
+}) {
+  const toneClass =
+    tone === "aqua"
+      ? "text-aqua/75"
+      : tone === "lilac"
+        ? "text-lilac/75"
+        : "text-white/40";
+  return (
+    <h2
+      className={cn(
+        "text-[11px] font-bold uppercase tracking-[0.22em]",
+        toneClass,
+      )}
+    >
+      {children}
+    </h2>
+  );
+}
 
 
 function relativeDate(value: string | null | undefined): string {


### PR DESCRIPTION
## Summary

Following the design review — three knowledge surfaces redesigned in one pass to feel like a magazine, not a 720px draft post.

### Index (\`/knowledge\`)
12-col grid. **Recent** feed (col-span-8) opens with a **lede article** (display 2xl/3xl + 3-line dek + gold hairline rule below), then divide-y rows. **Browse by area** sticky aside (col-span-4) with bucket names in \`font-display uppercase\` (lilac on hover) and a faint mono article count. Sources collapse to a full-width footer.

### Category (\`/knowledge/<slug>\`)
Full-width masthead (\`text-4xl\` title + capped description + uppercase metadata). 12-col body: article list 8 / sidebar 4 with **Other areas** (lilac sibling-bucket links — lateral nav without bouncing back to index) and an **About** blurb.

### Reader (\`/knowledge/<slug>?article=<id>\`)
12-col grid at \`lg\`: left meta rail (col-span-2) carrying \`Updated / Status / Source / Slug / Version\`; **prose column** (col-span-7, capped at 680px) with \`text-[16px] leading-[1.8]\` and a gold hairline under the H1; right rail (col-span-3) **reserved empty for future TOC / Related** (per design recs — articles too short to justify it now). Mobile collapses to single column with the meta rail below the body.

### Visual rules

- No bordered cards anywhere.
- Section kickers tinted per-section: \`aqua/75\` Recent, \`lilac/75\` Browse, \`white/40\` Sources/About.
- \`aqua\` (= champagne gold) reserved for editorial accents (lede hairline, link hover, inline code) — not UI primary.
- \`lilac\` for bucket nav; \`coral\` for errors only.
- Code blocks gain \`ring-1 ring-white/5\`.

### Implementation notes

- \`[id]/page.tsx\` \`load()\` now also fetches \`listBuckets\` for the sibling-bucket sidebar — bounded fan-out alongside existing \`getBucket\` + \`listBucketArticles\`.
- \`KnowledgeBucketRow.articleCount\` already in shape, used for the Browse list.

Net diff: 2 files, **+506 / −308**.

## Test plan

- [x] \`tsc --noEmit\` clean.
- [x] \`eslint --max-warnings=0\` clean on touched files.
- [ ] CI.
- [ ] Smoke desktop: index has lede + sticky sidebar; category has masthead + Other areas; reader has left rail + capped prose + empty right rail.
- [ ] Smoke mobile: collapses to single column on each surface.

## Follow-ups (intentional defers)

- TOC sidebar in reader — articles too short for now; rail reserved.
- Related-articles list — no view-tracking yet.