### PR TITLE
console: inbox tier ladder + drop bordered chrome

### DIFF
--- a/console/src/app/(authed)/inbox/page.tsx
+++ b/console/src/app/(authed)/inbox/page.tsx
@@ -1,18 +1,15 @@
 /**
- * Unified Inbox list page (RFC-0010 ticket P2-12).
+ * Unified Inbox list page.
  *
- * Server component that wires the just-shipped foundation pieces
- * together: `listInboxItems` from the API client, `InboxItemRow` for
- * each row, `InboxFilters` (via the `InboxFiltersControlled` client
- * shell) for ownership + type chips. State lives in the URL so
- * admins can deep-link / share / refresh without losing context;
- * `searchParams` are parsed defensively through the type guards in
- * `inbox-types.ts` so a hostile URL can't smuggle bad enum values
- * into the API query.
+ * Editorial layout: a typographic stats ribbon (mine · unassigned ·
+ * all open) replaces the segmented control; type chips sit on a
+ * single line with no bordered container; items group into three
+ * triage tiers (Tier 1 — needs you, Tier 2 — autonomy escapes,
+ * Tier 3 — later) with section kickers and a hairline rule.
  *
- * Session + workspace resolution live in `app/(authed)/layout.tsx`.
- * This page only reads the active workspace (via the cached helper)
- * and fetches inbox items.
+ * Per design rec we drop the bordered Filters card, the
+ * "X items" header, and the per-row card chrome. Per-row colour
+ * lives on a left-edge spine inside ``InboxItemRow``.
  */
 
 import Link from "next/link";
@@ -23,7 +20,8 @@ import { PageBody, PageHeader } from "@/components/app-shell";
 import { InboxFiltersControlled } from "@/components/inbox/inbox-filters-controlled";
 import { InboxItemRow } from "@/components/inbox/inbox-item-row";
 import { buildInboxUrl, countActiveFilters } from "@/components/inbox/inbox-url";
