### PR TITLE
knowledge: pick Notion pages from a real list, not raw JSON

### DIFF
--- a/backend/app/api/v1/routes/knowledge_import_sources.py
+++ b/backend/app/api/v1/routes/knowledge_import_sources.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import logging
 import uuid
 from datetime import datetime
-from typing import Any
+from typing import Any, Literal
 
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
+import httpx
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field, field_validator
 from sqlalchemy import desc, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -26,12 +28,16 @@ from backend.app.db.models.agent_memory import (
 from backend.app.db.models.integrations import WorkspaceRepo
 from backend.app.db.models.tenancy import Integration
 from backend.app.db.session import get_session
+from backend.app.security.encryption import safe_decrypt
 from backend.app.services.knowledge_ingestion import (
     KnowledgeIngestionError,
     create_import_source,
     sync_due_import_sources,
     sync_import_source,
 )
+
+
+logger = logging.getLogger(__name__)
 
 
 router = APIRouter(
@@ -333,4 +339,214 @@ def _run_out(row: KnowledgeIngestionRun) -> IngestionRunOut:
         created_by_user_id=row.created_by_user_id,
         created_at=row.created_at,
         updated_at=row.updated_at,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Connector resource discovery (wizard pickers)
+# ---------------------------------------------------------------------------
+#
+# Until ELS/closed-beta clients had to paste raw {"page_id":"…"} JSON
+# into the wizard. They didn't and got a silently-empty sync. These
+# endpoints back the picker UI: they list the pages/databases the
+# integration's token can actually see, so the wizard can render a
+# searchable checklist instead of a JSON textarea.
+
+NOTION_API_ROOT = "https://api.notion.com/v1"
+NOTION_VERSION = "2025-09-03"
+_NOTION_PAGE_SIZE = 50
+
+
+class NotionResourceItem(BaseModel):
+    id: str
+    type: Literal["page", "database"]
+    title: str
+    parent_path: str | None = None
+    url: str | None = None
+    last_edited_time: str | None = None
+    icon: str | None = None  # emoji shorthand or external icon URL
+
+
+class NotionResourceListOut(BaseModel):
+    items: list[NotionResourceItem]
+    next_cursor: str | None = None
+    has_more: bool = False
+
+
+def _notion_render_title(rich: list[dict[str, Any]] | None) -> str:
+    if not rich:
+        return ""
+    parts: list[str] = []
+    for chunk in rich:
+        text = chunk.get("plain_text") or (chunk.get("text") or {}).get("content") or ""
+        if text:
+            parts.append(text)
+    return "".join(parts).strip()
+
+
+def _notion_extract_title(obj: dict[str, Any]) -> str:
+    if obj.get("object") == "database":
+        rendered = _notion_render_title(obj.get("title"))
+        if rendered:
+            return rendered
+    props = obj.get("properties") or {}
+    for prop in props.values():
+        if (prop or {}).get("type") == "title":
+            rendered = _notion_render_title(prop.get("title"))
+            if rendered:
+                return rendered
+    return "Untitled"
+
+
+def _notion_extract_icon(obj: dict[str, Any]) -> str | None:
+    icon = obj.get("icon")
+    if not isinstance(icon, dict):
+        return None
+    if icon.get("type") == "emoji":
+        return str(icon.get("emoji") or "") or None
+    if icon.get("type") == "external":
+        return str(((icon.get("external") or {}).get("url")) or "") or None
+    if icon.get("type") == "file":
+        return str(((icon.get("file") or {}).get("url")) or "") or None
+    return None
+
+
+def _notion_extract_parent_hint(obj: dict[str, Any]) -> str | None:
+    parent = obj.get("parent") or {}
+    parent_type = parent.get("type")
+    if parent_type == "workspace":
+        return "Workspace"
+    if parent_type == "database_id":
+        return "Database"
+    if parent_type == "page_id":
+        return "Page"
+    if parent_type == "block_id":
+        return "Block"
+    return None
+
+
+async def _notion_search(
+    *, token: str, body: dict[str, Any], workspace_id: uuid.UUID
+) -> dict[str, Any]:
+    """POST to Notion /search with auth + version headers.
+
+    Extracted so tests can monkeypatch this single function (mirrors the
+    seam used by ``notion_oauth.exchange_code_for_token``) instead of
+    fighting ``httpx.MockTransport``.
+    """
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Notion-Version": NOTION_VERSION,
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+    }
+    try:
+        async with httpx.AsyncClient(timeout=httpx.Timeout(10.0)) as client:
+            response = await client.post(
+                f"{NOTION_API_ROOT}/search", json=body, headers=headers
+            )
+    except httpx.HTTPError as exc:
+        logger.warning("notion /search transport error for ws=%s: %s", workspace_id, exc)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="notion API is unreachable — try again",
+        ) from exc
+
+    if response.status_code in (401, 403):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="notion rejected the integration token — reconnect Notion",
+        )
+    if response.status_code >= 400:
+        logger.warning(
+            "notion /search returned HTTP %s for ws=%s: %s",
+            response.status_code,
+            workspace_id,
+            response.text[:200],
+        )
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=f"notion returned HTTP {response.status_code}",
+        )
+
+    return response.json()
+
+
+@router.get("/notion/resources", response_model=NotionResourceListOut)
+async def list_notion_resources(
+    workspace_id: uuid.UUID,
+    integration_id: uuid.UUID = Query(..., description="Notion integration row to query"),
+    q: str = Query("", description="Free-text search query forwarded to Notion"),
+    cursor: str | None = Query(default=None, description="Notion start_cursor for pagination"),
+    type_filter: Literal["page", "database", "any"] = Query(
+        default="page", alias="type", description="Restrict results to pages, databases, or both"
+    ),
+    auth: AuthContext = Depends(get_current_auth),
+    session: AsyncSession = Depends(get_session),
+) -> NotionResourceListOut:
+    """Proxy Notion's /search so the wizard can render a real picker.
+
+    Restricts ``type_filter`` to ``page`` by default because the
+    Notion connector's v1 fetcher (``backend/app/services/connectors/
+    notion.py``) only handles ``{"page_id": ...}`` refs — letting users
+    pick databases would just round-trip into ``ConnectorUnsupported``
+    fallback. ``type=any`` exists for forward compatibility once the
+    fetcher learns databases.
+    """
+    await _require_membership(session, workspace_id, auth.user.id, ROLES_ADMIN)
+
+    integration = await session.get(Integration, integration_id)
+    if (
+        integration is None
+        or integration.workspace_id != workspace_id
+        or integration.kind != "notion"
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="notion integration not found for this workspace",
+        )
+
+    token = safe_decrypt(integration.secret_ciphertext)
+    if not token:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="notion integration has no readable access token — reconnect it",
+        )
+
+    body: dict[str, Any] = {
+        "page_size": _NOTION_PAGE_SIZE,
+        "sort": {"direction": "descending", "timestamp": "last_edited_time"},
+    }
+    if q.strip():
+        body["query"] = q.strip()
+    if type_filter in ("page", "database"):
+        body["filter"] = {"value": type_filter, "property": "object"}
+    if cursor:
+        body["start_cursor"] = cursor
+
+    payload = await _notion_search(token=token, body=body, workspace_id=workspace_id)
+    raw_results = payload.get("results") or []
+    items: list[NotionResourceItem] = []
+    for obj in raw_results:
+        if not isinstance(obj, dict):
+            continue
+        obj_type = obj.get("object")
+        if obj_type not in ("page", "database"):
+            continue
+        items.append(
+            NotionResourceItem(
+                id=str(obj.get("id") or ""),
+                type=obj_type,
+                title=_notion_extract_title(obj),
+                parent_path=_notion_extract_parent_hint(obj),
+                url=str(obj.get("url") or "") or None,
+                last_edited_time=str(obj.get("last_edited_time") or "") or None,
+                icon=_notion_extract_icon(obj),
+            )
+        )
+
+    return NotionResourceListOut(
+        items=items,
+        next_cursor=payload.get("next_cursor"),
+        has_more=bool(payload.get("has_more")),
     )

