### PR TITLE
knowledge: website preview + static upload drop zone

### DIFF
--- a/backend/app/api/v1/routes/knowledge_import_sources.py
+++ b/backend/app/api/v1/routes/knowledge_import_sources.py
@@ -1221,3 +1221,72 @@ async def _docs_repo_fetch_tree(
         "trees": trees,
         "truncated": bool(payload.get("truncated")),
     }
+
+
+# ---------------------------------------------------------------------------
+# Website preview (Firecrawl /map proxy)
+# ---------------------------------------------------------------------------
+#
+# Operators creating a website source guess at what URLs Firecrawl will
+# discover. Surfacing the /map result before they hit "Create" turns the
+# guess into a confirmation and lets them tune limit/scope without a
+# create-sync-archive cycle.
+
+
+class WebsitePreviewOut(BaseModel):
+    urls: list[str]
+    truncated: bool  # we hit the requested limit; there may be more
+
+
+@router.get("/website/preview", response_model=WebsitePreviewOut)
+async def preview_website_crawl(
+    workspace_id: uuid.UUID,
+    url: str = Query(..., description="Root URL to map"),
+    limit: int = Query(default=25, ge=1, le=200),
+    include_subdomains: bool = Query(default=False),
+    auth: AuthContext = Depends(get_current_auth),
+    settings: Settings = Depends(get_settings),
+    session: AsyncSession = Depends(get_session),
+) -> WebsitePreviewOut:
+    """Run Firecrawl ``/map`` against ``url`` and return discovered links.
+
+    No persistence — purely a "what would happen" probe. Same FIRECRAWL_API_KEY
+    used by the sync path. Operator must be a workspace admin (consistent
+    with create_source) so we don't expose Firecrawl as a public probe.
+    """
+    await _require_membership(session, workspace_id, auth.user.id, ROLES_ADMIN)
+    if not settings.firecrawl_api_key:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Firecrawl is not configured on this deployment",
+        )
+
+    from backend.app.services.knowledge_ingestion import _firecrawl_map
+
+    cleaned = url.strip()
+    if not cleaned:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="url is required",
+        )
+
+    try:
+        urls = await _firecrawl_map(
+            cleaned,
+            config={"limit": limit, "include_subdomains": include_subdomains},
+            settings=settings,
+        )
+    except httpx.HTTPError as exc:
+        logger.warning(
+            "firecrawl /map preview failed for ws=%s url=%s: %s",
+            workspace_id,
+            cleaned,
+            exc,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Firecrawl could not map this URL — check that it's reachable",
+        ) from exc
+
+    truncated = len(urls) >= limit
+    return WebsitePreviewOut(urls=urls, truncated=truncated)

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -425,6 +425,12 @@ class Settings(BaseSettings):
         default=10.0, alias="EMAIL_SEND_TIMEOUT_SECONDS", gt=0.0
     )
 
