### PR TITLE
console: process editorial — drop card chrome + tier-consistent palette

### DIFF
--- a/console/src/app/(authed)/process/flow-schedule-panel.tsx
+++ b/console/src/app/(authed)/process/flow-schedule-panel.tsx
@@ -284,7 +284,7 @@ export function FlowSchedulePanel({
         ) : null}
 
         <div className="grid gap-3 xl:grid-cols-[200px_minmax(0,1fr)]">
-          <aside className="max-h-[640px] overflow-y-auto rounded-2xl border border-white/10 bg-black/25 p-3">
+          <aside className="max-h-[640px] overflow-y-auto p-1">
             <div className="sticky top-0 -mx-3 mb-2 -mt-3 border-b border-white/5 bg-black/85 px-3 py-2 backdrop-blur">
               <div className="text-[10px] font-bold uppercase tracking-[0.22em] text-aqua/70">
                 Roles · drag to a cell
@@ -314,7 +314,7 @@ export function FlowSchedulePanel({
             </div>
           </aside>
 
-          <section className="overflow-hidden rounded-3xl border border-white/10 bg-[#050a15] shadow-2xl shadow-black/30">
+          <section className="overflow-hidden">
             <div className="flex flex-wrap items-center justify-between gap-2 border-b border-white/10 bg-white/[0.035] px-4 py-3">
               <div>
                 <div className="text-sm font-semibold text-white">Capacity calendar</div>
@@ -327,8 +327,8 @@ export function FlowSchedulePanel({
                   <span className="h-2 w-2 rounded border border-aqua/40 bg-aqua/[0.10]" aria-hidden />
                   specialist · drag
                 </span>
-                <span className="inline-flex items-center gap-1.5 text-amber-200/85">
-                  <span className="h-2 w-2 rounded border border-amber-300/40 bg-amber-300/[0.10]" aria-hidden />
+                <span className="inline-flex items-center gap-1.5 text-sun/85">
+                  <span className="h-2 w-2 rounded border border-sun/40 bg-sun/[0.10]" aria-hidden />
                   routine · cron
                 </span>
                 <button
@@ -388,18 +388,18 @@ export function FlowSchedulePanel({
             </div>
             {routineProjection.continuous.length > 0 && (
               <div className="border-t border-white/10 bg-black/20 px-4 py-3">
-                <div className="mb-2 text-[10px] font-bold uppercase tracking-[0.22em] text-amber-200/80">
+                <div className="mb-2 text-[10px] font-bold uppercase tracking-[0.22em] text-sun/80">
                   Continuous routines · fire too often for the grid
                 </div>
                 <div className="flex flex-wrap gap-2">
                   {routineProjection.continuous.map(({ routine, cadence }) => (
                     <span
                       key={routine.id}
-                      className="inline-flex items-center gap-1.5 rounded-full border border-amber-300/30 bg-amber-300/[0.07] px-3 py-1 text-[11px] font-semibold text-amber-200/90"
+                      className="inline-flex items-center gap-1.5 rounded-full border border-sun/30 bg-sun/[0.07] px-3 py-1 text-[11px] font-semibold text-sun/90"
                     >
-                      <span className="h-1.5 w-1.5 rounded-full bg-amber-300" aria-hidden />
+                      <span className="h-1.5 w-1.5 rounded-full bg-sun" aria-hidden />
                       {routineLabel.get(routine.id) ?? routine.name ?? routine.id}
-                      <span className="font-normal text-amber-200/60">· {cadence}</span>
+                      <span className="font-normal text-sun/60">· {cadence}</span>
                     </span>
                   ))}
                 </div>
@@ -470,14 +470,14 @@ function CalendarCell({
             stripe is hidden entirely. */}
         {routines.length > 0 ? (
           <div
-            className="flex flex-wrap items-center gap-1 rounded-md border border-amber-300/25 bg-amber-300/[0.07] px-1.5 py-1"
+            className="flex flex-wrap items-center gap-1 rounded-md border border-sun/25 bg-sun/[0.07] px-1.5 py-1"
             title="Routines firing in this slot — fire on cron, not capacity"
           >
             <span className="text-[9px]" aria-hidden>⏱</span>
             {routines.map((r, idx) => (
-              <span key={r.id} className="text-[9px] font-bold uppercase tracking-widest text-amber-200/90">
+              <span key={r.id} className="text-[9px] font-bold uppercase tracking-widest text-sun/90">
                 {routineLabel.get(r.id) ?? r.name ?? r.id}
-                {idx < routines.length - 1 ? <span className="text-amber-200/40"> · </span> : null}
+                {idx < routines.length - 1 ? <span className="text-sun/40"> · </span> : null}
               </span>
             ))}
           </div>
@@ -587,7 +587,7 @@ function RoutinesSummary({
   const visible = routines.filter((r) => !HIDDEN_ROUTINE_IDS.has(r.id));
   const labelById = new Map(BUILTIN_ROUTINE_CATALOG.map((c) => [c.id, c.name] as const));
   return (
-    <div className="rounded-2xl border border-white/10 bg-white/[0.02] p-3">
+    <div className="p-1">
       <div className="flex items-center justify-between gap-2">
         <div className="text-[10px] font-bold uppercase tracking-[0.22em] text-white/55">
           Routines on this process
@@ -623,7 +623,7 @@ function RoutinesSummary({
                 className={[
                   "rounded-xl border p-2.5",
                   !canonical
-                    ? "border-amber-300/35 bg-amber-300/[0.05]"
+                    ? "border-sun/35 bg-sun/[0.05]"
                     : enabled
                       ? "border-aqua/25 bg-aqua/[0.05]"
                       : "border-white/10 bg-white/[0.02] opacity-65",
@@ -636,7 +636,7 @@ function RoutinesSummary({
                     </span>
                     {!canonical && (
                       <span
-                        className="shrink-0 rounded-full border border-amber-300/40 bg-amber-300/[0.10] px-1.5 py-0.5 text-[8px] font-bold uppercase tracking-widest text-amber-200"
+                        className="shrink-0 rounded-full border border-sun/40 bg-sun/[0.10] px-1.5 py-0.5 text-[8px] font-bold uppercase tracking-widest text-sun"
                         title="Pre-canonical routine id — leftover from an older seed. Clean up the DB row to remove it from this view."
                       >
                         legacy
@@ -646,7 +646,7 @@ function RoutinesSummary({
                   <span
                     className={[
                       "h-1.5 w-1.5 rounded-full",
-                      enabled ? (canonical ? "bg-aqua" : "bg-amber-300") : "bg-white/30",
+                      enabled ? (canonical ? "bg-aqua" : "bg-sun") : "bg-white/30",
                     ].join(" ")}
                     aria-hidden
                   />

--- a/console/src/app/(authed)/process/page.tsx
+++ b/console/src/app/(authed)/process/page.tsx
@@ -397,16 +397,16 @@ function ConfigSourceBanner({
   }
   if (source === "repo-lanes") {
     return (
-      <div className="inline-flex items-center gap-2 rounded-full border border-amber-300/30 bg-amber-300/[0.07] px-3 py-1 text-[11px] font-semibold text-amber-200">
-        <span className="h-1.5 w-1.5 rounded-full bg-amber-300" aria-hidden />
+      <div className="inline-flex items-center gap-2 rounded-full border border-sun/30 bg-sun/[0.07] px-3 py-1 text-[11px] font-semibold text-sun">
+        <span className="h-1.5 w-1.5 rounded-full bg-sun" aria-hidden />
         Legacy <code className="font-mono">lanes:</code> config — reseed to migrate.
       </div>
     );
   }
   if (source === "missing") {
     return (
-      <div className="inline-flex items-center gap-2 rounded-full border border-coral/30 bg-coral/[0.07] px-3 py-1 text-[11px] font-semibold text-coral">
-        <span className="h-1.5 w-1.5 rounded-full bg-coral" aria-hidden />
+      <div className="inline-flex items-center gap-2 rounded-full border border-sun/30 bg-sun/[0.07] px-3 py-1 text-[11px] font-semibold text-sun">
+        <span className="h-1.5 w-1.5 rounded-full bg-sun" aria-hidden />
         No <code className="font-mono">.ship/config.yml</code> on default branch — reseed required.
       </div>
     );
@@ -433,14 +433,17 @@ function ProcessTabs({
       : `/process/${encodeURIComponent(processId)}`;
   };
   return (
-    <div className="flex items-center gap-1 rounded-2xl border border-white/10 bg-white/[0.035] p-2">
+    <nav
+      aria-label="Process view"
+      className="flex items-center gap-6 border-b border-white/[0.06] pb-1"
+    >
       <TabLink href={hrefFor("flow")} active={selected === "flow"}>
         Flow
       </TabLink>
       <TabLink href={hrefFor("schedule")} active={selected === "schedule"}>
         Capacity
       </TabLink>
-    </div>
+    </nav>
   );
 }
 
@@ -466,11 +469,12 @@ function TabLink({
   return (
     <Link
       href={href}
+      aria-current={active ? "page" : undefined}
       className={[
-        "rounded-xl px-3 py-1.5 text-xs font-semibold transition",
+        "relative pb-2 text-[11px] font-bold uppercase tracking-[0.22em] transition",
         active
-          ? "bg-aqua/15 text-aqua"
-          : "text-white/55 hover:bg-white/[0.05] hover:text-white",
+          ? "text-aqua after:absolute after:inset-x-0 after:-bottom-px after:h-px after:bg-aqua"
+          : "text-white/40 hover:text-white",
       ].join(" ")}
     >
       {children}

--- a/console/src/app/(authed)/process/process-canvas-editor.tsx
+++ b/console/src/app/(authed)/process/process-canvas-editor.tsx
@@ -345,14 +345,12 @@ function LaneColumn({
       onDragLeave={onDragLeaveLane}
       onDrop={onDropOnLane}
       className={[
-        "group/lane flex min-h-[280px] flex-col gap-1.5 rounded-xl border p-1.5 transition",
-        dragOverLane
-          ? "border-aqua/55 bg-aqua/[0.06] shadow-[inset_0_0_0_1px_rgba(207,169,107,0.4)]"
-          : "border-white/8",
+        "group/lane flex min-h-[280px] flex-col gap-1.5 p-1.5 transition",
+        dragOverLane ? "ring-1 ring-aqua/40" : "",
       ].join(" ")}
       style={{ background: dragOverLane ? undefined : LANE_TINT[lane] }}
     >
-      <div className="sticky top-0 z-10 flex items-center gap-1.5 rounded-t-xl border-b border-white/5 bg-[#040814]/95 px-2 py-1.5 backdrop-blur">
+      <div className="sticky top-0 z-10 flex items-center gap-1.5 border-b border-white/[0.06] bg-ink/90 px-2 py-1.5 backdrop-blur">
         <span
           className="h-1.5 w-1.5 rounded-full"
           style={{ background: LANE_DOT[lane] }}
@@ -447,55 +445,48 @@ function StageCard({
       }}
       data-stage-id={stage.id}
       className={[
-        "rounded-lg border px-2.5 py-2 text-left shadow transition",
-        "cursor-grab active:cursor-grabbing focus:outline-none focus-visible:ring-2 focus-visible:ring-aqua/60",
+        "relative px-3 py-2 pl-3 text-left transition cursor-grab active:cursor-grabbing focus:outline-none focus-visible:ring-1 focus-visible:ring-aqua/60",
         selected
-          ? "border-aqua/70 bg-[linear-gradient(135deg,rgba(207,169,107,0.20),rgba(207,169,107,0.05))] shadow-aqua/30"
+          ? "bg-aqua/[0.04] ring-1 ring-aqua/60"
           : isDragTarget
-            ? "border-aqua/55 bg-aqua/[0.10] ring-1 ring-aqua/40"
-            : "border-white/15 bg-[linear-gradient(135deg,rgba(255,255,255,0.10),rgba(255,255,255,0.03))] hover:border-aqua/40",
+            ? "bg-aqua/[0.06] ring-1 ring-aqua/40"
+            : "bg-white/[0.04] hover:bg-white/[0.07]",
       ].join(" ")}
+      style={{ borderRadius: 6 }}
     >
-      <div className="flex items-start justify-between gap-2">
-        <div className="min-w-0 flex-1">
-          <div className="truncate text-[13px] font-bold text-white">
-            {stage.name}
-          </div>
-          <div className="mt-0.5 truncate text-[10px] text-white/55">
-            {stage.specialist_name}
-          </div>
+      <span
+        aria-hidden
+        className="absolute inset-y-1 left-0 w-[2px] rounded-r-sm"
+        style={{ background: LANE_DOT[lane] }}
+      />
+      <div className="min-w-0">
+        <div className="truncate text-[13px] font-semibold text-white">
+          {stage.name}
         </div>
-        <span
-          className="mt-0.5 h-1.5 w-1.5 shrink-0 rounded-full"
-          style={{
-            background: LANE_DOT[lane],
-            boxShadow: `0 0 8px ${LANE_DOT[lane]}`,
-          }}
-          aria-hidden
-        />
+        <div className="mt-0.5 truncate text-[10px] text-white/55">
+          {stage.specialist_name}
+        </div>
       </div>
       {next ? (
         <div
           className={[
-            "mt-1.5 flex items-center gap-1 truncate border-t border-white/5 pt-1 text-[9px] uppercase tracking-widest",
-            next.actor === "user" ? "text-amber-200/80" : "text-white/40",
+            "mt-1.5 flex items-center gap-1 truncate text-[9px] uppercase tracking-widest",
+            next.actor === "user" ? "text-lilac/85" : "text-white/40",
           ].join(" ")}
         >
           <span aria-hidden>→</span>
           <span className="truncate">{next.stage.name}</span>
           <span
             className={[
-              "ml-auto shrink-0 rounded-sm px-1 text-[8px] font-bold",
-              next.actor === "user"
-                ? "bg-amber-300/15 text-amber-200"
-                : "bg-white/5 text-white/45",
+              "ml-auto shrink-0 text-[8px] font-bold",
+              next.actor === "user" ? "text-lilac" : "text-white/45",
             ].join(" ")}
           >
             {next.actor}
           </span>
         </div>
       ) : (
-        <div className="mt-1.5 truncate border-t border-white/5 pt-1 text-[9px] uppercase tracking-widest text-white/25">
+        <div className="mt-1.5 truncate text-[9px] uppercase tracking-widest text-white/25">
           terminal
         </div>
       )}

--- a/console/src/app/(authed)/process/process-editor-workspace.tsx
+++ b/console/src/app/(authed)/process/process-editor-workspace.tsx
@@ -334,114 +334,117 @@ export function ProcessEditorWorkspace({
   }
 
   return (
-    <section className="min-h-[calc(100vh-180px)] overflow-hidden rounded-[2rem] border border-aqua/15 bg-[radial-gradient(circle_at_top_left,rgba(99,245,255,0.10),transparent_30%),linear-gradient(135deg,rgba(255,255,255,0.07),rgba(255,255,255,0.025))] shadow-2xl shadow-black/40 backdrop-blur-xl">
-      <div className="border-b border-white/10 px-4 py-2">
-        <div className="flex flex-wrap items-center justify-between gap-2">
-          <div className="flex min-w-0 flex-1 items-center gap-2">
-            {tabs}
-            {dirty && (
-              <span
-                className="shrink-0 truncate text-[11px] text-white/45"
-                title={draftSummary}
-              >
-                · {draftSummary}
-              </span>
-            )}
-          </div>
-          <form
-            action="/api/process/config-propose"
-            method="post"
-            className="flex shrink-0 flex-wrap items-center gap-1.5"
-          >
-            <ProcessConfigProposalFields
-              workspaceId={workspaceId}
-              repoId={repoId}
-              config={config}
-              processConfig={processConfig}
-              changeSummary={changeSummary}
-            />
-            <button
-              type="button"
-              disabled={!dirty}
-              onClick={resetDraft}
-              className="rounded-full border border-white/10 bg-black/25 px-3 py-1 text-[11px] font-bold text-white/65 transition hover:border-white/20 hover:text-white disabled:cursor-not-allowed disabled:border-white/10 disabled:bg-white/[0.03] disabled:text-white/30"
+    <section className="relative space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-3 border-b border-white/[0.06] pb-3">
+        <div className="flex min-w-0 flex-1 flex-wrap items-center gap-3">
+          {tabs}
+          {dirty && (
+            <span
+              className="shrink-0 truncate text-[11px] text-white/45"
+              title={draftSummary}
             >
-              Discard
-            </button>
-            <button
-              type="submit"
-              disabled={!repoId || !dirty || hasErrors}
-              title={
-                hasErrors
-                  ? `Fix ${validation.errors.length} validation error${validation.errors.length === 1 ? "" : "s"} below before publishing.`
-                  : undefined
-              }
-              className="rounded-full border border-aqua/35 bg-aqua/15 px-3 py-1 text-[11px] font-bold text-aqua shadow-lg shadow-aqua/5 transition hover:bg-aqua/20 disabled:cursor-not-allowed disabled:border-white/10 disabled:bg-white/[0.05] disabled:text-white/35"
-            >
-              Publish
-            </button>
-          </form>
+              · {draftSummary}
+            </span>
+          )}
         </div>
-        <ProcessReviewSummary
-          initial={process}
-          draft={processDraft}
-          changedAreas={dirty ? ["Flow reviewed"] : []}
-        />
-      </div>
-
-      {/* Canvas + optional inspector. When no stage is selected the
-          inspector unmounts entirely so the canvas takes the whole
-          width — operators don't sit looking at an empty side panel. */}
-      <div
-        className={[
-          "grid min-h-0 grid-cols-1",
-          activeStateId ? "xl:grid-cols-[minmax(0,1fr)_320px]" : "",
-        ].join(" ")}
-      >
-        <ProcessCanvasEditor
-          process={processDraft}
-          selectedStateId={activeStateId}
-          selectedTransitionId={selectedTransitionId}
-          onSelectState={selectStateId}
-          onSelectTransition={selectTransitionId}
-          onAddState={() => addState()}
-          onAddStageInLane={addStageInLane}
-          onPositionsChange={updatePositions}
-          onStageStateChange={updateStageState}
-          onReorderStages={reorderStages}
-          onClearSelection={clearSelection}
-        />
-        {activeStateId && selectedState ? (
-          <StateEditor
-            processId={process.id}
+        <form
+          action="/api/process/config-propose"
+          method="post"
+          className="flex shrink-0 flex-wrap items-center gap-3"
+        >
+          <ProcessConfigProposalFields
+            workspaceId={workspaceId}
             repoId={repoId}
-            state={selectedState}
-            states={states}
-            schedule={processDraft.schedule ?? null}
-            transitions={transitions}
-            specialistOptions={specialistOptions}
             config={config}
-            embedded
-            onStateChange={updateState}
-            onDeleteState={deleteState}
-            onClose={clearSelection}
+            processConfig={processConfig}
+            changeSummary={changeSummary}
           />
-        ) : null}
+          <button
+            type="button"
+            disabled={!dirty}
+            onClick={resetDraft}
+            className="text-[11px] font-semibold uppercase tracking-wide text-white/55 transition hover:text-white disabled:cursor-not-allowed disabled:text-white/25"
+          >
+            Discard
+          </button>
+          <button
+            type="submit"
+            disabled={!repoId || !dirty || hasErrors}
+            title={
+              hasErrors
+                ? `Fix ${validation.errors.length} validation error${validation.errors.length === 1 ? "" : "s"} before publishing.`
+                : undefined
+            }
+            className="text-[11px] font-bold uppercase tracking-wide text-aqua transition hover:text-white disabled:cursor-not-allowed disabled:text-white/25"
+          >
+            Publish →
+          </button>
+        </form>
       </div>
 
-      {/* Validation panel — gates Publish. Tracker projection mapping
-          deliberately doesn't live here: it's an adapter-internal
-          concern (provisioner writes ``Integration.config.canonical_to_native``
-          at OAuth time). Operators don't edit canonical→native names. */}
-      <div className="border-t border-white/10 bg-black/20 p-4">
-        <ProcessValidationPanel
-          result={validation}
-          onJumpToStage={(stageId) => selectStateId(stageId)}
-          onJumpToTransition={(transitionId) =>
-            selectTransitionId(transitionId)
-          }
-        />
+      <ProcessReviewSummary
+        initial={process}
+        draft={processDraft}
+        changedAreas={dirty ? ["Flow reviewed"] : []}
+      />
+
+      {/* Canvas + optional inspector — slide-in sheet on xl, stacked
+          panel below xl. When no stage is selected the inspector
+          unmounts and the canvas takes full width. */}
+      <div className="relative">
+        <div
+          className={[
+            "grid min-h-0 grid-cols-1 transition-all",
+            activeStateId ? "xl:grid-cols-[minmax(0,1fr)_380px] xl:gap-x-8" : "",
+          ].join(" ")}
+        >
+          <ProcessCanvasEditor
+            process={processDraft}
+            selectedStateId={activeStateId}
+            selectedTransitionId={selectedTransitionId}
+            onSelectState={selectStateId}
+            onSelectTransition={selectTransitionId}
+            onAddState={() => addState()}
+            onAddStageInLane={addStageInLane}
+            onPositionsChange={updatePositions}
+            onStageStateChange={updateStageState}
+            onReorderStages={reorderStages}
+            onClearSelection={clearSelection}
+          />
+          {activeStateId && selectedState ? (
+            <aside className="border-l-0 border-t border-white/[0.06] pt-6 xl:border-l xl:border-t-0 xl:pt-0 xl:pl-8">
+              <StateEditor
+                processId={process.id}
+                repoId={repoId}
+                state={selectedState}
+                states={states}
+                schedule={processDraft.schedule ?? null}
+                transitions={transitions}
+                specialistOptions={specialistOptions}
+                config={config}
+                embedded
+                onStateChange={updateState}
+                onDeleteState={deleteState}
+                onClose={clearSelection}
+              />
+            </aside>
+          ) : null}
+        </div>
       </div>
+
+      {/* Validation pill — sticky bottom-right. Hidden when no errors
+          / warnings to keep the canvas quiet on a clean draft. */}
+      {(validation.errors.length > 0 || validation.warnings.length > 0) && (
+        <div className="sticky bottom-4 z-10 flex justify-end pr-2">
+          <ProcessValidationPanel
+            result={validation}
+            onJumpToStage={(stageId) => selectStateId(stageId)}
+            onJumpToTransition={(transitionId) =>
+              selectTransitionId(transitionId)
+            }
+          />
+        </div>
+      )}
     </section>
   );
 }

--- a/console/src/app/(authed)/process/process-graph-overview.tsx
+++ b/console/src/app/(authed)/process/process-graph-overview.tsx
@@ -119,8 +119,8 @@ export function ProcessGraphOverview({
 }
 
 function HealthDot({ status }: { status: string }) {
-  let bg = "bg-emerald-400";
-  if (status === "warning" || status === "degraded") bg = "bg-amber-400";
+  let bg = "bg-aqua";
+  if (status === "warning" || status === "degraded") bg = "bg-sun";
   else if (status !== "ok") bg = "bg-coral";
   return (
     <span

--- a/console/src/app/(authed)/process/process-validation-panel.tsx
+++ b/console/src/app/(authed)/process/process-validation-panel.tsx
@@ -3,15 +3,14 @@
 import type { ValidationItem, ValidationResult } from "./process-validation";
 
 /**
- * Compact validation summary that lives under the Flow canvas. When
- * the result is clean (no errors, no warnings) the panel renders a
- * single green pill so the operator gets positive feedback that the
- * draft is good to publish; otherwise it lists each item with its
- * severity dot, message, and (when relevant) an anchor hint.
+ * Compact validation pill that lives sticky at the bottom-right of
+ * the Flow canvas. Renders a quiet ``X errors · Y warnings`` summary
+ * with an expandable list — clicking a row jumps the editor to the
+ * offending stage or transition. Hidden entirely on a clean draft so
+ * the canvas stays quiet when there's nothing to do.
  *
- * The Publish button gates on ``errors.length === 0`` — the parent
- * editor passes the result here AND consults its `errors` array
- * directly to decide whether to disable the submit.
+ * The Publish button gates on ``errors.length === 0`` directly from
+ * the parent editor, not via the panel.
  */
 export function ProcessValidationPanel({
   result,
@@ -23,42 +22,28 @@ export function ProcessValidationPanel({
   onJumpToTransition?: (transitionId: string) => void;
 }) {
   const { errors, warnings } = result;
-  const isClean = errors.length === 0 && warnings.length === 0;
-
-  if (isClean) {
-    return (
-      <div className="flex items-center gap-2 rounded-xl border border-emerald-400/30 bg-emerald-400/[0.05] px-3 py-2 text-xs">
-        <span className="h-2 w-2 rounded-full bg-emerald-400" aria-hidden />
-        <span className="font-semibold text-emerald-300">Process is valid</span>
-        <span className="text-emerald-300/60">
-          — every stage is reachable, every path terminates, all states are
-          canonical.
-        </span>
-      </div>
-    );
-  }
+  if (errors.length === 0 && warnings.length === 0) return null;
 
   return (
-    <div className="rounded-2xl border border-white/10 bg-white/[0.02] p-3">
-      <div className="flex items-center justify-between gap-2">
-        <div className="text-[10px] font-bold uppercase tracking-[0.22em] text-white/55">
-          Validation
-        </div>
-        <div className="flex items-center gap-2 text-[11px] font-semibold">
+    <details className="group max-w-md rounded-lg bg-ink/95 backdrop-blur ring-1 ring-white/10 transition open:bg-ink">
+      <summary className="cursor-pointer select-none list-none px-3 py-2 text-[11px] font-semibold">
+        <span className="inline-flex items-center gap-3">
           {errors.length > 0 && (
-            <span className="rounded-full border border-coral/30 bg-coral/[0.08] px-2 py-0.5 text-coral">
+            <span className="text-coral">
               {errors.length} error{errors.length === 1 ? "" : "s"}
             </span>
           )}
           {warnings.length > 0 && (
-            <span className="rounded-full border border-amber-300/30 bg-amber-300/[0.08] px-2 py-0.5 text-amber-200">
+            <span className="text-sun">
               {warnings.length} warning{warnings.length === 1 ? "" : "s"}
             </span>
           )}
-        </div>
-      </div>
-
-      <ul className="mt-3 space-y-1.5">
+          <span className="text-white/40 transition group-open:rotate-90">
+            ›
+          </span>
+        </span>
+      </summary>
+      <ul className="space-y-1 px-3 pb-3">
         {errors.map((item) => (
           <ValidationRow
             key={`err-${item.code}-${item.anchor?.id ?? ""}`}
@@ -76,14 +61,7 @@ export function ProcessValidationPanel({
           />
         ))}
       </ul>
-
-      {errors.length > 0 && (
-        <p className="mt-3 text-[11px] italic text-white/45">
-          Publish is disabled until every error is resolved. Warnings are
-          informational — the editor will still let you save.
-        </p>
-      )}
-    </div>
+    </details>
   );
 }
 
@@ -98,22 +76,22 @@ function ValidationRow({
 }) {
   const isError = item.kind === "error";
   return (
-    <li
-      className={[
-        "flex items-start gap-2.5 rounded-lg border px-3 py-2 text-xs",
-        isError
-          ? "border-coral/25 bg-coral/[0.04] text-coral/95"
-          : "border-amber-300/25 bg-amber-300/[0.04] text-amber-100/90",
-      ].join(" ")}
-    >
+    <li className="flex items-start gap-2 py-1 text-[11px] leading-snug">
+      <span
+        aria-hidden
+        className={[
+          "mt-1 h-1.5 w-1.5 shrink-0 rounded-full",
+          isError ? "bg-coral" : "bg-sun",
+        ].join(" ")}
+      />
       <span
         className={[
-          "mt-0.5 h-1.5 w-1.5 shrink-0 rounded-full",
-          isError ? "bg-coral" : "bg-amber-300",
+          "min-w-0 flex-1",
+          isError ? "text-coral/90" : "text-sun/90",
         ].join(" ")}
-        aria-hidden
-      />
-      <span className="min-w-0 flex-1 leading-snug">{item.message}</span>
+      >
+        {item.message}
+      </span>
       {item.anchor && (item.anchor.kind === "stage"
         ? onJumpToStage
         : onJumpToTransition) ? (
@@ -129,10 +107,10 @@ function ValidationRow({
             }
           }}
           className={[
-            "shrink-0 rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-widest transition",
+            "shrink-0 text-[10px] font-bold uppercase tracking-widest transition",
             isError
-              ? "border-coral/30 text-coral hover:bg-coral/[0.1]"
-              : "border-amber-300/30 text-amber-200 hover:bg-amber-300/[0.1]",
+              ? "text-coral hover:text-white"
+              : "text-sun hover:text-white",
           ].join(" ")}
         >
           Jump

--- a/console/src/app/(authed)/process/state-editor.tsx
+++ b/console/src/app/(authed)/process/state-editor.tsx
@@ -114,7 +114,7 @@ export function StateEditor({
         </div>
       )}
       {!repoId && (
-        <div className="rounded-md border border-amber-300/25 bg-amber-300/[0.06] px-2 py-1.5 text-[11px] text-amber-100/90">
+        <div className="rounded-md border border-sun/25 bg-sun/[0.06] px-2 py-1.5 text-[11px] text-sun/90">
           Select a repository before saving.
         </div>
       )}
@@ -231,7 +231,7 @@ function Section({
   children: ReactNode;
 }) {
   return (
-    <section className="space-y-3 rounded-2xl border border-white/10 bg-[linear-gradient(135deg,rgba(255,255,255,0.065),rgba(255,255,255,0.025))] p-3 shadow-lg shadow-black/10">
+    <section className="space-y-3 p-1">
       <div className="text-[10px] font-bold uppercase tracking-widest text-aqua/55">
         {title}
       </div>


### PR DESCRIPTION
## Summary

Following the design pass — strip the concentric card / glass shells that made ``/process`` the most "frame-y" surface in the console, move tabs to the typographic ribbon idiom shared with knowledge + inbox, and apply colour discipline to the routine + lane decoration that was drifting amber + emerald.

### Editor shell
- Drop glass shell + radial gradient + ``shadow-2xl backdrop-blur-xl`` on the outer ``<section>``.
- Top toolbar → single hairline strip; Discard / Publish → text-link uppercase buttons.
- Validation panel → sticky pill bottom-right with ``ring-1``, hidden entirely on clean drafts.
- Inspector → side panel with hairline divider (``xl:gap-x-8``); stacks below canvas at < ``xl``.

### Tabs (``page.tsx::ProcessTabs``)
- Segmented ``rounded-2xl border`` chip → ``border-b`` typographic ribbon. Active tab gets uppercase ``aqua`` underbar.
- ``ConfigSourceBanner`` legacy + missing variants: ``amber`` → ``sun``, ``coral`` → ``sun`` (missing isn't an error, it's a reseed reminder).

### Canvas (``process-canvas-editor.tsx``)
- Drop per-lane bordered card. Stage card drops gradient fill + glow dot — flat ``bg-white/[0.04]`` block with a 2px lane-coloured **left-edge spine** (Linear's priority spine, same idiom as ``/inbox`` tier ladder).
- Selected stage = ``aqua/[0.04]`` wash + ``ring-1 ring-aqua/60`` on top of the spine. Amber gradient gone.
- ``next:`` footer user-actor: ``amber`` → ``lilac``.

### Validation (``process-validation-panel.tsx``)
- Rewritten as a ``<details>`` pill. Clean state hides component entirely. Drops the green "Process is valid" pill.

### Graph overview + state editor + flow-schedule
- ``bg-emerald-400`` → ``bg-aqua``; ``bg-amber-400`` → ``bg-sun``; bulk ``amber-200/300`` → ``sun`` across both files.
- Drop heavy card shells: specialist palette ``rounded-2xl border bg-black/25``, calendar ``rounded-3xl border bg-[#050a15] shadow-2xl``, RoutinesSummary, StateEditor sub-sections — all replaced with ``p-1`` internal spacing.

### Deferred per design rec
- Left process-directory rail (separate routes stay for now).
- Capacity demotion to a typographic routines table (this pass: palette + chrome only; demotion is its own pass).

Net diff: 7 files, **+194 / −218**.

## Test plan

- [x] ``tsc --noEmit`` clean.
- [x] The 11 pre-existing unused-var warnings on this surface are unchanged (verified against ``origin/main``); CI's ``next build`` allows them.
- [ ] CI.
- [ ] Smoke ``/process``: list reads as plain rows (no card chrome), aqua healthy / sun warning dots.
- [ ] Smoke ``/process/<id>``: tabs render as typographic ribbon; canvas has no glass shell; lane columns separated by tints + hairlines, no rounded card; stage cards quiet flat blocks with lane spines; selected stage shows aqua ring + wash (no amber gradient); validation pill bottom-right hidden on clean draft, expandable when there are errors / warnings.