--- a/backend/app/services/knowledge_ingestion.py
+++ b/backend/app/services/knowledge_ingestion.py
@@ -335,6 +335,15 @@ async def _fetch_connector_documents(
         refs = [refs]
     if not isinstance(refs, list):
         raise KnowledgeIngestionError("connector source config.resource_refs must be a list")
+    # Empty list silently produced a "synced 0 of nothing" success — every
+    # field was 0 in the result panel and operators (incl. closed-beta
+    # clients) thought the connection was broken. Reject early so both
+    # the wizard and direct API callers get a clear error instead.
+    if not any(isinstance(ref, dict) and ref for ref in refs):
+        raise KnowledgeIngestionError(
+            "connector source needs at least one resource_ref "
+            "(e.g. {\"page_id\": \"...\"} or {\"database_id\": \"...\"})"
+        )
     documents: list[SourceDocument] = []
     for ref in refs[:MAX_SOURCE_DOCUMENTS]:
         if not isinstance(ref, dict):

--- a/backend/tests/test_v1_notion_resources.py
+++ b/backend/tests/test_v1_notion_resources.py
@@ -1,0 +1,180 @@
+"""Wizard picker — `/v1/workspaces/{ws}/knowledge/sources/notion/resources`.
+
+Stubs the Notion `/search` call via monkeypatch on the route's
+`_notion_search` helper (same seam pattern as the OAuth tests use for
+`exchange_code_for_token`). No live Notion calls.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from backend.app.db.models.tenancy import Integration
+from backend.app.security.encryption import encrypt
+
+
+def _auth(raw: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {raw}"}
+
+
+def _seed_notion_integration(db_session, workspace_id, *, secret: str | None = "ntn_test") -> Integration:
+    row = Integration(
+        id=uuid.uuid4(),
+        workspace_id=workspace_id,
+        kind="notion",
+        config={"notion_workspace_name": "Acme"},
+        status="ok",
+        secret_ciphertext=encrypt(secret) if secret else None,
+    )
+    db_session.add(row)
+    return row
+
+
+@pytest.mark.asyncio
+async def test_list_notion_resources_returns_picker_items(
+    v1_client, seed_workspace, db_session, monkeypatch
+) -> None:
+    _, raw, workspace = seed_workspace
+    integration = _seed_notion_integration(db_session, workspace.id)
+    await db_session.flush()
+
+    captured: dict = {}
+
+    async def _fake_search(*, token, body, workspace_id):
+        captured["token"] = token
+        captured["body"] = body
+        captured["workspace_id"] = workspace_id
+        return {
+            "results": [
+                {
+                    "object": "page",
+                    "id": "page-uuid-1",
+                    "url": "https://notion.so/page-1",
+                    "last_edited_time": "2026-04-30T10:00:00.000Z",
+                    "icon": {"type": "emoji", "emoji": "📘"},
+                    "parent": {"type": "workspace"},
+                    "properties": {
+                        "Name": {
+                            "type": "title",
+                            "title": [{"plain_text": "Onboarding handbook"}],
+                        }
+                    },
+                },
+                {
+                    "object": "database",
+                    "id": "db-uuid-1",
+                    "url": "https://notion.so/db-1",
+                    "title": [{"plain_text": "Customer FAQ"}],
+                    "parent": {"type": "page_id", "page_id": "parent-1"},
+                },
+                {"object": "block", "id": "ignored"},  # filtered out
+            ],
+            "next_cursor": "cursor-2",
+            "has_more": True,
+        }
+
+    monkeypatch.setattr(
+        "backend.app.api.v1.routes.knowledge_import_sources._notion_search",
+        _fake_search,
+    )
+
+    response = await v1_client.get(
+        f"/v1/workspaces/{workspace.id}/knowledge/sources/notion/resources",
+        headers=_auth(raw),
+        params={"integration_id": str(integration.id), "q": "onboarding", "type": "any"},
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["next_cursor"] == "cursor-2"
+    assert body["has_more"] is True
+    assert [item["id"] for item in body["items"]] == ["page-uuid-1", "db-uuid-1"]
+    page_item = body["items"][0]
+    assert page_item["type"] == "page"
+    assert page_item["title"] == "Onboarding handbook"
+    assert page_item["icon"] == "📘"
+    assert page_item["parent_path"] == "Workspace"
+    db_item = body["items"][1]
+    assert db_item["type"] == "database"
+    assert db_item["title"] == "Customer FAQ"
+    assert db_item["parent_path"] == "Page"
+
+    # Forwarded params: q ends up as `query`, type=any drops the filter,
+    # token came from the encrypted integration secret.
+    assert captured["token"] == "ntn_test"
+    assert captured["body"]["query"] == "onboarding"
+    assert "filter" not in captured["body"]
+    assert captured["body"]["page_size"] > 0
+
+
+@pytest.mark.asyncio
+async def test_list_notion_resources_defaults_to_pages_only(
+    v1_client, seed_workspace, db_session, monkeypatch
+) -> None:
+    """Default ``type=page`` filter matches what the connector can fetch."""
+    _, raw, workspace = seed_workspace
+    integration = _seed_notion_integration(db_session, workspace.id)
+    await db_session.flush()
+
+    captured = {}
+
+    async def _fake_search(*, token, body, workspace_id):
+        captured["body"] = body
+        return {"results": [], "next_cursor": None, "has_more": False}
+
+    monkeypatch.setattr(
+        "backend.app.api.v1.routes.knowledge_import_sources._notion_search",
+        _fake_search,
+    )
+
+    response = await v1_client.get(
+        f"/v1/workspaces/{workspace.id}/knowledge/sources/notion/resources",
+        headers=_auth(raw),
+        params={"integration_id": str(integration.id)},
+    )
+    assert response.status_code == 200
+    assert captured["body"]["filter"] == {"value": "page", "property": "object"}
+
+
+@pytest.mark.asyncio
+async def test_list_notion_resources_404_when_integration_kind_mismatches(
+    v1_client, seed_workspace, db_session
+) -> None:
+    """A non-Notion integration row (e.g. linear) must 404 — the route
+    refuses to leak any other provider's token via this path."""
+    _, raw, workspace = seed_workspace
+    wrong_kind = Integration(
+        id=uuid.uuid4(),
+        workspace_id=workspace.id,
+        kind="linear",
+        config={},
+        status="ok",
+        secret_ciphertext=encrypt("x"),
+    )
+    db_session.add(wrong_kind)
+    await db_session.flush()
+
+    response = await v1_client.get(
+        f"/v1/workspaces/{workspace.id}/knowledge/sources/notion/resources",
+        headers=_auth(raw),
+        params={"integration_id": str(wrong_kind.id)},
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_list_notion_resources_400_when_secret_missing(
+    v1_client, seed_workspace, db_session
+) -> None:
+    _, raw, workspace = seed_workspace
+    integration = _seed_notion_integration(db_session, workspace.id, secret=None)
+    await db_session.flush()
+
+    response = await v1_client.get(
+        f"/v1/workspaces/{workspace.id}/knowledge/sources/notion/resources",
+        headers=_auth(raw),
+        params={"integration_id": str(integration.id)},
+    )
+    assert response.status_code == 400
+    assert "reconnect" in response.json()["detail"].lower()

--- a/console/src/app/(authed)/knowledge/import-wizard.tsx
+++ b/console/src/app/(authed)/knowledge/import-wizard.tsx
@@ -8,6 +8,7 @@ import type { ApiActivatedRepo } from "@/lib/api/client";
 import type { ApiBucketScope, ApiIntegration } from "@/lib/api/types";
 
 import { createImportSourceAction, type ImportSourceResult } from "./actions";
+import { NotionResourcePicker, type NotionPageRef } from "./notion-resource-picker";
 
 type SourceKind = "website" | "notion" | "confluence" | "docs_repo" | "static_upload";
 
@@ -23,15 +24,18 @@ export function KnowledgeImportWizard({
   integrations,
   repos,
   defaultScope,
+  workspaceId,
 }: {
   integrations: ApiIntegration[];
   repos: ApiActivatedRepo[];
   defaultScope: ApiBucketScope;
+  workspaceId?: string;
 }) {
   const [kind, setKind] = useState<SourceKind>("website");
   const [name, setName] = useState("Website knowledge");
   const [url, setUrl] = useState("");
-  const [resourceRefs, setResourceRefs] = useState("[]");
+  const [notionRefs, setNotionRefs] = useState<NotionPageRef[]>([]);
+  const [confluenceRefs, setConfluenceRefs] = useState("[]");
   const [repoId, setRepoId] = useState(repos[0]?.id ?? "");
   const [repoPaths, setRepoPaths] = useState("docs\nREADME.md");
   const [uploadTitle, setUploadTitle] = useState("");
@@ -75,14 +79,32 @@ export function KnowledgeImportWizard({
       if (!url.trim()) return { ok: false, message: "Website URL is required." };
       return { ok: true, config: { url: url.trim(), limit: 25, change_tracking: true, only_main_content: true } };
     }
-    if (kind === "notion" || kind === "confluence") {
-      if (!selectedIntegrationId) return { ok: false, message: `Connect ${kind} first in integrations.` };
+    if (kind === "notion") {
+      if (!selectedIntegrationId) return { ok: false, message: "Connect Notion first in integrations." };
+      if (notionRefs.length === 0) {
+        return { ok: false, message: "Pick at least one Notion page from the list." };
+      }
+      return { ok: true, config: { resource_refs: notionRefs } };
+    }
+    if (kind === "confluence") {
+      if (!selectedIntegrationId) return { ok: false, message: "Connect Confluence first in integrations." };
+      let parsed: unknown;
       try {
-        const parsed = JSON.parse(resourceRefs || "[]") as unknown;
-        return { ok: true, config: { resource_refs: Array.isArray(parsed) ? parsed : [parsed] } };
+        parsed = JSON.parse(confluenceRefs || "[]");
       } catch {
         return { ok: false, message: "Resource refs must be valid JSON." };
       }
+      const refs = Array.isArray(parsed) ? parsed : [parsed];
+      const meaningful = refs.filter(
+        (ref) => ref && typeof ref === "object" && Object.keys(ref as object).length > 0,
+      );
+      if (meaningful.length === 0) {
+        return {
+          ok: false,
+          message: 'Add at least one Confluence page ref — e.g. {"page_id":"..."}.',
+        };
+      }
+      return { ok: true, config: { resource_refs: meaningful } };
     }
     if (kind === "docs_repo") {
       if (!repoId) return { ok: false, message: "Pick a repository." };
@@ -145,15 +167,40 @@ export function KnowledgeImportWizard({
               <input value={url} onChange={(event) => setUrl(event.target.value)} placeholder="https://docs.example.com" className="w-full rounded border border-white/15 bg-black/30 px-3 py-2 text-sm text-white/90" />
             </Field>
           )}
-          {(kind === "notion" || kind === "confluence") && (
+          {kind === "notion" && (
             <>
-              <Field label={`${kind} integration`}>
+              <Field label="Notion integration">
                 <select value={selectedIntegrationId} onChange={(event) => setIntegrationId(event.target.value)} className="w-full rounded border border-white/15 bg-black/30 px-3 py-2 text-sm text-white/90">
                   {matchingIntegrations.length === 0 ? <option value="">No integration connected</option> : matchingIntegrations.map((integration) => <option key={integration.id} value={integration.id}>{integration.kind} - {integration.status}</option>)}
                 </select>
               </Field>
-              <Field label="Resource refs JSON" hint='Examples: [{"page_id":"..."}] or [{"database_id":"..."}]'>
-                <textarea value={resourceRefs} onChange={(event) => setResourceRefs(event.target.value)} rows={5} className="w-full rounded border border-white/15 bg-black/30 px-3 py-2 font-mono text-[12px] text-aqua/85" />
+              <Field label="Pages to import">
+                {workspaceId && selectedIntegrationId ? (
+                  <NotionResourcePicker
+                    workspaceId={workspaceId}
+                    integrationId={selectedIntegrationId}
+                    value={notionRefs}
+                    onChange={setNotionRefs}
+                  />
+                ) : (
+                  <p className="text-[11px] text-white/55">
+                    {workspaceId
+                      ? "Connect Notion to pick pages."
+                      : "Workspace not loaded yet — refresh the page."}
+                  </p>
+                )}
+              </Field>
+            </>
+          )}
+          {kind === "confluence" && (
+            <>
+              <Field label="Confluence integration">
+                <select value={selectedIntegrationId} onChange={(event) => setIntegrationId(event.target.value)} className="w-full rounded border border-white/15 bg-black/30 px-3 py-2 text-sm text-white/90">
+                  {matchingIntegrations.length === 0 ? <option value="">No integration connected</option> : matchingIntegrations.map((integration) => <option key={integration.id} value={integration.id}>{integration.kind} - {integration.status}</option>)}
+                </select>
+              </Field>
+              <Field label="Resource refs JSON" hint='Examples: [{"page_id":"..."}] — picker is in the next phase.'>
+                <textarea value={confluenceRefs} onChange={(event) => setConfluenceRefs(event.target.value)} rows={5} className="w-full rounded border border-white/15 bg-black/30 px-3 py-2 font-mono text-[12px] text-aqua/85" />
               </Field>
             </>
           )}
@@ -194,7 +241,31 @@ function Field({ label, hint, children }: { label: string; hint?: string; childr
 
 function ResultBox({ result }: { result: ImportSourceResult }) {
   if (!result.ok) return <div className="rounded-xl border border-coral/35 bg-coral/10 p-3 text-sm text-coral">{result.message}</div>;
-  return <div className="rounded-xl border border-aqua/30 bg-aqua/10 p-3 text-sm text-aqua">Source created{result.synced ? " and synced" : ""}.{result.syncError && <div className="mt-1 text-xs text-coral">Sync failed: {result.syncError}</div>}{result.stats && <pre className="mt-2 overflow-x-auto text-[11px] text-aqua/80">{JSON.stringify(result.stats, null, 2)}</pre>}</div>;
+  // A "synced" run with all-zero stats means we accepted the source but
+  // nothing got pulled — usually misconfigured selection. Don't dress it
+  // up as a green success: amber + a hint so the operator sees something
+  // is off instead of trusting the checkmark.
+  const stats = result.stats as { discovered?: number; notes_created?: number; errors?: number } | undefined;
+  const emptyHarvest = result.synced
+    && stats
+    && (stats.discovered ?? 0) === 0
+    && (stats.notes_created ?? 0) === 0
+    && (stats.errors ?? 0) === 0;
+  if (emptyHarvest) {
+    return (
+      <div className="rounded-xl border border-amber-300/40 bg-amber-300/10 p-3 text-sm text-amber-100">
+        Source created, but the sync discovered nothing. Double-check the resources you selected — the integration may not have access, or the picks were empty.
+        <pre className="mt-2 overflow-x-auto text-[11px] text-amber-100/80">{JSON.stringify(result.stats, null, 2)}</pre>
+      </div>
+    );
+  }
+  return (
+    <div className="rounded-xl border border-aqua/30 bg-aqua/10 p-3 text-sm text-aqua">
+      Source created{result.synced ? " and synced" : ""}.
+      {result.syncError && <div className="mt-1 text-xs text-coral">Sync failed: {result.syncError}</div>}
+      {result.stats && <pre className="mt-2 overflow-x-auto text-[11px] text-aqua/80">{JSON.stringify(result.stats, null, 2)}</pre>}
+    </div>
+  );
 }
 
 function defaultName(kind: SourceKind): string {

--- a/console/src/app/(authed)/knowledge/knowledge-control-center.tsx
+++ b/console/src/app/(authed)/knowledge/knowledge-control-center.tsx
@@ -164,6 +164,7 @@ export function KnowledgeControlCenter({
           repos={repos}
           integrations={integrations}
           sources={sources}
+          workspaceId={workspace.id}
         />
       )}
 
@@ -468,10 +469,12 @@ function ImportPanel({
   repos,
   integrations,
   sources,
+  workspaceId,
 }: {
   repos: ApiActivatedRepo[];
   integrations: ApiIntegration[];
   sources: KnowledgeSourceRow[];
+  workspaceId: string | undefined;
 }) {
   return (
     <section className="space-y-6 border-l border-aqua/30 pl-6">
@@ -479,6 +482,7 @@ function ImportPanel({
         integrations={integrations}
         repos={repos}
         defaultScope="workspace"
+        workspaceId={workspaceId}
       />
       {sources.length > 0 && <ConnectedSources sources={sources} />}
     </section>

--- a/console/src/app/(authed)/knowledge/notion-resource-picker.tsx
+++ b/console/src/app/(authed)/knowledge/notion-resource-picker.tsx
@@ -1,0 +1,279 @@
+"use client";
+
+/**
+ * NotionResourcePicker — multi-select picker over the connected Notion
+ * integration's visible pages. Replaces the JSON textarea operators
+ * used to fill ``resource_refs`` by hand.
+ *
+ * Searches via ``/api/knowledge/notion-resources`` (Next route handler
+ * proxying ``/v1/.../notion/resources``). The picker's ``value`` is
+ * the same shape the backend already accepts in
+ * ``config.resource_refs``: ``{ page_id: <uuid> }[]`` — so no
+ * transform is needed on submit.
+ *
+ * Defaults to ``type=page`` because the connector fetcher only
+ * supports page refs today; database support arrives when the
+ * connector learns it.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import type { ApiNotionResourceItem } from "@/lib/api/client";
+
+export type NotionPageRef = { page_id: string } | { database_id: string };
+
+type FetchState =
+  | { kind: "idle" }
+  | { kind: "loading" }
+  | { kind: "ready"; items: ApiNotionResourceItem[]; nextCursor: string | null; hasMore: boolean }
+  | { kind: "error"; message: string };
+
+const SEARCH_DEBOUNCE_MS = 300;
+
+export function NotionResourcePicker({
+  workspaceId,
+  integrationId,
+  value,
+  onChange,
+}: {
+  workspaceId: string;
+  integrationId: string;
+  value: NotionPageRef[];
+  onChange: (next: NotionPageRef[]) => void;
+}) {
+  const [query, setQuery] = useState("");
+  const [debouncedQuery, setDebouncedQuery] = useState("");
+  const [state, setState] = useState<FetchState>({ kind: "idle" });
+  const [appending, setAppending] = useState(false);
+  const abortRef = useRef<AbortController | null>(null);
+
+  // Track selected refs by id so checkmarks stay correct across paginated pages.
+  const selectedIds = useMemo(() => new Set(value.map(refId)), [value]);
+  // Map id → item for resolving "selected" pills when the item isn't in the
+  // current visible list (e.g. user paginated past it).
+  const resolvedById = useMemo(() => {
+    const map = new Map<string, ApiNotionResourceItem>();
+    if (state.kind === "ready") {
+      for (const item of state.items) map.set(item.id, item);
+    }
+    return map;
+  }, [state]);
+
+  useEffect(() => {
+    const id = setTimeout(() => setDebouncedQuery(query.trim()), SEARCH_DEBOUNCE_MS);
+    return () => clearTimeout(id);
+  }, [query]);
+
+  const load = useCallback(
+    async (
+      args: { q: string; cursor?: string | null; append?: boolean },
+    ) => {
+      if (!integrationId) {
+        setState({ kind: "error", message: "Connect Notion first." });
+        return;
+      }
+      abortRef.current?.abort();
+      const controller = new AbortController();
+      abortRef.current = controller;
+
+      if (args.append) setAppending(true);
+      else setState({ kind: "loading" });
+
+      try {
+        const params = new URLSearchParams({ workspaceId, integrationId });
+        if (args.q) params.set("q", args.q);
+        if (args.cursor) params.set("cursor", args.cursor);
+        const resp = await fetch(`/api/knowledge/notion-resources?${params.toString()}`, {
+          method: "GET",
+          signal: controller.signal,
+        });
+        if (!resp.ok) {
+          const payload = await resp.json().catch(() => ({}));
+          const message =
+            typeof payload?.error === "string" ? payload.error : `HTTP ${resp.status}`;
+          setState({ kind: "error", message });
+          return;
+        }
+        const data = (await resp.json()) as {
+          items: ApiNotionResourceItem[];
+          next_cursor: string | null;
+          has_more: boolean;
+        };
+        setState((prev) => {
+          const baseItems =
+            args.append && prev.kind === "ready" ? prev.items : [];
+          const merged = [...baseItems, ...data.items];
+          return {
+            kind: "ready",
+            items: merged,
+            nextCursor: data.next_cursor,
+            hasMore: data.has_more,
+          };
+        });
+      } catch (err) {
+        if (controller.signal.aborted) return;
+        setState({
+          kind: "error",
+          message: err instanceof Error ? err.message : "Failed to load Notion resources",
+        });
+      } finally {
+        setAppending(false);
+      }
+    },
+    [integrationId, workspaceId],
+  );
+
+  // Re-run search whenever debounced query or integration changes.
+  useEffect(() => {
+    if (!integrationId) return;
+    void load({ q: debouncedQuery });
+  }, [debouncedQuery, integrationId, load]);
+
+  function toggle(item: ApiNotionResourceItem) {
+    const ref: NotionPageRef =
+      item.type === "page"
+        ? { page_id: item.id }
+        : { database_id: item.id };
+    const id = item.id;
+    if (selectedIds.has(id)) {
+      onChange(value.filter((existing) => refId(existing) !== id));
+    } else {
+      onChange([...value, ref]);
+    }
+  }
+
+  function unselect(id: string) {
+    onChange(value.filter((existing) => refId(existing) !== id));
+  }
+
+  return (
+    <div className="space-y-3" data-testid="notion-resource-picker">
+      <input
+        type="text"
+        value={query}
+        onChange={(event) => setQuery(event.target.value)}
+        placeholder="Search Notion pages your integration can see…"
+        className="w-full rounded border border-white/15 bg-black/30 px-3 py-2 text-sm text-white/90 placeholder:text-white/35"
+        aria-label="Search Notion pages"
+      />
+
+      {value.length > 0 && (
+        <div className="flex flex-wrap gap-1.5">
+          {value.map((ref) => {
+            const id = refId(ref);
+            const item = resolvedById.get(id);
+            const label = item?.title ?? truncateId(id);
+            const icon = item?.icon ?? null;
+            return (
+              <span
+                key={id}
+                className="inline-flex items-center gap-1.5 rounded-full border border-aqua/40 bg-aqua/10 px-2 py-0.5 text-[11px] text-aqua"
+              >
+                {icon && <span className="text-xs">{maybeRenderIcon(icon)}</span>}
+                <span className="max-w-[24ch] truncate">{label}</span>
+                <button
+                  type="button"
+                  onClick={() => unselect(id)}
+                  className="text-aqua/70 hover:text-aqua"
+                  aria-label={`Remove ${label}`}
+                >
+                  ×
+                </button>
+              </span>
+            );
+          })}
+        </div>
+      )}
+
+      <div className="rounded border border-white/10 bg-black/30">
+        {state.kind === "loading" && (
+          <p className="px-3 py-3 text-xs text-white/55">Loading…</p>
+        )}
+        {state.kind === "error" && (
+          <p className="px-3 py-3 text-xs text-coral">{state.message}</p>
+        )}
+        {state.kind === "ready" && state.items.length === 0 && (
+          <p className="px-3 py-3 text-xs text-white/55">
+            No Notion pages match. Make sure your integration is shared with the page in Notion (Share → Connections).
+          </p>
+        )}
+        {state.kind === "ready" && state.items.length > 0 && (
+          <ul className="max-h-72 divide-y divide-white/5 overflow-y-auto" role="listbox">
+            {state.items.map((item) => {
+              const checked = selectedIds.has(item.id);
+              return (
+                <li key={item.id}>
+                  <label className="flex cursor-pointer items-center gap-2 px-3 py-2 text-xs text-white/85 hover:bg-white/[0.04]">
+                    <input
+                      type="checkbox"
+                      checked={checked}
+                      onChange={() => toggle(item)}
+                      className="accent-aqua"
+                      aria-label={item.title}
+                    />
+                    {item.icon ? (
+                      <span className="w-4 text-center">{maybeRenderIcon(item.icon)}</span>
+                    ) : (
+                      <span className="w-4 text-center text-white/35">{item.type === "database" ? "▦" : "•"}</span>
+                    )}
+                    <span className="flex-1 truncate">
+                      <span className="text-white/90">{item.title || "Untitled"}</span>
+                      <span className="ml-2 text-white/35">{item.type === "database" ? "database" : "page"}</span>
+                    </span>
+                    {item.last_edited_time && (
+                      <span className="text-[10px] text-white/35">
+                        {formatDate(item.last_edited_time)}
+                      </span>
+                    )}
+                  </label>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+        {state.kind === "ready" && state.hasMore && state.nextCursor && (
+          <button
+            type="button"
+            disabled={appending}
+            onClick={() => void load({ q: debouncedQuery, cursor: state.nextCursor, append: true })}
+            className="w-full border-t border-white/5 px-3 py-2 text-[11px] text-aqua/85 hover:text-aqua disabled:opacity-40"
+          >
+            {appending ? "Loading more…" : "Load more"}
+          </button>
+        )}
+      </div>
+
+      <p className="text-[11px] text-white/45">
+        Pick at least one page. Don&apos;t see what you need? In Notion, open the page → <em>•••</em> → Connections, and add the integration named in your Notion settings.
+      </p>
+    </div>
+  );
+}
+
+function refId(ref: NotionPageRef): string {
+  return "page_id" in ref ? ref.page_id : ref.database_id;
+}
+
+function maybeRenderIcon(icon: string): string {
+  // Notion icons can be emoji strings or external image URLs. Show the
+  // emoji directly; for URLs we'd need <img> with sized rendering, which
+  // adds visual complexity for marginal value — skip and fall back to
+  // the type glyph by returning empty.
+  if (!icon) return "";
+  if (icon.length <= 4 && !icon.startsWith("http")) return icon;
+  return "";
+}
+
+function truncateId(id: string): string {
+  return id.length > 18 ? `${id.slice(0, 8)}…${id.slice(-4)}` : id;
+}
+
+function formatDate(iso: string): string {
+  try {
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return "";
+    return d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+  } catch {
+    return "";
+  }
+}

--- a/console/src/app/(authed)/process/flow-schedule-panel.tsx
+++ b/console/src/app/(authed)/process/flow-schedule-panel.tsx
@@ -284,7 +284,7 @@ export function FlowSchedulePanel({
         ) : null}
 
         <div className="grid gap-3 xl:grid-cols-[200px_minmax(0,1fr)]">
-          <aside className="max-h-[640px] overflow-y-auto rounded-2xl border border-white/10 bg-black/25 p-3">
+          <aside className="max-h-[640px] overflow-y-auto p-1">
             <div className="sticky top-0 -mx-3 mb-2 -mt-3 border-b border-white/5 bg-black/85 px-3 py-2 backdrop-blur">
               <div className="text-[10px] font-bold uppercase tracking-[0.22em] text-aqua/70">
                 Roles · drag to a cell
@@ -314,7 +314,7 @@ export function FlowSchedulePanel({
             </div>
           </aside>
 
-          <section className="overflow-hidden rounded-3xl border border-white/10 bg-[#050a15] shadow-2xl shadow-black/30">
+          <section className="overflow-hidden">
             <div className="flex flex-wrap items-center justify-between gap-2 border-b border-white/10 bg-white/[0.035] px-4 py-3">
               <div>
                 <div className="text-sm font-semibold text-white">Capacity calendar</div>
@@ -327,8 +327,8 @@ export function FlowSchedulePanel({
                   <span className="h-2 w-2 rounded border border-aqua/40 bg-aqua/[0.10]" aria-hidden />
                   specialist · drag
                 </span>
-                <span className="inline-flex items-center gap-1.5 text-amber-200/85">
-                  <span className="h-2 w-2 rounded border border-amber-300/40 bg-amber-300/[0.10]" aria-hidden />
+                <span className="inline-flex items-center gap-1.5 text-sun/85">
+                  <span className="h-2 w-2 rounded border border-sun/40 bg-sun/[0.10]" aria-hidden />
                   routine · cron
                 </span>
                 <button
@@ -388,18 +388,18 @@ export function FlowSchedulePanel({
             </div>
             {routineProjection.continuous.length > 0 && (
               <div className="border-t border-white/10 bg-black/20 px-4 py-3">
-                <div className="mb-2 text-[10px] font-bold uppercase tracking-[0.22em] text-amber-200/80">
+                <div className="mb-2 text-[10px] font-bold uppercase tracking-[0.22em] text-sun/80">
                   Continuous routines · fire too often for the grid
                 </div>
                 <div className="flex flex-wrap gap-2">
                   {routineProjection.continuous.map(({ routine, cadence }) => (
                     <span
                       key={routine.id}
-                      className="inline-flex items-center gap-1.5 rounded-full border border-amber-300/30 bg-amber-300/[0.07] px-3 py-1 text-[11px] font-semibold text-amber-200/90"
+                      className="inline-flex items-center gap-1.5 rounded-full border border-sun/30 bg-sun/[0.07] px-3 py-1 text-[11px] font-semibold text-sun/90"
                     >
-                      <span className="h-1.5 w-1.5 rounded-full bg-amber-300" aria-hidden />
+                      <span className="h-1.5 w-1.5 rounded-full bg-sun" aria-hidden />
                       {routineLabel.get(routine.id) ?? routine.name ?? routine.id}
-                      <span className="font-normal text-amber-200/60">· {cadence}</span>
+                      <span className="font-normal text-sun/60">· {cadence}</span>
                     </span>
                   ))}
                 </div>
@@ -470,14 +470,14 @@ function CalendarCell({
             stripe is hidden entirely. */}
         {routines.length > 0 ? (
           <div
-            className="flex flex-wrap items-center gap-1 rounded-md border border-amber-300/25 bg-amber-300/[0.07] px-1.5 py-1"
+            className="flex flex-wrap items-center gap-1 rounded-md border border-sun/25 bg-sun/[0.07] px-1.5 py-1"
             title="Routines firing in this slot — fire on cron, not capacity"
           >
             <span className="text-[9px]" aria-hidden>⏱</span>
             {routines.map((r, idx) => (
-              <span key={r.id} className="text-[9px] font-bold uppercase tracking-widest text-amber-200/90">
+              <span key={r.id} className="text-[9px] font-bold uppercase tracking-widest text-sun/90">
                 {routineLabel.get(r.id) ?? r.name ?? r.id}
-                {idx < routines.length - 1 ? <span className="text-amber-200/40"> · </span> : null}
+                {idx < routines.length - 1 ? <span className="text-sun/40"> · </span> : null}
               </span>
             ))}
           </div>
@@ -587,7 +587,7 @@ function RoutinesSummary({
   const visible = routines.filter((r) => !HIDDEN_ROUTINE_IDS.has(r.id));
   const labelById = new Map(BUILTIN_ROUTINE_CATALOG.map((c) => [c.id, c.name] as const));
   return (
-    <div className="rounded-2xl border border-white/10 bg-white/[0.02] p-3">
+    <div className="p-1">
       <div className="flex items-center justify-between gap-2">
         <div className="text-[10px] font-bold uppercase tracking-[0.22em] text-white/55">
           Routines on this process
@@ -623,7 +623,7 @@ function RoutinesSummary({
                 className={[
                   "rounded-xl border p-2.5",
                   !canonical
-                    ? "border-amber-300/35 bg-amber-300/[0.05]"
+                    ? "border-sun/35 bg-sun/[0.05]"
                     : enabled
                       ? "border-aqua/25 bg-aqua/[0.05]"
                       : "border-white/10 bg-white/[0.02] opacity-65",
@@ -636,7 +636,7 @@ function RoutinesSummary({
                     </span>
                     {!canonical && (
                       <span
-                        className="shrink-0 rounded-full border border-amber-300/40 bg-amber-300/[0.10] px-1.5 py-0.5 text-[8px] font-bold uppercase tracking-widest text-amber-200"
+                        className="shrink-0 rounded-full border border-sun/40 bg-sun/[0.10] px-1.5 py-0.5 text-[8px] font-bold uppercase tracking-widest text-sun"
                         title="Pre-canonical routine id — leftover from an older seed. Clean up the DB row to remove it from this view."
                       >
                         legacy
@@ -646,7 +646,7 @@ function RoutinesSummary({
                   <span
                     className={[
                       "h-1.5 w-1.5 rounded-full",
-                      enabled ? (canonical ? "bg-aqua" : "bg-amber-300") : "bg-white/30",
+                      enabled ? (canonical ? "bg-aqua" : "bg-sun") : "bg-white/30",
                     ].join(" ")}
                     aria-hidden
                   />

--- a/console/src/app/(authed)/process/page.tsx
+++ b/console/src/app/(authed)/process/page.tsx
@@ -397,16 +397,16 @@ function ConfigSourceBanner({
   }
   if (source === "repo-lanes") {
     return (
-      <div className="inline-flex items-center gap-2 rounded-full border border-amber-300/30 bg-amber-300/[0.07] px-3 py-1 text-[11px] font-semibold text-amber-200">
-        <span className="h-1.5 w-1.5 rounded-full bg-amber-300" aria-hidden />
+      <div className="inline-flex items-center gap-2 rounded-full border border-sun/30 bg-sun/[0.07] px-3 py-1 text-[11px] font-semibold text-sun">
+        <span className="h-1.5 w-1.5 rounded-full bg-sun" aria-hidden />
         Legacy <code className="font-mono">lanes:</code> config — reseed to migrate.
       </div>
     );
   }
   if (source === "missing") {
     return (
-      <div className="inline-flex items-center gap-2 rounded-full border border-coral/30 bg-coral/[0.07] px-3 py-1 text-[11px] font-semibold text-coral">
-        <span className="h-1.5 w-1.5 rounded-full bg-coral" aria-hidden />
+      <div className="inline-flex items-center gap-2 rounded-full border border-sun/30 bg-sun/[0.07] px-3 py-1 text-[11px] font-semibold text-sun">
+        <span className="h-1.5 w-1.5 rounded-full bg-sun" aria-hidden />
         No <code className="font-mono">.ship/config.yml</code> on default branch — reseed required.
       </div>
     );
@@ -433,14 +433,17 @@ function ProcessTabs({
       : `/process/${encodeURIComponent(processId)}`;
   };
   return (
-    <div className="flex items-center gap-1 rounded-2xl border border-white/10 bg-white/[0.035] p-2">
+    <nav
+      aria-label="Process view"
+      className="flex items-center gap-6 border-b border-white/[0.06] pb-1"
+    >
       <TabLink href={hrefFor("flow")} active={selected === "flow"}>
         Flow
       </TabLink>
       <TabLink href={hrefFor("schedule")} active={selected === "schedule"}>
         Capacity
       </TabLink>
-    </div>
+    </nav>
   );
 }
 
@@ -466,11 +469,12 @@ function TabLink({
   return (
     <Link
       href={href}
+      aria-current={active ? "page" : undefined}
       className={[
-        "rounded-xl px-3 py-1.5 text-xs font-semibold transition",
+        "relative pb-2 text-[11px] font-bold uppercase tracking-[0.22em] transition",
         active
-          ? "bg-aqua/15 text-aqua"
-          : "text-white/55 hover:bg-white/[0.05] hover:text-white",
+          ? "text-aqua after:absolute after:inset-x-0 after:-bottom-px after:h-px after:bg-aqua"
+          : "text-white/40 hover:text-white",
       ].join(" ")}
     >
       {children}

--- a/console/src/app/(authed)/process/process-canvas-editor.tsx
+++ b/console/src/app/(authed)/process/process-canvas-editor.tsx
@@ -345,14 +345,12 @@ function LaneColumn({
       onDragLeave={onDragLeaveLane}
       onDrop={onDropOnLane}
       className={[
-        "group/lane flex min-h-[280px] flex-col gap-1.5 rounded-xl border p-1.5 transition",
-        dragOverLane
-          ? "border-aqua/55 bg-aqua/[0.06] shadow-[inset_0_0_0_1px_rgba(207,169,107,0.4)]"
-          : "border-white/8",
+        "group/lane flex min-h-[280px] flex-col gap-1.5 p-1.5 transition",
+        dragOverLane ? "ring-1 ring-aqua/40" : "",
       ].join(" ")}
       style={{ background: dragOverLane ? undefined : LANE_TINT[lane] }}
     >
-      <div className="sticky top-0 z-10 flex items-center gap-1.5 rounded-t-xl border-b border-white/5 bg-[#040814]/95 px-2 py-1.5 backdrop-blur">
+      <div className="sticky top-0 z-10 flex items-center gap-1.5 border-b border-white/[0.06] bg-ink/90 px-2 py-1.5 backdrop-blur">
         <span
           className="h-1.5 w-1.5 rounded-full"
           style={{ background: LANE_DOT[lane] }}
@@ -447,55 +445,48 @@ function StageCard({
       }}
       data-stage-id={stage.id}
       className={[
-        "rounded-lg border px-2.5 py-2 text-left shadow transition",
-        "cursor-grab active:cursor-grabbing focus:outline-none focus-visible:ring-2 focus-visible:ring-aqua/60",
+        "relative px-3 py-2 pl-3 text-left transition cursor-grab active:cursor-grabbing focus:outline-none focus-visible:ring-1 focus-visible:ring-aqua/60",
         selected
-          ? "border-aqua/70 bg-[linear-gradient(135deg,rgba(207,169,107,0.20),rgba(207,169,107,0.05))] shadow-aqua/30"
+          ? "bg-aqua/[0.04] ring-1 ring-aqua/60"
           : isDragTarget
-            ? "border-aqua/55 bg-aqua/[0.10] ring-1 ring-aqua/40"
-            : "border-white/15 bg-[linear-gradient(135deg,rgba(255,255,255,0.10),rgba(255,255,255,0.03))] hover:border-aqua/40",
+            ? "bg-aqua/[0.06] ring-1 ring-aqua/40"
+            : "bg-white/[0.04] hover:bg-white/[0.07]",
       ].join(" ")}
+      style={{ borderRadius: 6 }}
     >
-      <div className="flex items-start justify-between gap-2">
-        <div className="min-w-0 flex-1">
-          <div className="truncate text-[13px] font-bold text-white">
-            {stage.name}
-          </div>
-          <div className="mt-0.5 truncate text-[10px] text-white/55">
-            {stage.specialist_name}
-          </div>
+      <span
+        aria-hidden
+        className="absolute inset-y-1 left-0 w-[2px] rounded-r-sm"
+        style={{ background: LANE_DOT[lane] }}
+      />
+      <div className="min-w-0">
+        <div className="truncate text-[13px] font-semibold text-white">
+          {stage.name}
         </div>
-        <span
-          className="mt-0.5 h-1.5 w-1.5 shrink-0 rounded-full"
-          style={{
-            background: LANE_DOT[lane],
-            boxShadow: `0 0 8px ${LANE_DOT[lane]}`,
-          }}
-          aria-hidden
-        />
+        <div className="mt-0.5 truncate text-[10px] text-white/55">
+          {stage.specialist_name}
+        </div>
       </div>
       {next ? (
         <div
           className={[
-            "mt-1.5 flex items-center gap-1 truncate border-t border-white/5 pt-1 text-[9px] uppercase tracking-widest",
-            next.actor === "user" ? "text-amber-200/80" : "text-white/40",
+            "mt-1.5 flex items-center gap-1 truncate text-[9px] uppercase tracking-widest",
+            next.actor === "user" ? "text-lilac/85" : "text-white/40",
           ].join(" ")}
         >
           <span aria-hidden>→</span>
           <span className="truncate">{next.stage.name}</span>
           <span
             className={[
-              "ml-auto shrink-0 rounded-sm px-1 text-[8px] font-bold",
-              next.actor === "user"
-                ? "bg-amber-300/15 text-amber-200"
-                : "bg-white/5 text-white/45",
+              "ml-auto shrink-0 text-[8px] font-bold",
+              next.actor === "user" ? "text-lilac" : "text-white/45",
             ].join(" ")}
           >
             {next.actor}
           </span>
         </div>
       ) : (
-        <div className="mt-1.5 truncate border-t border-white/5 pt-1 text-[9px] uppercase tracking-widest text-white/25">
+        <div className="mt-1.5 truncate text-[9px] uppercase tracking-widest text-white/25">
           terminal
         </div>
       )}

--- a/console/src/app/(authed)/process/process-editor-workspace.tsx
+++ b/console/src/app/(authed)/process/process-editor-workspace.tsx
@@ -334,114 +334,117 @@ export function ProcessEditorWorkspace({
   }
 
   return (
-    <section className="min-h-[calc(100vh-180px)] overflow-hidden rounded-[2rem] border border-aqua/15 bg-[radial-gradient(circle_at_top_left,rgba(99,245,255,0.10),transparent_30%),linear-gradient(135deg,rgba(255,255,255,0.07),rgba(255,255,255,0.025))] shadow-2xl shadow-black/40 backdrop-blur-xl">
-      <div className="border-b border-white/10 px-4 py-2">
-        <div className="flex flex-wrap items-center justify-between gap-2">
-          <div className="flex min-w-0 flex-1 items-center gap-2">
-            {tabs}
-            {dirty && (
-              <span
-                className="shrink-0 truncate text-[11px] text-white/45"
-                title={draftSummary}
-              >
-                · {draftSummary}
-              </span>
-            )}
-          </div>
-          <form
-            action="/api/process/config-propose"
-            method="post"
-            className="flex shrink-0 flex-wrap items-center gap-1.5"
-          >
-            <ProcessConfigProposalFields
-              workspaceId={workspaceId}
-              repoId={repoId}
-              config={config}
-              processConfig={processConfig}
-              changeSummary={changeSummary}
-            />
-            <button
-              type="button"
-              disabled={!dirty}
-              onClick={resetDraft}
-              className="rounded-full border border-white/10 bg-black/25 px-3 py-1 text-[11px] font-bold text-white/65 transition hover:border-white/20 hover:text-white disabled:cursor-not-allowed disabled:border-white/10 disabled:bg-white/[0.03] disabled:text-white/30"
+    <section className="relative space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-3 border-b border-white/[0.06] pb-3">
+        <div className="flex min-w-0 flex-1 flex-wrap items-center gap-3">
+          {tabs}
+          {dirty && (
+            <span
+              className="shrink-0 truncate text-[11px] text-white/45"
+              title={draftSummary}
             >
-              Discard
-            </button>
-            <button
-              type="submit"
-              disabled={!repoId || !dirty || hasErrors}
-              title={
-                hasErrors
-                  ? `Fix ${validation.errors.length} validation error${validation.errors.length === 1 ? "" : "s"} below before publishing.`
-                  : undefined
-              }
-              className="rounded-full border border-aqua/35 bg-aqua/15 px-3 py-1 text-[11px] font-bold text-aqua shadow-lg shadow-aqua/5 transition hover:bg-aqua/20 disabled:cursor-not-allowed disabled:border-white/10 disabled:bg-white/[0.05] disabled:text-white/35"
-            >
-              Publish
-            </button>
-          </form>
+              · {draftSummary}
+            </span>
+          )}
         </div>
-        <ProcessReviewSummary
-          initial={process}
-          draft={processDraft}
-          changedAreas={dirty ? ["Flow reviewed"] : []}
-        />
-      </div>
-
-      {/* Canvas + optional inspector. When no stage is selected the
-          inspector unmounts entirely so the canvas takes the whole
-          width — operators don't sit looking at an empty side panel. */}
-      <div
-        className={[
-          "grid min-h-0 grid-cols-1",
-          activeStateId ? "xl:grid-cols-[minmax(0,1fr)_320px]" : "",
-        ].join(" ")}
-      >
-        <ProcessCanvasEditor
-          process={processDraft}
-          selectedStateId={activeStateId}
-          selectedTransitionId={selectedTransitionId}
-          onSelectState={selectStateId}
-          onSelectTransition={selectTransitionId}
-          onAddState={() => addState()}
-          onAddStageInLane={addStageInLane}
-          onPositionsChange={updatePositions}
-          onStageStateChange={updateStageState}
-          onReorderStages={reorderStages}
-          onClearSelection={clearSelection}
-        />
-        {activeStateId && selectedState ? (
-          <StateEditor
-            processId={process.id}
+        <form
+          action="/api/process/config-propose"
+          method="post"
+          className="flex shrink-0 flex-wrap items-center gap-3"
+        >
+          <ProcessConfigProposalFields
+            workspaceId={workspaceId}
             repoId={repoId}
-            state={selectedState}
-            states={states}
-            schedule={processDraft.schedule ?? null}
-            transitions={transitions}
-            specialistOptions={specialistOptions}
             config={config}
-            embedded
-            onStateChange={updateState}
-            onDeleteState={deleteState}
-            onClose={clearSelection}
+            processConfig={processConfig}
+            changeSummary={changeSummary}
           />
-        ) : null}
+          <button
+            type="button"
+            disabled={!dirty}
+            onClick={resetDraft}
+            className="text-[11px] font-semibold uppercase tracking-wide text-white/55 transition hover:text-white disabled:cursor-not-allowed disabled:text-white/25"
+          >
+            Discard
+          </button>
+          <button
+            type="submit"
+            disabled={!repoId || !dirty || hasErrors}
+            title={
+              hasErrors
+                ? `Fix ${validation.errors.length} validation error${validation.errors.length === 1 ? "" : "s"} before publishing.`
+                : undefined
+            }
+            className="text-[11px] font-bold uppercase tracking-wide text-aqua transition hover:text-white disabled:cursor-not-allowed disabled:text-white/25"
+          >
+            Publish →
+          </button>
+        </form>
       </div>
 
-      {/* Validation panel — gates Publish. Tracker projection mapping
-          deliberately doesn't live here: it's an adapter-internal
-          concern (provisioner writes ``Integration.config.canonical_to_native``
-          at OAuth time). Operators don't edit canonical→native names. */}
-      <div className="border-t border-white/10 bg-black/20 p-4">
-        <ProcessValidationPanel
-          result={validation}
-          onJumpToStage={(stageId) => selectStateId(stageId)}
-          onJumpToTransition={(transitionId) =>
-            selectTransitionId(transitionId)
-          }
-        />
+      <ProcessReviewSummary
+        initial={process}
+        draft={processDraft}
+        changedAreas={dirty ? ["Flow reviewed"] : []}
+      />
+
+      {/* Canvas + optional inspector — slide-in sheet on xl, stacked
+          panel below xl. When no stage is selected the inspector
+          unmounts and the canvas takes full width. */}
+      <div className="relative">
+        <div
+          className={[
+            "grid min-h-0 grid-cols-1 transition-all",
+            activeStateId ? "xl:grid-cols-[minmax(0,1fr)_380px] xl:gap-x-8" : "",
+          ].join(" ")}
+        >
+          <ProcessCanvasEditor
+            process={processDraft}
+            selectedStateId={activeStateId}
+            selectedTransitionId={selectedTransitionId}
+            onSelectState={selectStateId}
+            onSelectTransition={selectTransitionId}
+            onAddState={() => addState()}
+            onAddStageInLane={addStageInLane}
+            onPositionsChange={updatePositions}
+            onStageStateChange={updateStageState}
+            onReorderStages={reorderStages}
+            onClearSelection={clearSelection}
+          />
+          {activeStateId && selectedState ? (
+            <aside className="border-l-0 border-t border-white/[0.06] pt-6 xl:border-l xl:border-t-0 xl:pt-0 xl:pl-8">
+              <StateEditor
+                processId={process.id}
+                repoId={repoId}
+                state={selectedState}
+                states={states}
+                schedule={processDraft.schedule ?? null}
+                transitions={transitions}
+                specialistOptions={specialistOptions}
+                config={config}
+                embedded
+                onStateChange={updateState}
+                onDeleteState={deleteState}
+                onClose={clearSelection}
+              />
+            </aside>
+          ) : null}
+        </div>
       </div>
+
+      {/* Validation pill — sticky bottom-right. Hidden when no errors
+          / warnings to keep the canvas quiet on a clean draft. */}
+      {(validation.errors.length > 0 || validation.warnings.length > 0) && (
+        <div className="sticky bottom-4 z-10 flex justify-end pr-2">
+          <ProcessValidationPanel
+            result={validation}
+            onJumpToStage={(stageId) => selectStateId(stageId)}
+            onJumpToTransition={(transitionId) =>
+              selectTransitionId(transitionId)
+            }
+          />
+        </div>
+      )}
     </section>
   );
 }

--- a/console/src/app/(authed)/process/process-graph-overview.tsx
+++ b/console/src/app/(authed)/process/process-graph-overview.tsx
@@ -119,8 +119,8 @@ export function ProcessGraphOverview({
 }
 
 function HealthDot({ status }: { status: string }) {
-  let bg = "bg-emerald-400";
-  if (status === "warning" || status === "degraded") bg = "bg-amber-400";
+  let bg = "bg-aqua";
+  if (status === "warning" || status === "degraded") bg = "bg-sun";
   else if (status !== "ok") bg = "bg-coral";
   return (
     <span

--- a/console/src/app/(authed)/process/process-validation-panel.tsx
+++ b/console/src/app/(authed)/process/process-validation-panel.tsx
@@ -3,15 +3,14 @@
 import type { ValidationItem, ValidationResult } from "./process-validation";
 
 /**
- * Compact validation summary that lives under the Flow canvas. When
- * the result is clean (no errors, no warnings) the panel renders a
- * single green pill so the operator gets positive feedback that the
- * draft is good to publish; otherwise it lists each item with its
- * severity dot, message, and (when relevant) an anchor hint.
+ * Compact validation pill that lives sticky at the bottom-right of
+ * the Flow canvas. Renders a quiet ``X errors · Y warnings`` summary
+ * with an expandable list — clicking a row jumps the editor to the
+ * offending stage or transition. Hidden entirely on a clean draft so
+ * the canvas stays quiet when there's nothing to do.
  *
- * The Publish button gates on ``errors.length === 0`` — the parent
- * editor passes the result here AND consults its `errors` array
- * directly to decide whether to disable the submit.
+ * The Publish button gates on ``errors.length === 0`` directly from
+ * the parent editor, not via the panel.
  */
 export function ProcessValidationPanel({
   result,
@@ -23,42 +22,28 @@ export function ProcessValidationPanel({
   onJumpToTransition?: (transitionId: string) => void;
 }) {
   const { errors, warnings } = result;
-  const isClean = errors.length === 0 && warnings.length === 0;
-
-  if (isClean) {
-    return (
-      <div className="flex items-center gap-2 rounded-xl border border-emerald-400/30 bg-emerald-400/[0.05] px-3 py-2 text-xs">
-        <span className="h-2 w-2 rounded-full bg-emerald-400" aria-hidden />
-        <span className="font-semibold text-emerald-300">Process is valid</span>
-        <span className="text-emerald-300/60">
-          — every stage is reachable, every path terminates, all states are
-          canonical.
-        </span>
-      </div>
-    );
-  }
+  if (errors.length === 0 && warnings.length === 0) return null;
 
   return (
-    <div className="rounded-2xl border border-white/10 bg-white/[0.02] p-3">
-      <div className="flex items-center justify-between gap-2">
-        <div className="text-[10px] font-bold uppercase tracking-[0.22em] text-white/55">
-          Validation
-        </div>
-        <div className="flex items-center gap-2 text-[11px] font-semibold">
+    <details className="group max-w-md rounded-lg bg-ink/95 backdrop-blur ring-1 ring-white/10 transition open:bg-ink">
+      <summary className="cursor-pointer select-none list-none px-3 py-2 text-[11px] font-semibold">
+        <span className="inline-flex items-center gap-3">
           {errors.length > 0 && (
-            <span className="rounded-full border border-coral/30 bg-coral/[0.08] px-2 py-0.5 text-coral">
+            <span className="text-coral">
               {errors.length} error{errors.length === 1 ? "" : "s"}
             </span>
           )}
           {warnings.length > 0 && (
-            <span className="rounded-full border border-amber-300/30 bg-amber-300/[0.08] px-2 py-0.5 text-amber-200">
+            <span className="text-sun">
               {warnings.length} warning{warnings.length === 1 ? "" : "s"}
             </span>
           )}
-        </div>
-      </div>
-
-      <ul className="mt-3 space-y-1.5">
+          <span className="text-white/40 transition group-open:rotate-90">
+            ›
+          </span>
+        </span>
+      </summary>
+      <ul className="space-y-1 px-3 pb-3">
         {errors.map((item) => (
           <ValidationRow
             key={`err-${item.code}-${item.anchor?.id ?? ""}`}
@@ -76,14 +61,7 @@ export function ProcessValidationPanel({
           />
         ))}
       </ul>
-
-      {errors.length > 0 && (
-        <p className="mt-3 text-[11px] italic text-white/45">
-          Publish is disabled until every error is resolved. Warnings are
-          informational — the editor will still let you save.
-        </p>
-      )}
-    </div>
+    </details>
   );
 }
 
@@ -98,22 +76,22 @@ function ValidationRow({
 }) {
   const isError = item.kind === "error";
   return (
-    <li
-      className={[
-        "flex items-start gap-2.5 rounded-lg border px-3 py-2 text-xs",
-        isError
-          ? "border-coral/25 bg-coral/[0.04] text-coral/95"
-          : "border-amber-300/25 bg-amber-300/[0.04] text-amber-100/90",
-      ].join(" ")}
-    >
+    <li className="flex items-start gap-2 py-1 text-[11px] leading-snug">
+      <span
+        aria-hidden
+        className={[
+          "mt-1 h-1.5 w-1.5 shrink-0 rounded-full",
+          isError ? "bg-coral" : "bg-sun",
+        ].join(" ")}
+      />
       <span
         className={[
-          "mt-0.5 h-1.5 w-1.5 shrink-0 rounded-full",
-          isError ? "bg-coral" : "bg-amber-300",
+          "min-w-0 flex-1",
+          isError ? "text-coral/90" : "text-sun/90",
         ].join(" ")}
-        aria-hidden
-      />
-      <span className="min-w-0 flex-1 leading-snug">{item.message}</span>
+      >
+        {item.message}
+      </span>
       {item.anchor && (item.anchor.kind === "stage"
         ? onJumpToStage
         : onJumpToTransition) ? (
@@ -129,10 +107,10 @@ function ValidationRow({
             }
           }}
           className={[
-            "shrink-0 rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-widest transition",
+            "shrink-0 text-[10px] font-bold uppercase tracking-widest transition",
             isError
-              ? "border-coral/30 text-coral hover:bg-coral/[0.1]"
-              : "border-amber-300/30 text-amber-200 hover:bg-amber-300/[0.1]",
+              ? "text-coral hover:text-white"
+              : "text-sun hover:text-white",
           ].join(" ")}
         >
           Jump

--- a/console/src/app/(authed)/process/state-editor.tsx
+++ b/console/src/app/(authed)/process/state-editor.tsx
@@ -114,7 +114,7 @@ export function StateEditor({
         </div>
       )}
       {!repoId && (
-        <div className="rounded-md border border-amber-300/25 bg-amber-300/[0.06] px-2 py-1.5 text-[11px] text-amber-100/90">
+        <div className="rounded-md border border-sun/25 bg-sun/[0.06] px-2 py-1.5 text-[11px] text-sun/90">
           Select a repository before saving.
         </div>
       )}
@@ -231,7 +231,7 @@ function Section({
   children: ReactNode;
 }) {
   return (
-    <section className="space-y-3 rounded-2xl border border-white/10 bg-[linear-gradient(135deg,rgba(255,255,255,0.065),rgba(255,255,255,0.025))] p-3 shadow-lg shadow-black/10">
+    <section className="space-y-3 p-1">
       <div className="text-[10px] font-bold uppercase tracking-widest text-aqua/55">
         {title}
       </div>

--- a/console/src/app/api/knowledge/notion-resources/route.ts
+++ b/console/src/app/api/knowledge/notion-resources/route.ts
@@ -1,0 +1,82 @@
+/**
+ * Server-side proxy for the wizard's Notion resource picker
+ * (``GET /v1/workspaces/{ws}/knowledge/sources/notion/resources``).
+ *
+ * Same shape as ``api/knowledge/search/route.ts`` — keeps the bearer
+ * token in the httpOnly session cookie instead of shipping it to the
+ * browser.
+ */
+
+import { NextResponse } from "next/server";
+
+import {
+  ApiHttpError,
+  ApiUnavailableError,
+  isApiConfigured,
+  listNotionResources,
+} from "@/lib/api/client";
+import { getSessionToken } from "@/lib/api/session";
+
+export async function GET(request: Request) {
+  if (!isApiConfigured()) {
+    return NextResponse.json(
+      { error: "Backend is not configured.", code: "api_unavailable" },
+      { status: 503 },
+    );
+  }
+
+  const url = new URL(request.url);
+  const workspaceId = url.searchParams.get("workspaceId");
+  const integrationId = url.searchParams.get("integrationId");
+  if (!workspaceId || !integrationId) {
+    return NextResponse.json(
+      { error: "workspaceId and integrationId are required.", code: "bad_request" },
+      { status: 400 },
+    );
+  }
+  const q = url.searchParams.get("q") ?? undefined;
+  const cursor = url.searchParams.get("cursor") ?? undefined;
+  const typeParam = url.searchParams.get("type");
+  const type =
+    typeParam === "page" || typeParam === "database" || typeParam === "any"
+      ? typeParam
+      : undefined;
+
+  try {
+    const token = (await getSessionToken()) ?? undefined;
+    const data = await listNotionResources(
+      workspaceId,
+      { integrationId, q, cursor, type },
+      { token },
+    );
+    return NextResponse.json(data, { status: 200 });
+  } catch (err) {
+    return errorResponse(err);
+  }
+}
+
+function errorResponse(err: unknown): NextResponse {
+  if (err instanceof ApiUnavailableError) {
+    return NextResponse.json(
+      { error: "Backend is unreachable.", code: "api_unavailable" },
+      { status: 503 },
+    );
+  }
+  if (err instanceof ApiHttpError) {
+    const detail =
+      err.detail && typeof err.detail === "object"
+        ? (err.detail as Record<string, unknown>)
+        : null;
+    const message =
+      detail && typeof detail.message === "string"
+        ? detail.message
+        : typeof err.detail === "string"
+          ? err.detail
+          : `HTTP ${err.status}`;
+    return NextResponse.json({ error: message, detail }, { status: err.status });
+  }
+  return NextResponse.json(
+    { error: err instanceof Error ? err.message : "Unknown error", code: "unknown" },
+    { status: 500 },
+  );
+}

--- a/console/src/lib/api/client.ts
+++ b/console/src/lib/api/client.ts
@@ -1246,6 +1246,42 @@ export function syncKnowledgeImportSource(
   );
 }
 
+export type ApiNotionResourceItem = {
+  id: string;
+  type: "page" | "database";
+  title: string;
+  parent_path: string | null;
+  url: string | null;
+  last_edited_time: string | null;
+  icon: string | null;
+};
+
+export type ApiNotionResourceList = {
+  items: ApiNotionResourceItem[];
+  next_cursor: string | null;
+  has_more: boolean;
+};
+
+export function listNotionResources(
+  workspaceId: string,
+  params: {
+    integrationId: string;
+    q?: string;
+    cursor?: string | null;
+    type?: "page" | "database" | "any";
+  },
+  options: { token?: string; signal?: AbortSignal } = {},
+): Promise<ApiNotionResourceList> {
+  const search = new URLSearchParams({ integration_id: params.integrationId });
+  if (params.q) search.set("q", params.q);
+  if (params.cursor) search.set("cursor", params.cursor);
+  if (params.type) search.set("type", params.type);
+  return apiFetch<ApiNotionResourceList>(
+    `/v1/workspaces/${encodeURIComponent(workspaceId)}/knowledge/sources/notion/resources?${search.toString()}`,
+    { token: options.token, signal: options.signal },
+  );
+}
+
 export function archiveBucket(
   workspaceId: string,
   slug: string,


### PR DESCRIPTION
## Summary

Closed-beta client (askslayer@gmail.com) hit the import wizard for Notion, left the "Resource refs JSON" textarea at the default `[]`, got a green "Source created and synced" message with all-zero stats, and reasonably concluded the integration was broken. The textarea was the actual UX bug — there was no way to discover what to put in it without copy-pasting page IDs from Notion URLs.

This PR swaps the textarea for a real picker and closes the empty-input footgun on both ends.

### What changed

- **Notion picker** (`<NotionResourcePicker>`): searchable, paginated checklist of pages the integration's token can see. Calls `/api/knowledge/notion-resources` (Next route handler) which proxies a new backend endpoint at `/v1/workspaces/{ws}/knowledge/sources/notion/resources?integration_id=…&q=…&cursor=…`. Selected pages emit `{page_id}` refs straight into `config.resource_refs` — no transform.
- **Backend search proxy**: `_notion_search` helper extracted as a test seam (mirrors the `exchange_code_for_token` pattern). Defaults to `type=page` since the v1 connector only handles page refs; databases would round-trip into `ConnectorUnsupported` silent fallback. `type=any` is wired for forward compat once the connector learns databases.
- **Empty-refs guardrail** at the API boundary in `_fetch_connector_documents`: an empty `resource_refs` is now a 400 with a clear error, not a silent zero-discovery success. Catches direct API callers and any wizard-bypass too.
- **Result panel**: amber "Source created, but the sync discovered nothing — double-check selections" replaces the misleading green checkmark when stats land on all zeros.
- **Confluence** keeps the JSON textarea for now (clearly labelled "picker is in the next phase").

### Phase context

This is Phase 0 (safety net) + Phase 1 (Notion picker) of the larger "replace JSON textarea with proper pickers for every source" plan. Next phases queued: Confluence picker, docs-repo file-tree picker, website map preview, static-upload drop zone.

## Test plan

- [x] pytest backend/tests/test_v1_notion_resources.py — 4 new tests: search proxy + token forwarding, default-page-filter, kind-mismatch 404, missing-secret 400.
- [x] pytest backend/tests/test_v1_knowledge_import_sources.py backend/tests/test_connectors_notion.py — existing tests still pass.
- [x] npx tsc --noEmit clean.
- [x] npx next build clean.
- [ ] Manual UI smoke — needs human eyes on a real Notion-connected workspace: search box debounces, list paginates, checked pages persist across pagination, Load-more works, error states render readably. (Couldn't drive a browser from CI.)
- [ ] Verify with askslayer@gmail.com or another closed-beta tester that the picker actually replaces the JSON-textarea pain.