### PR TITLE
knowledge: pick docs-repo paths from a tree, not a textarea

### DIFF
--- a/backend/app/api/v1/routes/knowledge_import_sources.py
+++ b/backend/app/api/v1/routes/knowledge_import_sources.py
@@ -19,13 +19,16 @@ from backend.app.api.v1.routes.workspaces import (
     ROLES_READ,
     _require_membership,
 )
+from backend.app.core.config import Settings, get_settings
+from backend.app.integrations.gateway.code_host import RepoRef
+from backend.app.integrations.github.code_host_adapter import GitHubCodeHost
 from backend.app.db.models.agent_memory import (
     KnowledgeImportSource,
     KnowledgeImportSourceKind,
     KnowledgeIngestionRun,
     KnowledgeSourceItem,
 )
-from backend.app.db.models.integrations import WorkspaceRepo
+from backend.app.db.models.integrations import GitHubInstallation, WorkspaceRepo
 from backend.app.db.models.tenancy import AuditLog, Integration
 from backend.app.db.session import get_session
 from backend.app.security.encryption import safe_decrypt
@@ -1042,3 +1045,179 @@ async def list_confluence_resources(
         next_start=next_start_value,
         has_more=next_start_value is not None,
     )
+
+
+# ---------------------------------------------------------------------------
+# Docs-repo file-tree picker
+# ---------------------------------------------------------------------------
+#
+# The wizard's docs_repo source previously asked operators to type path
+# prefixes by hand into a textarea (default: ``docs\nREADME.md``). This
+# endpoint surfaces the actual file tree so operators check folders/files
+# instead of guessing names. Resource refs end up in ``config.paths`` —
+# same shape the connector already accepts (any path that startswith
+# any prefix in ``paths`` and matches an extension is ingested), so a
+# folder pick = "include this folder recursively" without any backend
+# behaviour change.
+
+_DOCS_REPO_DEFAULT_EXTENSIONS: tuple[str, ...] = (
+    ".md",
+    ".mdx",
+    ".rst",
+    ".txt",
+    ".adoc",
+)
+
+
+class DocsRepoTreeNode(BaseModel):
+    path: str
+    name: str
+    type: Literal["tree", "blob"]
+    matches_extension: bool  # blobs only; trees pass through as True
+
+
+class DocsRepoTreeOut(BaseModel):
+    repo_id: uuid.UUID
+    ref: str
+    truncated: bool  # tree exceeded GitHub's 100k-entry / 7MB cap
+    nodes: list[DocsRepoTreeNode]
+
+
+def _node_for_blob(path: str, *, extensions: tuple[str, ...]) -> DocsRepoTreeNode:
+    return DocsRepoTreeNode(
+        path=path,
+        name=path.rsplit("/", 1)[-1],
+        type="blob",
+        matches_extension=path.lower().endswith(extensions),
+    )
+
+
+def _node_for_tree(path: str) -> DocsRepoTreeNode:
+    return DocsRepoTreeNode(
+        path=path,
+        name=path.rsplit("/", 1)[-1] if "/" in path else path,
+        type="tree",
+        matches_extension=True,
+    )
+
+
+@router.get("/docs-repo/tree", response_model=DocsRepoTreeOut)
+async def list_docs_repo_tree(
+    workspace_id: uuid.UUID,
+    repo_id: uuid.UUID = Query(..., description="Workspace repo to list"),
+    auth: AuthContext = Depends(get_current_auth),
+    session: AsyncSession = Depends(get_session),
+    settings: Settings = Depends(get_settings),
+) -> DocsRepoTreeOut:
+    """Flat tree (folders + doc files) for the wizard's docs-repo picker.
+
+    Uses GitHub's recursive Trees API so we get the whole tree in one
+    call (capped server-side at 100k entries / 7MB by GitHub itself —
+    surfaced to the client via ``truncated``). The frontend builds the
+    expandable tree view from the flat list; we don't expose per-folder
+    pagination because GitHub's recursive=1 already returns everything
+    cheaply for the repos closed-beta operators ingest.
+    """
+    await _require_membership(session, workspace_id, auth.user.id, ROLES_ADMIN)
+
+    repo = await session.get(WorkspaceRepo, repo_id)
+    if repo is None or repo.workspace_id != workspace_id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="repo not found for this workspace",
+        )
+    if repo.installation_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="repo has no GitHub installation — re-authorize Ship for this org",
+        )
+    installation = await session.get(GitHubInstallation, repo.installation_id)
+    if installation is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="GitHub installation row is missing",
+        )
+
+    owner, name = repo.full_name.split("/", 1)
+    ref = RepoRef(kind="github", owner=owner, repo=name)
+    gateway = GitHubCodeHost(installation.installation_id, settings=settings)
+
+    try:
+        tree_payload = await _docs_repo_fetch_tree(
+            gateway,
+            owner=owner,
+            repo=name,
+            ref=repo.default_branch or "HEAD",
+        )
+    except FileNotFoundError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=str(exc),
+        ) from exc
+    except httpx.HTTPError as exc:
+        logger.warning(
+            "github trees fetch failed for repo=%s ws=%s: %s",
+            repo.full_name,
+            workspace_id,
+            exc,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="GitHub is unreachable — try again",
+        ) from exc
+
+    extensions = tuple(s.lower() for s in _DOCS_REPO_DEFAULT_EXTENSIONS)
+    blob_paths = sorted(
+        path for path in tree_payload["blobs"] if path.lower().endswith(extensions)
+    )
+    tree_paths = sorted(
+        path
+        for path in tree_payload["trees"]
+        # Drop folders that have no doc descendants; otherwise the picker
+        # is full of empty folders the operator can never use.
+        if any(blob.startswith(f"{path}/") for blob in blob_paths)
+    )
+    nodes = [_node_for_tree(p) for p in tree_paths] + [
+        _node_for_blob(p, extensions=extensions) for p in blob_paths
+    ]
+
+    return DocsRepoTreeOut(
+        repo_id=repo.id,
+        ref=tree_payload["ref"],
+        truncated=bool(tree_payload["truncated"]),
+        nodes=nodes,
+    )
+
+
+async def _docs_repo_fetch_tree(
+    gateway: GitHubCodeHost, *, owner: str, repo: str, ref: str
+) -> dict[str, Any]:
+    """Hit GitHub's recursive trees API and split blobs/trees.
+
+    Wrapped so tests can monkeypatch the GitHub round-trip without
+    touching ``GitHubCodeHost.list_files`` (which has slightly different
+    semantics — it drops trees and only returns blob paths).
+    """
+    response = await gateway._request(  # type: ignore[attr-defined]
+        "GET",
+        f"/repos/{owner}/{repo}/git/trees/{ref}",
+        params={"recursive": "1"},
+    )
+    payload = response.json()
+    blobs: list[str] = []
+    trees: list[str] = []
+    for entry in payload.get("tree") or []:
+        path = entry.get("path")
+        kind = entry.get("type")
+        if not path or not kind:
+            continue
+        if kind == "blob":
+            blobs.append(str(path))
+        elif kind == "tree":
+            trees.append(str(path))
+    return {
+        "ref": str(payload.get("sha") or ref),
+        "blobs": blobs,
+        "trees": trees,
+        "truncated": bool(payload.get("truncated")),
+    }

