### PR TITLE
knowledge: pick Confluence sections by space, not raw page ids

### DIFF
--- a/backend/app/api/v1/routes/knowledge_import_sources.py
+++ b/backend/app/api/v1/routes/knowledge_import_sources.py
@@ -550,3 +550,456 @@ async def list_notion_resources(
         next_cursor=payload.get("next_cursor"),
         has_more=bool(payload.get("has_more")),
     )
+
+
+# ---------------------------------------------------------------------------
+# Confluence picker
+# ---------------------------------------------------------------------------
+
+_CONFLUENCE_PAGE_SIZE = 25
+
+
+class ConfluenceResourceItem(BaseModel):
+    id: str
+    title: str
+    space_key: str | None = None
+    space_name: str | None = None
+    url: str | None = None
+    last_edited_time: str | None = None
+
+
+class ConfluenceResourceListOut(BaseModel):
+    items: list[ConfluenceResourceItem]
+    next_start: int | None = None  # offset for the next page
+    has_more: bool = False
+
+
+def _confluence_site_creds(integration: Integration) -> tuple[str, str, str]:
+    """Return (site_url, email, api_token) or raise HTTPException."""
+    token = safe_decrypt(integration.secret_ciphertext)
+    if not token:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="confluence integration has no readable API token — reconnect it",
+        )
+    config = integration.config or {}
+    site_url = str(config.get("site_url") or config.get("site") or "").strip().rstrip("/")
+    email = str(config.get("email") or config.get("user") or "").strip()
+    if not site_url or not email:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="confluence integration is missing site_url/email — reconnect it",
+        )
+    if not site_url.startswith("http"):
+        site_url = f"https://{site_url}"
+    return site_url, email, token
+
+
+async def _confluence_search(
+    *,
+    site_url: str,
+    email: str,
+    token: str,
+    cql: str,
+    start: int,
+    workspace_id: uuid.UUID,
+) -> dict[str, Any]:
+    """GET /wiki/rest/api/content/search with CQL.
+
+    Confluence v2 REST has no full-text search, only paginated lists by
+    space. The v1 ``/content/search`` endpoint with CQL is the supported
+    way to do typeahead. Same Basic-auth shape as the connector fetcher.
+    """
+    params = {
+        "cql": cql,
+        "limit": _CONFLUENCE_PAGE_SIZE,
+        "start": start,
+        "expand": "space,history.lastUpdated",
+    }
+    headers = {"Accept": "application/json"}
+    try:
+        async with httpx.AsyncClient(timeout=httpx.Timeout(10.0)) as client:
+            response = await client.get(
+                f"{site_url}/wiki/rest/api/content/search",
+                params=params,
+                headers=headers,
+                auth=(email, token),
+            )
+    except httpx.HTTPError as exc:
+        logger.warning(
+            "confluence /content/search transport error for ws=%s: %s",
+            workspace_id,
+            exc,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="confluence is unreachable — try again",
+        ) from exc
+
+    if response.status_code in (401, 403):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="confluence rejected the API token — reconnect Confluence",
+        )
+    if response.status_code >= 400:
+        logger.warning(
+            "confluence /content/search returned HTTP %s for ws=%s: %s",
+            response.status_code,
+            workspace_id,
+            response.text[:200],
+        )
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=f"confluence returned HTTP {response.status_code}",
+        )
+    return response.json()
+
+
+def _build_confluence_cql(query: str, space_key: str | None) -> str:
+    """Build a CQL clause for the picker.
+
+    Always restricts to ``type = "page"`` because the connector fetcher
+    only supports page refs. ``query`` and ``space_key`` are optional
+    narrowers; both are CQL-quoted to avoid injection of operators.
+    """
+    parts = ['type = "page"']
+    if space_key:
+        parts.append(f'space.key = "{_cql_escape(space_key)}"')
+    cleaned = query.strip()
+    if cleaned:
+        parts.append(f'text ~ "{_cql_escape(cleaned)}"')
+    return " AND ".join(parts) + ' ORDER BY lastModified DESC'
+
+
+def _cql_escape(value: str) -> str:
+    # CQL strings are double-quoted; escape backslashes and quotes only.
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+# --- Space + section listing (the picker primitives) ---
+
+
+class ConfluenceSpaceItem(BaseModel):
+    id: str
+    key: str
+    name: str
+    type: str | None = None  # global, personal, etc.
+    homepage_id: str | None = None
+    description: str | None = None
+
+
+class ConfluenceSpaceListOut(BaseModel):
+    items: list[ConfluenceSpaceItem]
+
+
+class ConfluenceSectionItem(BaseModel):
+    """A top-level page in a space — the natural "section" unit operators
+    pick to ingest a chunk of docs (root + descendants) at once.
+    """
+
+    id: str
+    title: str
+    space_id: str
+    space_key: str | None = None
+    space_name: str | None = None
+    url: str | None = None
+    last_edited_time: str | None = None
+    has_children: bool = False
+
+
+class ConfluenceSectionListOut(BaseModel):
+    items: list[ConfluenceSectionItem]
+    next_cursor: str | None = None
+    has_more: bool = False
+
+
+async def _confluence_get(
+    *,
+    site_url: str,
+    email: str,
+    token: str,
+    path: str,
+    params: dict[str, Any],
+    workspace_id: uuid.UUID,
+) -> dict[str, Any]:
+    headers = {"Accept": "application/json"}
+    try:
+        async with httpx.AsyncClient(timeout=httpx.Timeout(10.0)) as client:
+            response = await client.get(
+                f"{site_url}{path}",
+                params={k: v for k, v in params.items() if v is not None},
+                headers=headers,
+                auth=(email, token),
+            )
+    except httpx.HTTPError as exc:
+        logger.warning(
+            "confluence GET %s transport error for ws=%s: %s",
+            path,
+            workspace_id,
+            exc,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="confluence is unreachable — try again",
+        ) from exc
+
+    if response.status_code in (401, 403):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="confluence rejected the API token — reconnect Confluence",
+        )
+    if response.status_code >= 400:
+        logger.warning(
+            "confluence GET %s returned HTTP %s for ws=%s: %s",
+            path,
+            response.status_code,
+            workspace_id,
+            response.text[:200],
+        )
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=f"confluence returned HTTP {response.status_code}",
+        )
+    return response.json()
+
+
+@router.get("/confluence/spaces", response_model=ConfluenceSpaceListOut)
+async def list_confluence_spaces(
+    workspace_id: uuid.UUID,
+    integration_id: uuid.UUID = Query(..., description="Confluence integration row to query"),
+    auth: AuthContext = Depends(get_current_auth),
+    session: AsyncSession = Depends(get_session),
+) -> ConfluenceSpaceListOut:
+    """List Confluence spaces visible to the integration's API token."""
+    await _require_membership(session, workspace_id, auth.user.id, ROLES_ADMIN)
+
+    integration = await session.get(Integration, integration_id)
+    if (
+        integration is None
+        or integration.workspace_id != workspace_id
+        or integration.kind != "confluence"
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="confluence integration not found for this workspace",
+        )
+
+    site_url, email, token = _confluence_site_creds(integration)
+    payload = await _confluence_get(
+        site_url=site_url,
+        email=email,
+        token=token,
+        path="/wiki/api/v2/spaces",
+        params={"limit": 100, "description-format": "plain"},
+        workspace_id=workspace_id,
+    )
+
+    items: list[ConfluenceSpaceItem] = []
+    for obj in payload.get("results") or []:
+        if not isinstance(obj, dict):
+            continue
+        items.append(
+            ConfluenceSpaceItem(
+                id=str(obj.get("id") or ""),
+                key=str(obj.get("key") or ""),
+                name=str(obj.get("name") or "Untitled space"),
+                type=str(obj.get("type") or "") or None,
+                homepage_id=str(obj.get("homepageId") or "") or None,
+                description=_confluence_extract_description(obj.get("description")),
+            )
+        )
+    return ConfluenceSpaceListOut(items=items)
+
+
+def _confluence_extract_description(raw: Any) -> str | None:
+    """v2 spaces returns description as ``{plain: {value: "..."}}`` or null."""
+    if not isinstance(raw, dict):
+        return None
+    plain = raw.get("plain")
+    if isinstance(plain, dict):
+        value = str(plain.get("value") or "").strip()
+        return value or None
+    return None
+
+
+@router.get("/confluence/sections", response_model=ConfluenceSectionListOut)
+async def list_confluence_sections(
+    workspace_id: uuid.UUID,
+    integration_id: uuid.UUID = Query(..., description="Confluence integration row to query"),
+    space_id: str = Query(..., description="Confluence space id to list sections from"),
+    cursor: str | None = Query(default=None, description="Confluence pagination cursor"),
+    auth: AuthContext = Depends(get_current_auth),
+    session: AsyncSession = Depends(get_session),
+) -> ConfluenceSectionListOut:
+    """Top-level pages (= sections) of a space.
+
+    A "section" is the natural ingestion unit — usually a chapter/handbook
+    rooted at a top-level page. Selecting a section ingests its root
+    page plus every descendant.
+    """
+    await _require_membership(session, workspace_id, auth.user.id, ROLES_ADMIN)
+
+    integration = await session.get(Integration, integration_id)
+    if (
+        integration is None
+        or integration.workspace_id != workspace_id
+        or integration.kind != "confluence"
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="confluence integration not found for this workspace",
+        )
+
+    site_url, email, token = _confluence_site_creds(integration)
+
+    # Resolve space metadata once so we can stamp it on each section item
+    # (saves the picker UI from a second lookup; one space = one cheap call).
+    try:
+        space_payload = await _confluence_get(
+            site_url=site_url,
+            email=email,
+            token=token,
+            path=f"/wiki/api/v2/spaces/{space_id}",
+            params={},
+            workspace_id=workspace_id,
+        )
+    except HTTPException as exc:
+        if exc.status_code == status.HTTP_502_BAD_GATEWAY:
+            space_payload = {}
+        else:
+            raise
+    space_key = str(space_payload.get("key") or "") or None
+    space_name = str(space_payload.get("name") or "") or None
+
+    payload = await _confluence_get(
+        site_url=site_url,
+        email=email,
+        token=token,
+        path="/wiki/api/v2/pages",
+        params={
+            "space-id": space_id,
+            "limit": 50,
+            "depth": "root",  # only top-level pages
+            "cursor": cursor,
+            "body-format": None,  # we don't need bodies in the picker
+        },
+        workspace_id=workspace_id,
+    )
+
+    items: list[ConfluenceSectionItem] = []
+    for obj in payload.get("results") or []:
+        if not isinstance(obj, dict):
+            continue
+        web_url = ((obj.get("_links") or {}).get("webui")) if isinstance(obj.get("_links"), dict) else None
+        absolute_url = f"{site_url}/wiki{web_url}" if isinstance(web_url, str) and web_url.startswith("/") else web_url
+        version = obj.get("version") if isinstance(obj.get("version"), dict) else {}
+        items.append(
+            ConfluenceSectionItem(
+                id=str(obj.get("id") or ""),
+                title=str(obj.get("title") or "Untitled"),
+                space_id=str(obj.get("spaceId") or space_id),
+                space_key=space_key,
+                space_name=space_name,
+                url=absolute_url,
+                last_edited_time=str(version.get("createdAt") or "") or None,
+            )
+        )
+
+    next_cursor = _extract_confluence_cursor(payload)
+    return ConfluenceSectionListOut(
+        items=items,
+        next_cursor=next_cursor,
+        has_more=next_cursor is not None,
+    )
+
+
+def _extract_confluence_cursor(payload: dict[str, Any]) -> str | None:
+    """v2 paginated responses include _links.next as a relative path with
+    cursor=… in the query string. Parse it out so callers can pass it back."""
+    links = payload.get("_links") if isinstance(payload.get("_links"), dict) else {}
+    next_link = links.get("next")
+    if not isinstance(next_link, str) or not next_link:
+        return None
+    # The link looks like "/wiki/api/v2/pages?space-id=...&cursor=eyJ..."
+    if "cursor=" not in next_link:
+        return None
+    try:
+        from urllib.parse import parse_qs, urlparse
+
+        parsed = urlparse(next_link)
+        cursor_values = parse_qs(parsed.query).get("cursor")
+        if cursor_values:
+            return cursor_values[0]
+    except Exception:  # noqa: BLE001
+        return None
+    return None
+
+
+# --- CQL-based page search (kept as advanced-mode hook; not exposed in UI v1) ---
+
+
+@router.get("/confluence/resources", response_model=ConfluenceResourceListOut)
+async def list_confluence_resources(
+    workspace_id: uuid.UUID,
+    integration_id: uuid.UUID = Query(..., description="Confluence integration row to query"),
+    q: str = Query("", description="Free-text query forwarded to Confluence via CQL text~"),
+    space_key: str | None = Query(default=None, description="Optional space key narrower"),
+    start: int = Query(default=0, ge=0, description="Offset into the Confluence result set"),
+    auth: AuthContext = Depends(get_current_auth),
+    session: AsyncSession = Depends(get_session),
+) -> ConfluenceResourceListOut:
+    """Page-level CQL search. The picker UI ships space-first; this stays
+    available for power-user / API callers who want to pick specific pages."""
+    await _require_membership(session, workspace_id, auth.user.id, ROLES_ADMIN)
+
+    integration = await session.get(Integration, integration_id)
+    if (
+        integration is None
+        or integration.workspace_id != workspace_id
+        or integration.kind != "confluence"
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="confluence integration not found for this workspace",
+        )
+
+    site_url, email, token = _confluence_site_creds(integration)
+    cql = _build_confluence_cql(q, space_key)
+    payload = await _confluence_search(
+        site_url=site_url,
+        email=email,
+        token=token,
+        cql=cql,
+        start=start,
+        workspace_id=workspace_id,
+    )
+
+    raw_results = payload.get("results") or []
+    items: list[ConfluenceResourceItem] = []
+    for obj in raw_results:
+        if not isinstance(obj, dict):
+            continue
+        space = obj.get("space") if isinstance(obj.get("space"), dict) else {}
+        history = obj.get("history") if isinstance(obj.get("history"), dict) else {}
+        last_updated = (history.get("lastUpdated") or {}).get("when") if isinstance(history.get("lastUpdated"), dict) else None
+        web_url = ((obj.get("_links") or {}).get("webui")) if isinstance(obj.get("_links"), dict) else None
+        absolute_url = f"{site_url}/wiki{web_url}" if isinstance(web_url, str) and web_url.startswith("/") else web_url
+        items.append(
+            ConfluenceResourceItem(
+                id=str(obj.get("id") or ""),
+                title=str(obj.get("title") or "Untitled"),
+                space_key=str(space.get("key") or "") or None,
+                space_name=str(space.get("name") or "") or None,
+                url=absolute_url,
+                last_edited_time=str(last_updated) if last_updated else None,
+            )
+        )
+
+    size = int(payload.get("size") or len(raw_results))
+    limit = int(payload.get("limit") or _CONFLUENCE_PAGE_SIZE)
+    next_start_value = start + size if size >= limit else None
+    return ConfluenceResourceListOut(
+        items=items,
+        next_start=next_start_value,
+        has_more=next_start_value is not None,
+    )

