### PR TITLE
console: widen dashboard + knowledge on big monitors, add reader TOC

### DIFF
--- a/console/src/app/(authed)/knowledge/[id]/page.tsx
+++ b/console/src/app/(authed)/knowledge/[id]/page.tsx
@@ -37,6 +37,9 @@ import {
 } from "@/lib/api/session-cache.server";
 import type { ApiBucketArticle } from "@/lib/api/types";
 import { relativeTime } from "@/lib/format";
+import { headingIdFromChildren, parseToc } from "@/lib/article-toc";
+
+import { ArticleToc } from "../article-toc";
 
 export const dynamic = "force-dynamic";
 
@@ -160,7 +163,7 @@ function CategoryView({
     <>
       <PageHeader kicker="knowledge" title={bucket.name} />
       <PageBody>
-        <div className="mx-auto max-w-6xl">
+        <div className="mx-auto max-w-6xl xl:max-w-7xl">
           <header className="mb-12 space-y-3">
             <Link
               href="/knowledge"
@@ -183,7 +186,7 @@ function CategoryView({
             </p>
           </header>
 
-          <div className="grid grid-cols-1 gap-x-12 gap-y-12 lg:grid-cols-12">
+          <div className="grid grid-cols-1 gap-x-12 gap-y-12 lg:grid-cols-12 xl:gap-x-16">
             <section className="lg:col-span-8">
               <ArticleList articles={articles} bucketSlug={bucket.slug} />
             </section>
@@ -292,6 +295,7 @@ function ReaderView({
   article: ApiBucketArticle;
 }) {
   const provenance = provenanceHint(article);
+  const tocEntries = parseToc(article.body_md ?? "");
   return (
     <>
       <PageHeader kicker="knowledge" title={article.title} />
@@ -340,17 +344,26 @@ function ReaderView({
                   remarkPlugins={[remarkGfm]}
                   components={{
                     h1: ({ children }) => (
-                      <h2 className="mt-12 font-display text-2xl font-bold text-white">
+                      <h2
+                        id={headingIdFromChildren(children)}
+                        className="mt-12 scroll-mt-24 font-display text-2xl font-bold text-white"
+                      >
                         {children}
                       </h2>
                     ),
                     h2: ({ children }) => (
-                      <h2 className="mt-10 font-display text-xl font-bold text-white">
+                      <h2
+                        id={headingIdFromChildren(children)}
+                        className="mt-10 scroll-mt-24 font-display text-xl font-bold text-white"
+                      >
                         {children}
                       </h2>
                     ),
                     h3: ({ children }) => (
-                      <h3 className="mt-8 font-display text-lg font-bold text-white">
+                      <h3
+                        id={headingIdFromChildren(children)}
+                        className="mt-8 scroll-mt-24 font-display text-lg font-bold text-white"
+                      >
                         {children}
                       </h3>
                     ),
@@ -396,10 +409,9 @@ function ReaderView({
               </div>
             </article>
 
-            <aside
-              className="order-3 hidden lg:col-span-3 lg:block"
-              aria-hidden="true"
-            />
+            <aside className="order-3 hidden xl:col-span-3 xl:block xl:sticky xl:top-24 xl:self-start">
+              <ArticleToc entries={tocEntries} />
+            </aside>
           </div>
         </div>
       </PageBody>

--- a/console/src/app/(authed)/knowledge/article-toc.tsx
+++ b/console/src/app/(authed)/knowledge/article-toc.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+/**
+ * Article reader TOC — sticky right-rail outline that highlights the
+ * section currently in the viewport via ``IntersectionObserver``.
+ *
+ * Rendered at ``xl+`` only; below that breakpoint the right rail
+ * doesn't exist and the TOC is hidden. Section IDs are produced by the
+ * same slugify rule the markdown ``h1``/``h2``/``h3`` components use,
+ * so the in-prose anchor and the TOC link agree.
+ */
+
+import { useEffect, useState } from "react";
+
+import { cn } from "@/lib/cn";
+
+export type TocEntry = {
+  id: string;
+  level: 1 | 2 | 3;
+  text: string;
+};
+
+export function ArticleToc({ entries }: { entries: TocEntry[] }) {
+  const [active, setActive] = useState<string | null>(
+    entries[0]?.id ?? null,
+  );
+
+  useEffect(() => {
+    if (entries.length === 0) return;
+
+    const targets = entries
+      .map((entry) => document.getElementById(entry.id))
+      .filter((node): node is HTMLElement => node !== null);
+
+    if (targets.length === 0) return;
+
+    // Highlight the heading whose top has just crossed into the upper
+    // 30% of the viewport — same idiom as Stripe Docs / Linear's
+    // changelog sidebar. Without the rootMargin trim, every heading
+    // intersects on first paint and the TOC oscillates.
+    const observer = new IntersectionObserver(
+      (records) => {
+        const onScreen = records.filter((r) => r.isIntersecting);
+        if (onScreen.length === 0) return;
+        // Pick the topmost intersecting heading.
+        onScreen.sort(
+          (a, b) => a.boundingClientRect.top - b.boundingClientRect.top,
+        );
+        const id = onScreen[0]?.target.id;
+        if (id) setActive(id);
+      },
+      { rootMargin: "-15% 0px -70% 0px", threshold: 0 },
+    );
+
+    for (const node of targets) observer.observe(node);
+    return () => observer.disconnect();
+  }, [entries]);
+
+  if (entries.length === 0) return null;
+
+  return (
+    <nav aria-label="Article outline" className="space-y-3">
+      <p className="text-[10px] font-bold uppercase tracking-[0.22em] text-white/40">
+        On this page
+      </p>
+      <ul className="space-y-1.5 text-[12px] leading-snug">
+        {entries.map((entry) => {
+          const isActive = entry.id === active;
+          return (
+            <li
+              key={entry.id}
+              className={cn(entry.level === 3 && "pl-3")}
+            >
+              <a
+                href={`#${entry.id}`}
+                className={cn(
+                  "block py-0.5 transition",
+                  isActive
+                    ? "text-aqua"
+                    : "text-white/55 hover:text-white",
+                )}
+              >
+                {entry.text}
+              </a>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}

--- a/console/src/app/(authed)/knowledge/knowledge-control-center.tsx
+++ b/console/src/app/(authed)/knowledge/knowledge-control-center.tsx
@@ -144,7 +144,7 @@ export function KnowledgeControlCenter({
   const rest = articles.slice(1);
 
   return (
-    <div className="mx-auto max-w-6xl space-y-12">
+    <div className="mx-auto max-w-6xl space-y-12 2xl:max-w-screen-2xl">
       <SearchHeader
         query={query}
         onChange={setQuery}
@@ -170,8 +170,8 @@ export function KnowledgeControlCenter({
       {isSearching ? (
         <SearchResults hits={searchHits ?? []} queriedFor={searchedFor} />
       ) : (
-        <div className="grid grid-cols-1 gap-x-12 gap-y-12 lg:grid-cols-12">
-          <section className="space-y-8 lg:col-span-8">
+        <div className="grid grid-cols-1 gap-x-12 gap-y-12 lg:grid-cols-12 2xl:gap-x-16">
+          <section className="space-y-8 lg:col-span-8 2xl:col-span-7">
             <SectionKicker tone="aqua">Recent</SectionKicker>
             {lede ? (
               <>
@@ -194,13 +194,13 @@ export function KnowledgeControlCenter({
             )}
           </section>
 
-          <aside className="space-y-6 lg:col-span-4 lg:sticky lg:top-24 lg:self-start">
+          <aside className="space-y-6 lg:col-span-4 lg:sticky lg:top-24 lg:self-start 2xl:col-span-3">
             <SectionKicker tone="lilac">Browse by area</SectionKicker>
             <BucketDirectory buckets={liveBuckets} />
           </aside>
 
           {sources.length > 0 && (
-            <section className="space-y-3 lg:col-span-12">
+            <section className="space-y-3 lg:col-span-12 2xl:col-span-2 2xl:sticky 2xl:top-24 2xl:self-start">
               <SectionKicker tone="muted">Sources</SectionKicker>
               <ConnectedSources sources={sources} />
             </section>

--- a/console/src/components/workspace-home.tsx
+++ b/console/src/components/workspace-home.tsx
@@ -65,9 +65,9 @@ export function WorkspaceHome({
     summary.blockers.length + reposNeedingUpdate.length;
 
   return (
-    <div className="mx-auto max-w-6xl">
-      <div className="grid grid-cols-1 gap-x-12 gap-y-10 lg:grid-cols-12">
-        <div className="space-y-10 lg:col-span-8">
+    <div className="mx-auto max-w-6xl 2xl:max-w-screen-2xl">
+      <div className="grid grid-cols-1 gap-x-12 gap-y-10 lg:grid-cols-12 2xl:gap-x-16">
+        <div className="space-y-10 lg:col-span-8 2xl:col-span-7">
           {(reposNeedingUpdate.length > 0 || summary.blockers.length > 0) && (
             <StatusAlerts
               blockers={summary.blockers}
@@ -92,11 +92,22 @@ export function WorkspaceHome({
           />
         </div>
 
-        <aside className="space-y-10 lg:col-span-4 lg:sticky lg:top-20 lg:self-start">
-          <SystemPulse summary={summary} />
-          <RecentActivity summary={summary} />
-          <RepoChannelList repos={repos} workspaceId={workspaceId} />
-        </aside>
+        {/*
+          ``2xl:contents`` dissolves this wrapper at 2xl so the two
+          inner ``<aside>`` elements become direct grid children with
+          their own col-spans. Below 2xl the wrapper acts as a normal
+          col-span-4 sticky right rail with both panels stacked
+          inside.
+        */}
+        <div className="space-y-10 lg:col-span-4 lg:sticky lg:top-20 lg:self-start 2xl:contents">
+          <aside className="space-y-10 2xl:col-span-3 2xl:sticky 2xl:top-20 2xl:self-start">
+            <SystemPulse summary={summary} />
+          </aside>
+          <aside className="space-y-10 2xl:col-span-2 2xl:sticky 2xl:top-20 2xl:self-start">
+            <RecentActivity summary={summary} />
+            <RepoChannelList repos={repos} workspaceId={workspaceId} />
+          </aside>
+        </div>
       </div>
     </div>
   );

--- a/console/src/lib/article-toc.ts
+++ b/console/src/lib/article-toc.ts
@@ -1,0 +1,73 @@
+/**
+ * Server-side TOC parser for markdown article bodies.
+ *
+ * Walks ``body_md`` line-by-line for ``# / ## / ###`` headings and
+ * emits ``{ id, level, text }`` rows. The slug rule is deterministic
+ * and shared with the in-prose ``h1``/``h2``/``h3`` ReactMarkdown
+ * renderer so TOC links and rendered anchors agree.
+ *
+ * Fenced code blocks (``` ... ```) are skipped so a literal ``# command``
+ * inside a shell snippet can't end up in the outline.
+ */
+
+export type TocEntry = {
+  id: string;
+  level: 1 | 2 | 3;
+  text: string;
+};
+
+export function slugifyHeading(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 80);
+}
+
+export function parseToc(body: string): TocEntry[] {
+  if (!body) return [];
+  const out: TocEntry[] = [];
+  let inFence = false;
+  for (const rawLine of body.split("\n")) {
+    const line = rawLine.trimEnd();
+    if (line.startsWith("```")) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) continue;
+    const match = /^(#{1,3})\s+(.+?)\s*$/.exec(line);
+    if (!match) continue;
+    const level = match[1].length as 1 | 2 | 3;
+    const text = match[2].trim();
+    if (!text) continue;
+    const id = slugifyHeading(text);
+    if (!id) continue;
+    out.push({ id, level, text });
+  }
+  return out;
+}
+
+
+/**
+ * Match the slug ReactMarkdown will use for an inline heading. Pulls
+ * the visible text out of whatever the renderer hands us as
+ * ``children`` — strings, arrays of strings, or wrapped React nodes.
+ */
+export function headingIdFromChildren(children: unknown): string {
+  return slugifyHeading(nodeText(children));
+}
+
+
+function nodeText(node: unknown): string {
+  if (node == null) return "";
+  if (typeof node === "string") return node;
+  if (typeof node === "number") return String(node);
+  if (Array.isArray(node)) return node.map(nodeText).join("");
+  if (typeof node === "object") {
+    const maybe = node as { props?: { children?: unknown } };
+    if (maybe.props && "children" in maybe.props) {
+      return nodeText(maybe.props.children);
+    }
+  }
+  return "";
+}


### PR DESCRIPTION
## Summary

Following the width-audit design pass — dashboard and knowledge index expand to ``max-w-screen-2xl`` on the ``2xl`` breakpoint (≥1536px), knowledge category bumps to ``max-w-7xl`` on ``xl`` (≥1280px), and the reader's reserved right rail finally renders a real auto-generated TOC at ``xl+``. Inbox stays at ``max-w-5xl``.

### Knowledge index
``max-w-6xl 2xl:max-w-screen-2xl``. At ``2xl`` the grid shifts from 8/4 to **7/3/2** — Recent / Browse / Sources-as-third-rail.

### Knowledge category
``max-w-6xl xl:max-w-7xl`` + ``xl:gap-x-16``. Layout otherwise unchanged.

### Knowledge reader
- Shell stays at ``max-w-6xl``, prose capped at 680px (legibility load-bearer).
- New ``ArticleToc`` client component in the right rail at ``xl+``, auto-generated from ``# / ## / ###`` headings via server-side ``parseToc``. ``IntersectionObserver`` highlights the active section (Stripe Docs idiom).
- ``h1``/``h2``/``h3`` markdown render emits ``id`` attributes via the same slug rule (``headingIdFromChildren``); ``scroll-mt-24`` so anchors land below the AppShell header.
- Empty reserved aside is gone.

### Dashboard
``max-w-6xl 2xl:max-w-screen-2xl``. At ``2xl`` shifts from 8/4 to **7/3/2** via ``2xl:contents`` on the right-rail wrapper (System pulse alone in 3 cols, Recent activity + Repo channels in 2 cols). Below ``2xl`` the wrapper is the normal sticky right rail with both panels stacked inside.

### Inbox
Untouched.

### Files added
- ``console/src/lib/article-toc.ts`` — ``parseToc``, ``headingIdFromChildren``, ``slugifyHeading``. Skips fenced code blocks.
- ``console/src/app/(authed)/knowledge/article-toc.tsx`` — client TOC with IntersectionObserver.

Net diff: **+209 / −22** across 5 files.

## Test plan

- [x] ``tsc --noEmit`` clean.
- [x] ``eslint --max-warnings=0`` clean on touched files.
- [ ] CI.
- [ ] Smoke at 1366×768: layout matches today's (no regressions).
- [ ] Smoke at 1440×900: knowledge category gets ``max-w-7xl``; reader right rail un-reserves and shows a TOC; rest unchanged.
- [ ] Smoke at 2560×1440: dashboard + knowledge index 7/3/2 split visible; sources sit in the third rail of index; system pulse and activity split into separate columns of dashboard.
- [ ] Smoke TOC: scroll an ADR — current section highlights; click → smooth scroll; deep link ``?article=…#why`` lands at the right heading below the header.