--- a/backend/tests/test_v1_docs_repo_tree.py
+++ b/backend/tests/test_v1_docs_repo_tree.py
@@ -1,0 +1,129 @@
+"""Wizard picker — `/v1/.../knowledge/sources/docs-repo/tree`.
+
+Stubs the GitHub round-trip via the route's `_docs_repo_fetch_tree`
+helper (same seam pattern used elsewhere) so tests don't reach the
+real GitHub API.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from backend.app.db.models.integrations import GitHubInstallation, WorkspaceRepo
+
+
+def _auth(raw: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {raw}"}
+
+
+def _seed_repo(db_session, workspace_id, *, with_installation: bool = True) -> WorkspaceRepo:
+    install = None
+    if with_installation:
+        install = GitHubInstallation(
+            id=uuid.uuid4(),
+            workspace_id=workspace_id,
+            installation_id=42,
+            account_login="askslayer",
+            account_id=1,
+            account_type="User",
+        )
+        db_session.add(install)
+    repo = WorkspaceRepo(
+        id=uuid.uuid4(),
+        workspace_id=workspace_id,
+        installation_id=install.id if install else None,
+        full_name="askslayer/visitor-back",
+        provider="github",
+        external_id=12345,
+        default_branch="main",
+        html_url="https://github.com/askslayer/visitor-back",
+    )
+    db_session.add(repo)
+    return repo
+
+
+@pytest.mark.asyncio
+async def test_docs_repo_tree_returns_doc_nodes_and_filters_empty_dirs(
+    v1_client, seed_workspace, db_session, monkeypatch
+) -> None:
+    _, raw, workspace = seed_workspace
+    repo = _seed_repo(db_session, workspace.id)
+    await db_session.flush()
+
+    async def _fake_tree(gateway, *, owner, repo, ref):
+        assert owner == "askslayer"
+        assert repo == "visitor-back"
+        return {
+            "ref": "abc123",
+            "blobs": [
+                "README.md",
+                "docs/setup.md",
+                "docs/usage.mdx",
+                "src/main.py",  # filtered: not a doc extension
+                "build/output.bin",
+            ],
+            "trees": [
+                "docs",
+                "src",
+                "build",  # filtered: no doc descendants
+            ],
+            "truncated": False,
+        }
+
+    monkeypatch.setattr(
+        "backend.app.api.v1.routes.knowledge_import_sources._docs_repo_fetch_tree",
+        _fake_tree,
+    )
+
+    response = await v1_client.get(
+        f"/v1/workspaces/{workspace.id}/knowledge/sources/docs-repo/tree",
+        headers=_auth(raw),
+        params={"repo_id": str(repo.id)},
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["ref"] == "abc123"
+    assert body["truncated"] is False
+
+    # Empty folders ("build/") and non-doc files dropped, doc folders+blobs kept.
+    paths_by_type = {(node["type"], node["path"]) for node in body["nodes"]}
+    assert ("tree", "docs") in paths_by_type
+    assert ("tree", "build") not in paths_by_type
+    assert ("blob", "README.md") in paths_by_type
+    assert ("blob", "docs/setup.md") in paths_by_type
+    assert ("blob", "src/main.py") not in paths_by_type
+
+
+@pytest.mark.asyncio
+async def test_docs_repo_tree_404_for_unknown_repo(
+    v1_client, seed_workspace
+) -> None:
+    """A repo_id that doesn't exist must 404 — same path that protects
+    against foreign-workspace ids since the membership + ``workspace_id``
+    match are checked together."""
+    _, raw, workspace = seed_workspace
+    response = await v1_client.get(
+        f"/v1/workspaces/{workspace.id}/knowledge/sources/docs-repo/tree",
+        headers=_auth(raw),
+        params={"repo_id": str(uuid.uuid4())},
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_docs_repo_tree_400_when_no_installation(
+    v1_client, seed_workspace, db_session
+) -> None:
+    _, raw, workspace = seed_workspace
+    repo = _seed_repo(db_session, workspace.id, with_installation=False)
+    await db_session.flush()
+
+    response = await v1_client.get(
+        f"/v1/workspaces/{workspace.id}/knowledge/sources/docs-repo/tree",
+        headers=_auth(raw),
+        params={"repo_id": str(repo.id)},
+    )
+    assert response.status_code == 400
+    assert "installation" in response.json()["detail"].lower()

--- a/console/src/app/(authed)/knowledge/docs-repo-tree-picker.tsx
+++ b/console/src/app/(authed)/knowledge/docs-repo-tree-picker.tsx
@@ -1,0 +1,308 @@
+"use client";
+
+/**
+ * DocsRepoTreePicker — pick folders/files from the activated repo's tree
+ * instead of typing path prefixes by hand.
+ *
+ * Resource refs are just ``string[]`` — same shape the existing connector
+ * accepts in ``config.paths`` (a path matches if it ``startswith`` any
+ * prefix). Selecting a folder = include the folder recursively; selecting
+ * an individual file = include just that file.
+ *
+ * The picker collapses the flat tree returned by the backend into an
+ * expandable hierarchy. Folders that contain no doc files are pruned
+ * server-side, so the visible tree is always actionable.
+ */
+
+import { useEffect, useMemo, useState } from "react";
+
+import type { ApiDocsRepoTreeNode } from "@/lib/api/client";
+
+type FetchState =
+  | { kind: "idle" }
+  | { kind: "loading" }
+  | {
+      kind: "ready";
+      nodes: ApiDocsRepoTreeNode[];
+      ref: string;
+      truncated: boolean;
+    }
+  | { kind: "error"; message: string };
+
+type TreeNode = {
+  path: string;
+  name: string;
+  type: "tree" | "blob";
+  children: TreeNode[];
+};
+
+export function DocsRepoTreePicker({
+  workspaceId,
+  repoId,
+  value,
+  onChange,
+}: {
+  workspaceId: string;
+  repoId: string;
+  value: string[];
+  onChange: (next: string[]) => void;
+}) {
+  const [state, setState] = useState<FetchState>({ kind: "idle" });
+  const [expanded, setExpanded] = useState<Set<string>>(new Set([""]));
+
+  useEffect(() => {
+    if (!repoId) return;
+    let cancelled = false;
+    setState({ kind: "loading" });
+    (async () => {
+      try {
+        const params = new URLSearchParams({ workspaceId, repoId });
+        const resp = await fetch(`/api/knowledge/docs-repo-tree?${params.toString()}`, {
+          method: "GET",
+        });
+        if (cancelled) return;
+        if (!resp.ok) {
+          const payload = await resp.json().catch(() => ({}));
+          const message =
+            typeof payload?.error === "string" ? payload.error : `HTTP ${resp.status}`;
+          setState({ kind: "error", message });
+          return;
+        }
+        const data = (await resp.json()) as {
+          nodes: ApiDocsRepoTreeNode[];
+          ref: string;
+          truncated: boolean;
+        };
+        setState({ kind: "ready", nodes: data.nodes, ref: data.ref, truncated: data.truncated });
+        // Auto-expand top-level folders that look like doc roots so the
+        // picker is useful on first paint.
+        const autoExpand = new Set<string>([""]);
+        for (const node of data.nodes) {
+          if (node.type === "tree" && /^(docs|documentation|guides|wiki)$/i.test(node.name)) {
+            autoExpand.add(node.path);
+          }
+        }
+        setExpanded(autoExpand);
+      } catch (err) {
+        if (cancelled) return;
+        setState({
+          kind: "error",
+          message: err instanceof Error ? err.message : "Failed to load tree",
+        });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [repoId, workspaceId]);
+
+  const tree = useMemo<TreeNode[]>(() => {
+    if (state.kind !== "ready") return [];
+    return buildTree(state.nodes);
+  }, [state]);
+
+  const selectedSet = useMemo(() => new Set(value), [value]);
+
+  function isSelected(path: string): boolean {
+    if (selectedSet.has(path)) return true;
+    // A path is also "selected" if any of its prefixes is in the selected set
+    // (e.g. selecting "docs" implicitly selects "docs/setup.md").
+    for (const sel of selectedSet) {
+      if (path.startsWith(`${sel}/`)) return true;
+    }
+    return false;
+  }
+
+  function toggle(path: string) {
+    if (selectedSet.has(path)) {
+      onChange(value.filter((existing) => existing !== path));
+      return;
+    }
+    // If a parent is already selected, unselecting via a child doesn't
+    // make sense — surface "implicit" selection by not adding duplicates.
+    const parentSelected = value.some((sel) => path.startsWith(`${sel}/`));
+    if (parentSelected) return;
+    // Drop any descendants of this path before adding it (selecting a
+    // folder makes the previously-checked individual files redundant).
+    const filtered = value.filter((sel) => !sel.startsWith(`${path}/`));
+    onChange([...filtered, path]);
+  }
+
+  function toggleExpanded(path: string) {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(path)) next.delete(path);
+      else next.add(path);
+      return next;
+    });
+  }
+
+  return (
+    <div className="space-y-3" data-testid="docs-repo-tree-picker">
+      {state.kind === "loading" && (
+        <p className="text-xs text-white/55">Loading repository tree…</p>
+      )}
+      {state.kind === "error" && (
+        <p className="text-xs text-coral">{state.message}</p>
+      )}
+      {state.kind === "ready" && state.nodes.length === 0 && (
+        <p className="text-xs text-white/55">
+          No doc files (.md, .mdx, .rst, .txt, .adoc) found in this repo.
+        </p>
+      )}
+
+      {state.kind === "ready" && tree.length > 0 && (
+        <>
+          {value.length > 0 && (
+            <div className="flex flex-wrap gap-1.5 border-t border-white/5 pt-3">
+              {value.map((path) => (
+                <span
+                  key={path}
+                  className="inline-flex items-center gap-1.5 rounded-full border border-aqua/40 bg-aqua/10 px-2 py-0.5 text-[11px] text-aqua"
+                >
+                  <span className="max-w-[28ch] truncate">{path}</span>
+                  <button
+                    type="button"
+                    onClick={() => toggle(path)}
+                    className="text-aqua/70 hover:text-aqua"
+                    aria-label={`Remove ${path}`}
+                  >
+                    ×
+                  </button>
+                </span>
+              ))}
+            </div>
+          )}
+
+          <div className="max-h-72 overflow-y-auto rounded border border-white/10 bg-black/30 px-1 py-1">
+            {tree.map((node) => (
+              <TreeRow
+                key={node.path}
+                node={node}
+                depth={0}
+                expanded={expanded}
+                onToggleExpanded={toggleExpanded}
+                isSelected={isSelected}
+                onToggle={toggle}
+              />
+            ))}
+          </div>
+
+          {state.truncated && (
+            <p className="text-[11px] text-amber-200">
+              GitHub truncated this tree (very large repo). Some files may not be visible — paste the path manually under Advanced if you need them.
+            </p>
+          )}
+        </>
+      )}
+
+      <p className="text-[11px] text-white/45">
+        Select folders to ingest them recursively, or individual files.
+        ``.md``, ``.mdx``, ``.rst``, ``.txt``, ``.adoc`` are picked up. Branch:{" "}
+        <span className="font-mono text-white/70">
+          {state.kind === "ready" ? state.ref.slice(0, 7) : "…"}
+        </span>
+        .
+      </p>
+    </div>
+  );
+}
+
+
+function TreeRow({
+  node,
+  depth,
+  expanded,
+  onToggleExpanded,
+  isSelected,
+  onToggle,
+}: {
+  node: TreeNode;
+  depth: number;
+  expanded: Set<string>;
+  onToggleExpanded: (path: string) => void;
+  isSelected: (path: string) => boolean;
+  onToggle: (path: string) => void;
+}) {
+  const isExpanded = expanded.has(node.path);
+  const checked = isSelected(node.path);
+  const isDir = node.type === "tree";
+  return (
+    <div>
+      <div
+        className="flex items-center gap-2 rounded px-2 py-1 text-xs hover:bg-white/[0.04]"
+        style={{ paddingLeft: `${depth * 16 + 8}px` }}
+      >
+        {isDir ? (
+          <button
+            type="button"
+            onClick={() => onToggleExpanded(node.path)}
+            className="w-3 text-white/40 hover:text-white/80"
+            aria-label={isExpanded ? "Collapse" : "Expand"}
+          >
+            {isExpanded ? "▾" : "▸"}
+          </button>
+        ) : (
+          <span className="w-3" />
+        )}
+        <input
+          type="checkbox"
+          checked={checked}
+          onChange={() => onToggle(node.path)}
+          className="accent-aqua"
+          aria-label={node.path}
+        />
+        <span className={`w-3 text-center ${isDir ? "text-aqua/70" : "text-white/35"}`}>
+          {isDir ? "▦" : "•"}
+        </span>
+        <span className={isDir ? "font-semibold text-white/85" : "text-white/75"}>
+          {node.name}
+        </span>
+      </div>
+      {isDir && isExpanded && node.children.length > 0 && (
+        <div>
+          {node.children.map((child) => (
+            <TreeRow
+              key={child.path}
+              node={child}
+              depth={depth + 1}
+              expanded={expanded}
+              onToggleExpanded={onToggleExpanded}
+              isSelected={isSelected}
+              onToggle={onToggle}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+
+function buildTree(nodes: ApiDocsRepoTreeNode[]): TreeNode[] {
+  // The backend returns a flat list of folders + doc files (folders
+  // without doc descendants are already dropped). Build the parent/child
+  // graph by splitting on "/" so the picker renders a real hierarchy.
+  const byPath = new Map<string, TreeNode>();
+  const roots: TreeNode[] = [];
+  // Sort so parents are inserted before children regardless of input order.
+  const sorted = [...nodes].sort((a, b) => a.path.localeCompare(b.path));
+  for (const entry of sorted) {
+    const node: TreeNode = {
+      path: entry.path,
+      name: entry.name,
+      type: entry.type,
+      children: [],
+    };
+    byPath.set(entry.path, node);
+    const lastSlash = entry.path.lastIndexOf("/");
+    if (lastSlash === -1) {
+      roots.push(node);
+      continue;
+    }
+    const parent = byPath.get(entry.path.slice(0, lastSlash));
+    if (parent) parent.children.push(node);
+    else roots.push(node);
+  }
+  return roots;
+}

--- a/console/src/app/(authed)/knowledge/import-wizard.tsx
+++ b/console/src/app/(authed)/knowledge/import-wizard.tsx
@@ -12,6 +12,7 @@ import {
   ConfluenceSectionPicker,
   type ConfluenceSectionRef,
 } from "./confluence-section-picker";
+import { DocsRepoTreePicker } from "./docs-repo-tree-picker";
 import { NotionResourcePicker, type NotionPageRef } from "./notion-resource-picker";
 
 type SourceKind = "website" | "notion" | "confluence" | "docs_repo" | "static_upload";
@@ -41,7 +42,7 @@ export function KnowledgeImportWizard({
   const [notionRefs, setNotionRefs] = useState<NotionPageRef[]>([]);
   const [confluenceRefs, setConfluenceRefs] = useState<ConfluenceSectionRef[]>([]);
   const [repoId, setRepoId] = useState(repos[0]?.id ?? "");
-  const [repoPaths, setRepoPaths] = useState("docs\nREADME.md");
+  const [repoPaths, setRepoPaths] = useState<string[]>([]);
   const [uploadTitle, setUploadTitle] = useState("");
   const [uploadBody, setUploadBody] = useState("");
   const [syncNow, setSyncNow] = useState(true);
@@ -99,11 +100,14 @@ export function KnowledgeImportWizard({
     }
     if (kind === "docs_repo") {
       if (!repoId) return { ok: false, message: "Pick a repository." };
+      if (repoPaths.length === 0) {
+        return { ok: false, message: "Pick at least one folder or file from the repo tree." };
+      }
       return {
         ok: true,
         config: {
-          paths: repoPaths.split(/\r?\n/).map((line) => line.trim()).filter(Boolean),
-          extensions: [".md", ".mdx", ".txt"],
+          paths: repoPaths,
+          extensions: [".md", ".mdx", ".rst", ".txt", ".adoc"],
           limit: 50,
         },
       };
@@ -215,8 +219,19 @@ export function KnowledgeImportWizard({
                   {repos.length === 0 ? <option value="">No activated repos</option> : repos.map((repo) => <option key={repo.id} value={repo.id}>{repo.full_name}</option>)}
                 </select>
               </Field>
-              <Field label="Docs paths" hint="One path prefix per line. Markdown files under these paths are synced by blob SHA.">
-                <textarea value={repoPaths} onChange={(event) => setRepoPaths(event.target.value)} rows={4} className="w-full rounded border border-white/15 bg-black/30 px-3 py-2 font-mono text-[12px] text-aqua/85" />
+              <Field label="Docs to import">
+                {workspaceId && repoId ? (
+                  <DocsRepoTreePicker
+                    workspaceId={workspaceId}
+                    repoId={repoId}
+                    value={repoPaths}
+                    onChange={setRepoPaths}
+                  />
+                ) : (
+                  <p className="text-[11px] text-white/55">
+                    {workspaceId ? "Pick a repository first." : "Workspace not loaded yet — refresh the page."}
+                  </p>
+                )}
               </Field>
             </>
           )}

--- a/console/src/app/api/knowledge/docs-repo-tree/route.ts
+++ b/console/src/app/api/knowledge/docs-repo-tree/route.ts
@@ -1,0 +1,67 @@
+/**
+ * Server-side proxy for the docs-repo file-tree picker
+ * (``GET /v1/workspaces/{ws}/knowledge/sources/docs-repo/tree``).
+ */
+
+import { NextResponse } from "next/server";
+
+import {
+  ApiHttpError,
+  ApiUnavailableError,
+  isApiConfigured,
+  listDocsRepoTree,
+} from "@/lib/api/client";
+import { getSessionToken } from "@/lib/api/session";
+
+export async function GET(request: Request) {
+  if (!isApiConfigured()) {
+    return NextResponse.json(
+      { error: "Backend is not configured.", code: "api_unavailable" },
+      { status: 503 },
+    );
+  }
+
+  const url = new URL(request.url);
+  const workspaceId = url.searchParams.get("workspaceId");
+  const repoId = url.searchParams.get("repoId");
+  if (!workspaceId || !repoId) {
+    return NextResponse.json(
+      { error: "workspaceId and repoId are required.", code: "bad_request" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const token = (await getSessionToken()) ?? undefined;
+    const data = await listDocsRepoTree(workspaceId, { repoId }, { token });
+    return NextResponse.json(data, { status: 200 });
+  } catch (err) {
+    return errorResponse(err);
+  }
+}
+
+function errorResponse(err: unknown): NextResponse {
+  if (err instanceof ApiUnavailableError) {
+    return NextResponse.json(
+      { error: "Backend is unreachable.", code: "api_unavailable" },
+      { status: 503 },
+    );
+  }
+  if (err instanceof ApiHttpError) {
+    const detail =
+      err.detail && typeof err.detail === "object"
+        ? (err.detail as Record<string, unknown>)
+        : null;
+    const message =
+      detail && typeof detail.message === "string"
+        ? detail.message
+        : typeof err.detail === "string"
+          ? err.detail
+          : `HTTP ${err.status}`;
+    return NextResponse.json({ error: message, detail }, { status: err.status });
+  }
+  return NextResponse.json(
+    { error: err instanceof Error ? err.message : "Unknown error", code: "unknown" },
+    { status: 500 },
+  );
+}

--- a/console/src/lib/api/client.ts
+++ b/console/src/lib/api/client.ts
@@ -1341,6 +1341,25 @@ export function listConfluenceSections(
   );
 }
 
+export type ApiDocsRepoTreeNode = {
+  path: string;
+  name: string;
+  type: "tree" | "blob";
+  matches_extension: boolean;
+};
+
+export function listDocsRepoTree(
+  workspaceId: string,
+  params: { repoId: string },
+  options: { token?: string; signal?: AbortSignal } = {},
+): Promise<{ repo_id: string; ref: string; truncated: boolean; nodes: ApiDocsRepoTreeNode[] }> {
+  const search = new URLSearchParams({ repo_id: params.repoId });
+  return apiFetch<{ repo_id: string; ref: string; truncated: boolean; nodes: ApiDocsRepoTreeNode[] }>(
+    `/v1/workspaces/${encodeURIComponent(workspaceId)}/knowledge/sources/docs-repo/tree?${search.toString()}`,
+    { token: options.token, signal: options.signal },
+  );
+}
+
 export function archiveBucket(
   workspaceId: string,
   slug: string,


### PR DESCRIPTION
## Summary

Closes the last "type the answer into a textarea" picker in the import wizard. The docs-repo source previously asked operators to hand-type path prefixes (default ``docs\nREADME.md``) — easy to typo, impossible to discover folder names without alt-tabbing to the GitHub UI.

### What changed

- **Backend** ``GET /v1/.../knowledge/sources/docs-repo/tree`` proxies GitHub's recursive trees API for the activated repo. Server-side filtering: drops non-doc extensions (``.md``, ``.mdx``, ``.rst``, ``.txt``, ``.adoc``) and folders with no doc descendants, so the picker is always actionable.
- **Frontend** ``DocsRepoTreePicker`` renders the flat list as an expandable hierarchy. Auto-expands ``docs/``, ``documentation/``, ``guides/``, ``wiki/`` if present. Folder pick = recursive include (matches existing connector ``startswith`` semantics — **no backend behavior change**). Selecting a folder drops any redundant child picks; selecting a child under an already-picked parent is a no-op.
- **Truncated tree** (>100k entries / 7MB GitHub cap) surfaces as an amber hint so operators know to fall back to the JSON API for the rare giant monorepo.

## Phase context

Phase 3 of the picker plan. Previously shipped: #103 (Notion picker), #106 (Confluence sections), #105 (archive button). Remaining: Notion database-as-source (Phase 5), website preview / static drag-drop (Phase 4 polish).

## Test plan

- [x] ``pytest backend/tests/test_v1_docs_repo_tree.py`` — 3 tests: tree filtering + empty-folder pruning, 404 for unknown repo, 400 when repo has no GitHub installation.
- [x] All 26 knowledge-area tests green.
- [x] ``npx tsc --noEmit`` clean.
- [x] ``npx next build`` clean.
- [ ] Manual UI smoke on a workspace with an activated repo: tree expands, folder check selects recursively, file check works, truncation hint visible on giant repos (or skipped if no candidates).