--- a/backend/app/services/connectors/confluence.py
+++ b/backend/app/services/connectors/confluence.py
@@ -1,4 +1,20 @@
-"""Confluence connector — fetch one page into markdown."""
+"""Confluence connector — fetch a single page or a section subtree.
+
+resource_ref shapes
+-------------------
+
+- ``{"page_id": "<id>"}`` — fetch one page (legacy single-doc shape).
+- ``{"root_page_id": "<id>", "space_id": "<id>"}`` — fetch the page and
+  every descendant. This is the "section" shape the wizard picker
+  produces; one section in the picker maps to one resource_ref here, and
+  each Confluence page in the subtree becomes one ``ConnectorPage`` so
+  the ingestion pipeline can fingerprint/skip per-page.
+
+We use ``/wiki/api/v2/pages/{id}/descendants`` which already paginates
+flat over the whole subtree; pulling content per descendant via
+``GET /pages/{id}?body-format=storage`` keeps the round-trip count
+predictable (1 + N).
+"""
 
 from __future__ import annotations
 
@@ -11,6 +27,13 @@ from backend.app.db.models.tenancy import Integration
 from backend.app.security.encryption import safe_decrypt
 
 from . import ConnectorConfigError, ConnectorPage, ConnectorUnsupported, register
+
+
+# Cap descendants per section so a runaway 5000-page space doesn't wedge
+# a sync. The ingestion pipeline already caps total source documents at
+# ``MAX_SOURCE_DOCUMENTS`` (100); this is the per-section ceiling so a
+# single section can't starve the rest of a multi-section source.
+_MAX_DESCENDANTS_PER_SECTION = 200
 
 
 class _HtmlToMarkdown(HTMLParser):
