### PR TITLE
knowledge: archive button on each connected import source

### DIFF
--- a/backend/app/api/v1/routes/knowledge_import_sources.py
+++ b/backend/app/api/v1/routes/knowledge_import_sources.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Literal
 
 import httpx
@@ -26,7 +26,7 @@ from backend.app.db.models.agent_memory import (
     KnowledgeSourceItem,
 )
 from backend.app.db.models.integrations import WorkspaceRepo
-from backend.app.db.models.tenancy import Integration
+from backend.app.db.models.tenancy import AuditLog, Integration
 from backend.app.db.session import get_session
 from backend.app.security.encryption import safe_decrypt
 from backend.app.services.knowledge_ingestion import (
@@ -210,6 +210,45 @@ async def sync_source(
             status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
         ) from exc
     return _run_out(run)
+
+
+@router.post("/{source_id}/archive", response_model=ImportSourceOut)
+async def archive_source(
+    workspace_id: uuid.UUID,
+    source_id: uuid.UUID,
+    auth: AuthContext = Depends(get_current_auth),
+    session: AsyncSession = Depends(get_session),
+) -> ImportSourceOut:
+    """Soft-delete an import source.
+
+    Sets ``archived_at = now`` and stops scheduled syncs by virtue of the
+    ``list_import_sources`` filter excluding archived rows. The row itself
+    stays so an audit search by source_id still resolves; restoring is a
+    DB op for now (no closed-beta operator has asked for a restore button).
+    """
+    await _require_membership(session, workspace_id, auth.user.id, ROLES_ADMIN)
+    source = await _load_source(session, workspace_id, source_id)
+
+    # Idempotent: a flaky-network retry shouldn't compound the audit trail.
+    if source.archived_at is None:
+        now = datetime.now(timezone.utc)
+        source.archived_at = now
+        source.updated_at = now
+        session.add(
+            AuditLog(
+                workspace_id=workspace_id,
+                actor_user_id=auth.user.id,
+                actor_token_id=None,
+                action="knowledge.import_source.archive",
+                target_kind="knowledge_import_source",
+                target_id=str(source.id),
+                payload={"kind": source.kind, "name": source.name},
+            )
+        )
+        await session.flush()
+        await session.refresh(source)
+
+    return _source_out(source)
 
 
 @router.get("/{source_id}/items", response_model=list[SourceItemOut])

--- a/backend/tests/test_v1_knowledge_import_sources.py
+++ b/backend/tests/test_v1_knowledge_import_sources.py
@@ -13,6 +13,7 @@ from backend.app.db.models.agent_memory import (
     KnowledgeSourceItem,
 )
 from backend.app.db.models.agent_surface import Improvement
+from backend.app.db.models.tenancy import AuditLog
 
 
 def _auth(raw: str) -> dict[str, str]:
@@ -108,3 +109,106 @@ async def test_static_import_source_sync_emits_knowledge_note_and_skips_unchange
     stored_source = await db_session.get(KnowledgeImportSource, uuid.UUID(source_id))
     assert stored_source is not None
     assert stored_source.status == "ready"
+
+
+@pytest.mark.asyncio
+async def test_archive_import_source_hides_it_from_list_and_audits(
+    v1_client, seed_workspace, db_session
+) -> None:
+    """Archive marks ``archived_at``, drops the source from the list
+    response, and writes a ``knowledge.import_source.archive`` audit row."""
+    _, raw, workspace = seed_workspace
+
+    create_resp = await v1_client.post(
+        f"/v1/workspaces/{workspace.id}/knowledge/sources",
+        headers=_auth(raw),
+        json={
+            "kind": "static_upload",
+            "name": "To be archived",
+            "config": {
+                "documents": [
+                    {
+                        "title": "Doomed",
+                        "filename": "doomed.md",
+                        "body_md": "# Bye",
+                    }
+                ]
+            },
+        },
+    )
+    assert create_resp.status_code == 201, create_resp.text
+    source_id = create_resp.json()["id"]
+
+    archive_resp = await v1_client.post(
+        f"/v1/workspaces/{workspace.id}/knowledge/sources/{source_id}/archive",
+        headers=_auth(raw),
+    )
+    assert archive_resp.status_code == 200, archive_resp.text
+    body = archive_resp.json()
+    assert body["archived_at"] is not None
+
+    # List excludes archived rows.
+    list_resp = await v1_client.get(
+        f"/v1/workspaces/{workspace.id}/knowledge/sources",
+        headers=_auth(raw),
+    )
+    assert list_resp.status_code == 200
+    assert all(row["id"] != source_id for row in list_resp.json())
+
+    audits = list(
+        (
+            await db_session.execute(
+                select(AuditLog).where(
+                    AuditLog.target_id == source_id,
+                    AuditLog.action == "knowledge.import_source.archive",
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(audits) == 1
+    assert audits[0].payload["kind"] == "static_upload"
+
+
+@pytest.mark.asyncio
+async def test_archive_is_idempotent(v1_client, seed_workspace, db_session) -> None:
+    """Hitting archive twice doesn't double the audit row."""
+    _, raw, workspace = seed_workspace
+
+    create_resp = await v1_client.post(
+        f"/v1/workspaces/{workspace.id}/knowledge/sources",
+        headers=_auth(raw),
+        json={
+            "kind": "static_upload",
+            "name": "Idempotent target",
+            "config": {
+                "documents": [
+                    {"title": "T", "filename": "t.md", "body_md": "# T"}
+                ]
+            },
+        },
+    )
+    assert create_resp.status_code == 201
+    source_id = create_resp.json()["id"]
+
+    for _ in range(2):
+        resp = await v1_client.post(
+            f"/v1/workspaces/{workspace.id}/knowledge/sources/{source_id}/archive",
+            headers=_auth(raw),
+        )
+        assert resp.status_code == 200
+
+    audits = list(
+        (
+            await db_session.execute(
+                select(AuditLog).where(
+                    AuditLog.target_id == source_id,
+                    AuditLog.action == "knowledge.import_source.archive",
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(audits) == 1

--- a/console/src/app/(authed)/knowledge/actions.ts
+++ b/console/src/app/(authed)/knowledge/actions.ts
@@ -14,6 +14,7 @@
 import {
   ApiHttpError,
   archiveBucket,
+  archiveKnowledgeImportSource,
   createKnowledgeImportSource,
   listWorkspaces,
   restoreBucket,
@@ -129,6 +130,35 @@ export async function createImportSourceAction(input: {
     } catch (err) {
       return { ok: true, sourceId: source.id, synced: false, syncError: apiErrorMessage(err) };
     }
+  } catch (err) {
+    if (err instanceof ApiHttpError) {
+      return { ok: false, message: apiErrorMessage(err), status: err.status };
+    }
+    return { ok: false, message: apiErrorMessage(err) };
+  }
+}
+
+export type ArchiveSourceResult =
+  | { ok: true; sourceId: string }
+  | { ok: false; message: string; status?: number };
+
+export async function archiveImportSourceAction(
+  sourceId: string,
+): Promise<ArchiveSourceResult> {
+  if (!sourceId) return { ok: false, message: "Source id is required." };
+
+  let token: string;
+  let workspaceId: string;
+  try {
+    token = await requireToken();
+    workspaceId = await requireWorkspaceId(token);
+  } catch (err) {
+    return { ok: false, message: err instanceof Error ? err.message : String(err) };
+  }
+
+  try {
+    await archiveKnowledgeImportSource(workspaceId, sourceId, token);
+    return { ok: true, sourceId };
   } catch (err) {
     if (err instanceof ApiHttpError) {
       return { ok: false, message: apiErrorMessage(err), status: err.status };

--- a/console/src/app/(authed)/knowledge/knowledge-control-center.tsx
+++ b/console/src/app/(authed)/knowledge/knowledge-control-center.tsx
@@ -36,6 +36,7 @@ import type {
 } from "@/lib/api/client";
 import type { ApiIntegration } from "@/lib/api/types";
 
+import { archiveImportSourceAction } from "./actions";
 import { KnowledgeImportWizard } from "./import-wizard";
 
 
@@ -495,34 +496,68 @@ function ConnectedSources({ sources }: { sources: KnowledgeSourceRow[] }) {
   return (
     <ul className="divide-y divide-white/5">
       {sources.map((source) => (
-        <li
-          key={source.id}
-          className="grid grid-cols-[1fr_auto] items-center gap-3 py-3"
-        >
-          <div className="min-w-0">
-            <div className="flex items-center gap-2">
-              <span className="truncate text-sm font-semibold text-white">
-                {source.name}
-              </span>
-              <span className="text-[11px] uppercase tracking-widest text-white/40">
-                {source.kind}
-              </span>
-            </div>
-            {source.lastError && (
-              <p className="mt-0.5 line-clamp-1 text-[11px] text-coral">
-                {source.lastError}
-              </p>
-            )}
-          </div>
-          <div className="flex flex-col items-end text-[11px] text-white/45">
-            <span className={statusColor(source.status)}>{source.status}</span>
-            <span>
-              {source.lastSyncedAt ? relativeDate(source.lastSyncedAt) : "never"}
-            </span>
-          </div>
-        </li>
+        <ConnectedSourceRow key={source.id} source={source} />
       ))}
     </ul>
+  );
+}
+
+
+function ConnectedSourceRow({ source }: { source: KnowledgeSourceRow }) {
+  const [archived, setArchived] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  if (archived) return null;
+
+  function archive() {
+    if (!confirm(`Archive “${source.name}”? It will stop syncing and disappear from this list.`)) {
+      return;
+    }
+    setError(null);
+    startTransition(async () => {
+      const result = await archiveImportSourceAction(source.id);
+      if (result.ok) {
+        setArchived(true);
+      } else {
+        setError(result.message);
+      }
+    });
+  }
+
+  return (
+    <li className="grid grid-cols-[1fr_auto_auto] items-center gap-3 py-3">
+      <div className="min-w-0">
+        <div className="flex items-center gap-2">
+          <span className="truncate text-sm font-semibold text-white">
+            {source.name}
+          </span>
+          <span className="text-[11px] uppercase tracking-widest text-white/40">
+            {source.kind}
+          </span>
+        </div>
+        {(source.lastError || error) && (
+          <p className="mt-0.5 line-clamp-1 text-[11px] text-coral">
+            {error ?? source.lastError}
+          </p>
+        )}
+      </div>
+      <div className="flex flex-col items-end text-[11px] text-white/45">
+        <span className={statusColor(source.status)}>{source.status}</span>
+        <span>
+          {source.lastSyncedAt ? relativeDate(source.lastSyncedAt) : "never"}
+        </span>
+      </div>
+      <button
+        type="button"
+        disabled={pending}
+        onClick={archive}
+        className="rounded-full border border-white/10 px-2.5 py-1 text-[11px] text-white/55 transition hover:border-coral/40 hover:text-coral disabled:cursor-not-allowed disabled:opacity-50"
+        data-testid={`source-archive-${source.id}`}
+      >
+        {pending ? "Archiving…" : "Archive"}
+      </button>
+    </li>
   );
 }
 

--- a/console/src/lib/api/client.ts
+++ b/console/src/lib/api/client.ts
@@ -1246,6 +1246,17 @@ export function syncKnowledgeImportSource(
   );
 }
 
+export function archiveKnowledgeImportSource(
+  workspaceId: string,
+  sourceId: string,
+  token?: string,
+): Promise<ApiKnowledgeImportSource> {
+  return apiFetch<ApiKnowledgeImportSource>(
+    `/v1/workspaces/${encodeURIComponent(workspaceId)}/knowledge/sources/${encodeURIComponent(sourceId)}/archive`,
+    { method: "POST", token },
+  );
+}
+
 export type ApiNotionResourceItem = {
   id: string;
   type: "page" | "database";


### PR DESCRIPTION
## Summary

Closed-beta clients can create knowledge import sources from the wizard but have no way to remove a misclick. The model already supported soft-delete (``archived_at``) and the list endpoint already filtered archived rows, but there was no surface — operators were stuck with whatever they accidentally created.

This PR closes the loop with one button.

### What changed

- **Backend**: ``POST /v1/workspaces/{ws}/knowledge/sources/{id}/archive`` — admin-only, idempotent so a flaky-network retry doesn't double the audit trail. Writes a ``knowledge.import_source.archive`` ``AuditLog`` entry capturing kind/name so the rationale survives the soft-delete.
- **Frontend**: each row in the "Connected sources" list gets an Archive button. Native ``confirm()`` for the destructive prompt, optimistic UI removes the row on success, the ``coral`` error banner appears inline if the API call fails.

### Why no restore button

- No closed-beta operator has asked for one yet.
- Adding restore needs a "show archived" toggle in the list, which broadens scope.
- A restore is a one-line DB op (set ``archived_at = NULL``) when needed.

This is independent of the Notion picker (#103) and Confluence picker (#104) PRs — branch from main, no stack.

## Test plan

- [x] ``pytest backend/tests/test_v1_knowledge_import_sources.py`` — 3 tests now (existing static-upload sync + 2 new: archive hides + audit, archive idempotent).
- [x] ``npx tsc --noEmit`` clean.
- [x] ``npx next build`` clean.
- [ ] Manual UI smoke after deploy: create a source, click Archive, confirm row disappears and a refresh confirms it stays gone.