### PR TITLE
knowledge: route to description-only buckets via LLM tiebreaker

### DIFF
--- a/backend/app/services/knowledge_router.py
+++ b/backend/app/services/knowledge_router.py
@@ -79,11 +79,20 @@ _LLM_NOTE_BODY_CAP = 4000
 
 @dataclass(slots=True)
 class BucketCentroid:
+    """A workspace bucket the router can route into.
+
+    ``centroid`` is ``None`` for buckets with zero embedded published
+    articles — the bucket is description-only. Such buckets can't
+    auto-pin (we have no vector to compare against), but they're still
+    valid targets for ``bucket_hint`` matches and the LLM tiebreaker
+    (which uses ``description`` to decide fit).
+    """
+
     bucket_id: uuid.UUID
     slug: str
     name: str
     description: str | None
-    centroid: list[float]
+    centroid: list[float] | None
     sample_count: int
 
 
@@ -140,9 +149,10 @@ async def route_pending_notes(
         return report
 
     if not centroids:
-        # Nothing to route into — but this shouldn't be a hard skip;
-        # KB-1's notes still want their tick counted so the report
-        # surfaces "you have notes but no buckets" cleanly.
+        # Workspace has zero buckets at all — there's literally nothing
+        # to route into. (Buckets that exist but have no articles are
+        # NOT this branch; they're still candidates via description-only
+        # routing — see ``_bucket_centroids``.)
         report.skipped_no_buckets = len(pending)
         return report
 
@@ -260,28 +270,29 @@ async def _route_one(
     if not note_vec:
         return None
 
-    scored = sorted(
-        (
-            (b, _cosine(note_vec, b.centroid))
-            for b in centroids
-        ),
-        key=lambda x: x[1],
-        reverse=True,
-    )
-    top, top_score = scored[0]
+    populated = [b for b in centroids if b.centroid is not None]
+    if populated:
+        scored = sorted(
+            ((b, _cosine(note_vec, b.centroid or [])) for b in populated),
+            key=lambda x: x[1],
+            reverse=True,
+        )
+        top, top_score = scored[0]
+        if top_score >= AUTO_PIN_THRESHOLD:
+            return top, top_score, "auto_pin"
 
-    if top_score >= AUTO_PIN_THRESHOLD:
-        return top, top_score, "auto_pin"
-
-    # Centroid was ambiguous; check the LLM extractor's hint first.
+    # Centroid scoring was ambiguous (or every bucket is description-only);
+    # check the LLM extractor's hint first against ALL candidates.
     hint = (note.context or {}).get("bucket_hint")
     if isinstance(hint, str):
         match = next((b for b in centroids if b.slug == hint), None)
         if match is not None:
             return match, HINT_CONFIDENCE, "bucket_hint"
 
-    # Last resort: tiebreaker LLM. Falls back to "no_fit" on any
-    # failure or if the model returns null.
+    # Last resort: tiebreaker LLM. Sees ALL buckets (populated or not)
+    # via their descriptions, so a brand-new workspace whose buckets are
+    # description-only still gets a routing decision instead of stuck
+    # "no_fit" forever. Falls back to "no_fit" on any failure.
     if llm_client is not None:
         slug, conf = await _llm_tiebreaker(
             note=note, centroids=centroids, client=llm_client
@@ -302,12 +313,15 @@ async def _route_one(
 async def _bucket_centroids(
     session: AsyncSession, *, workspace_id: uuid.UUID
 ) -> list[BucketCentroid]:
-    """Pull every workspace-scoped bucket and compute its centroid.
+    """Pull every workspace-scoped bucket and (when possible) its centroid.
 
-    A bucket with zero embedded published articles produces no
-    centroid (it's invisible to the router until it has at least one
-    representative article). KB-4 review will surface notes that hit
-    a freshly-empty bucket as "no_fit".
+    Description-only buckets (zero embedded published articles) are still
+    returned, with ``centroid=None``. They can't auto-pin via cosine
+    similarity, but they're valid targets for ``bucket_hint`` matches and
+    the LLM tiebreaker (which uses ``description`` to decide fit). This
+    is what unblocks brand-new workspaces whose preset buckets ship with
+    descriptions but no seed articles — without it, every note routes to
+    ``no_fit`` forever and the synthesiser never runs.
     """
     bucket_rows = (
         await session.execute(
@@ -330,9 +344,7 @@ async def _bucket_centroids(
             )
         ).scalars().all()
         vectors = [list(v) for v in article_rows if v is not None]
-        if not vectors:
-            continue
-        centroid = _mean_vector(vectors)
+        centroid = _mean_vector(vectors) if vectors else None
         centroids.append(
             BucketCentroid(
                 bucket_id=bucket.id,

--- a/backend/tests/test_services_knowledge_router.py
+++ b/backend/tests/test_services_knowledge_router.py
@@ -294,10 +294,86 @@ async def test_route_no_fit_when_llm_says_null(
 
 
 @pytest.mark.asyncio
-async def test_route_skips_when_no_embedded_buckets(
+async def test_route_uses_description_when_buckets_are_empty(
     db_session, seed_workspace, monkeypatch
 ):
-    """Workspace with zero embedded articles → notes stay pending."""
+    """Brand-new workspace: bucket exists with a description but zero
+    articles. The router must still surface it to the LLM tiebreaker
+    (using the description), not silently mark every note ``no_fit``.
+
+    Pre-fix: ``_bucket_centroids`` filtered out buckets without
+    embedded articles, so the LLM caller saw ``- (no buckets)`` and
+    every note routed to ``no_fit`` forever. New workspaces never
+    progressed past the ingest step.
+    """
+    _, _, workspace = seed_workspace
+
+    arch = KnowledgeBucket(
+        workspace_id=workspace.id,
+        scope_kind=BucketScope.WORKSPACE,
+        source_kind=BucketSource.EXTERNAL_STATIC,
+        slug="architecture-decisions",
+        name="Architecture Decisions",
+        description="ADRs and architectural choices.",
+    )
+    eng = KnowledgeBucket(
+        workspace_id=workspace.id,
+        scope_kind=BucketScope.WORKSPACE,
+        source_kind=BucketSource.EXTERNAL_STATIC,
+        slug="engineering-standards",
+        name="Engineering Standards",
+        description="Conventions and standards we hold ourselves to.",
+    )
+    db_session.add_all([arch, eng])
+    await db_session.flush()
+
+    note = _make_note(workspace.id, body="proposed: adopt SemVer for the gateway")
+    db_session.add(note)
+    await db_session.flush()
+
+    async def fake_embed(text, settings=None):
+        return _vec(1.0)
+
+    monkeypatch.setattr(
+        "backend.app.services.knowledge_router.embed_text", fake_embed
+    )
+
+    stub = _StubLLMClient(
+        '{"slug": "architecture-decisions", "confidence": 0.8}'
+    )
+    report = await route_pending_notes(
+        db_session, workspace_id=workspace.id, llm_client=stub
+    )
+    assert report.routed_via_llm == 1, report
+    assert report.skipped_no_buckets == 0
+    assert len(stub.calls) == 1
+
+    # Crucial: the LLM saw BOTH buckets in its catalogue, including the
+    # description-only ones — pre-fix it saw none.
+    user_msg = stub.calls[0]["messages"][1].content
+    assert "architecture-decisions" in user_msg
+    assert "engineering-standards" in user_msg
+    assert "ADRs and architectural choices." in user_msg
+
+    refreshed = (
+        await db_session.execute(
+            select(Improvement).where(Improvement.id == note.id)
+        )
+    ).scalar_one()
+    assert refreshed.context["routed_bucket_id"] == str(arch.id)
+    assert refreshed.context["route_source"] == "llm_tiebreaker"
+
+
+@pytest.mark.asyncio
+async def test_route_skips_when_workspace_has_no_buckets_at_all(
+    db_session, seed_workspace, monkeypatch
+):
+    """Workspace with zero buckets total → notes stay pending.
+
+    Distinct from the case above: there's literally nothing to route
+    into, not even description-only buckets. Caller can use the
+    ``skipped_no_buckets`` counter to surface "create a bucket first".
+    """
     _, _, workspace = seed_workspace
     note = _make_note(workspace.id)
     db_session.add(note)


### PR DESCRIPTION
## Summary

Brand-new workspaces ship with 6 preset buckets that have crisp descriptions but zero seed articles. Pre-fix the router filtered those out of the candidate list before scoring, so:

- Centroid scoring saw an empty list and skipped to the LLM tiebreaker.
- LLM tiebreaker prompt was built from the same filtered list, so the model saw ``- (no buckets)`` in its catalogue.
- Every note routed to ``no_fit`` forever; the synthesiser never ran; the wizard's "imported 74 notes" appeared to vanish.

Confirmed live in prod for ws ``d591af28`` — 77 ``knowledge_note`` Improvements all stuck on ``decision=pending`` / ``routed_bucket_id=NULL``, hourly router cron emitted ``{source: 'no_fit', confidence: 0.0, bucket_slug: null}`` for the same notes turn after turn.

## Fix

``_bucket_centroids`` now returns **every** workspace bucket, with ``centroid=None`` for description-only ones. Auto-pin still requires a centroid (cosine math has nothing to compare to without one), but ``bucket_hint`` matches and the **LLM tiebreaker now see the full catalogue with descriptions**. The model can route a note to a bucket on the basis of the bucket's description alone — which is exactly what an operator would do when sorting an empty filing cabinet.

The existing ``skipped_no_buckets`` counter still kicks in when a workspace genuinely has zero buckets (rare — preset seeding creates 6 at workspace bootstrap).

## Test plan

- [x] ``pytest backend/tests/test_services_knowledge_router.py`` — 7 tests pass: 6 existing + 1 new asserting the LLM caller now sees both empty buckets in its catalogue with their descriptions.
- [ ] Once deployed, next router tick (every hour at :30) should re-route the 77 stuck notes via LLM tiebreaker. Manual verification: poll ``improvements`` for ``routed_bucket_id IS NOT NULL`` after the next tick.