@@ -58,16 +81,7 @@ def _html_to_markdown(html: str) -> str:
     return parser.markdown()
 
 
-@register("confluence")
-async def fetch_confluence_pages(
-    integration: Integration,
-    resource_ref: Mapping[str, Any],
-    http_client: httpx.AsyncClient | None = None,
-) -> list[ConnectorPage]:
-    page_id = str(resource_ref.get("page_id") or "").strip()
-    if not page_id:
-        raise ConnectorUnsupported("resource_ref.page_id is required")
-
+def _resolve_creds(integration: Integration) -> tuple[str, str, str]:
     token = safe_decrypt(integration.secret_ciphertext)
     if not token:
         raise ConnectorConfigError("Confluence integration has no API token")
@@ -78,39 +92,211 @@ async def fetch_confluence_pages(
         raise ConnectorConfigError("Confluence integration is missing site_url/email")
     if not site_url.startswith("http"):
         site_url = f"https://{site_url}"
+    return site_url, email, token
 
-    owns_client = http_client is None
-    http = http_client or httpx.AsyncClient(timeout=httpx.Timeout(10.0))
-    try:
-        response = await http.get(
-            f"{site_url}/wiki/api/v2/pages/{page_id}",
-            auth=(email, token),
-            params={"body-format": "storage"},
-            headers={"Accept": "application/json"},
-        )
-    finally:
-        if owns_client:
-            await http.aclose()
-    response.raise_for_status()
-    payload = response.json()
+
+def _absolute_url(site_url: str, web_link: Any) -> str | None:
+    if isinstance(web_link, str) and web_link.startswith("/"):
+        return f"{site_url}/wiki{web_link}"
+    if isinstance(web_link, str):
+        return web_link
+    return None
+
+
+def _page_to_connector_page(
+    payload: dict[str, Any], *, site_url: str, fallback_id: str
+) -> ConnectorPage:
+    page_id = str(payload.get("id") or fallback_id)
     title = str(payload.get("title") or f"Confluence page {page_id}")
     body = ((payload.get("body") or {}).get("storage") or {}).get("value") or ""
     markdown = _html_to_markdown(body)
     if not markdown:
-        markdown = f"# {title}\n\n<empty Confluence page>"
+        markdown = "<empty Confluence page>"
+    web_link = (payload.get("_links") or {}).get("webui") if isinstance(payload.get("_links"), dict) else None
+    return ConnectorPage(
+        slug=f"confluence-{page_id}",
+        title=title,
+        body_md=f"# {title}\n\n{markdown}",
+        page_ref={
+            "page_id": page_id,
+            "title": title,
+            "url": _absolute_url(site_url, web_link),
+            "space_id": str(payload.get("spaceId") or ""),
+        },
+    )
 
-    return [
-        ConnectorPage(
-            slug=f"confluence-{page_id}",
-            title=title,
-            body_md=f"# {title}\n\n{markdown}",
-            page_ref={
-                "page_id": page_id,
-                "title": title,
-                "url": payload.get("_links", {}).get("webui"),
-            },
+
+async def _get(
+    http: httpx.AsyncClient,
+    *,
+    site_url: str,
+    path: str,
+    email: str,
+    token: str,
+    params: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    response = await http.get(
+        f"{site_url}{path}",
+        auth=(email, token),
+        params={k: v for k, v in (params or {}).items() if v is not None},
+        headers={"Accept": "application/json"},
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+async def _fetch_page(
+    http: httpx.AsyncClient,
+    *,
+    site_url: str,
+    email: str,
+    token: str,
+    page_id: str,
+) -> dict[str, Any]:
+    return await _get(
+        http,
+        site_url=site_url,
+        path=f"/wiki/api/v2/pages/{page_id}",
+        email=email,
+        token=token,
+        params={"body-format": "storage"},
+    )
+
+
+async def _fetch_descendants(
+    http: httpx.AsyncClient,
+    *,
+    site_url: str,
+    email: str,
+    token: str,
+    root_page_id: str,
+    limit: int,
+) -> list[dict[str, Any]]:
+    """Walk ``/pages/{id}/descendants`` until we hit the cap or run out.
+
+    Returns the raw v2 page payloads (id + minimal metadata, no body —
+    the descendants endpoint doesn't expand bodies). Caller fetches each
+    body via ``_fetch_page``.
+    """
+    out: list[dict[str, Any]] = []
+    cursor: str | None = None
+    while len(out) < limit:
+        payload = await _get(
+            http,
+            site_url=site_url,
+            path=f"/wiki/api/v2/pages/{root_page_id}/descendants",
+            email=email,
+            token=token,
+            params={"limit": min(250, limit - len(out)), "cursor": cursor},
         )
+        for entry in payload.get("results") or []:
+            if isinstance(entry, dict) and entry.get("id"):
+                out.append(entry)
+                if len(out) >= limit:
+                    break
+        next_link = (payload.get("_links") or {}).get("next") if isinstance(payload.get("_links"), dict) else None
+        if not isinstance(next_link, str) or "cursor=" not in next_link:
+            break
+        try:
+            from urllib.parse import parse_qs, urlparse
+
+            cursor_values = parse_qs(urlparse(next_link).query).get("cursor")
+            if not cursor_values:
+                break
+            cursor = cursor_values[0]
+        except Exception:  # noqa: BLE001
+            break
+    return out
+
+
+@register("confluence")
+async def fetch_confluence_pages(
+    integration: Integration,
+    resource_ref: Mapping[str, Any],
+    http_client: httpx.AsyncClient | None = None,
+) -> list[ConnectorPage]:
+    """Fetch one page or a whole section subtree.
+
+    Shape dispatch:
+
+    - ``{root_page_id}``: section mode — fetch root + descendants.
+    - ``{page_id}``: legacy single-page mode.
+    """
+    root_page_id = str(resource_ref.get("root_page_id") or "").strip()
+    page_id = str(resource_ref.get("page_id") or "").strip()
+    if not root_page_id and not page_id:
+        raise ConnectorUnsupported(
+            "resource_ref needs root_page_id (section) or page_id (single page)"
+        )
+
+    site_url, email, token = _resolve_creds(integration)
+
+    owns_client = http_client is None
+    http = http_client or httpx.AsyncClient(timeout=httpx.Timeout(15.0))
+    try:
+        if root_page_id:
+            return await _fetch_section(
+                http,
+                site_url=site_url,
+                email=email,
+                token=token,
+                root_page_id=root_page_id,
+            )
+        return [
+            _page_to_connector_page(
+                await _fetch_page(
+                    http,
+                    site_url=site_url,
+                    email=email,
+                    token=token,
+                    page_id=page_id,
+                ),
+                site_url=site_url,
+                fallback_id=page_id,
+            )
+        ]
+    finally:
+        if owns_client:
+            await http.aclose()
+
+
+async def _fetch_section(
+    http: httpx.AsyncClient,
+    *,
+    site_url: str,
+    email: str,
+    token: str,
+    root_page_id: str,
+) -> list[ConnectorPage]:
+    root_payload = await _fetch_page(
+        http, site_url=site_url, email=email, token=token, page_id=root_page_id
+    )
+    pages: list[ConnectorPage] = [
+        _page_to_connector_page(root_payload, site_url=site_url, fallback_id=root_page_id)
     ]
+    descendants = await _fetch_descendants(
+        http,
+        site_url=site_url,
+        email=email,
+        token=token,
+        root_page_id=root_page_id,
+        limit=_MAX_DESCENDANTS_PER_SECTION,
+    )
+    for descendant in descendants:
+        descendant_id = str(descendant.get("id") or "")
+        if not descendant_id:
+            continue
+        body_payload = await _fetch_page(
+            http,
+            site_url=site_url,
+            email=email,
+            token=token,
+            page_id=descendant_id,
+        )
+        pages.append(
+            _page_to_connector_page(body_payload, site_url=site_url, fallback_id=descendant_id)
+        )
+    return pages
 
 
 __all__ = ["fetch_confluence_pages"]

--- a/backend/tests/test_connectors_confluence.py
+++ b/backend/tests/test_connectors_confluence.py
@@ -89,3 +89,80 @@ async def test_confluence_fetcher_requires_secret() -> None:
     )
     with pytest.raises(ConnectorConfigError, match="no API token"):
         await fetch_connector_pages(integration, {"page_id": "12345"})
+
+
+@pytest.mark.asyncio
+async def test_confluence_section_fetches_root_plus_descendants(integration) -> None:
+    """resource_ref={root_page_id} pulls the root + every descendant.
+
+    Each descendant becomes its own ConnectorPage so the ingestion
+    pipeline fingerprints/skips per-page on subsequent syncs.
+    """
+    fetched_paths: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        fetched_paths.append(request.url.path)
+        if request.url.path == "/wiki/api/v2/pages/100":
+            return httpx.Response(
+                200,
+                json={
+                    "id": "100",
+                    "title": "Onboarding handbook",
+                    "spaceId": "S1",
+                    "body": {"storage": {"value": "<p>Welcome.</p>"}},
+                    "_links": {"webui": "/wiki/spaces/ENG/pages/100"},
+                },
+            )
+        if request.url.path == "/wiki/api/v2/pages/100/descendants":
+            return httpx.Response(
+                200,
+                json={
+                    "results": [{"id": "101"}, {"id": "102"}],
+                    "_links": {},
+                },
+            )
+        if request.url.path == "/wiki/api/v2/pages/101":
+            return httpx.Response(
+                200,
+                json={
+                    "id": "101",
+                    "title": "Day 1",
+                    "spaceId": "S1",
+                    "body": {"storage": {"value": "<p>Read this first.</p>"}},
+                    "_links": {"webui": "/wiki/spaces/ENG/pages/101"},
+                },
+            )
+        if request.url.path == "/wiki/api/v2/pages/102":
+            return httpx.Response(
+                200,
+                json={
+                    "id": "102",
+                    "title": "Day 2",
+                    "spaceId": "S1",
+                    "body": {"storage": {"value": "<p>Then this.</p>"}},
+                    "_links": {"webui": "/wiki/spaces/ENG/pages/102"},
+                },
+            )
+        return httpx.Response(404)
+
+    async with _make_client(handler) as client:
+        pages = await fetch_connector_pages(
+            integration,
+            {"root_page_id": "100", "space_id": "S1"},
+            http_client=client,
+        )
+
+    assert [p.title for p in pages] == ["Onboarding handbook", "Day 1", "Day 2"]
+    assert all(p.page_ref["space_id"] == "S1" for p in pages)
+    # Root + descendants list + 2 descendant body fetches = 4 calls.
+    assert "/wiki/api/v2/pages/100" in fetched_paths
+    assert "/wiki/api/v2/pages/100/descendants" in fetched_paths
+    assert fetched_paths.count("/wiki/api/v2/pages/101") == 1
+    assert fetched_paths.count("/wiki/api/v2/pages/102") == 1
+
+
+@pytest.mark.asyncio
+async def test_confluence_unknown_shape_falls_back(integration) -> None:
+    """A ref without page_id or root_page_id is unsupported (silent stub)."""
+    pages = await fetch_connector_pages(integration, {"space_id": "S1"})
+    assert pages == []

--- a/backend/tests/test_v1_confluence_resources.py
+++ b/backend/tests/test_v1_confluence_resources.py
@@ -1,0 +1,198 @@
+"""Wizard picker endpoints for Confluence — spaces + sections.
+
+Stubs the Confluence HTTP via monkeypatching the route's `_confluence_get`
+helper (same seam pattern used elsewhere) so tests don't reach Atlassian.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from backend.app.db.models.tenancy import Integration
+from backend.app.security.encryption import encrypt
+
+
+def _auth(raw: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {raw}"}
+
+
+def _seed_confluence_integration(
+    db_session, workspace_id, *, secret: str | None = "atl_token"
+) -> Integration:
+    row = Integration(
+        id=uuid.uuid4(),
+        workspace_id=workspace_id,
+        kind="confluence",
+        config={
+            "site_url": "https://acme.atlassian.net",
+            "email": "ops@example.com",
+        },
+        status="ok",
+        secret_ciphertext=encrypt(secret) if secret else None,
+    )
+    db_session.add(row)
+    return row
+
+
+@pytest.mark.asyncio
+async def test_list_confluence_spaces_returns_picker_items(
+    v1_client, seed_workspace, db_session, monkeypatch
+) -> None:
+    _, raw, workspace = seed_workspace
+    integration = _seed_confluence_integration(db_session, workspace.id)
+    await db_session.flush()
+
+    captured = {}
+
+    async def _fake_get(*, site_url, email, token, path, params, workspace_id):
+        captured["path"] = path
+        captured["site_url"] = site_url
+        return {
+            "results": [
+                {
+                    "id": "S1",
+                    "key": "ENG",
+                    "name": "Engineering",
+                    "type": "global",
+                    "homepageId": "h1",
+                    "description": {"plain": {"value": "Engineering team space"}},
+                },
+                {"id": "S2", "key": "ONB", "name": "Onboarding"},
+            ],
+        }
+
+    monkeypatch.setattr(
+        "backend.app.api.v1.routes.knowledge_import_sources._confluence_get",
+        _fake_get,
+    )
+
+    response = await v1_client.get(
+        f"/v1/workspaces/{workspace.id}/knowledge/sources/confluence/spaces",
+        headers=_auth(raw),
+        params={"integration_id": str(integration.id)},
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert [s["key"] for s in body["items"]] == ["ENG", "ONB"]
+    assert body["items"][0]["description"] == "Engineering team space"
+    assert body["items"][0]["type"] == "global"
+    assert captured["path"] == "/wiki/api/v2/spaces"
+    assert captured["site_url"] == "https://acme.atlassian.net"
+
+
+@pytest.mark.asyncio
+async def test_list_confluence_sections_includes_space_metadata(
+    v1_client, seed_workspace, db_session, monkeypatch
+) -> None:
+    _, raw, workspace = seed_workspace
+    integration = _seed_confluence_integration(db_session, workspace.id)
+    await db_session.flush()
+
+    paths: list[str] = []
+
+    async def _fake_get(*, site_url, email, token, path, params, workspace_id):
+        paths.append(path)
+        if path == "/wiki/api/v2/spaces/S1":
+            return {"id": "S1", "key": "ENG", "name": "Engineering"}
+        # /wiki/api/v2/pages with depth=root
+        assert path == "/wiki/api/v2/pages"
+        assert params["depth"] == "root"
+        assert params["space-id"] == "S1"
+        return {
+            "results": [
+                {
+                    "id": "100",
+                    "title": "Onboarding handbook",
+                    "spaceId": "S1",
+                    "version": {"createdAt": "2026-04-30T10:00:00Z"},
+                    "_links": {"webui": "/spaces/ENG/pages/100"},
+                },
+                {
+                    "id": "200",
+                    "title": "Engineering runbooks",
+                    "spaceId": "S1",
+                    "_links": {"webui": "/spaces/ENG/pages/200"},
+                },
+            ],
+            "_links": {
+                "next": "/wiki/api/v2/pages?space-id=S1&cursor=eyJfaWQiOiAiMSJ9"
+            },
+        }
+
+    monkeypatch.setattr(
+        "backend.app.api.v1.routes.knowledge_import_sources._confluence_get",
+        _fake_get,
+    )
+
+    response = await v1_client.get(
+        f"/v1/workspaces/{workspace.id}/knowledge/sources/confluence/sections",
+        headers=_auth(raw),
+        params={"integration_id": str(integration.id), "space_id": "S1"},
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert [item["title"] for item in body["items"]] == [
+        "Onboarding handbook",
+        "Engineering runbooks",
+    ]
+    first = body["items"][0]
+    assert first["space_key"] == "ENG"
+    assert first["space_name"] == "Engineering"
+    assert first["space_id"] == "S1"
+    assert first["url"] == "https://acme.atlassian.net/wiki/spaces/ENG/pages/100"
+    assert first["last_edited_time"] == "2026-04-30T10:00:00Z"
+    assert body["next_cursor"] == "eyJfaWQiOiAiMSJ9"
+    assert body["has_more"] is True
+    assert paths == ["/wiki/api/v2/spaces/S1", "/wiki/api/v2/pages"]
+
+
+@pytest.mark.asyncio
+async def test_list_confluence_spaces_404_for_wrong_kind(
+    v1_client, seed_workspace, db_session
+) -> None:
+    _, raw, workspace = seed_workspace
+    wrong = Integration(
+        id=uuid.uuid4(),
+        workspace_id=workspace.id,
+        kind="notion",
+        config={},
+        status="ok",
+        secret_ciphertext=encrypt("x"),
+    )
+    db_session.add(wrong)
+    await db_session.flush()
+
+    response = await v1_client.get(
+        f"/v1/workspaces/{workspace.id}/knowledge/sources/confluence/spaces",
+        headers=_auth(raw),
+        params={"integration_id": str(wrong.id)},
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_list_confluence_spaces_400_when_creds_missing(
+    v1_client, seed_workspace, db_session
+) -> None:
+    """Missing site_url/email is operator error — surface as 400, not 502."""
+    _, raw, workspace = seed_workspace
+    bad = Integration(
+        id=uuid.uuid4(),
+        workspace_id=workspace.id,
+        kind="confluence",
+        config={},  # no site_url/email
+        status="ok",
+        secret_ciphertext=encrypt("x"),
+    )
+    db_session.add(bad)
+    await db_session.flush()
+
+    response = await v1_client.get(
+        f"/v1/workspaces/{workspace.id}/knowledge/sources/confluence/spaces",
+        headers=_auth(raw),
+        params={"integration_id": str(bad.id)},
+    )
+    assert response.status_code == 400
+    assert "site_url" in response.json()["detail"]

--- a/console/src/app/(authed)/knowledge/confluence-section-picker.tsx
+++ b/console/src/app/(authed)/knowledge/confluence-section-picker.tsx
@@ -1,0 +1,349 @@
+"use client";
+
+/**
+ * ConfluenceSectionPicker — pick a space, then check sections (= top-level
+ * page subtrees) to ingest. Each checked section emits one resource_ref:
+ *
+ *     { root_page_id, space_id, space_key, space_name, title }
+ *
+ * The connector (`backend/app/services/connectors/confluence.py`)
+ * resolves that ref into root + every descendant at sync time, so one
+ * "section" pick maps to a whole chapter/handbook in the source.
+ *
+ * Spaces themselves aren't directly selectable — operators always pick at
+ * least one section. This avoids accidentally ingesting an entire
+ * thousand-page space and getting truncated by the per-source document
+ * cap; the section unit is the right granularity.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import type {
+  ApiConfluenceSection,
+  ApiConfluenceSpace,
+} from "@/lib/api/client";
+
+export type ConfluenceSectionRef = {
+  root_page_id: string;
+  space_id: string;
+  space_key: string | null;
+  space_name: string | null;
+  title: string;
+};
+
+type SpaceState =
+  | { kind: "idle" }
+  | { kind: "loading" }
+  | { kind: "ready"; spaces: ApiConfluenceSpace[] }
+  | { kind: "error"; message: string };
+
+type SectionState =
+  | { kind: "idle" }
+  | { kind: "loading" }
+  | {
+      kind: "ready";
+      sections: ApiConfluenceSection[];
+      nextCursor: string | null;
+      hasMore: boolean;
+    }
+  | { kind: "error"; message: string };
+
+export function ConfluenceSectionPicker({
+  workspaceId,
+  integrationId,
+  value,
+  onChange,
+}: {
+  workspaceId: string;
+  integrationId: string;
+  value: ConfluenceSectionRef[];
+  onChange: (next: ConfluenceSectionRef[]) => void;
+}) {
+  const [spaceState, setSpaceState] = useState<SpaceState>({ kind: "idle" });
+  const [sectionState, setSectionState] = useState<SectionState>({ kind: "idle" });
+  const [appending, setAppending] = useState(false);
+  const [activeSpaceId, setActiveSpaceId] = useState<string>("");
+  const sectionAbortRef = useRef<AbortController | null>(null);
+
+  const selectedIds = useMemo(
+    () => new Set(value.map((ref) => ref.root_page_id)),
+    [value],
+  );
+
+  // Resolve already-picked refs back to display info so pills survive a
+  // space switch (the active section list won't contain them).
+  const resolvedById = useMemo(() => {
+    const map = new Map<string, ConfluenceSectionRef>();
+    for (const ref of value) map.set(ref.root_page_id, ref);
+    return map;
+  }, [value]);
+
+  // Load spaces once per (workspace, integration).
+  useEffect(() => {
+    if (!integrationId) {
+      setSpaceState({ kind: "error", message: "Connect Confluence first." });
+      return;
+    }
+    let cancelled = false;
+    setSpaceState({ kind: "loading" });
+    (async () => {
+      try {
+        const params = new URLSearchParams({ workspaceId, integrationId });
+        const resp = await fetch(`/api/knowledge/confluence-spaces?${params.toString()}`, {
+          method: "GET",
+        });
+        if (cancelled) return;
+        if (!resp.ok) {
+          const payload = await resp.json().catch(() => ({}));
+          const message =
+            typeof payload?.error === "string" ? payload.error : `HTTP ${resp.status}`;
+          setSpaceState({ kind: "error", message });
+          return;
+        }
+        const data = (await resp.json()) as { items: ApiConfluenceSpace[] };
+        setSpaceState({ kind: "ready", spaces: data.items });
+        if (data.items.length > 0 && !activeSpaceId) {
+          setActiveSpaceId(data.items[0].id);
+        }
+      } catch (err) {
+        if (cancelled) return;
+        setSpaceState({
+          kind: "error",
+          message: err instanceof Error ? err.message : "Failed to load spaces",
+        });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [activeSpaceId, integrationId, workspaceId]);
+
+  const loadSections = useCallback(
+    async (args: { spaceId: string; cursor?: string | null; append?: boolean }) => {
+      if (!args.spaceId) return;
+      sectionAbortRef.current?.abort();
+      const controller = new AbortController();
+      sectionAbortRef.current = controller;
+
+      if (args.append) setAppending(true);
+      else setSectionState({ kind: "loading" });
+
+      try {
+        const params = new URLSearchParams({
+          workspaceId,
+          integrationId,
+          spaceId: args.spaceId,
+        });
+        if (args.cursor) params.set("cursor", args.cursor);
+        const resp = await fetch(
+          `/api/knowledge/confluence-sections?${params.toString()}`,
+          { method: "GET", signal: controller.signal },
+        );
+        if (!resp.ok) {
+          const payload = await resp.json().catch(() => ({}));
+          const message =
+            typeof payload?.error === "string" ? payload.error : `HTTP ${resp.status}`;
+          setSectionState({ kind: "error", message });
+          return;
+        }
+        const data = (await resp.json()) as {
+          items: ApiConfluenceSection[];
+          next_cursor: string | null;
+          has_more: boolean;
+        };
+        setSectionState((prev) => {
+          const baseSections =
+            args.append && prev.kind === "ready" ? prev.sections : [];
+          return {
+            kind: "ready",
+            sections: [...baseSections, ...data.items],
+            nextCursor: data.next_cursor,
+            hasMore: data.has_more,
+          };
+        });
+      } catch (err) {
+        if (controller.signal.aborted) return;
+        setSectionState({
+          kind: "error",
+          message: err instanceof Error ? err.message : "Failed to load sections",
+        });
+      } finally {
+        setAppending(false);
+      }
+    },
+    [integrationId, workspaceId],
+  );
+
+  // Reload sections whenever the active space changes.
+  useEffect(() => {
+    if (activeSpaceId) {
+      void loadSections({ spaceId: activeSpaceId });
+    }
+  }, [activeSpaceId, loadSections]);
+
+  function toggle(section: ApiConfluenceSection) {
+    const id = section.id;
+    if (selectedIds.has(id)) {
+      onChange(value.filter((existing) => existing.root_page_id !== id));
+    } else {
+      onChange([
+        ...value,
+        {
+          root_page_id: id,
+          space_id: section.space_id,
+          space_key: section.space_key,
+          space_name: section.space_name,
+          title: section.title,
+        },
+      ]);
+    }
+  }
+
+  function unselect(id: string) {
+    onChange(value.filter((existing) => existing.root_page_id !== id));
+  }
+
+  return (
+    <div className="space-y-3" data-testid="confluence-section-picker">
+      {/* Space chooser */}
+      {spaceState.kind === "loading" && (
+        <p className="text-xs text-white/55">Loading spaces…</p>
+      )}
+      {spaceState.kind === "error" && (
+        <p className="text-xs text-coral">{spaceState.message}</p>
+      )}
+      {spaceState.kind === "ready" && spaceState.spaces.length === 0 && (
+        <p className="text-xs text-white/55">
+          No Confluence spaces visible. Make sure your API token user has access to at
+          least one space.
+        </p>
+      )}
+      {spaceState.kind === "ready" && spaceState.spaces.length > 0 && (
+        <div className="flex flex-wrap gap-1.5">
+          {spaceState.spaces.map((space) => {
+            const active = space.id === activeSpaceId;
+            return (
+              <button
+                key={space.id}
+                type="button"
+                onClick={() => setActiveSpaceId(space.id)}
+                className={`rounded-full border px-3 py-1 text-[11px] transition ${
+                  active
+                    ? "border-aqua/60 bg-aqua/15 text-aqua"
+                    : "border-white/10 bg-white/[0.03] text-white/60 hover:border-white/30"
+                }`}
+              >
+                <span className="font-semibold">{space.name}</span>
+                <span className="ml-1.5 text-white/40">{space.key}</span>
+              </button>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Selected pills */}
+      {value.length > 0 && (
+        <div className="flex flex-wrap gap-1.5 border-t border-white/5 pt-3">
+          {value.map((ref) => {
+            const resolved = resolvedById.get(ref.root_page_id) ?? ref;
+            return (
+              <span
+                key={ref.root_page_id}
+                className="inline-flex items-center gap-1.5 rounded-full border border-aqua/40 bg-aqua/10 px-2 py-0.5 text-[11px] text-aqua"
+              >
+                <span className="max-w-[28ch] truncate">
+                  {resolved.title}
+                  {resolved.space_key && (
+                    <span className="ml-1 text-aqua/55">· {resolved.space_key}</span>
+                  )}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => unselect(ref.root_page_id)}
+                  className="text-aqua/70 hover:text-aqua"
+                  aria-label={`Remove ${resolved.title}`}
+                >
+                  ×
+                </button>
+              </span>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Section list */}
+      <div className="rounded border border-white/10 bg-black/30">
+        {sectionState.kind === "loading" && (
+          <p className="px-3 py-3 text-xs text-white/55">Loading sections…</p>
+        )}
+        {sectionState.kind === "error" && (
+          <p className="px-3 py-3 text-xs text-coral">{sectionState.message}</p>
+        )}
+        {sectionState.kind === "ready" && sectionState.sections.length === 0 && (
+          <p className="px-3 py-3 text-xs text-white/55">
+            No top-level pages in this space — nothing to ingest as a section.
+          </p>
+        )}
+        {sectionState.kind === "ready" && sectionState.sections.length > 0 && (
+          <ul className="max-h-72 divide-y divide-white/5 overflow-y-auto" role="listbox">
+            {sectionState.sections.map((section) => {
+              const checked = selectedIds.has(section.id);
+              return (
+                <li key={section.id}>
+                  <label className="flex cursor-pointer items-center gap-2 px-3 py-2 text-xs text-white/85 hover:bg-white/[0.04]">
+                    <input
+                      type="checkbox"
+                      checked={checked}
+                      onChange={() => toggle(section)}
+                      className="accent-aqua"
+                      aria-label={section.title}
+                    />
+                    <span className="flex-1 truncate">
+                      <span className="text-white/90">{section.title || "Untitled"}</span>
+                    </span>
+                    {section.last_edited_time && (
+                      <span className="text-[10px] text-white/35">
+                        {formatDate(section.last_edited_time)}
+                      </span>
+                    )}
+                  </label>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+        {sectionState.kind === "ready" && sectionState.hasMore && sectionState.nextCursor && (
+          <button
+            type="button"
+            disabled={appending}
+            onClick={() =>
+              void loadSections({
+                spaceId: activeSpaceId,
+                cursor: sectionState.nextCursor,
+                append: true,
+              })
+            }
+            className="w-full border-t border-white/5 px-3 py-2 text-[11px] text-aqua/85 hover:text-aqua disabled:opacity-40"
+          >
+            {appending ? "Loading more…" : "Load more"}
+          </button>
+        )}
+      </div>
+
+      <p className="text-[11px] text-white/45">
+        Each section ingests its root page plus every descendant. Pick the chapters you
+        want; pick from multiple spaces by switching the space chip above.
+      </p>
+    </div>
+  );
+}
+
+function formatDate(iso: string): string {
+  try {
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return "";
+    return d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+  } catch {
+    return "";
+  }
+}

--- a/console/src/app/(authed)/knowledge/import-wizard.tsx
+++ b/console/src/app/(authed)/knowledge/import-wizard.tsx
@@ -8,6 +8,10 @@ import type { ApiActivatedRepo } from "@/lib/api/client";
 import type { ApiBucketScope, ApiIntegration } from "@/lib/api/types";
 
 import { createImportSourceAction, type ImportSourceResult } from "./actions";
+import {
+  ConfluenceSectionPicker,
+  type ConfluenceSectionRef,
+} from "./confluence-section-picker";
 import { NotionResourcePicker, type NotionPageRef } from "./notion-resource-picker";
 
 type SourceKind = "website" | "notion" | "confluence" | "docs_repo" | "static_upload";
@@ -35,7 +39,7 @@ export function KnowledgeImportWizard({
   const [name, setName] = useState("Website knowledge");
   const [url, setUrl] = useState("");
   const [notionRefs, setNotionRefs] = useState<NotionPageRef[]>([]);
-  const [confluenceRefs, setConfluenceRefs] = useState("[]");
+  const [confluenceRefs, setConfluenceRefs] = useState<ConfluenceSectionRef[]>([]);
   const [repoId, setRepoId] = useState(repos[0]?.id ?? "");
   const [repoPaths, setRepoPaths] = useState("docs\nREADME.md");
   const [uploadTitle, setUploadTitle] = useState("");
@@ -88,23 +92,10 @@ export function KnowledgeImportWizard({
     }
     if (kind === "confluence") {
       if (!selectedIntegrationId) return { ok: false, message: "Connect Confluence first in integrations." };
-      let parsed: unknown;
-      try {
-        parsed = JSON.parse(confluenceRefs || "[]");
-      } catch {
-        return { ok: false, message: "Resource refs must be valid JSON." };
+      if (confluenceRefs.length === 0) {
+        return { ok: false, message: "Pick at least one section from a Confluence space." };
       }
-      const refs = Array.isArray(parsed) ? parsed : [parsed];
-      const meaningful = refs.filter(
-        (ref) => ref && typeof ref === "object" && Object.keys(ref as object).length > 0,
-      );
-      if (meaningful.length === 0) {
-        return {
-          ok: false,
-          message: 'Add at least one Confluence page ref — e.g. {"page_id":"..."}.',
-        };
-      }
-      return { ok: true, config: { resource_refs: meaningful } };
+      return { ok: true, config: { resource_refs: confluenceRefs } };
     }
     if (kind === "docs_repo") {
       if (!repoId) return { ok: false, message: "Pick a repository." };
@@ -199,8 +190,21 @@ export function KnowledgeImportWizard({
                   {matchingIntegrations.length === 0 ? <option value="">No integration connected</option> : matchingIntegrations.map((integration) => <option key={integration.id} value={integration.id}>{integration.kind} - {integration.status}</option>)}
                 </select>
               </Field>
-              <Field label="Resource refs JSON" hint='Examples: [{"page_id":"..."}] — picker is in the next phase.'>
-                <textarea value={confluenceRefs} onChange={(event) => setConfluenceRefs(event.target.value)} rows={5} className="w-full rounded border border-white/15 bg-black/30 px-3 py-2 font-mono text-[12px] text-aqua/85" />
+              <Field label="Sections to import">
+                {workspaceId && selectedIntegrationId ? (
+                  <ConfluenceSectionPicker
+                    workspaceId={workspaceId}
+                    integrationId={selectedIntegrationId}
+                    value={confluenceRefs}
+                    onChange={setConfluenceRefs}
+                  />
+                ) : (
+                  <p className="text-[11px] text-white/55">
+                    {workspaceId
+                      ? "Connect Confluence (Atlassian API token) to pick sections."
+                      : "Workspace not loaded yet — refresh the page."}
+                  </p>
+                )}
               </Field>
             </>
           )}

--- a/console/src/app/api/knowledge/confluence-sections/route.ts
+++ b/console/src/app/api/knowledge/confluence-sections/route.ts
@@ -1,0 +1,76 @@
+/**
+ * Server-side proxy for the Confluence section list (top-level pages of
+ * a space) — ``GET /v1/workspaces/{ws}/knowledge/sources/confluence/sections``.
+ */
+
+import { NextResponse } from "next/server";
+
+import {
+  ApiHttpError,
+  ApiUnavailableError,
+  isApiConfigured,
+  listConfluenceSections,
+} from "@/lib/api/client";
+import { getSessionToken } from "@/lib/api/session";
+
+export async function GET(request: Request) {
+  if (!isApiConfigured()) {
+    return NextResponse.json(
+      { error: "Backend is not configured.", code: "api_unavailable" },
+      { status: 503 },
+    );
+  }
+
+  const url = new URL(request.url);
+  const workspaceId = url.searchParams.get("workspaceId");
+  const integrationId = url.searchParams.get("integrationId");
+  const spaceId = url.searchParams.get("spaceId");
+  if (!workspaceId || !integrationId || !spaceId) {
+    return NextResponse.json(
+      {
+        error: "workspaceId, integrationId, and spaceId are required.",
+        code: "bad_request",
+      },
+      { status: 400 },
+    );
+  }
+  const cursor = url.searchParams.get("cursor") ?? undefined;
+
+  try {
+    const token = (await getSessionToken()) ?? undefined;
+    const data = await listConfluenceSections(
+      workspaceId,
+      { integrationId, spaceId, cursor },
+      { token },
+    );
+    return NextResponse.json(data, { status: 200 });
+  } catch (err) {
+    return errorResponse(err);
+  }
+}
+
+function errorResponse(err: unknown): NextResponse {
+  if (err instanceof ApiUnavailableError) {
+    return NextResponse.json(
+      { error: "Backend is unreachable.", code: "api_unavailable" },
+      { status: 503 },
+    );
+  }
+  if (err instanceof ApiHttpError) {
+    const detail =
+      err.detail && typeof err.detail === "object"
+        ? (err.detail as Record<string, unknown>)
+        : null;
+    const message =
+      detail && typeof detail.message === "string"
+        ? detail.message
+        : typeof err.detail === "string"
+          ? err.detail
+          : `HTTP ${err.status}`;
+    return NextResponse.json({ error: message, detail }, { status: err.status });
+  }
+  return NextResponse.json(
+    { error: err instanceof Error ? err.message : "Unknown error", code: "unknown" },
+    { status: 500 },
+  );
+}

--- a/console/src/app/api/knowledge/confluence-spaces/route.ts
+++ b/console/src/app/api/knowledge/confluence-spaces/route.ts
@@ -1,0 +1,67 @@
+/**
+ * Server-side proxy for the Confluence space-picker
+ * (``GET /v1/workspaces/{ws}/knowledge/sources/confluence/spaces``).
+ */
+
+import { NextResponse } from "next/server";
+
+import {
+  ApiHttpError,
+  ApiUnavailableError,
+  isApiConfigured,
+  listConfluenceSpaces,
+} from "@/lib/api/client";
+import { getSessionToken } from "@/lib/api/session";
+
+export async function GET(request: Request) {
+  if (!isApiConfigured()) {
+    return NextResponse.json(
+      { error: "Backend is not configured.", code: "api_unavailable" },
+      { status: 503 },
+    );
+  }
+
+  const url = new URL(request.url);
+  const workspaceId = url.searchParams.get("workspaceId");
+  const integrationId = url.searchParams.get("integrationId");
+  if (!workspaceId || !integrationId) {
+    return NextResponse.json(
+      { error: "workspaceId and integrationId are required.", code: "bad_request" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const token = (await getSessionToken()) ?? undefined;
+    const data = await listConfluenceSpaces(workspaceId, { integrationId }, { token });
+    return NextResponse.json(data, { status: 200 });
+  } catch (err) {
+    return errorResponse(err);
+  }
+}
+
+function errorResponse(err: unknown): NextResponse {
+  if (err instanceof ApiUnavailableError) {
+    return NextResponse.json(
+      { error: "Backend is unreachable.", code: "api_unavailable" },
+      { status: 503 },
+    );
+  }
+  if (err instanceof ApiHttpError) {
+    const detail =
+      err.detail && typeof err.detail === "object"
+        ? (err.detail as Record<string, unknown>)
+        : null;
+    const message =
+      detail && typeof detail.message === "string"
+        ? detail.message
+        : typeof err.detail === "string"
+          ? err.detail
+          : `HTTP ${err.status}`;
+    return NextResponse.json({ error: message, detail }, { status: err.status });
+  }
+  return NextResponse.json(
+    { error: err instanceof Error ? err.message : "Unknown error", code: "unknown" },
+    { status: 500 },
+  );
+}

--- a/console/src/lib/api/client.ts
+++ b/console/src/lib/api/client.ts
@@ -1282,6 +1282,54 @@ export function listNotionResources(
   );
 }
 
+export type ApiConfluenceSpace = {
+  id: string;
+  key: string;
+  name: string;
+  type: string | null;
+  homepage_id: string | null;
+  description: string | null;
+};
+
+export type ApiConfluenceSection = {
+  id: string;
+  title: string;
+  space_id: string;
+  space_key: string | null;
+  space_name: string | null;
+  url: string | null;
+  last_edited_time: string | null;
+  has_children: boolean;
+};
+
+export function listConfluenceSpaces(
+  workspaceId: string,
+  params: { integrationId: string },
+  options: { token?: string; signal?: AbortSignal } = {},
+): Promise<{ items: ApiConfluenceSpace[] }> {
+  const search = new URLSearchParams({ integration_id: params.integrationId });
+  return apiFetch<{ items: ApiConfluenceSpace[] }>(
+    `/v1/workspaces/${encodeURIComponent(workspaceId)}/knowledge/sources/confluence/spaces?${search.toString()}`,
+    { token: options.token, signal: options.signal },
+  );
+}
+
+export function listConfluenceSections(
+  workspaceId: string,
+  params: { integrationId: string; spaceId: string; cursor?: string | null },
+  options: { token?: string; signal?: AbortSignal } = {},
+): Promise<{ items: ApiConfluenceSection[]; next_cursor: string | null; has_more: boolean }> {
+  const search = new URLSearchParams({
+    integration_id: params.integrationId,
+    space_id: params.spaceId,
+  });
+  if (params.cursor) search.set("cursor", params.cursor);
+  return apiFetch<{ items: ApiConfluenceSection[]; next_cursor: string | null; has_more: boolean }>(
+    `/v1/workspaces/${encodeURIComponent(workspaceId)}/knowledge/sources/confluence/sections?${search.toString()}`,
+    { token: options.token, signal: options.signal },
+  );
+}
+
 export function archiveBucket(
   workspaceId: string,
   slug: string,


### PR DESCRIPTION
## Summary

Replaces the JSON-textarea Confluence picker with a real space → section UI. One section pick = root page + every descendant. Operators don't pick docs one-by-one and they don't slurp whole spaces — section is the right granularity (handbook, runbook collection, etc.).

Reopened after the original PR (#104) was auto-closed when the stacked base branch was deleted by the #103 squash merge. Branch was rebased clean onto main.

### What changed

- **Connector** (`backend/app/services/connectors/confluence.py`): handles `{root_page_id, space_id, …}` resource_refs by fetching the root page + walking `/pages/{id}/descendants` (capped at 200/section so a runaway 5k-page space can't wedge a sync). Each subtree page becomes its own `ConnectorPage` so fingerprint/skip happens per-page on resync. Legacy `{page_id}` shape kept for back-compat.
- **Backend endpoints**:
  - `GET /v1/.../confluence/spaces` — all spaces visible to the integration's API token (id, key, name, type, description).
  - `GET /v1/.../confluence/sections?space_id=…&cursor=…` — top-level pages of a space with v2 cursor pagination, stamped with space key/name.
  - The CQL page-search endpoint added in this PR is kept but **not** exposed in the wizard — forward-compat hook for an "advanced: pick specific pages" mode.
- **Frontend** (`<ConfluenceSectionPicker>`): space chips at top (click to switch), section checklist below, selected-pill row with × removers. Each pick → `{root_page_id, space_id, space_key, space_name, title}` straight into `config.resource_refs`.

## Test plan

- [x] `pytest backend/tests/test_connectors_confluence.py` — 5 tests including new section-walk + unsupported-shape fallback.
- [x] `pytest backend/tests/test_v1_confluence_resources.py` — 4 tests: spaces list, section list with metadata, kind-mismatch 404, missing-creds 400.
- [x] `npx tsc --noEmit` clean.
- [x] `npx next build` clean.
- [ ] Manual UI smoke on a workspace with a Confluence integration.

## Phase context

Phase 2 of the picker plan. Phase 0+1 (Notion picker, empty-refs guardrail) shipped in #103. Phase 3+ queued: docs-repo file-tree picker, Notion database-as-source, website map preview, static-upload drop zone.