### PR TITLE
knowledge: ingest a Notion database as a collection of entries

### DIFF
--- a/backend/app/services/connectors/notion.py
+++ b/backend/app/services/connectors/notion.py
@@ -59,6 +59,13 @@ NOTION_VERSION = "2025-09-03"
 # truncate with a trailing note rather than silently cutting off.
 _MAX_BLOCKS = 200
 
+# Cap pages pulled from one database/data_source resource_ref. Each
+# database entry costs a page fetch + a blocks fetch; without a cap
+# a 5k-row database wedges sync runs and starves other resource_refs
+# (the ingestion pipeline already caps total documents per source at
+# MAX_SOURCE_DOCUMENTS = 100, so this is the per-database ceiling).
+_MAX_PAGES_PER_DATABASE = 50
+
 
 def _headers(token: str) -> dict[str, str]:
     return {
@@ -261,67 +268,19 @@ def _normalize_page_id(raw: str) -> str:
     return cleaned
 
 
-@register("notion")
-async def fetch_notion_pages(
-    integration: Integration,
-    resource_ref: Mapping[str, Any],
-    http_client: httpx.AsyncClient | None,
-) -> list[ConnectorPage]:
-    """Fetcher entry point registered for ``Integration.kind='notion'``.
+async def _render_one_page(
+    client: httpx.AsyncClient, page_id: str, *, token: str
+) -> ConnectorPage:
+    """Fetch one Notion page + its top-level blocks → ConnectorPage.
 
-    v1 shape: ``{"page_id": "<uuid>"}`` only. Anything else raises
-    :class:`ConnectorUnsupported` which the dispatcher turns into a
-    stub-body fallback — the connector bucket keeps working, the
-    operator sees in the UI that sync succeeded, and we log a
-    warning with the unsupported shape so extensions are easy to
-    prioritize.
-
-    Shape validation runs BEFORE secret decryption so an integration
-    that's missing its secret but targets a resource_ref shape we
-    don't support (e.g. ``{database_id}``) still resolves via stub
-    fallback instead of 502'ing.
+    Lifted out of the dispatcher so database-mode can call it once per
+    entry without duplicating the markdown rendering / truncation rule.
     """
-
-    if not isinstance(resource_ref, Mapping):
-        raise ConnectorUnsupported("resource_ref must be an object")
-
-    raw_page_id = resource_ref.get("page_id")
-    if not isinstance(raw_page_id, str) or not raw_page_id.strip():
-        raise ConnectorUnsupported(
-            "notion v1 only supports resource_ref.page_id (a Notion page uuid)"
-        )
-
-    page_id = _normalize_page_id(raw_page_id)
-
-    token = safe_decrypt(integration.secret_ciphertext)
-    if not token:
-        raise ConnectorConfigError(
-            "notion integration has no readable access token — "
-            "reconnect the integration"
-        )
-
-    owns_client = http_client is None
-    client = http_client or httpx.AsyncClient(timeout=httpx.Timeout(10.0))
-    try:
-        page = await _fetch_page(client, page_id, token=token)
-        title = _extract_title(page)
-        url = page.get("url") or ""
-        last_edited = page.get("last_edited_time") or ""
-        blocks = await _fetch_blocks(client, page_id, token=token)
-    except httpx.HTTPStatusError as exc:
-        status = exc.response.status_code if exc.response is not None else 0
-        # A 404 means the bot doesn't have access to the page — raise
-        # ConnectorConfigError so the endpoint can surface a clean
-        # "re-share the page with the integration" message.
-        if status in (401, 403, 404):
-            raise ConnectorConfigError(
-                f"notion returned HTTP {status} for page {page_id} — is the "
-                "integration shared with the page?"
-            ) from exc
-        raise
-    finally:
-        if owns_client:
-            await client.aclose()
+    page = await _fetch_page(client, page_id, token=token)
+    title = _extract_title(page)
+    url = page.get("url") or ""
+    last_edited = page.get("last_edited_time") or ""
+    blocks = await _fetch_blocks(client, page_id, token=token)
 
     rendered_blocks = [_render_block(b) for b in blocks]
     rendered_blocks = [line for line in rendered_blocks if line]
@@ -341,18 +300,193 @@ async def fetch_notion_pages(
         header.append(" · ".join(meta_bits))
     body = "\n\n".join(header + rendered_blocks).strip() + "\n"
 
-    return [
-        ConnectorPage(
-            slug=page_id,
-            title=title,
-            body_md=body,
-            page_ref={
-                "page_id": page_id,
-                "url": url,
-                "last_edited_time": last_edited,
-            },
+    return ConnectorPage(
+        slug=page_id,
+        title=title,
+        body_md=body,
+        page_ref={
+            "page_id": page_id,
+            "url": url,
+            "last_edited_time": last_edited,
+        },
+    )
+
+
+async def _resolve_data_source_id(
+    client: httpx.AsyncClient, raw_id: str, *, token: str
+) -> str:
+    """Resolve a Notion ``database_id`` or ``data_source_id`` to a
+    queryable data_source id.
+
+    Notion API ``2025-09-03`` split the legacy "database" into a
+    container (``/databases/{id}``) plus 1+ data sources that own the
+    schema. Operator-facing URLs still expose database ids, so accept
+    both shapes:
+
+    1. Try ``GET /data_sources/{id}`` — succeeds if ``raw_id`` already
+       points at a data source.
+    2. On 404, fall back to ``GET /databases/{id}`` and pick the only
+       (or first) data source. We don't currently surface multi-source
+       picks in the wizard; if a closed-beta operator hits this we'll
+       extend the picker rather than guessing.
+    """
+    try:
+        await _get(client, f"/data_sources/{raw_id}", token=token)
+        return raw_id
+    except httpx.HTTPStatusError as exc:
+        if exc.response is None or exc.response.status_code != 404:
+            raise
+    db = await _get(client, f"/databases/{raw_id}", token=token)
+    sources = db.get("data_sources") or []
+    if not sources:
+        raise ConnectorConfigError(
+            f"notion database {raw_id} has no data sources — re-share it with the integration"
         )
-    ]
+    first = sources[0] if isinstance(sources[0], dict) else {}
+    data_source_id = str(first.get("id") or "")
+    if not data_source_id:
+        raise ConnectorConfigError(
+            f"notion database {raw_id} returned a malformed data source list"
+        )
+    return data_source_id
+
+
+async def _query_data_source_pages(
+    client: httpx.AsyncClient, data_source_id: str, *, token: str, limit: int
+) -> list[str]:
+    """List page ids in a data source, newest-edited first, up to ``limit``."""
+    page_ids: list[str] = []
+    cursor: str | None = None
+    while len(page_ids) < limit:
+        body: dict[str, Any] = {
+            "page_size": min(100, limit - len(page_ids)),
+            "sorts": [{"timestamp": "last_edited_time", "direction": "descending"}],
+        }
+        if cursor:
+            body["start_cursor"] = cursor
+        response = await client.post(
+            f"{NOTION_API_ROOT}/data_sources/{data_source_id}/query",
+            headers=_headers(token),
+            json=body,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        for entry in payload.get("results") or []:
+            if isinstance(entry, dict) and entry.get("object") == "page" and entry.get("id"):
+                page_ids.append(str(entry["id"]))
+                if len(page_ids) >= limit:
+                    break
+        if not payload.get("has_more") or not payload.get("next_cursor"):
+            break
+        cursor = payload.get("next_cursor")
+    return page_ids
+
+
+@register("notion")
+async def fetch_notion_pages(
+    integration: Integration,
+    resource_ref: Mapping[str, Any],
+    http_client: httpx.AsyncClient | None,
+) -> list[ConnectorPage]:
+    """Fetcher entry point registered for ``Integration.kind='notion'``.
+
+    Supported shapes:
+
+    - ``{"page_id": "<uuid>"}`` — fetch a single page.
+    - ``{"database_id": "<uuid>"}`` / ``{"data_source_id": "<uuid>"}`` —
+      treat the database (or its data source under v2025-09-03) as a
+      collection: query the entries newest-first, fetch each as a
+      ConnectorPage. Capped at ``_MAX_PAGES_PER_DATABASE`` per ref.
+
+    Shape validation runs BEFORE secret decryption so an integration
+    that's missing its secret but targets an unsupported shape still
+    resolves via stub fallback instead of 502'ing.
+    """
+
+    if not isinstance(resource_ref, Mapping):
+        raise ConnectorUnsupported("resource_ref must be an object")
+
+    raw_page_id = resource_ref.get("page_id")
+    raw_database_id = resource_ref.get("database_id") or resource_ref.get("data_source_id")
+    page_mode = isinstance(raw_page_id, str) and bool(raw_page_id.strip())
+    db_mode = isinstance(raw_database_id, str) and bool(raw_database_id.strip())
+
+    if not page_mode and not db_mode:
+        raise ConnectorUnsupported(
+            "notion resource_ref needs page_id or database_id"
+        )
+
+    token = safe_decrypt(integration.secret_ciphertext)
+    if not token:
+        raise ConnectorConfigError(
+            "notion integration has no readable access token — "
+            "reconnect the integration"
+        )
+
+    owns_client = http_client is None
+    client = http_client or httpx.AsyncClient(timeout=httpx.Timeout(10.0))
+    try:
+        if db_mode:
+            return await _fetch_database_pages(
+                client, _normalize_page_id(str(raw_database_id)), token=token
+            )
+        return [
+            await _fetch_single_page(
+                client, _normalize_page_id(str(raw_page_id)), token=token
+            )
+        ]
+    finally:
+        if owns_client:
+            await client.aclose()
+
+
+async def _fetch_single_page(
+    client: httpx.AsyncClient, page_id: str, *, token: str
+) -> ConnectorPage:
+    try:
+        return await _render_one_page(client, page_id, token=token)
+    except httpx.HTTPStatusError as exc:
+        status = exc.response.status_code if exc.response is not None else 0
+        if status in (401, 403, 404):
+            raise ConnectorConfigError(
+                f"notion returned HTTP {status} for page {page_id} — is the "
+                "integration shared with the page?"
+            ) from exc
+        raise
+
+
+async def _fetch_database_pages(
+    client: httpx.AsyncClient, database_id: str, *, token: str
+) -> list[ConnectorPage]:
+    try:
+        data_source_id = await _resolve_data_source_id(client, database_id, token=token)
+        page_ids = await _query_data_source_pages(
+            client, data_source_id, token=token, limit=_MAX_PAGES_PER_DATABASE
+        )
+    except httpx.HTTPStatusError as exc:
+        status = exc.response.status_code if exc.response is not None else 0
+        if status in (401, 403, 404):
+            raise ConnectorConfigError(
+                f"notion returned HTTP {status} for database {database_id} — is the "
+                "integration shared with it?"
+            ) from exc
+        raise
+
+    pages: list[ConnectorPage] = []
+    for page_id in page_ids:
+        try:
+            pages.append(await _render_one_page(client, page_id, token=token))
+        except httpx.HTTPStatusError as exc:
+            # One inaccessible page in a database shouldn't fail the whole
+            # ref — log and continue. The dispatcher's stub fallback isn't
+            # right here because we've already produced some valid pages.
+            logger.warning(
+                "notion database %s: skipping page %s (HTTP %s)",
+                database_id,
+                page_id,
+                exc.response.status_code if exc.response is not None else "?",
+            )
+    return pages
 
 
 __all__ = ["fetch_notion_pages"]

--- a/backend/tests/test_connectors_notion.py
+++ b/backend/tests/test_connectors_notion.py
@@ -231,15 +231,76 @@ async def test_notion_fetcher_renders_rich_page(integration) -> None:
 
 
 @pytest.mark.asyncio
-async def test_notion_rejects_database_id_shape(integration) -> None:
-    """``{database_id}`` is not wired yet and must raise Unsupported."""
+async def test_notion_database_id_fetches_entries(integration) -> None:
+    """``{database_id}`` resolves to a data source, queries it, and
+    returns one ConnectorPage per entry.
 
-    pages = await fetch_connector_pages(
-        integration, {"database_id": "xyz"}, http_client=None
-    )
-    # fetch_connector_pages catches ConnectorUnsupported internally
-    # and returns [] so the dispatcher falls back to the stub body.
-    assert pages == []
+    Exercises the v2025-09-03 split: ``/data_sources/{id}`` returns 404
+    when the id actually points at a database container, then
+    ``/databases/{id}`` returns ``data_sources[]`` and we follow the
+    first one.
+    """
+    calls: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(f"{request.method} {request.url.path}")
+        if request.url.path == "/v1/data_sources/db-xyz":
+            return httpx.Response(404, json={"object": "error", "code": "object_not_found"})
+        if request.url.path == "/v1/databases/db-xyz":
+            return httpx.Response(
+                200,
+                json={
+                    "object": "database",
+                    "id": "db-xyz",
+                    "data_sources": [{"id": "ds-1", "name": "Default"}],
+                },
+            )
+        if request.url.path == "/v1/data_sources/ds-1/query" and request.method == "POST":
+            return httpx.Response(
+                200,
+                json={
+                    "results": [
+                        {"object": "page", "id": "page-A"},
+                        {"object": "page", "id": "page-B"},
+                    ],
+                    "has_more": False,
+                    "next_cursor": None,
+                },
+            )
+        if request.url.path == "/v1/pages/page-A":
+            return httpx.Response(200, json=_page_payload("page-A", title="Entry A"))
+        if request.url.path == "/v1/pages/page-B":
+            return httpx.Response(200, json=_page_payload("page-B", title="Entry B"))
+        if request.url.path.startswith("/v1/blocks/"):
+            return httpx.Response(200, json={"results": [], "has_more": False, "next_cursor": None})
+        return httpx.Response(404)
+
+    async with _make_client(handler) as client:
+        pages = await fetch_connector_pages(
+            integration, {"database_id": "db-xyz"}, http_client=client
+        )
+
+    assert [p.title for p in pages] == ["Entry A", "Entry B"]
+    assert all(p.page_ref["page_id"] for p in pages)
+    # The /data_sources/{id}/query endpoint is the queryable surface
+    # under v2025-09-03; the test verifies we hit it after resolving
+    # the container.
+    assert "POST /v1/data_sources/ds-1/query" in calls
+
+
+@pytest.mark.asyncio
+async def test_notion_database_id_404_surfaces_config_error(integration) -> None:
+    """Database the bot can't see → ConnectorConfigError so the wizard
+    surfaces a re-share hint instead of silently 502'ing."""
+    def handler(request: httpx.Request) -> httpx.Response:
+        # Both data_sources and databases lookups return 404
+        return httpx.Response(404, json={"object": "error", "code": "object_not_found"})
+
+    async with _make_client(handler) as client:
+        with pytest.raises(ConnectorConfigError, match="shared"):
+            await fetch_connector_pages(
+                integration, {"database_id": "unknown"}, http_client=client
+            )
 
 
 @pytest.mark.asyncio
@@ -256,15 +317,16 @@ async def test_notion_shape_check_runs_before_secret_decrypt(
 ) -> None:
     """No secret + unsupported shape must still resolve to stub fallback.
 
-    This is the invariant that protects Phase 7b buckets with
-    resource_ref shapes we haven't wired yet — the endpoint would
-    502 on secret-missing even though it should only fall back to
-    stub.
+    This invariant protects buckets with resource_ref shapes we haven't
+    wired yet — the endpoint would 502 on secret-missing even though it
+    should only fall back to stub. Both ``{page_id}`` and
+    ``{database_id}`` are now supported, so test with a genuinely
+    unknown shape.
     """
 
     pages = await fetch_connector_pages(
         integration_no_secret,
-        {"database_id": "anything"},
+        {"future_shape_id": "anything"},
         http_client=None,
     )
     assert pages == []

--- a/console/src/app/(authed)/knowledge/import-wizard.tsx
+++ b/console/src/app/(authed)/knowledge/import-wizard.tsx
@@ -87,7 +87,7 @@ export function KnowledgeImportWizard({
     if (kind === "notion") {
       if (!selectedIntegrationId) return { ok: false, message: "Connect Notion first in integrations." };
       if (notionRefs.length === 0) {
-        return { ok: false, message: "Pick at least one Notion page from the list." };
+        return { ok: false, message: "Pick at least one Notion page or database from the list." };
       }
       return { ok: true, config: { resource_refs: notionRefs } };
     }

--- a/console/src/app/(authed)/knowledge/notion-resource-picker.tsx
+++ b/console/src/app/(authed)/knowledge/notion-resource-picker.tsx
@@ -80,7 +80,15 @@ export function NotionResourcePicker({
       else setState({ kind: "loading" });
 
       try {
-        const params = new URLSearchParams({ workspaceId, integrationId });
+        const params = new URLSearchParams({
+          workspaceId,
+          integrationId,
+          // The connector now supports both pages and databases — pages
+          // ingest as a single doc, databases ingest each entry as one
+          // doc (capped per source). Default to "any" so operators see
+          // both shapes in the picker.
+          type: "any",
+        });
         if (args.q) params.set("q", args.q);
         if (args.cursor) params.set("cursor", args.cursor);
         const resp = await fetch(`/api/knowledge/notion-resources?${params.toString()}`, {
@@ -152,9 +160,9 @@ export function NotionResourcePicker({
         type="text"
         value={query}
         onChange={(event) => setQuery(event.target.value)}
-        placeholder="Search Notion pages your integration can see…"
+        placeholder="Search Notion pages and databases your integration can see…"
         className="w-full rounded border border-white/15 bg-black/30 px-3 py-2 text-sm text-white/90 placeholder:text-white/35"
-        aria-label="Search Notion pages"
+        aria-label="Search Notion pages and databases"
       />
 
       {value.length > 0 && (
@@ -194,7 +202,7 @@ export function NotionResourcePicker({
         )}
         {state.kind === "ready" && state.items.length === 0 && (
           <p className="px-3 py-3 text-xs text-white/55">
-            No Notion pages match. Make sure your integration is shared with the page in Notion (Share → Connections).
+            Nothing matches. Make sure your integration is shared with the page or database in Notion (Share → Connections).
           </p>
         )}
         {state.kind === "ready" && state.items.length > 0 && (
@@ -244,7 +252,7 @@ export function NotionResourcePicker({
       </div>
 
       <p className="text-[11px] text-white/45">
-        Pick at least one page. Don&apos;t see what you need? In Notion, open the page → <em>•••</em> → Connections, and add the integration named in your Notion settings.
+        Pick a page (one doc) or a database (each entry becomes one doc, capped at 50). Don&apos;t see what you need? In Notion, open the page → <em>•••</em> → Connections and add the integration.
       </p>
     </div>
   );


### PR DESCRIPTION
## Summary

Mirrors the "ingest by collection" pivot already shipped for Confluence (#106 = section subtree) and docs-repo (#107 = folder subtree). When an operator picks a Notion **database** in the wizard, the connector now resolves it (handling the v2025-09-03 database/data_source split), queries the data source newest-edited first, and emits one ``ConnectorPage`` per entry — capped at 50 entries per ``resource_ref`` so a 5k-row CRM table doesn't wedge a sync.

### What changed

- **Notion connector** dispatches on resource_ref shape:
  - ``{page_id}`` — fetch one page (existing, refactored into a shared ``_render_one_page`` helper).
  - ``{database_id}`` / ``{data_source_id}`` — resolve via ``/data_sources/{id}`` first; on 404 fall back to ``/databases/{id}.data_sources[0]``. Query the resolved data source for entries (newest first), fetch each as its own ``ConnectorPage``. One inaccessible entry mid-list logs and skips rather than failing the whole ref.
- **Notion picker UI** defaults to ``?type=any`` so databases appear beside pages in the search list. Selecting a database row produces a ``{database_id}`` ref. Search placeholder, empty-state, and hint text updated accordingly.

### Why a 50-entry cap per database

- ``MAX_SOURCE_DOCUMENTS`` (100) caps the *total* docs per source — without a per-database cap, one giant database could starve every other ``resource_ref`` in the same source.
- Same reasoning as the 200-page cap on Confluence sections (#106).
- Operators who want all 5k rows can split into multiple sources or wait until we add a "stream the rest" mode.

## Phase context

Phase 5 of the picker plan. Previously shipped: #103 (Notion picker), #105 (archive), #106 (Confluence sections), #107 (docs-repo tree). Remaining: website map preview / static-upload drop zone (Phase 4 polish, low priority).

## Test plan

- [x] ``pytest backend/tests/test_connectors_notion.py`` — 8 tests including 2 new: full database fetch flow (``/data_sources/{id}`` 404 → ``/databases/{id}`` → ``/data_sources/{id}/query`` → page fetches) and database-not-shared → ``ConnectorConfigError``.
- [x] All 27 knowledge tests still green.
- [x] ``npx tsc --noEmit`` clean.
- [x] ``npx next build`` clean.
- [ ] Manual UI smoke on a workspace with Notion + a database shared with the integration: pick a database, run sync, confirm one knowledge_note per entry up to 50.