+    # --- Firecrawl (website knowledge source) ---
+    firecrawl_api_key: str | None = Field(default=None, alias="FIRECRAWL_API_KEY")
+    firecrawl_api_url: str = Field(
+        default="https://api.firecrawl.dev/v1", alias="FIRECRAWL_API_URL"
+    )
+
     @model_validator(mode="after")
     def _validate_email_provider(self) -> "Settings":
         """Refuse to start in ``email_provider=sendgrid`` without credentials.

--- a/backend/tests/test_v1_website_preview.py
+++ b/backend/tests/test_v1_website_preview.py
@@ -1,0 +1,103 @@
+"""Wizard preview — `/v1/.../knowledge/sources/website/preview`."""
+
+from __future__ import annotations
+
+import pytest
+
+
+def _auth(raw: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {raw}"}
+
+
+@pytest.mark.asyncio
+async def test_website_preview_returns_firecrawl_urls(
+    v1_client, seed_workspace, monkeypatch
+) -> None:
+    """The preview proxies Firecrawl /map and returns the discovered URLs."""
+    _, raw, workspace = seed_workspace
+    monkeypatch.setenv("FIRECRAWL_API_KEY", "fc_test_key")
+    from backend.app.core.config import get_settings
+
+    get_settings.cache_clear()
+    try:
+        captured = {}
+
+        async def _fake_map(root_url, *, config, settings):
+            captured["root_url"] = root_url
+            captured["limit"] = config["limit"]
+            return [
+                "https://docs.example.com/intro",
+                "https://docs.example.com/setup",
+                "https://docs.example.com/cli",
+            ]
+
+        monkeypatch.setattr(
+            "backend.app.services.knowledge_ingestion._firecrawl_map", _fake_map
+        )
+
+        response = await v1_client.get(
+            f"/v1/workspaces/{workspace.id}/knowledge/sources/website/preview",
+            headers=_auth(raw),
+            params={"url": "https://docs.example.com", "limit": 25},
+        )
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["urls"] == [
+            "https://docs.example.com/intro",
+            "https://docs.example.com/setup",
+            "https://docs.example.com/cli",
+        ]
+        assert body["truncated"] is False
+        assert captured["root_url"] == "https://docs.example.com"
+        assert captured["limit"] == 25
+    finally:
+        get_settings.cache_clear()
+
+
+@pytest.mark.asyncio
+async def test_website_preview_503_when_firecrawl_unconfigured(
+    v1_client, seed_workspace, monkeypatch
+) -> None:
+    _, raw, workspace = seed_workspace
+    monkeypatch.delenv("FIRECRAWL_API_KEY", raising=False)
+    from backend.app.core.config import get_settings
+
+    get_settings.cache_clear()
+    try:
+        response = await v1_client.get(
+            f"/v1/workspaces/{workspace.id}/knowledge/sources/website/preview",
+            headers=_auth(raw),
+            params={"url": "https://docs.example.com"},
+        )
+        assert response.status_code == 503
+    finally:
+        get_settings.cache_clear()
+
+
+@pytest.mark.asyncio
+async def test_website_preview_truncated_when_limit_hit(
+    v1_client, seed_workspace, monkeypatch
+) -> None:
+    _, raw, workspace = seed_workspace
+    monkeypatch.setenv("FIRECRAWL_API_KEY", "fc_test_key")
+    from backend.app.core.config import get_settings
+
+    get_settings.cache_clear()
+    try:
+        async def _fake_map(root_url, *, config, settings):
+            # Return exactly the limit so caller knows there may be more.
+            return [f"https://docs.example.com/page-{i}" for i in range(config["limit"])]
+
+        monkeypatch.setattr(
+            "backend.app.services.knowledge_ingestion._firecrawl_map", _fake_map
+        )
+
+        response = await v1_client.get(
+            f"/v1/workspaces/{workspace.id}/knowledge/sources/website/preview",
+            headers=_auth(raw),
+            params={"url": "https://docs.example.com", "limit": 5},
+        )
+        assert response.status_code == 200
+        assert response.json()["truncated"] is True
+    finally:
+        get_settings.cache_clear()

--- a/console/src/app/(authed)/knowledge/import-wizard.tsx
+++ b/console/src/app/(authed)/knowledge/import-wizard.tsx
@@ -14,6 +14,12 @@ import {
 } from "./confluence-section-picker";
 import { DocsRepoTreePicker } from "./docs-repo-tree-picker";
 import { NotionResourcePicker, type NotionPageRef } from "./notion-resource-picker";
+import { StaticUploadDropzone, type UploadedDoc } from "./static-upload-dropzone";
+import {
+  WebsiteSourceForm,
+  DEFAULT_WEBSITE_CONFIG,
+  type WebsiteConfig,
+} from "./website-source-form";
 
 type SourceKind = "website" | "notion" | "confluence" | "docs_repo" | "static_upload";
 
@@ -38,13 +44,12 @@ export function KnowledgeImportWizard({
 }) {
   const [kind, setKind] = useState<SourceKind>("website");
   const [name, setName] = useState("Website knowledge");
-  const [url, setUrl] = useState("");
+  const [websiteConfig, setWebsiteConfig] = useState<WebsiteConfig>(DEFAULT_WEBSITE_CONFIG);
   const [notionRefs, setNotionRefs] = useState<NotionPageRef[]>([]);
   const [confluenceRefs, setConfluenceRefs] = useState<ConfluenceSectionRef[]>([]);
   const [repoId, setRepoId] = useState(repos[0]?.id ?? "");
   const [repoPaths, setRepoPaths] = useState<string[]>([]);
-  const [uploadTitle, setUploadTitle] = useState("");
-  const [uploadBody, setUploadBody] = useState("");
+  const [uploadDocs, setUploadDocs] = useState<UploadedDoc[]>([]);
   const [syncNow, setSyncNow] = useState(true);
   const [result, setResult] = useState<ImportSourceResult | null>(null);
   const [pending, startTransition] = useTransition();
@@ -81,8 +86,17 @@ export function KnowledgeImportWizard({
     | { ok: true; config: Record<string, unknown> }
     | { ok: false; message: string } {
     if (kind === "website") {
-      if (!url.trim()) return { ok: false, message: "Website URL is required." };
-      return { ok: true, config: { url: url.trim(), limit: 25, change_tracking: true, only_main_content: true } };
+      if (!websiteConfig.url.trim()) return { ok: false, message: "Website URL is required." };
+      return {
+        ok: true,
+        config: {
+          url: websiteConfig.url.trim(),
+          limit: websiteConfig.limit,
+          include_subdomains: websiteConfig.include_subdomains,
+          change_tracking: websiteConfig.change_tracking,
+          only_main_content: websiteConfig.only_main_content,
+        },
+      };
     }
     if (kind === "notion") {
       if (!selectedIntegrationId) return { ok: false, message: "Connect Notion first in integrations." };
@@ -112,11 +126,17 @@ export function KnowledgeImportWizard({
         },
       };
     }
-    if (!uploadBody.trim()) return { ok: false, message: "Paste Markdown content for uploaded files." };
+    if (uploadDocs.length === 0) {
+      return { ok: false, message: "Drop at least one file (.md, .mdx, .txt, .rst, .adoc) to upload." };
+    }
     return {
       ok: true,
       config: {
-        documents: [{ title: uploadTitle.trim() || name, filename: `${slugify(uploadTitle || name)}.md`, body_md: uploadBody }],
+        documents: uploadDocs.map((doc) => ({
+          title: doc.title.trim() || stripExtension(doc.filename) || name,
+          filename: doc.filename,
+          body_md: doc.body_md,
+        })),
       },
     };
   }
@@ -158,8 +178,12 @@ export function KnowledgeImportWizard({
             <input value={name} onChange={(event) => setName(event.target.value)} className="w-full rounded border border-white/15 bg-black/30 px-3 py-2 text-sm text-white/90" />
           </Field>
           {kind === "website" && (
-            <Field label="Website URL" hint="Firecrawl will map URLs, scrape Markdown, and Ship will skip unchanged hashes.">
-              <input value={url} onChange={(event) => setUrl(event.target.value)} placeholder="https://docs.example.com" className="w-full rounded border border-white/15 bg-black/30 px-3 py-2 text-sm text-white/90" />
+            <Field label="Website URL">
+              <WebsiteSourceForm
+                workspaceId={workspaceId}
+                config={websiteConfig}
+                onChange={setWebsiteConfig}
+              />
             </Field>
           )}
           {kind === "notion" && (
@@ -236,10 +260,9 @@ export function KnowledgeImportWizard({
             </>
           )}
           {kind === "static_upload" && (
-            <>
-              <Field label="Document title"><input value={uploadTitle} onChange={(event) => setUploadTitle(event.target.value)} className="w-full rounded border border-white/15 bg-black/30 px-3 py-2 text-sm text-white/90" /></Field>
-              <Field label="Markdown content" hint="This source is one-shot and has no scheduled sync."><textarea value={uploadBody} onChange={(event) => setUploadBody(event.target.value)} rows={7} className="w-full rounded border border-white/15 bg-black/30 px-3 py-2 font-mono text-[12px] text-aqua/85" /></Field>
-            </>
+            <Field label="Files to upload" hint="One-shot import — no scheduled sync. Each file becomes one knowledge note.">
+              <StaticUploadDropzone value={uploadDocs} onChange={setUploadDocs} />
+            </Field>
           )}
           <label className="flex items-center gap-2 text-xs text-white/70">
             <input type="checkbox" checked={syncNow} onChange={(event) => setSyncNow(event.target.checked)} className="accent-aqua" />
@@ -294,6 +317,8 @@ function defaultName(kind: SourceKind): string {
   return `${kind[0]?.toUpperCase() ?? ""}${kind.slice(1)} knowledge`;
 }
 
-function slugify(value: string): string {
-  return value.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 80) || "upload";
+function stripExtension(filename: string): string {
+  const dot = filename.lastIndexOf(".");
+  if (dot <= 0) return filename;
+  return filename.slice(0, dot);
 }

--- a/console/src/app/(authed)/knowledge/static-upload-dropzone.tsx
+++ b/console/src/app/(authed)/knowledge/static-upload-dropzone.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+/**
+ * StaticUploadDropzone — drag/drop or click-to-pick text files. Each
+ * file becomes one entry in ``config.documents``: ``{title, filename,
+ * body_md}``. Title defaults to the filename without extension, but is
+ * editable per file. Removing a file is one click.
+ *
+ * Files are read in the browser (FileReader). Static-upload sources are
+ * one-shot, so this is the only operator-facing path that needs a real
+ * upload — there's no server-side file store; the content lives inside
+ * the source's ``config`` row.
+ */
+
+import { useRef, useState } from "react";
+
+export type UploadedDoc = {
+  title: string;
+  filename: string;
+  body_md: string;
+};
+
+const ACCEPTED_EXTENSIONS = [".md", ".mdx", ".txt", ".rst", ".adoc"];
+// Keep documents reasonable so we don't bloat the source row's JSON
+// past Postgres' practical 1MB jsonb sweet spot. ~200kB per doc allows
+// a handful of substantial handbooks before the operator should switch
+// to a docs-repo or website source.
+const MAX_BYTES_PER_DOC = 200 * 1024;
+const MAX_DOCS = 25;
+
+export function StaticUploadDropzone({
+  value,
+  onChange,
+}: {
+  value: UploadedDoc[];
+  onChange: (next: UploadedDoc[]) => void;
+}) {
+  const [dragOver, setDragOver] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  async function ingestFiles(files: FileList | null) {
+    if (!files || files.length === 0) return;
+    setError(null);
+    const additions: UploadedDoc[] = [];
+    for (const file of Array.from(files)) {
+      const lower = file.name.toLowerCase();
+      if (!ACCEPTED_EXTENSIONS.some((ext) => lower.endsWith(ext))) {
+        setError(`${file.name} — only ${ACCEPTED_EXTENSIONS.join(", ")} are accepted`);
+        continue;
+      }
+      if (file.size > MAX_BYTES_PER_DOC) {
+        setError(`${file.name} — too large (max ${Math.round(MAX_BYTES_PER_DOC / 1024)}KB)`);
+        continue;
+      }
+      const body = await file.text();
+      additions.push({
+        title: stripExtension(file.name),
+        filename: file.name,
+        body_md: body,
+      });
+    }
+    if (additions.length === 0) return;
+    const merged = dedupeByFilename([...value, ...additions]).slice(0, MAX_DOCS);
+    onChange(merged);
+  }
+
+  function updateTitle(idx: number, title: string) {
+    const next = value.map((doc, i) => (i === idx ? { ...doc, title } : doc));
+    onChange(next);
+  }
+
+  function removeAt(idx: number) {
+    onChange(value.filter((_, i) => i !== idx));
+  }
+
+  return (
+    <div className="space-y-3" data-testid="static-upload-dropzone">
+      <div
+        onDragOver={(event) => {
+          event.preventDefault();
+          setDragOver(true);
+        }}
+        onDragLeave={() => setDragOver(false)}
+        onDrop={(event) => {
+          event.preventDefault();
+          setDragOver(false);
+          void ingestFiles(event.dataTransfer.files);
+        }}
+        onClick={() => inputRef.current?.click()}
+        role="button"
+        tabIndex={0}
+        onKeyDown={(event) => {
+          if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault();
+            inputRef.current?.click();
+          }
+        }}
+        className={`cursor-pointer rounded border-2 border-dashed px-4 py-6 text-center transition ${
+          dragOver
+            ? "border-aqua/60 bg-aqua/[0.06]"
+            : "border-white/15 bg-black/30 hover:border-white/30"
+        }`}
+      >
+        <p className="text-sm text-white/85">
+          Drop files here or <span className="text-aqua">click to browse</span>
+        </p>
+        <p className="mt-1 text-[11px] text-white/45">
+          {ACCEPTED_EXTENSIONS.join(", ")} · up to {Math.round(MAX_BYTES_PER_DOC / 1024)}KB each · {MAX_DOCS} max
+        </p>
+        <input
+          ref={inputRef}
+          type="file"
+          multiple
+          accept={ACCEPTED_EXTENSIONS.join(",")}
+          className="hidden"
+          onChange={(event) => void ingestFiles(event.target.files)}
+        />
+      </div>
+
+      {error && <p className="text-xs text-coral">{error}</p>}
+
+      {value.length > 0 && (
+        <ul className="divide-y divide-white/5 rounded border border-white/10 bg-black/30">
+          {value.map((doc, idx) => (
+            <li key={`${doc.filename}-${idx}`} className="grid grid-cols-[1fr_auto] items-center gap-3 px-3 py-2 text-xs">
+              <div className="min-w-0">
+                <input
+                  value={doc.title}
+                  onChange={(event) => updateTitle(idx, event.target.value)}
+                  className="w-full rounded border border-transparent bg-transparent px-1 py-0.5 text-sm text-white/90 hover:border-white/15 focus:border-aqua/40 focus:outline-none"
+                  aria-label={`Title for ${doc.filename}`}
+                />
+                <div className="mt-0.5 truncate text-[11px] text-white/45">
+                  {doc.filename} · {Math.round(doc.body_md.length / 1024) || 1}KB
+                </div>
+              </div>
+              <button
+                type="button"
+                onClick={() => removeAt(idx)}
+                className="rounded-full border border-white/10 px-2 py-0.5 text-[11px] text-white/55 hover:border-coral/40 hover:text-coral"
+                aria-label={`Remove ${doc.filename}`}
+              >
+                Remove
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+
+function stripExtension(filename: string): string {
+  const dot = filename.lastIndexOf(".");
+  if (dot <= 0) return filename;
+  return filename.slice(0, dot);
+}
+
+
+function dedupeByFilename(docs: UploadedDoc[]): UploadedDoc[] {
+  // Re-uploading a file replaces the previous one — preserves manual
+  // title edits if they kept the same filename, but the body refreshes.
+  const seen = new Map<string, UploadedDoc>();
+  for (const doc of docs) seen.set(doc.filename, doc);
+  return Array.from(seen.values());
+}

--- a/console/src/app/(authed)/knowledge/website-source-form.tsx
+++ b/console/src/app/(authed)/knowledge/website-source-form.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+/**
+ * WebsiteSourceForm — URL field + "Preview crawl" probe + advanced
+ * scrape options (limit, subdomains, change-tracking, only-main-content).
+ *
+ * Without the preview, operators created a website source and discovered
+ * the crawl scope only after the first sync. This component runs
+ * Firecrawl /map ahead of submit so the operator confirms the URL set
+ * and tunes the limit before paying for the scrape budget.
+ */
+
+import { useState } from "react";
+
+export type WebsiteConfig = {
+  url: string;
+  limit: number;
+  include_subdomains: boolean;
+  change_tracking: boolean;
+  only_main_content: boolean;
+};
+
+export const DEFAULT_WEBSITE_CONFIG: WebsiteConfig = {
+  url: "",
+  limit: 25,
+  include_subdomains: false,
+  change_tracking: true,
+  only_main_content: true,
+};
+
+type PreviewState =
+  | { kind: "idle" }
+  | { kind: "loading" }
+  | { kind: "ready"; urls: string[]; truncated: boolean }
+  | { kind: "error"; message: string };
+
+export function WebsiteSourceForm({
+  workspaceId,
+  config,
+  onChange,
+}: {
+  workspaceId: string | undefined;
+  config: WebsiteConfig;
+  onChange: (next: WebsiteConfig) => void;
+}) {
+  const [preview, setPreview] = useState<PreviewState>({ kind: "idle" });
+  const [showAdvanced, setShowAdvanced] = useState(false);
+
+  function update<K extends keyof WebsiteConfig>(key: K, value: WebsiteConfig[K]) {
+    onChange({ ...config, [key]: value });
+  }
+
+  async function runPreview() {
+    if (!workspaceId || !config.url.trim()) return;
+    setPreview({ kind: "loading" });
+    try {
+      const params = new URLSearchParams({
+        workspaceId,
+        url: config.url.trim(),
+        limit: String(config.limit),
+      });
+      if (config.include_subdomains) params.set("includeSubdomains", "true");
+      const resp = await fetch(`/api/knowledge/website-preview?${params.toString()}`, {
+        method: "GET",
+      });
+      if (!resp.ok) {
+        const payload = await resp.json().catch(() => ({}));
+        const message =
+          typeof payload?.error === "string" ? payload.error : `HTTP ${resp.status}`;
+        setPreview({ kind: "error", message });
+        return;
+      }
+      const data = (await resp.json()) as { urls: string[]; truncated: boolean };
+      setPreview({ kind: "ready", urls: data.urls, truncated: data.truncated });
+    } catch (err) {
+      setPreview({
+        kind: "error",
+        message: err instanceof Error ? err.message : "Preview failed",
+      });
+    }
+  }
+
+  return (
+    <div className="space-y-3" data-testid="website-source-form">
+      <div className="flex gap-2">
+        <input
+          value={config.url}
+          onChange={(event) => update("url", event.target.value)}
+          placeholder="https://docs.example.com"
+          className="flex-1 rounded border border-white/15 bg-black/30 px-3 py-2 text-sm text-white/90"
+          aria-label="Website URL"
+        />
+        <button
+          type="button"
+          onClick={runPreview}
+          disabled={!config.url.trim() || !workspaceId || preview.kind === "loading"}
+          className="rounded-full border border-aqua/40 bg-aqua/10 px-3 py-1.5 text-xs font-semibold text-aqua hover:bg-aqua/20 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {preview.kind === "loading" ? "Mapping…" : "Preview crawl"}
+        </button>
+      </div>
+
+      <details
+        open={showAdvanced}
+        onToggle={(event) => setShowAdvanced((event.target as HTMLDetailsElement).open)}
+        className="rounded border border-white/10 bg-white/[0.02] px-3 py-2"
+      >
+        <summary className="cursor-pointer text-[11px] uppercase tracking-wider text-white/55">
+          Advanced options
+        </summary>
+        <div className="mt-3 space-y-2 text-xs text-white/80">
+          <label className="flex items-center justify-between gap-3">
+            <span>Page limit (max URLs scraped)</span>
+            <input
+              type="number"
+              min={1}
+              max={200}
+              value={config.limit}
+              onChange={(event) => update("limit", Number(event.target.value) || 25)}
+              className="w-20 rounded border border-white/15 bg-black/30 px-2 py-1 text-right text-white/90"
+            />
+          </label>
+          <label className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={config.include_subdomains}
+              onChange={(event) => update("include_subdomains", event.target.checked)}
+              className="accent-aqua"
+            />
+            Include subdomains
+          </label>
+          <label className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={config.only_main_content}
+              onChange={(event) => update("only_main_content", event.target.checked)}
+              className="accent-aqua"
+            />
+            Strip nav / footer (only-main-content mode)
+          </label>
+          <label className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={config.change_tracking}
+              onChange={(event) => update("change_tracking", event.target.checked)}
+              className="accent-aqua"
+            />
+            Track diffs across syncs (skips unchanged pages)
+          </label>
+        </div>
+      </details>
+
+      {preview.kind === "loading" && (
+        <p className="text-xs text-white/55">Mapping the site via Firecrawl…</p>
+      )}
+      {preview.kind === "error" && (
+        <p className="text-xs text-coral">{preview.message}</p>
+      )}
+      {preview.kind === "ready" && (
+        <div className="rounded border border-white/10 bg-black/30">
+          <div className="border-b border-white/5 px-3 py-2 text-[11px] uppercase tracking-wider text-white/55">
+            {preview.urls.length} URL{preview.urls.length === 1 ? "" : "s"}
+            {preview.truncated && " (more available — bump the limit)"}
+          </div>
+          {preview.urls.length === 0 ? (
+            <p className="px-3 py-3 text-xs text-white/55">
+              Firecrawl found nothing reachable from this URL. Check the URL or whether it&apos;s behind auth.
+            </p>
+          ) : (
+            <ul className="max-h-48 divide-y divide-white/5 overflow-y-auto text-xs">
+              {preview.urls.map((url) => (
+                <li key={url} className="truncate px-3 py-1.5 text-white/75">
+                  {url}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+
+      <p className="text-[11px] text-white/45">
+        Firecrawl maps URLs from the root, scrapes Markdown, and skips unchanged pages by hash on subsequent syncs.
+      </p>
+    </div>
+  );
+}

--- a/console/src/app/api/knowledge/website-preview/route.ts
+++ b/console/src/app/api/knowledge/website-preview/route.ts
@@ -1,0 +1,73 @@
+/**
+ * Server-side proxy for the website map preview
+ * (``GET /v1/workspaces/{ws}/knowledge/sources/website/preview``).
+ */
+
+import { NextResponse } from "next/server";
+
+import {
+  ApiHttpError,
+  ApiUnavailableError,
+  isApiConfigured,
+  previewWebsiteCrawl,
+} from "@/lib/api/client";
+import { getSessionToken } from "@/lib/api/session";
+
+export async function GET(request: Request) {
+  if (!isApiConfigured()) {
+    return NextResponse.json(
+      { error: "Backend is not configured.", code: "api_unavailable" },
+      { status: 503 },
+    );
+  }
+
+  const url = new URL(request.url);
+  const workspaceId = url.searchParams.get("workspaceId");
+  const target = url.searchParams.get("url");
+  if (!workspaceId || !target) {
+    return NextResponse.json(
+      { error: "workspaceId and url are required.", code: "bad_request" },
+      { status: 400 },
+    );
+  }
+  const limit = Number(url.searchParams.get("limit") ?? "25") || 25;
+  const includeSubdomains = url.searchParams.get("includeSubdomains") === "true";
+
+  try {
+    const token = (await getSessionToken()) ?? undefined;
+    const data = await previewWebsiteCrawl(
+      workspaceId,
+      { url: target, limit, includeSubdomains },
+      { token },
+    );
+    return NextResponse.json(data, { status: 200 });
+  } catch (err) {
+    return errorResponse(err);
+  }
+}
+
+function errorResponse(err: unknown): NextResponse {
+  if (err instanceof ApiUnavailableError) {
+    return NextResponse.json(
+      { error: "Backend is unreachable.", code: "api_unavailable" },
+      { status: 503 },
+    );
+  }
+  if (err instanceof ApiHttpError) {
+    const detail =
+      err.detail && typeof err.detail === "object"
+        ? (err.detail as Record<string, unknown>)
+        : null;
+    const message =
+      detail && typeof detail.message === "string"
+        ? detail.message
+        : typeof err.detail === "string"
+          ? err.detail
+          : `HTTP ${err.status}`;
+    return NextResponse.json({ error: message, detail }, { status: err.status });
+  }
+  return NextResponse.json(
+    { error: err instanceof Error ? err.message : "Unknown error", code: "unknown" },
+    { status: 500 },
+  );
+}

--- a/console/src/lib/api/client.ts
+++ b/console/src/lib/api/client.ts
@@ -1341,6 +1341,20 @@ export function listConfluenceSections(
   );
 }
 
+export function previewWebsiteCrawl(
+  workspaceId: string,
+  params: { url: string; limit?: number; includeSubdomains?: boolean },
+  options: { token?: string; signal?: AbortSignal } = {},
+): Promise<{ urls: string[]; truncated: boolean }> {
+  const search = new URLSearchParams({ url: params.url });
+  if (params.limit !== undefined) search.set("limit", String(params.limit));
+  if (params.includeSubdomains) search.set("include_subdomains", "true");
+  return apiFetch<{ urls: string[]; truncated: boolean }>(
+    `/v1/workspaces/${encodeURIComponent(workspaceId)}/knowledge/sources/website/preview?${search.toString()}`,
+    { token: options.token, signal: options.signal },
+  );
+}
+
 export type ApiDocsRepoTreeNode = {
   path: string;
   name: string;


### PR DESCRIPTION
## Summary

Closes the wizard polish phase — the last two sources (website + static-upload) that still felt under-built compared to the Notion / Confluence / docs-repo pickers.

### Website source

- **New endpoint** ``GET /v1/.../knowledge/sources/website/preview`` proxies Firecrawl ``/map`` so operators see the URL set **before** they pay for the scrape budget.
- **``<WebsiteSourceForm>``** — URL field + "Preview crawl" button that lists the discovered URLs inline. Advanced disclosure exposes ``limit`` / ``include_subdomains`` / ``change_tracking`` / ``only_main_content`` (previously hardcoded in ``buildConfig``).
- **Side fix:** ``firecrawl_api_key`` and ``firecrawl_api_url`` were referenced in the Firecrawl client code but never declared on ``Settings`` — would ``AttributeError`` on the first real call. Added the two fields with the env-var aliases the existing code expected.

### Static upload

- **``<StaticUploadDropzone>``** — drag/drop or click-to-pick text files (``.md``, ``.mdx``, ``.txt``, ``.rst``, ``.adoc``); 200KB per file, 25 max. Each file becomes one entry in ``config.documents``. Title defaults to filename-without-extension, editable per row; re-uploading the same filename replaces the previous body.
- Replaces the single title + textarea, which was fine for one doc but unusable when an operator wanted to seed a workspace with a real handbook.

## Phase context

Final picker-plan PR. Previously shipped: #103 (Notion), #105 (archive), #106 (Confluence sections), #107 (docs-repo tree), #108 (Notion database-as-source). With this in, every source kind has a real picker and the JSON-textarea era is over.

## Test plan

- [x] ``pytest backend/tests/test_v1_website_preview.py`` — 3 tests: Firecrawl proxy + truncation + 503-when-unconfigured.
- [x] All 30 knowledge tests still green.
- [x] ``npx tsc --noEmit`` clean.
- [x] ``npx next build`` clean.
- [ ] Manual UI smoke: paste a docs site URL, click Preview crawl, verify URL list. Drop a few .md files into the static-upload zone, edit a title, remove one, submit.