-import { Card, CardHeader, EmptyState } from "@/components/ui";
+import { EmptyState } from "@/components/ui";
+import { cn } from "@/lib/cn";
 import {
   ApiHttpError,
   listInboxItems,
@@ -36,11 +34,14 @@ import { getResolvedWorkspaceId } from "@/lib/workspace-resolve.server";
 import {
   DEFAULT_INBOX_FILTERS,
   INBOX_LIST_DEFAULT_STATUSES,
+  INBOX_TIER_LABEL,
   INBOX_TYPES,
+  inboxTier,
   isInboxType,
   type InboxFilterState,
   type InboxItem,
   type InboxListResponse,
+  type InboxTier,
   type InboxType,
 } from "@/lib/inbox-types";
 import {
@@ -51,6 +52,13 @@ import {
 export const dynamic = "force-dynamic";
 
 const PAGE_LIMIT = 25;
+const TIERS: InboxTier[] = [1, 2, 3];
+
+const TIER_KICKER_TONE: Record<InboxTier, string> = {
+  1: "text-sun/80",
+  2: "text-coral/80",
+  3: "text-white/40",
+};
 
 type ParsedParams = {
   filters: InboxFilterState;
@@ -133,10 +141,6 @@ async function load(
   searchParams: Record<string, string | string[] | undefined>,
 ): Promise<Mode> {
   const token = await getCachedSessionToken();
-  // The layout already redirected on missing session/workspaces, so by
-  // the time this runs we are guaranteed both. Defensive token check
-  // stays so a server action that swaps the bearer mid-render still
-  // sends us back to /login instead of throwing.
   if (!token) {
     redirect("/login?next=%2Finbox&reason=session_expired");
   }
@@ -198,6 +202,14 @@ function sumInboxTypeCounts(
   return n;
 }
 
+function partitionByTier(items: InboxItem[]): Record<InboxTier, InboxItem[]> {
+  const out: Record<InboxTier, InboxItem[]> = { 1: [], 2: [], 3: [] };
+  for (const item of items) {
+    out[inboxTier(item.type)].push(item);
+  }
+  return out;
+}
+
 export default async function InboxPage({
   searchParams,
 }: {
@@ -216,7 +228,7 @@ export default async function InboxPage({
         <PageHeader kicker="attention" title="Inbox" />
         <PageBody>
           {parsed.errorCode && (
-            <div className="mb-5 rounded-xl border border-coral/30 bg-coral/[0.06] px-3 py-2 text-xs text-coral/95">
+            <div className="mb-5 text-xs text-coral/95">
               {errorMessage(parsed.errorCode)}
             </div>
           )}
@@ -231,6 +243,7 @@ export default async function InboxPage({
   const allTypesCount = sumInboxTypeCounts(typeCounts);
   const activeFilterCount = countActiveFilters(filters, { repo, play });
   const inboxWs = multiWs ? workspaceId : undefined;
+  const tiers = partitionByTier(list.items);
 
   return (
     <>
@@ -248,182 +261,279 @@ export default async function InboxPage({
         }
       />
       <PageBody>
-        {parsed.errorCode && (
-          <div className="mb-5 rounded-xl border border-coral/30 bg-coral/[0.06] px-3 py-2 text-xs text-coral/95">
-            {errorMessage(parsed.errorCode)}
-          </div>
-        )}
-
-        {/* Compact filter strip — replaces the old "Filters" card.
-          * Single bordered row: ownership tabs + type chips + scope pills.
-          * Avoids the chrome (CardHeader + subtitle) that ate a quarter of
-          * the viewport before. */}
-        <section className="rounded-2xl border border-white/10 bg-white/[0.02] px-4 py-3">
-          <div className="flex flex-wrap items-center gap-3">
-            <p className="text-[10px] font-bold uppercase tracking-[0.18em] text-white/45">
-              Filters
+        <div className="mx-auto max-w-5xl space-y-8">
+          {parsed.errorCode && (
+            <p className="text-xs text-coral/95">
+              {errorMessage(parsed.errorCode)}
             </p>
-            <InboxFiltersControlled
-              value={filters}
-              counts={{ types: typeCounts, allTypes: allTypesCount }}
+          )}
+
+          <OwnershipRibbon
+            current={filters.ownership}
+            filters={filters}
+            repo={repo}
+            play={play}
+            workspaceScope={inboxWs}
+          />
+
+          <InboxFiltersControlled
+            value={filters}
+            counts={{ types: typeCounts, allTypes: allTypesCount }}
+            repo={repo}
+            play={play}
+            workspaceScope={inboxWs}
+          />
+
+          {(repo || play) && (
+            <div className="flex flex-wrap items-center gap-2 text-[11px] text-white/55">
+              {repo && (
+                <span>
+                  scope:{" "}
+                  <code className="font-mono text-white/80">{repo}</code>
+                </span>
+              )}
+              {play && (
+                <span>
+                  play:{" "}
+                  <code className="font-mono text-white/80">{play}</code>
+                </span>
+              )}
+              <a
+                href={buildInboxUrl(filters, { workspaceScope: inboxWs })}
+                className="font-semibold text-sun hover:text-white"
+              >
+                clear scope
+              </a>
+            </div>
+          )}
+
+          {list.items.length === 0 ? (
+            <InboxEmpty
+              filters={filters}
+              activeFilterCount={activeFilterCount}
               repo={repo}
               play={play}
               workspaceScope={inboxWs}
             />
-            {(repo || play) && (
-              <div className="flex flex-wrap items-center gap-1.5 text-[11px] text-white/55">
-                {repo && (
-                  <span className="inline-flex items-center gap-1 rounded-full border border-white/10 bg-white/[0.04] px-2 py-0.5">
-                    repo: <code className="font-mono text-white/80">{repo}</code>
-                  </span>
-                )}
-                {play && (
-                  <span className="inline-flex items-center gap-1 rounded-full border border-white/10 bg-white/[0.04] px-2 py-0.5">
-                    play: <code className="font-mono text-white/80">{play}</code>
-                  </span>
-                )}
-                <a
-                  href={buildInboxUrl(filters, { workspaceScope: inboxWs })}
-                  className="text-[11px] font-semibold text-sun hover:text-white"
-                >
-                  clear scope
-                </a>
-              </div>
-            )}
-          </div>
-        </section>
+          ) : (
+            <div className="space-y-10">
+              {TIERS.map((tier) => {
+                const items = tiers[tier];
+                if (items.length === 0) return null;
+                return (
+                  <TierSection
+                    key={tier}
+                    tier={tier}
+                    items={items}
+                    workspaceScope={inboxWs}
+                  />
+                );
+              })}
+            </div>
+          )}
 
-        {/* Counts kicker for the items list — was buried inside a CardHeader. */}
-        <div className="mt-5 flex flex-wrap items-baseline gap-3">
-          <h2 className="font-display text-lg font-bold text-white">
-            {list.items.length === 0 ? "No items" : `${list.items.length} item${list.items.length === 1 ? "" : "s"}`}
-          </h2>
-          <span className="text-[11px] text-white/45">
-            Oldest-first; resolved / dismissed rows fade out so the queue keeps reading top-down.
-          </span>
-        </div>
-
-        <div className="mt-3">
-          <ItemsTable
-            items={list.items}
+          <Pager
+            nextCursor={list.next_cursor}
+            currentCursor={cursor}
             filters={filters}
             repo={repo}
             play={play}
-            activeFilterCount={activeFilterCount}
             workspaceScope={inboxWs}
           />
         </div>
-
-        <Pager
-          nextCursor={list.next_cursor}
-          currentCursor={cursor}
-          filters={filters}
-          repo={repo}
-          play={play}
-          workspaceScope={inboxWs}
-        />
       </PageBody>
     </>
   );
 }
 
-function ItemsTable({
-  items,
+
+// ---------------------------------------------------------------------------
+// Ownership stats ribbon — typographic
+// ---------------------------------------------------------------------------
+
+
+function OwnershipRibbon({
+  current,
   filters,
   repo,
   play,
-  activeFilterCount,
   workspaceScope,
 }: {
-  items: InboxItem[];
+  current: InboxFilterState["ownership"];
   filters: InboxFilterState;
   repo: string | null;
   play: string | null;
-  activeFilterCount: number;
   workspaceScope?: string;
 }) {
-  if (items.length === 0) {
-    if (activeFilterCount > 0) {
-      return (
-        <div className="mt-5">
-          <EmptyState
-            title="No items match these filters"
-            body="Try widening the ownership tab to All, clearing the type chips, or dropping the repo/play scope."
-            action={
-              <Link
-                href={buildInboxUrl(DEFAULT_INBOX_FILTERS, {
-                  workspaceScope,
-                })}
-                className="inline-flex items-center gap-1 rounded-full border border-aqua/40 bg-aqua/10 px-3 py-1.5 text-xs font-semibold text-aqua hover:bg-aqua/20"
-              >
-                Clear all filters
-              </Link>
-            }
-          />
-        </div>
-      );
-    }
-    if (filters.ownership === "mine") {
-      return (
-        <div className="mt-5">
-          <EmptyState
-            title="Nothing on your plate"
-            body="Either you're caught up or nobody's routing things your way. Switch to All to see the workspace firehose."
-            action={
-              <a
-                href={buildInboxUrl(
-                  { ...filters, ownership: "all" },
-                  { repo, play, workspaceScope },
-                )}
-                className="inline-flex items-center gap-1 rounded-full border border-white/15 bg-white/[0.04] px-3 py-1.5 text-xs font-semibold text-white/85 hover:border-white/30 hover:bg-white/[0.08]"
-              >
-                Switch to All
-              </a>
-            }
-          />
-        </div>
-      );
-    }
-    return (
-      <div className="mt-5">
-        <EmptyState
-          title="Inbox empty"
-          body="Either nothing has fired or your team coverage needs attention — check who can answer under Settings → Members."
-            action={
-            <a
-              href={withWorkspaceQuery(
-                "/settings?tab=members",
-                workspaceScope ?? "",
-                Boolean(workspaceScope),
-              )}
-              className="inline-flex items-center gap-1 rounded-full border border-aqua/40 bg-aqua/10 px-3 py-1.5 text-xs font-semibold text-aqua hover:bg-aqua/20"
-            >
-              Open Members
-            </a>
-          }
-        />
-      </div>
-    );
-  }
-
+  const lenses: { key: InboxFilterState["ownership"]; label: string }[] = [
+    { key: "mine", label: "Mine" },
+    { key: "unassigned", label: "Unassigned" },
+    { key: "all", label: "All open" },
+  ];
   return (
-    <ul className="space-y-1.5">
-      {items.map((item) => (
-        <li key={item.id}>
-          <InboxItemRow
-            item={item}
-            workspaceId={workspaceScope}
-            href={
-              workspaceScope
-                ? `/inbox/${item.id}?ws=${encodeURIComponent(workspaceScope)}`
-                : `/inbox/${item.id}`
-            }
-          />
-        </li>
-      ))}
-    </ul>
+    <nav
+      aria-label="Inbox ownership"
+      className="flex flex-wrap items-baseline gap-x-3 gap-y-1 text-sm"
+    >
+      {lenses.map((lens, idx) => {
+        const active = current === lens.key;
+        const href = buildInboxUrl(
+          { ...filters, ownership: lens.key },
+          { repo, play, workspaceScope },
+        );
+        return (
+          <span key={lens.key} className="flex items-baseline">
+            <Link
+              href={href}
+              aria-current={active ? "page" : undefined}
+              className={cn(
+                "transition",
+                active
+                  ? "font-semibold text-white"
+                  : "text-white/45 hover:text-white",
+              )}
+            >
+              {lens.label}
+            </Link>
+            {idx < lenses.length - 1 && (
+              <span className="ml-3 text-white/15">·</span>
+            )}
+          </span>
+        );
+      })}
+    </nav>
   );
 }
+
+
+// ---------------------------------------------------------------------------
+// Tier section — kicker + divide-y rows
+// ---------------------------------------------------------------------------
+
+
+function TierSection({
+  tier,
+  items,
+  workspaceScope,
+}: {
+  tier: InboxTier;
+  items: InboxItem[];
+  workspaceScope?: string;
+}) {
+  return (
+    <section>
+      <header className="mb-3 flex items-center gap-3">
+        <h2
+          className={cn(
+            "text-[11px] font-bold uppercase tracking-[0.22em]",
+            TIER_KICKER_TONE[tier],
+          )}
+        >
+          {INBOX_TIER_LABEL[tier]}
+        </h2>
+        <div className="h-px flex-1 bg-white/[0.06]" />
+        <span className="font-mono text-[11px] text-white/35">
+          {items.length}
+        </span>
+      </header>
+      <ul className="divide-y divide-white/[0.06]">
+        {items.map((item) => (
+          <li key={item.id}>
+            <InboxItemRow
+              item={item}
+              workspaceId={workspaceScope}
+              href={
+                workspaceScope
+                  ? `/inbox/${item.id}?ws=${encodeURIComponent(workspaceScope)}`
+                  : `/inbox/${item.id}`
+              }
+            />
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+
+// ---------------------------------------------------------------------------
+// Empty states
+// ---------------------------------------------------------------------------
+
+
+function InboxEmpty({
+  filters,
+  activeFilterCount,
+  repo,
+  play,
+  workspaceScope,
+}: {
+  filters: InboxFilterState;
+  activeFilterCount: number;
+  repo: string | null;
+  play: string | null;
+  workspaceScope?: string;
+}) {
+  if (activeFilterCount > 0) {
+    return (
+      <EmptyState
+        title="No items match these filters"
+        body="Try widening the ownership lens to All, clearing the type chips, or dropping the repo/play scope."
+        action={
+          <Link
+            href={buildInboxUrl(DEFAULT_INBOX_FILTERS, { workspaceScope })}
+            className="text-xs font-semibold text-aqua hover:text-white"
+          >
+            Clear all filters
+          </Link>
+        }
+      />
+    );
+  }
+  if (filters.ownership === "mine") {
+    return (
+      <EmptyState
+        title="Nothing on your plate"
+        body="Either you're caught up or nobody's routing things your way. Switch to All open to see the workspace firehose."
+        action={
+          <a
+            href={buildInboxUrl(
+              { ...filters, ownership: "all" },
+              { repo, play, workspaceScope },
+            )}
+            className="text-xs font-semibold text-white/85 hover:text-white"
+          >
+            Switch to All open
+          </a>
+        }
+      />
+    );
+  }
+  return (
+    <EmptyState
+      title="Inbox empty"
+      body="Either nothing has fired or your team coverage needs attention — check who can answer under Settings → Members."
+      action={
+        <a
+          href={withWorkspaceQuery(
+            "/settings?tab=members",
+            workspaceScope ?? "",
+            Boolean(workspaceScope),
+          )}
+          className="text-xs font-semibold text-aqua hover:text-white"
+        >
+          Open Members
+        </a>
+      }
+    />
+  );
+}
+
+
+// ---------------------------------------------------------------------------
+// Pager + Refresh
+// ---------------------------------------------------------------------------
+
 
 function Pager({
   nextCursor,
@@ -442,11 +552,11 @@ function Pager({
 }) {
   if (!nextCursor && !currentCursor) return null;
   return (
-    <div className="mt-5 flex items-center justify-between">
+    <div className="flex items-center justify-between text-[11px]">
       {currentCursor ? (
         <a
           href={buildInboxUrl(filters, { repo, play, workspaceScope })}
-          className="text-[11px] font-semibold text-white/55 hover:text-white"
+          className="font-semibold text-white/55 hover:text-white"
         >
           ← First page
         </a>
@@ -461,7 +571,7 @@ function Pager({
             cursor: nextCursor,
             workspaceScope,
           })}
-          className="rounded-full border border-aqua/40 bg-aqua/10 px-3 py-1.5 text-xs font-semibold text-aqua hover:bg-aqua/20"
+          className="font-semibold text-white/55 hover:text-white"
         >
           Load older →
         </a>
@@ -469,6 +579,7 @@ function Pager({
     </div>
   );
 }
+
 
 function RefreshButton({
   filters,
@@ -499,7 +610,7 @@ function RefreshButton({
       )}
       <button
         type="submit"
-        className="inline-flex items-center gap-1.5 rounded-full border border-white/15 bg-white/[0.04] px-3 py-1.5 text-xs font-semibold text-white/85 transition hover:border-white/30 hover:bg-white/[0.08]"
+        className="text-xs font-semibold text-white/55 transition hover:text-white"
         title="Reload the current view"
       >
         ↻ Refresh

--- a/console/src/components/inbox/inbox-filters.tsx
+++ b/console/src/components/inbox/inbox-filters.tsx
@@ -9,36 +9,20 @@ import {
 } from "@/lib/inbox-types";
 
 /**
- * Filter controls for the unified Inbox list (RFC-0010 P2-12).
+ * Type chip row for the unified Inbox list.
  *
- * Ownership: All (default) | Mine | Unassigned
- * Type row:  All, then Clarifications … Exceptions (stuck / blockers stay in the
- * list but are not in this chip row).
- *
- * List status slice (e.g. open + snoozed) is fixed in the data layer — not
- * user-configurable here.
+ * Ownership lives in the page-level stats ribbon now, so this
+ * component only renders the type filter strip. Chips are
+ * transparent in the resting state with a hairline border, lit up
+ * via the section accent when active. Counts only render on the
+ * active chip + the All chip — inactive chips stay quiet.
  */
-
-const OWNERSHIP_OPTIONS: {
-  key: InboxFilterState["ownership"];
-  label: string;
-  hint: string;
-}[] = [
-  { key: "all", label: "All", hint: "Entire workspace queue" },
-  { key: "mine", label: "Mine", hint: "Items routed to you" },
-  {
-    key: "unassigned",
-    label: "Unassigned",
-    hint: "No owner — needs assignment",
-  },
-];
 
 export type InboxFiltersProps = {
   value: InboxFilterState;
   onChange: (next: InboxFilterState) => void;
   /** Optional count badges, keyed by filter dimension. */
   counts?: {
-    ownership?: Partial<Record<InboxFilterState["ownership"], number>>;
     types?: Partial<Record<InboxType, number>>;
     /** Total across types for this view (no type filter); matches sum of per-type counts. */
     allTypes?: number;
@@ -57,105 +41,73 @@ export function InboxFilters({
   className,
 }: InboxFiltersProps) {
   return (
-    <div className={cn("flex flex-col gap-3", className)}>
-      <div
-        role="tablist"
-        aria-label="Inbox ownership filter"
-        className="flex items-center gap-1 rounded-full border border-white/10 bg-white/[0.04] p-1"
+    <div className={cn("flex flex-wrap items-center gap-x-4 gap-y-2", className)}>
+      <ChipButton
+        active={value.types.length === 0}
+        count={counts?.allTypes}
+        showCount
+        onClick={() => onChange({ ...value, types: [] })}
       >
-        {OWNERSHIP_OPTIONS.map((opt) => {
-          const active = value.ownership === opt.key;
-          const count = counts?.ownership?.[opt.key];
-          return (
-            <button
-              key={opt.key}
-              type="button"
-              role="tab"
-              aria-selected={active}
-              title={opt.hint}
-              onClick={() => onChange({ ...value, ownership: opt.key })}
-              className={cn(
-                "inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-semibold transition",
-                active
-                  ? "bg-white/15 text-white shadow-sm"
-                  : "text-white/65 hover:bg-white/[0.06] hover:text-white/85",
-              )}
-            >
-              {opt.label}
-              {count !== undefined && (
-                <span
-                  className={cn(
-                    "rounded-full px-1.5 text-[10px] font-bold",
-                    active ? "bg-white/20 text-white" : "bg-white/10 text-white/55",
-                  )}
-                >
-                  {count}
-                </span>
-              )}
-            </button>
-          );
-        })}
-      </div>
+        All
+      </ChipButton>
+      {INBOX_FILTER_TYPES.map((t) => {
+        const active = value.types.includes(t);
+        const count = counts?.types?.[t];
+        return (
+          <ChipButton
+            key={t}
+            active={active}
+            count={count}
+            showCount={active}
+            onClick={() =>
+              onChange({ ...value, types: toggle(value.types, t) })
+            }
+          >
+            {INBOX_TYPE_META[t].label}
+          </ChipButton>
+        );
+      })}
+    </div>
+  );
+}
 
-      <div className="flex flex-wrap items-center gap-1.5">
-        <button
-          type="button"
-          aria-pressed={value.types.length === 0}
-          onClick={() => onChange({ ...value, types: [] })}
+
+function ChipButton({
+  active,
+  count,
+  showCount,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  count?: number;
+  showCount?: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      aria-pressed={active}
+      onClick={onClick}
+      className={cn(
+        "group inline-flex items-baseline gap-1.5 text-[11px] font-semibold uppercase tracking-wider transition",
+        active
+          ? "text-aqua"
+          : "text-white/55 hover:text-white",
+      )}
+    >
+      <span>{children}</span>
+      {showCount && count !== undefined && (
+        <span
           className={cn(
-            "inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-[11px] font-semibold transition",
-            value.types.length === 0
-              ? "border-aqua/50 bg-aqua/15 text-aqua"
-              : "border-white/10 bg-white/[0.04] text-white/65 hover:border-white/20 hover:text-white/85",
+            "font-mono text-[10px] font-bold",
+            active ? "text-aqua/70" : "text-white/35",
           )}
         >
-          All
-          {counts?.allTypes !== undefined && (
-            <span
-              className={cn(
-                "rounded-full px-1.5 text-[10px] font-bold",
-                value.types.length === 0
-                  ? "bg-aqua/30 text-white"
-                  : "bg-white/10 text-white/55",
-              )}
-            >
-              {counts.allTypes}
-            </span>
-          )}
-        </button>
-        {INBOX_FILTER_TYPES.map((t) => {
-          const active = value.types.includes(t);
-          const count = counts?.types?.[t];
-          return (
-            <button
-              key={t}
-              type="button"
-              aria-pressed={active}
-              onClick={() =>
-                onChange({ ...value, types: toggle(value.types, t) })
-              }
-              className={cn(
-                "inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-[11px] font-semibold transition",
-                active
-                  ? "border-aqua/50 bg-aqua/15 text-aqua"
-                  : "border-white/10 bg-white/[0.04] text-white/65 hover:border-white/20 hover:text-white/85",
-              )}
-            >
-              {INBOX_TYPE_META[t].label}
-              {count !== undefined && (
-                <span
-                  className={cn(
-                    "rounded-full px-1.5 text-[10px] font-bold",
-                    active ? "bg-aqua/30 text-white" : "bg-white/10 text-white/55",
-                  )}
-                >
-                  {count}
-                </span>
-              )}
-            </button>
-          );
-        })}
-      </div>
-    </div>
+          {count}
+        </span>
+      )}
+    </button>
   );
 }

--- a/console/src/components/inbox/inbox-item-row.tsx
+++ b/console/src/components/inbox/inbox-item-row.tsx
@@ -1,6 +1,5 @@
 import Link from "next/link";
 
-import { Badge, type BadgeTone } from "@/components/ui";
 import { cn } from "@/lib/cn";
 import { INBOX_TYPE_META, type InboxItem } from "@/lib/inbox-types";
 
@@ -8,26 +7,35 @@ import { InboxRowActions } from "./inbox-row-actions";
 import { StaleBadge } from "./stale-badge";
 
 /**
- * One row in the unified Inbox list (RFC-0010 P2-12).
+ * One row in the unified Inbox list.
  *
- * Pure presentational — receives a fully-typed `InboxItem` from the
- * list page and renders:
- *   - type chip + age badge (escalates yellow at 2d, red at 7d)
- *   - title + summary preview (single-line truncated)
- *   - owner pill (or "Unassigned" warn pill when `owner` is null)
- *   - intake reason (debug-grade tooltip; surfaces routing path)
- *   - status side-marker for snoozed/resolved/dismissed rows
- *
- * Linking is delegated to the parent: provide `href` to make the
- * whole row a Link, or omit it for static demos. The full keyboard
- * a11y story (focus ring, aria-label) lives on the wrapping `<a>`.
+ * Per design rec: no rounded card around the row. Per-kind colour
+ * lives on a 3px left-edge **spine** (Linear's priority spine
+ * idiom). Rows sit on a ``divide-y`` rhythm provided by the
+ * parent — this component contributes zero borders / backgrounds
+ * in the resting state. Hover gets a faint ``bg-white/[0.025]``
+ * tint and reveals the inline action buttons (touch breakpoints
+ * keep the actions visible at all times).
  */
 
-const STATUS_TONE: Record<InboxItem["status"], BadgeTone> = {
-  new: "info",
-  snoozed: "warn",
-  resolved: "neutral",
-  dismissed: "neutral",
+const SPINE_TONE: Record<InboxItem["type"], string> = {
+  clarification: "bg-sun",
+  approval: "bg-aqua",
+  improvement: "bg-lilac",
+  failure: "bg-coral",
+  blocker: "bg-coral",
+  exception: "bg-coral/60",
+  stuck: "bg-white/30",
+};
+
+const SPINE_WIDTH: Record<InboxItem["type"], string> = {
+  clarification: "w-[3px]",
+  approval: "w-[3px]",
+  improvement: "w-[2px]",
+  failure: "w-[3px]",
+  blocker: "w-[4px]",
+  exception: "w-[2px]",
+  stuck: "w-px",
 };
 
 function ownerLabel(owner: InboxItem["owner"]): string {
@@ -36,10 +44,10 @@ function ownerLabel(owner: InboxItem["owner"]): string {
 }
 
 function ownerInitials(owner: InboxItem["owner"]): string {
-  if (!owner) return "?";
+  if (!owner) return "—";
   const source = owner.display_name?.trim() || owner.email;
   const tokens = source.split(/[\s@.]+/).filter(Boolean);
-  if (tokens.length === 0) return "?";
+  if (tokens.length === 0) return "—";
   if (tokens.length === 1) return tokens[0].slice(0, 2).toUpperCase();
   return (tokens[0][0] + tokens[1][0]).toUpperCase();
 }
@@ -64,52 +72,36 @@ export function InboxItemRow({
   const meta = INBOX_TYPE_META[item.type];
   const isTerminal =
     item.status === "resolved" || item.status === "dismissed";
-
-  // Dense single-row layout: type-dot · title (truncated) · meta · owner pill.
-  // Summary collapses under the title only when it adds new info beyond the
-  // title (no duplicate-text wraps). Each row is ~52px tall; the previous
-  // 3-column grid with a 36px avatar and stacked badges took ~120px.
-  const dotClass =
-    item.type === "clarification"
-      ? "bg-sun"
-      : item.type === "approval"
-        ? "bg-aqua"
-        : item.type === "improvement"
-          ? "bg-lilac"
-          : item.type === "failure" || item.type === "blocker" || item.type === "exception"
-            ? "bg-coral"
-            : item.type === "stuck"
-              ? "bg-sun/80"
-              : "bg-white/40";
-
   const showSummary =
-    item.summary && item.summary.trim().toLowerCase() !== item.title.trim().toLowerCase();
+    item.summary &&
+    item.summary.trim().toLowerCase() !== item.title.trim().toLowerCase();
 
   const body = (
     <div
       className={cn(
-        "group flex items-start gap-3 rounded-xl border px-3 py-2.5 transition",
-        isTerminal
-          ? "border-white/[0.06] bg-white/[0.015] opacity-65"
-          : "border-white/10 bg-white/[0.03] hover:border-white/25 hover:bg-white/[0.06]",
+        "group relative flex items-start gap-4 py-3 pl-4 pr-2 transition",
+        isTerminal ? "opacity-50" : "hover:bg-white/[0.025]",
         className,
       )}
     >
-      {/* Type dot */}
       <span
-        className={cn("mt-1.5 inline-block h-2 w-2 shrink-0 rounded-full", dotClass)}
-        title={meta.label}
         aria-hidden
+        title={meta.label}
+        className={cn(
+          "absolute inset-y-2 left-0 rounded-r-sm",
+          SPINE_TONE[item.type],
+          SPINE_WIDTH[item.type],
+        )}
       />
 
-      {/* Main column */}
       <div className="min-w-0 flex-1">
-        <div className="flex items-center gap-2">
-          <span className="text-[10px] font-bold uppercase tracking-[0.14em] text-white/45">
-            {meta.label.replace(/s$/, "")}
-          </span>
+        <div className="flex items-center gap-2 text-[10px] uppercase tracking-[0.16em] text-white/45">
+          <span>{meta.label.replace(/s$/, "")}</span>
           {item.status !== "new" && (
-            <Badge tone={STATUS_TONE[item.status]}>{item.status}</Badge>
+            <>
+              <span className="text-white/15">·</span>
+              <span className="text-white/55">{item.status}</span>
+            </>
           )}
           <StaleBadge
             createdAt={item.created_at}
@@ -118,51 +110,69 @@ export function InboxItemRow({
             referenceDate={referenceDate}
           />
           {item.intake_reason?.startsWith("fallback:") && (
-            <Badge tone="warn" className="!normal-case" dot={false}>
-              fallback routing
-            </Badge>
+            <>
+              <span className="text-white/15">·</span>
+              <span className="text-sun/80">fallback routing</span>
+            </>
           )}
         </div>
         <p
           className={cn(
-            "mt-1 truncate text-sm font-semibold",
+            "mt-1 truncate text-[15px] font-semibold",
             isTerminal ? "text-white/55" : "text-white",
           )}
         >
           {item.title}
         </p>
         {showSummary && (
-          <p className="mt-0.5 truncate text-xs text-white/50">{item.summary}</p>
+          <p className="mt-0.5 truncate text-xs text-white/55">{item.summary}</p>
         )}
       </div>
 
-      {/* Right rail: actions + owner + play key. */}
       <div
-        className="flex shrink-0 items-center gap-2 self-center"
+        className="flex shrink-0 items-center gap-3 self-center"
         title={item.intake_reason ?? undefined}
       >
         {item.play_key && (
-          <code className="hidden font-mono text-[10px] text-white/35 lg:inline">
+          <code className="hidden font-mono text-[10px] text-white/30 lg:inline">
             {item.play_key}
           </code>
         )}
         {workspaceId && href && !isTerminal && (
-          <InboxRowActions
-            workspaceId={workspaceId}
-            item={{ id: item.id, type: item.type, status: item.status }}
-            detailHref={href}
-          />
+          <span className="hidden lg:inline-flex lg:opacity-0 lg:transition lg:group-hover:opacity-100 lg:focus-within:opacity-100">
+            <InboxRowActions
+              workspaceId={workspaceId}
+              item={{ id: item.id, type: item.type, status: item.status }}
+              detailHref={href}
+            />
+          </span>
+        )}
+        {workspaceId && href && !isTerminal && (
+          <span className="inline-flex lg:hidden">
+            <InboxRowActions
+              workspaceId={workspaceId}
+              item={{ id: item.id, type: item.type, status: item.status }}
+              detailHref={href}
+            />
+          </span>
         )}
         <span
           className={cn(
-            "inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-[11px] font-semibold",
-            item.owner
-              ? "border-aqua/35 bg-aqua/10 text-aqua"
-              : "border-coral/35 bg-coral/10 text-coral",
+            "inline-flex items-center gap-1.5 text-xs",
+            item.owner ? "text-white/85" : "text-coral/85",
           )}
         >
-          <span className="font-mono text-[9px]">{ownerInitials(item.owner)}</span>
-          <span>{ownerLabel(item.owner)}</span>
+          <span
+            className={cn(
+              "inline-flex h-5 w-5 items-center justify-center rounded-full font-mono text-[9px] font-bold",
+              item.owner
+                ? "bg-white/[0.08] text-white/75"
+                : "bg-coral/15 text-coral",
+            )}
+          >
+            {ownerInitials(item.owner)}
+          </span>
+          <span className="truncate">{ownerLabel(item.owner)}</span>
         </span>
       </div>
     </div>
@@ -172,7 +182,7 @@ export function InboxItemRow({
   return (
     <Link
       href={href}
-      className="block focus:outline-none focus-visible:ring-2 focus-visible:ring-aqua/60 focus-visible:ring-offset-2 focus-visible:ring-offset-ink rounded-2xl"
+      className="block focus:outline-none focus-visible:ring-1 focus-visible:ring-aqua/60 focus-visible:ring-offset-0"
       aria-label={`${INBOX_TYPE_META[item.type].label}: ${item.title}`}
     >
       {body}

--- a/console/src/components/inbox/inbox-row-actions.tsx
+++ b/console/src/components/inbox/inbox-row-actions.tsx
@@ -136,7 +136,7 @@ export function InboxRowActions({ workspaceId, item, detailHref }: Props) {
           type="button"
           onClick={onPrimary}
           disabled={!!busy || isTerminal}
-          className="rounded-md border border-aqua/40 bg-aqua/10 px-2.5 py-1 text-[11px] font-bold uppercase tracking-wide text-aqua transition hover:border-aqua/70 hover:bg-aqua/20 disabled:opacity-40"
+          className="text-[11px] font-semibold uppercase tracking-wide text-aqua transition hover:text-white disabled:opacity-40"
         >
           {busy === "primary" ? "…" : primaryLabel}
         </button>
@@ -145,7 +145,7 @@ export function InboxRowActions({ workspaceId, item, detailHref }: Props) {
           type="button"
           onClick={onPrimary}
           disabled={!!busy || isTerminal}
-          className="rounded-md border border-sun/40 bg-sun/10 px-2.5 py-1 text-[11px] font-bold uppercase tracking-wide text-sun transition hover:border-sun/70 hover:bg-sun/20 disabled:opacity-40"
+          className="text-[11px] font-semibold uppercase tracking-wide text-sun transition hover:text-white disabled:opacity-40"
         >
           Answer
         </button>
@@ -156,7 +156,7 @@ export function InboxRowActions({ workspaceId, item, detailHref }: Props) {
           type="button"
           onClick={onSecondary}
           disabled={!!busy || isTerminal}
-          className="rounded-md border border-coral/40 bg-coral/10 px-2.5 py-1 text-[11px] font-bold uppercase tracking-wide text-coral transition hover:border-coral/70 hover:bg-coral/20 disabled:opacity-40"
+          className="text-[11px] font-semibold uppercase tracking-wide text-coral/80 transition hover:text-coral disabled:opacity-40"
         >
           {busy === "secondary" ? "…" : secondaryLabel}
         </button>
@@ -167,7 +167,7 @@ export function InboxRowActions({ workspaceId, item, detailHref }: Props) {
           type="button"
           onClick={onDiscuss}
           disabled={!!busy || isTerminal}
-          className="rounded-md border border-lilac/40 bg-lilac/10 px-2.5 py-1 text-[11px] font-bold uppercase tracking-wide text-lilac transition hover:border-lilac/70 hover:bg-lilac/20 disabled:opacity-40"
+          className="text-[11px] font-semibold uppercase tracking-wide text-lilac/80 transition hover:text-lilac disabled:opacity-40"
           title="Open Navigator chat seeded with this item's context"
         >
           {busy === "discuss" ? "…" : "Discuss"}

--- a/console/src/lib/inbox-types.ts
+++ b/console/src/lib/inbox-types.ts
@@ -201,3 +201,35 @@ export function isInboxType(value: string): value is InboxType {
 export function isInboxStatus(value: string): value is InboxStatus {
   return (INBOX_STATUSES as readonly string[]).includes(value);
 }
+
+/**
+ * Triage tier — the visual ladder operators scan top-down on the list
+ * page. Assignment is fixed by item kind; orderings inside a tier come
+ * from the existing ``created_at`` sort.
+ *
+ *   Tier 1 (needs you)         clarification, approval
+ *   Tier 2 (autonomy escapes)  failure, blocker, exception
+ *   Tier 3 (later)             improvement, stuck
+ */
+export type InboxTier = 1 | 2 | 3;
+
+export function inboxTier(type: InboxType): InboxTier {
+  switch (type) {
+    case "clarification":
+    case "approval":
+      return 1;
+    case "failure":
+    case "blocker":
+    case "exception":
+      return 2;
+    case "improvement":
+    case "stuck":
+      return 3;
+  }
+}
+
+export const INBOX_TIER_LABEL: Record<InboxTier, string> = {
+  1: "Needs you",
+  2: "Autonomy escapes",
+  3: "Later",
+};


### PR DESCRIPTION
## Summary

Editorial triage ladder for ``/inbox`` — same treatment as the knowledge surface. Drops the concentric-card chrome (Filters card → "X items" header → per-row card), groups items into three triage tiers, replaces the segmented ownership control with a typographic ribbon, moves per-kind colour from a 2px dot to a left-edge spine.

### Tier ladder

- **Tier 1 — Needs you** (\`sun/80\` kicker): \`clarification\`, \`approval\`. Operator-blocking work.
- **Tier 2 — Autonomy escapes** (\`coral/80\` kicker): \`failure\`, \`blocker\`, \`exception\`. Came out of self-heal.
- **Tier 3 — Later** (\`white/40\` kicker): \`improvement\`, \`stuck\`. Lower visual weight.

\`inbox-types.ts\` adds \`inboxTier()\` + \`INBOX_TIER_LABEL\` so future surfaces share the taxonomy.

### Row redesign

- No bordered card, no ``bg-white/[0.03]`` fill. Separators come from parent \`divide-y divide-white/[0.06]\`.
- Per-kind colour → 2–4px **left-edge spine** (Linear's priority spine). 4px for blockers, 3px for clarification/approval/failure, 2px for improvement/exception, 1px for stuck.
- Owner pill loses the aqua chrome — plain initials avatar + display name; \`coral\` only when unassigned.
- Action buttons → minimal text-link uppercase, **hover-revealed at \`lg+\`**, always-on at touch breakpoints.

### Page chrome

- Drop bordered Filters card + "X items" header.
- Stats ribbon: \`Mine · Unassigned · All open\` as typographic links, active lens bolder. Replaces the segmented control.
- Filter chips: transparent unless active, no bordered wrapper, count badges only on active + All.

### Reference patterns

Linear inbox priority spine · Gmail typographic category links · Superhuman quiet-row aesthetic.

### Defer

Bulk-selection toolbar, section collapse persistence, j/k keyboard nav — per design rec, ship the visual ladder first.

Net diff: 5 files, **+462 / −357**.

## Test plan

- [x] \`tsc --noEmit\` clean.
- [x] \`eslint --max-warnings=0\` clean on touched files.
- [ ] CI.
- [ ] Smoke: visit \`/inbox\` with mixed kinds — three tier kickers render with correct tints; spines visible per-kind; owner pills plain (no aqua border); ownership ribbon at top; chips transparent unless active; hover reveals action buttons at lg+.