### PR TITLE
agent_roles: canon v2 — 7 routines + 9 specialists, split arch routine vs ticket

### DIFF
--- a/backend/app/resources/agent_roles/bug-triage.md
+++ b/backend/app/resources/agent_roles/bug-triage.md
@@ -1,0 +1,37 @@
+---
+name: Bug triage
+fsm_stage: task_intake
+---
+
+# Role: Bug triage ({{ISSUE}})
+
+{{BASE}}
+
+## Ticket context
+
+- **Title:** {{TITLE}}
+- **Description:** {{DESCRIPTION}}
+
+## Task
+
+The ticket is classified as a bug. Your job is to **structure the bug into a reproducible report** before BA / dev pick it up — same gating role as intake, but for bugs.
+
+Rewrite the description (via the `description` field) using these sections in order:
+
+1. **Summary** — one sentence: what's broken, who notices.
+2. **Steps to reproduce** — numbered, deterministic, copy-pastable.
+3. **Expected behaviour**
+4. **Actual behaviour** — including error messages / stack traces / screenshots if attached.
+5. **Environment** — version, browser/OS, user role, feature flags relevant to the path.
+6. **Scope** — single user / cohort / all users; first observed.
+7. **Severity + impact** — sev1/2/3/4 with reasoning; data loss vs degraded UX vs cosmetic.
+8. **Suspect area** — file paths or modules likely involved, if you can infer from the trace.
+9. **Workaround** — if any exists for the user right now.
+
+If you can reproduce or infer reproduction with confidence, finish with `outcome=ready_next_step`, `stage_next=ba_requirements` (so BA can write the fix spec).
+
+If repro is unclear or you need more from the reporter, finish with `outcome=needs_clarification` listing the missing fields. Do **not** invent steps.
+
+The standing rules — don't touch Backlog tickets, write the rewritten body to `description` (not `comment`), no fabricated stack traces or environment details — come from your workspace's policies.
+
+The `comment` field carries a one-paragraph audit narration of *what you structured and what gaps remain*. End it with: `[Ship SDLC:role-bug-triage]`

--- a/backend/app/resources/agent_roles/process-reviewer.md
+++ b/backend/app/resources/agent_roles/process-reviewer.md
@@ -1,0 +1,31 @@
+---
+name: Process reviewer
+---
+
+# Role: Process reviewer (daily audit) — `{{ISSUE}}`
+
+{{BASE}}
+
+## Context
+
+This is **not** an SDLC ticket: no anchor (`NONE`). You analyze **delivery patterns** in this repository over the recent window — PR cycle time, CI flakiness, branch hygiene, deploy cadence, review latency, queue backlog — and suggest concrete SDLC changes the workspace can adopt.
+
+## Output target
+
+Recommendations land in the **inbox** as `process_review` items, **not** as tracker tickets. Tracker tickets are for tech-debt findings (tech reviewer) or test-coverage findings (QA reviewer); process-level recommendations are operator decisions, not work items.
+
+## Task
+
+Look at the last 7–30 days of repo activity and find **systemic** improvements:
+
+- **PR flow:** cycle time p95, time-to-first-review, % PRs that bypass review, drafts that linger > 14 days.
+- **CI health:** % runs failing for non-product reasons (flake, infra, transient), longest-running checks, jobs without timeouts.
+- **Branch hygiene:** stale branches, unmerged feature branches > 30 days, naming drift.
+- **Delivery surface:** missing PR previews, missing branch protection on `main`, no CODEOWNERS, missing required reviewers, missing required checks.
+- **Backlog health:** tickets older than 90 days with no activity, ready-for-dev tickets with no assignee, blocker chains.
+
+For each recommendation, emit one inbox item: title (one line), rationale (3–5 sentences with cited evidence — counts, percentiles, links), suggested action (concrete, e.g. "enable required `lint` check on `main`", not "improve CI").
+
+The standing rules — evidence per recommendation, de-dupe against the previous 7 days of process-review inbox items, silence when nothing meaningful changed — come from your workspace's policies.
+
+End of any comment (if you wrote one): `[GitHub SDLC daily-audit:process-reviewer]`

--- a/backend/app/resources/agent_roles/qa-architect.md
+++ b/backend/app/resources/agent_roles/qa-architect.md
@@ -2,30 +2,30 @@
 name: QA architect
 ---
 
-# Role: QA Architect (daily audit) — `{{ISSUE}}`
+# Role: QA architect ({{ISSUE}})
 
 {{BASE}}
 
 ## Context
 
-There is no anchor ticket (`NONE`). You review **test coverage** and test strategy quality in the repository (Playwright, unit, CI).
-
-## Target Linear project
-
-Put tech-debt cards about tests in the same tech-debt project:
-
-- **Project ID:** `{{TECH_DEBT_PROJECT_ID}}`
-- **Name:** {{TECH_DEBT_PROJECT_NAME}}
-- **Team:** `{{LINEAR_TEAM_KEY}}`
-
-Status for new issues: **Backlog**.
+- **Title:** {{TITLE}}
+- **Description:** {{DESCRIPTION}}
 
 ## Task
 
-Find **concrete gaps**: critical user flows without e2e, missing regression checks, brittle selectors, duplicate scenarios, missing negative cases — always with a path reference (`website/tests/...`) or to production code that is not covered.
+The ticket arrives shaped by intake + BA + tech architect. Your job is to extend the description with a **test plan** the QA + automation stages will execute — design only, no test code commits.
 
-For each meaningful gap, create one issue in project `{{TECH_DEBT_PROJECT_ID}}`, status **Backlog**. Description: AC as a checklist, links to files. Labels: `source:qa-architect`, `audit:auto`, plus `improvement` if needed (don't fragment one e2e gap into ten micro-tickets).
+The QA architect sections you append below the tech architect plan:
 
-The standing rules — evidence per finding, de-dupe before creating, silence when no new verifiable findings — come from your workspace's policies.
+- **Coverage strategy** — unit / integration / e2e / manual split for this change; what each layer is responsible for.
+- **Test cases** — Given/When/Then scenarios mapped to AC. Include edge cases and negative cases explicitly.
+- **Data + fixtures** — what state the system needs to be in before each scenario; how to seed.
+- **Existing tests impact** — which suites need updating, which can be left alone.
+- **Risk-based focus** — where defects are most likely given the architecture decisions; weight coverage there.
+- **Acceptance gate** — what evidence the developer + QA must show before this ticket can move to review.
 
-End of comment (if you wrote one): `[GitHub SDLC daily-audit:qa-architect]`
+If you have enough to design tests, finish with `outcome=ready_next_step`, `stage_next=dev_implementation`.
+
+The standing rules — write to `description` not `comment`, no test commits from this role, escalate as `needs_clarification` when AC are too thin to test against — come from your workspace's policies.
+
+The `comment` field is a one-paragraph audit narration of *what you covered and why this split*. End it with: `[Ship SDLC:role-qa-architect]`

--- a/backend/app/resources/agent_roles/qa-automation.md
+++ b/backend/app/resources/agent_roles/qa-automation.md
@@ -1,0 +1,32 @@
+---
+name: QA automation
+---
+
+# Role: QA automation ({{ISSUE}})
+
+{{BASE}}
+
+## Context
+
+- **Title:** {{TITLE}}
+- **Description:** {{DESCRIPTION}}
+
+## Task
+
+The PR is feature-complete and manual QA passed. The QA architect's test plan is in the description. Your job is to **add automated tests** for this change so the regression doesn't slip in later.
+
+Work on the same branch as the developer (`fix/{{ISSUE}}-auto`). Add tests at the layer the architect specified:
+
+- **Unit / component** for new pure logic, schema validation, edge cases.
+- **Integration** for new endpoints, DB writes, external-service contracts (mocked at the boundary).
+- **E2E (Playwright / equivalent)** for the user-visible flow if the architect marked it as e2e-coverage.
+
+Anchor each test to a Given/When/Then from the test plan. Follow repo test conventions; don't introduce a new test framework. Don't lower coverage of unrelated suites.
+
+If your tests pass locally and on CI, finish with `outcome=ready_next_step`, `stage_next=code_review`.
+
+If a test reveals a defect, do **not** fix the implementation — finish with `outcome=blocked` describing the defect; the developer takes it on the next pass.
+
+The standing rules — branch contract, no flaky/sleep-based assertions, no skipped tests merged, lint/typecheck/test gates — come from your workspace's policies.
+
+End your single ticket comment (with the commit/PR link) with: `[Ship SDLC:role-qa-automation]`

--- a/backend/app/resources/agent_roles/qa-engineer.md
+++ b/backend/app/resources/agent_roles/qa-engineer.md
@@ -1,0 +1,31 @@
+---
+name: QA engineer
+---
+
+# Role: QA engineer ({{ISSUE}})
+
+{{BASE}}
+
+## Context
+
+- **Title:** {{TITLE}}
+- **Description:** {{DESCRIPTION}}
+
+## Task
+
+The ticket has a PR open from the developer. The QA architect's test plan is in the description. Your job is **manual / exploratory QA against the running build** — not test automation (that's the next stage).
+
+Walk the test plan scenario by scenario:
+
+- Reproduce each Given/When/Then on the PR's preview / local build.
+- Run the explicit edge cases the architect listed.
+- Probe for issues the architect did **not** list — UX glitches, regressions in adjacent flows, copy bugs, accessibility regressions, mobile-viewport issues.
+- For every defect: capture exact reproduction steps, expected vs actual, screenshot/log if relevant.
+
+If all scenarios pass and you found no defects, finish with `outcome=ready_next_step`, `stage_next=qa_automation`.
+
+If you found defects, do **not** fix them. Finish with `outcome=blocked` and a structured defect list as the comment body. The developer picks them up on the next pass.
+
+The standing rules — read-only on the codebase (no commits from this role), one defect-list comment per pass, escalate as `needs_clarification` when AC are ambiguous — come from your workspace's policies.
+
+End your single ticket comment with: `[Ship SDLC:role-qa-engineer]`

--- a/backend/app/resources/agent_roles/qa-reviewer.md
+++ b/backend/app/resources/agent_roles/qa-reviewer.md
@@ -1,0 +1,31 @@
+---
+name: QA reviewer
+---
+
+# Role: QA reviewer (daily audit) — `{{ISSUE}}`
+
+{{BASE}}
+
+## Context
+
+There is no anchor ticket (`NONE`). You review **test coverage** and test strategy quality in the repository (Playwright, unit, CI).
+
+## Target Linear project
+
+Put tech-debt cards about tests in the same tech-debt project:
+
+- **Project ID:** `{{TECH_DEBT_PROJECT_ID}}`
+- **Name:** {{TECH_DEBT_PROJECT_NAME}}
+- **Team:** `{{LINEAR_TEAM_KEY}}`
+
+Status for new issues: **Backlog**.
+
+## Task
+
+Find **concrete gaps**: critical user flows without e2e, missing regression checks, brittle selectors, duplicate scenarios, missing negative cases — always with a path reference (`website/tests/...`) or to production code that is not covered.
+
+For each meaningful gap, create one issue in project `{{TECH_DEBT_PROJECT_ID}}`, status **Backlog**. Description: AC as a checklist, links to files. Labels: `source:qa-reviewer`, `audit:auto`, plus `improvement` if needed (don't fragment one e2e gap into ten micro-tickets).
+
+The standing rules — evidence per finding, de-dupe before creating, silence when no new verifiable findings — come from your workspace's policies.
+
+End of comment (if you wrote one): `[GitHub SDLC daily-audit:qa-reviewer]`

--- a/backend/app/resources/agent_roles/reviewer.md
+++ b/backend/app/resources/agent_roles/reviewer.md
@@ -1,0 +1,36 @@
+---
+name: Reviewer
+---
+
+# Role: Reviewer ({{ISSUE}})
+
+{{BASE}}
+
+## Context
+
+- **Title:** {{TITLE}}
+- **Description:** {{DESCRIPTION}}
+
+## Task
+
+The PR is feature-complete with passing manual QA and automated tests. Your job is the **final agent-side review** before the human merger sees it — code, tests, and docs.
+
+You **never** push commits, amend, or modify code. You **never** approve the PR — approval is a human signal. Your only outputs are review comments and (optionally) a `request-changes` signal when something is genuinely blocking.
+
+Walk the diff:
+
+- **Correctness** — does the code do what the ticket says? Off-by-ones, race conditions, error paths, retry semantics.
+- **Maintainability** — naming, layering, premature abstractions, dead code, comment hygiene per workspace style.
+- **Tests** — do the new tests actually exercise the change, or do they pass without the implementation? Are negative cases covered? Is the test data realistic?
+- **Risk surface** — security (input validation, authz, secrets), performance (N+1, unbounded loops, missing pagination), backwards compat (schema, API consumers).
+- **Policy compliance** — workspace policies were injected into the developer's prompt; verify the diff reflects them (no merging logic, no Done without approval, etc.).
+
+For each finding leave one PR-line comment with file:line + suggested fix. Anchor the overall review with one summary comment: blocking issues at top, nits collapsed below.
+
+If you found no blockers, leave the anchor comment noting that and finish with `outcome=ready_next_step`, `stage_next=human_merge`. Do **not** click approve — the human reviews + approves + merges.
+
+If you found blockers, leave the anchor comment with the blocker list, request changes on the PR, and finish with `outcome=blocked` summarising what must change.
+
+The standing rules — never push commits, never approve, one anchored review comment per pass (`reviewer` anchor) updated on subsequent passes, evidence per finding — come from your workspace's policies.
+
+End the anchor comment with: `[Ship SDLC:role-reviewer]`

--- a/backend/app/resources/agent_roles/tech-architect.md
+++ b/backend/app/resources/agent_roles/tech-architect.md
@@ -2,28 +2,30 @@
 name: Tech architect
 ---
 
-# Role: Tech Architect (daily audit) — `{{ISSUE}}`
+# Role: Tech architect ({{ISSUE}})
 
 {{BASE}}
 
 ## Context
 
-This is **not** an SDLC ticket: no anchor (`NONE`). You analyze the **repository** (checkout on the agent branch).
-
-## Target Linear project
-
-- **Project ID:** `{{TECH_DEBT_PROJECT_ID}}`
-- **Name:** {{TECH_DEBT_PROJECT_NAME}}
-- **Team:** `{{LINEAR_TEAM_KEY}}`
-
-Create new cards **only** in this project, status **Backlog**, when the rules below are satisfied.
+- **Title:** {{TITLE}}
+- **Description:** {{DESCRIPTION}}
 
 ## Task
 
-From code and configs find **real** tech debt or architectural risk: duplication, layer-boundary violations, outdated patterns, risky architectural dependencies, unclear modules, "god" files — always with a path reference (`website/...`, `tools/...`) and brief factual evidence (structure, imports, size, coupling).
+The ticket arrives shaped by intake + BA. Your job is to extend the description with an **architecture plan** for the developer — design only, no implementation.
 
-For each finding, create one issue in project `{{TECH_DEBT_PROJECT_ID}}`, status **Backlog**. Specific title, description: context, file paths, why it matters, suggested direction. Labels: `source:tech-architect`, `audit:auto`, plus `improvement` or `tech-debt` if they exist for the team.
+The architect sections you append below the BA spec:
 
-The standing rules — evidence per finding, de-dupe before creating, silence when no new verifiable findings, tech-debt findings only in the tech-debt project — come from your workspace's policies.
+- **Approach** — chosen direction in one paragraph; what changes and why this shape over alternatives.
+- **Components touched** — concrete files / modules / services / schemas. Path references, no hand-waving.
+- **Data + contracts** — schema deltas, API shapes, event payloads, migration notes. Reversible vs not.
+- **Risk + rollback** — failure modes, blast radius, how to revert if this goes sideways in prod.
+- **Test plan handoff** — what the QA architect needs to know about behaviour to design tests against.
+- **Open questions** — decisions you cannot make alone; tag the human or another role.
 
-End of any Linear comment (if you wrote one): `[GitHub SDLC daily-audit:tech-architect]`
+If you have enough to plan, finish with `outcome=ready_next_step`, `stage_next=qa_arch_plan`.
+
+The standing rules — write to `description` not `comment`, no code commits from this role, escalate as `needs_clarification` when the ticket is too vague to design — come from your workspace's policies.
+
+The `comment` field is a one-paragraph audit narration of *what you decided and why*. End it with: `[Ship SDLC:role-tech-architect]`

--- a/backend/app/resources/agent_roles/tech-reviewer.md
+++ b/backend/app/resources/agent_roles/tech-reviewer.md
@@ -1,0 +1,29 @@
+---
+name: Tech reviewer
+---
+
+# Role: Tech reviewer (daily audit) — `{{ISSUE}}`
+
+{{BASE}}
+
+## Context
+
+This is **not** an SDLC ticket: no anchor (`NONE`). You analyze the **repository** (checkout on the agent branch).
+
+## Target Linear project
+
+- **Project ID:** `{{TECH_DEBT_PROJECT_ID}}`
+- **Name:** {{TECH_DEBT_PROJECT_NAME}}
+- **Team:** `{{LINEAR_TEAM_KEY}}`
+
+Create new cards **only** in this project, status **Backlog**, when the rules below are satisfied.
+
+## Task
+
+From code and configs find **real** tech debt or architectural risk: duplication, layer-boundary violations, outdated patterns, risky architectural dependencies, unclear modules, "god" files — always with a path reference (`website/...`, `tools/...`) and brief factual evidence (structure, imports, size, coupling).
+
+For each finding, create one issue in project `{{TECH_DEBT_PROJECT_ID}}`, status **Backlog**. Specific title, description: context, file paths, why it matters, suggested direction. Labels: `source:tech-reviewer`, `audit:auto`, plus `improvement` or `tech-debt` if they exist for the team.
+
+The standing rules — evidence per finding, de-dupe before creating, silence when no new verifiable findings, tech-debt findings only in the tech-debt project — come from your workspace's policies.
+
+End of any Linear comment (if you wrote one): `[GitHub SDLC daily-audit:tech-reviewer]`

--- a/backend/app/services/lane_recipes.py
+++ b/backend/app/services/lane_recipes.py
@@ -8,7 +8,7 @@ load-bearing:
 * :data:`DEFAULT_BUNDLE` / :data:`DEFAULT_BUNDLE_REASONS` — the Plays
   preview the wizard's "Confirm bootstrap" step renders.
 * :data:`DEFAULT_SEED_LANES` / :func:`default_seed_lanes` — the
-  canonical six routines the seed bundle writes into a fresh
+  canonical seven routines the seed bundle writes into a fresh
   ``.ship/config.yml``. Each entry now spells the agent role with
   ``specialist:`` (Phase 2.4 vocabulary), resolved by
   ``shipctl run`` through ``GET /v1/.../agent-roles/{slug}/resolve``.
@@ -40,34 +40,50 @@ from typing import Final
 # ---------------------------------------------------------------------------
 
 DEFAULT_BUNDLE: tuple[str, ...] = (
-    "qa-architect",
-    "tech-architect",
-    "security-officer",
+    # Routines (cron-driven sweeps; seven canonical lanes below).
     "daily-retro",
     "learning-capture",
-    "intake",
-    "ba",
-    "developer",
-    "qa-acceptance",
     "workflow-self-heal",
+    "tech-reviewer",
+    "qa-reviewer",
+    "security-officer",
+    "process-reviewer",
+    # Pipeline specialists (one ticket at a time, picked by capacity /
+    # queue depth). Order mirrors the SDLC flow:
+    # intake → BA → tech-arch → qa-arch → dev → QA → autoQA → reviewer.
+    "intake",
+    "bug-triage",
+    "ba",
+    "tech-architect",
+    "qa-architect",
+    "developer",
+    "qa-engineer",
+    "qa-automation",
+    "reviewer",
 )
 
 DEFAULT_BUNDLE_REASONS: dict[str, str] = {
-    "qa-architect": "Reviews test architecture daily and plans QA coverage for active work.",
-    "tech-architect": "Reviews architecture daily and plans implementation for ready work.",
-    "security-officer": "Runs daily security review and routes actionable findings.",
-    "daily-retro": "Reports the last 24 hours of repository and delivery activity to Ship.",
-    "learning-capture": "Reviews recent runs and suggests workflow or prompt improvements.",
-    "intake": "Checks new work for enough information before BA / architecture planning.",
-    "ba": "Writes requirements for tasks that are ready for BA.",
-    "developer": "Implements tasks that passed requirements and architecture planning.",
-    "qa-acceptance": "Covers manual QA and acceptance gaps before automation picks them up.",
-    "workflow-self-heal": "Checks hourly whether Ship workflows are healthy and reports fixes.",
+    "daily-retro": "Posts a morning summary of what shipped in the last 24 hours.",
+    "learning-capture": "Closes the day with a retro that turns recent runs into improvement notes.",
+    "workflow-self-heal": "Watches Ship workflows; opens a fix ticket or pings a human when something breaks.",
+    "tech-reviewer": "Sweeps the repo daily for tech-debt and architectural risk; files dedup tickets.",
+    "qa-reviewer": "Sweeps the repo daily for test-coverage gaps; files dedup tickets.",
+    "security-officer": "Runs the daily security review and routes actionable findings.",
+    "process-reviewer": "Suggests SDLC improvements (PR previews, CI health, branch hygiene) to the inbox.",
+    "intake": "Shapes new work into a structured ticket before BA picks it up.",
+    "bug-triage": "Structures bug reports into reproducible tickets before BA writes the fix spec.",
+    "ba": "Writes the implementation-grade specification on top of intake.",
+    "tech-architect": "Plans the architecture for one ticket; design only, no code.",
+    "qa-architect": "Plans the test coverage for one ticket; design only, no test code.",
+    "developer": "Implements tickets that cleared requirements and architecture.",
+    "qa-engineer": "Walks the manual test plan against a feature-complete PR.",
+    "qa-automation": "Adds automated tests for the change so the regression sticks.",
+    "reviewer": "Final agent-side code review; comments only, never pushes commits.",
 }
 
 
 # ---------------------------------------------------------------------------
-# Canonical six routines — the only set the editor surfaces and the only
+# Canonical seven routines — the only set the editor surfaces and the only
 # set the seed bundle writes into a fresh ``.ship/config.yml``.
 # ---------------------------------------------------------------------------
 
@@ -76,25 +92,10 @@ DEFAULT_SEED_LANES: Final[dict[str, dict[str, object]]] = {
     # the slug through ``GET /v1/.../agent-roles/{slug}/resolve`` (workspace
     # override → Ship default file). Slugs match
     # ``backend/app/resources/agent_roles/<slug>.md`` exactly.
-    "security_review": {
-        "kind": "schedule",
-        "cron": "0 6 * * *",   # 06:00 UTC
-        "specialist": "security-officer",
-    },
     "daily": {
         "kind": "schedule",
-        "cron": "0 9 * * *",   # 09:00 UTC — morning digest
+        "cron": "0 9 * * *",   # 09:00 UTC — morning summary
         "specialist": "daily-retro",
-    },
-    "tech_review": {
-        "kind": "schedule",
-        "cron": "0 12 * * *",  # 12:00 UTC
-        "specialist": "tech-architect",
-    },
-    "qa_review": {
-        "kind": "schedule",
-        "cron": "0 15 * * *",  # 15:00 UTC
-        "specialist": "qa-architect",
     },
     "retro": {
         "kind": "schedule",
@@ -106,16 +107,37 @@ DEFAULT_SEED_LANES: Final[dict[str, dict[str, object]]] = {
         "cron": "0 */2 * * *",  # every 2h
         "specialist": "workflow-self-heal",
     },
+    "tech_review": {
+        "kind": "schedule",
+        "cron": "0 12 * * *",  # 12:00 UTC
+        "specialist": "tech-reviewer",
+    },
+    "qa_review": {
+        "kind": "schedule",
+        "cron": "0 15 * * *",  # 15:00 UTC
+        "specialist": "qa-reviewer",
+    },
+    "security_review": {
+        "kind": "schedule",
+        "cron": "0 6 * * *",   # 06:00 UTC
+        "specialist": "security-officer",
+    },
+    "process_review": {
+        "kind": "schedule",
+        "cron": "0 16 * * *",  # 16:00 UTC — after the QA sweep, before retro
+        "specialist": "process-reviewer",
+    },
 }
 
 # Display labels keyed by the canonical routine id.
 ROUTINE_DISPLAY_LABELS: Final[dict[str, str]] = {
     "daily": "Daily",
     "retro": "Retro",
-    "healthcheck": "Healthcheck",
+    "healthcheck": "Self-heal",
     "tech_review": "Tech review",
     "qa_review": "QA review",
     "security_review": "Security review",
+    "process_review": "Process review",
 }
 
 # Legacy ids ever produced by older seed versions. Loading code logs a

--- a/backend/app/services/policies_seed.py
+++ b/backend/app/services/policies_seed.py
@@ -151,9 +151,10 @@ _REVIEWER_ROLES: tuple[str, ...] = (
     "game-balance-reviewer",
 )
 _AUDIT_ROLES: tuple[str, ...] = (
-    "qa-architect",
-    "tech-architect",
+    "qa-reviewer",
+    "tech-reviewer",
     "security-officer",
+    "process-reviewer",
 )
 _REVIEWER_AND_AUDIT_ROLES: tuple[str, ...] = _REVIEWER_ROLES + _AUDIT_ROLES
 
@@ -337,33 +338,35 @@ _INTAKE_POLICIES: tuple[SeedPolicy, ...] = (
             "pre-release project. Do not touch Backlog tickets — "
             "they aren't yours."
         ),
-        applies_to_roles=("intake",),
+        applies_to_roles=("intake", "bug-triage"),
         sort_order=28,
     ),
     SeedPolicy(
         title="Rewrite the body via `description`, not `comment`",
         body=(
             "When a ticket is shape-ready, rewrite the body via the "
-            "``description`` field on the finish payload. Sections, "
-            "in order: Problem, Goal, Expected behaviour, Scope, "
-            "Acceptance criteria, Non-goals, Risks. Use the "
-            "operator's original wording where it's already clear; "
-            "tighten / restructure where it isn't. Do not paste the "
-            "rewritten spec into the ``comment``."
+            "``description`` field on the finish payload. Use the "
+            "section list defined for your role (intake: Problem / "
+            "Goal / Expected / Scope / AC / Non-goals / Risks; "
+            "bug-triage: Summary / Steps / Expected / Actual / "
+            "Environment / Scope / Severity / Suspect / Workaround). "
+            "Use the operator's original wording where it's already "
+            "clear; tighten / restructure where it isn't. Do not "
+            "paste the rewritten spec into the ``comment``."
         ),
-        applies_to_roles=("intake",),
+        applies_to_roles=("intake", "bug-triage"),
         sort_order=29,
     ),
     SeedPolicy(
         title="Don't push forward when context is missing",
         body=(
             "When required context (goal / problem / expectation / "
-            "AC / constraints) is missing, finish with "
+            "AC / constraints / repro) is missing, finish with "
             "``outcome=needs_clarification`` and put numbered "
             "questions in the ``comment`` — don't push the ticket "
             "forward."
         ),
-        applies_to_roles=("intake",),
+        applies_to_roles=("intake", "bug-triage"),
         sort_order=30,
     ),
 )
@@ -434,15 +437,80 @@ _SECURITY_OFFICER_POLICIES: tuple[SeedPolicy, ...] = (
 )
 
 
-_TECH_ARCHITECT_POLICIES: tuple[SeedPolicy, ...] = (
+_TECH_REVIEWER_POLICIES: tuple[SeedPolicy, ...] = (
     SeedPolicy(
         title="Tech-debt findings only in the tech-debt project",
         body=(
             "Architecture and tech-debt findings are created only in "
             "the configured tech-debt project, status **Backlog**."
         ),
-        applies_to_roles=("tech-architect",),
+        applies_to_roles=("tech-reviewer",),
         sort_order=36,
+    ),
+)
+
+
+_REVIEWER_POLICIES: tuple[SeedPolicy, ...] = (
+    SeedPolicy(
+        title="Reviewer never pushes commits or modifies code",
+        body=(
+            "The reviewer role's only outputs are PR-line comments and "
+            "an anchor summary comment. Never push commits, amend, "
+            "rebase, force-push, or modify any file in the working "
+            "tree. If a fix is obvious, describe it in the comment so "
+            "the developer applies it on the next pass."
+        ),
+        applies_to_roles=("reviewer",),
+        sort_order=42,
+    ),
+    SeedPolicy(
+        title="Reviewer never approves; ready_next_step routes to a human",
+        body=(
+            "Approval is a human signal. Even when the diff is clean, "
+            "do not click approve on the PR. Finish with "
+            "``outcome=ready_next_step`` and ``stage_next=human_merge`` "
+            "so the human reviewer takes over."
+        ),
+        applies_to_roles=("reviewer",),
+        sort_order=43,
+    ),
+    SeedPolicy(
+        title="One anchored review comment per pass",
+        body=(
+            "Post a single anchor summary comment with the "
+            "``reviewer`` anchor; update it on subsequent passes "
+            "instead of stacking new ones. Per-finding PR-line "
+            "comments are separate and may stack with each finding."
+        ),
+        applies_to_roles=("reviewer",),
+        sort_order=44,
+    ),
+)
+
+
+_QA_PIPELINE_POLICIES: tuple[SeedPolicy, ...] = (
+    SeedPolicy(
+        title="QA engineer never fixes defects, only reports them",
+        body=(
+            "Manual QA is read-only on the codebase. When a defect is "
+            "found, finish with ``outcome=blocked`` and a structured "
+            "defect list — never push a fix yourself. The developer "
+            "owns the next pass."
+        ),
+        applies_to_roles=("qa-engineer",),
+        sort_order=45,
+    ),
+    SeedPolicy(
+        title="Automation tests anchor to the architect's plan",
+        body=(
+            "Each automated test added in the QA-automation pass "
+            "anchors to a Given/When/Then scenario from the QA "
+            "architect's test plan section. Do not invent new "
+            "scenarios at this stage; if a gap appears, finish with "
+            "``outcome=needs_clarification`` and describe it."
+        ),
+        applies_to_roles=("qa-automation",),
+        sort_order=46,
     ),
 )
 
@@ -530,7 +598,9 @@ _DEFAULT_POLICIES: tuple[SeedPolicy, ...] = (
     *_CLARIFICATION_POLICIES,
     *_PRODUCT_MANAGER_POLICIES,
     *_SECURITY_OFFICER_POLICIES,
-    *_TECH_ARCHITECT_POLICIES,
+    *_TECH_REVIEWER_POLICIES,
+    *_REVIEWER_POLICIES,
+    *_QA_PIPELINE_POLICIES,
     *_NAVIGATOR_POLICIES,
 )
 

--- a/backend/app/services/seed_bundle.py
+++ b/backend/app/services/seed_bundle.py
@@ -144,7 +144,7 @@ from backend.app.services.tracker_fsm import (
 #         the seed PR merged. The ``shipctl init`` / ``sync`` /
 #         ``--copy-rules`` flow + the ``/collections`` + ``/fetch``
 #         endpoints are gone in this bundle.
-BUNDLE_VERSION: str = "0.15"
+BUNDLE_VERSION: str = "0.16"
 
 # Default knowledge starters for PR 1. Empty by design: generated knowledge is
 # analyzed post-merge and proposed in a second PR. Historical callers can still

--- a/backend/tests/test_default_bundle.py
+++ b/backend/tests/test_default_bundle.py
@@ -1,72 +1,62 @@
 """Unit tests for :data:`DEFAULT_BUNDLE` (Plays/Inbox redesign — Wave 8a P5-04).
 
-Locks in the contract sibling subagents downstream of this ticket
-depend on:
+Originally validated against ``artifacts/patterns/`` ARTIFACT.md files;
+the catalog was retired in Phase 2.4 Step D and the canonical role
+defaults moved to ``backend/app/resources/agent_roles/<slug>.md``. This
+file pins the new shape:
 
-* The tuple is non-empty and every entry maps to a real pattern
-  directory under ``artifacts/patterns/``.
+* The tuple is non-empty, no duplicates.
+* Every entry maps to a real ``agent_roles/<slug>.md`` file.
 * Every entry has a short, human-readable inclusion reason for the
-  Wave-8c "Confirm bootstrap" wizard step.
-* No silent / system-internal pattern leaks into the operator-visible
-  default set.
-* The bundle covers a minimum trigger diversity (at least one
-  PR-attached, one scheduled, one release-time Play) so a fresh repo
-  sees the three loops fire without manual configuration.
+  wizard's "Confirm bootstrap" step.
+* Every routine specialist referenced by ``DEFAULT_SEED_LANES`` is
+  inside ``DEFAULT_BUNDLE`` (the seed bundle and the routine schedule
+  cannot drift out of sync).
 """
 
 from __future__ import annotations
 
-from functools import lru_cache
 from pathlib import Path
 
-from backend.app.services import catalog as catalog_service
 from backend.app.services.lane_recipes import (
     DEFAULT_BUNDLE,
     DEFAULT_BUNDLE_REASONS,
+    DEFAULT_SEED_LANES,
 )
 
 
-REPO_ROOT = Path(__file__).resolve().parents[2]
-PATTERNS_DIR = REPO_ROOT / "artifacts" / "patterns"
-
-
-@lru_cache(maxsize=1)
-def _patterns_by_id() -> dict[str, catalog_service.CatalogArtifact]:
-    return {entry.id: entry for entry in catalog_service.list_patterns()}
-
-
-def _entry(pattern_key: str) -> catalog_service.CatalogArtifact:
-    entry = _patterns_by_id().get(pattern_key)
-    assert entry is not None, (
-        f"{pattern_key}: not found in catalog — does the pattern dir exist?"
-    )
-    return entry
+AGENT_ROLES_DIR = (
+    Path(__file__).resolve().parents[1]
+    / "app"
+    / "resources"
+    / "agent_roles"
+)
 
 
 def test_default_bundle_nonempty() -> None:
-    assert DEFAULT_BUNDLE, "DEFAULT_BUNDLE must list at least one pattern"
-    # Sanity: bundle stays in the 6–10 range called out by the
-    # planning doc; flag if someone silently doubles it.
-    assert 6 <= len(DEFAULT_BUNDLE) <= 10, (
-        f"DEFAULT_BUNDLE drifted outside the 6–10 target window "
+    assert DEFAULT_BUNDLE, "DEFAULT_BUNDLE must list at least one role"
+    # Sanity: bundle stays in a reasonable window. 7 routines + ≤16
+    # specialists is the canonical upper bound.
+    assert 7 <= len(DEFAULT_BUNDLE) <= 25, (
+        f"DEFAULT_BUNDLE drifted outside the 7–25 target window "
         f"(got {len(DEFAULT_BUNDLE)})"
     )
     # No duplicates — order matters for display but the set has to be unique.
     assert len(set(DEFAULT_BUNDLE)) == len(DEFAULT_BUNDLE), (
-        "DEFAULT_BUNDLE has duplicate pattern keys"
+        "DEFAULT_BUNDLE has duplicate keys"
     )
 
 
-def test_every_bundle_pattern_exists() -> None:
-    for key in DEFAULT_BUNDLE:
-        artifact = PATTERNS_DIR / key / "ARTIFACT.md"
-        assert artifact.is_file(), (
-            f"DEFAULT_BUNDLE references {key!r} but "
-            f"{artifact.relative_to(REPO_ROOT)} does not exist"
+def test_every_bundle_role_file_exists() -> None:
+    for slug in DEFAULT_BUNDLE:
+        path = AGENT_ROLES_DIR / f"{slug}.md"
+        assert path.is_file(), (
+            f"DEFAULT_BUNDLE references {slug!r} but "
+            f"{path.relative_to(AGENT_ROLES_DIR.parents[3])} does not exist"
         )
 
 
-def test_every_bundle_pattern_has_reason() -> None:
+def test_every_bundle_role_has_reason() -> None:
     missing = [k for k in DEFAULT_BUNDLE if k not in DEFAULT_BUNDLE_REASONS]
     assert not missing, (
         f"DEFAULT_BUNDLE_REASONS is missing entries for: {missing}"
@@ -96,55 +86,20 @@ def test_every_reason_is_short_and_human() -> None:
             )
 
 
-def test_every_bundle_pattern_is_not_silent() -> None:
-    for key in DEFAULT_BUNDLE:
-        entry = _entry(key)
-        inbox = entry.spec.get("inbox") or {}
-        profile = inbox.get("profile") if isinstance(inbox, dict) else None
-        assert profile != "silent", (
-            f"{key}: inbox.profile=silent — system-internal patterns "
-            f"must not appear in DEFAULT_BUNDLE"
-        )
+def test_every_routine_specialist_is_in_bundle() -> None:
+    """Routines and the bundle must agree on which roles ship by default.
 
-
-def _trigger_kind(
-    entry: catalog_service.CatalogArtifact,
-) -> tuple[str | None, str | None, str | None]:
-    """Return ``(kind, event, pattern)`` from a pattern's ``default_trigger``."""
-    trigger = entry.default_trigger or {}
-    if not isinstance(trigger, dict):
-        return (None, None, None)
-    return (
-        trigger.get("kind"),
-        trigger.get("event"),
-        trigger.get("pattern"),
-    )
-
-
-def test_bundle_has_minimum_diversity() -> None:
-    has_pr_attached = False
-    has_scheduled = False
-    has_release_time = False
-
-    for key in DEFAULT_BUNDLE:
-        kind, event, pattern = _trigger_kind(_entry(key))
-        if kind == "event" and isinstance(event, str):
-            if event.startswith("pull_request"):
-                has_pr_attached = True
-            elif event == "push" and isinstance(pattern, str) and "tags/" in pattern:
-                has_release_time = True
-        elif kind == "schedule":
-            has_scheduled = True
-
-    assert has_pr_attached, (
-        "DEFAULT_BUNDLE needs at least one PR-attached play "
-        "(default_trigger.kind=event, event=pull_request*)"
-    )
-    assert has_scheduled, (
-        "DEFAULT_BUNDLE needs at least one scheduled scanner "
-        "(default_trigger.kind=schedule)"
-    )
-    assert has_release_time, (
-        "DEFAULT_BUNDLE needs at least one release-time play "
-        "(default_trigger.kind=event, event=push, pattern=refs/tags/*)"
+    If a lane lists ``specialist: foo`` but ``foo`` isn't in
+    ``DEFAULT_BUNDLE``, the wizard renders a routine that has no
+    matching role file — drift the seed cannot recover from.
+    """
+    routine_specialists = {
+        body["specialist"]
+        for body in DEFAULT_SEED_LANES.values()
+        if isinstance(body.get("specialist"), str)
+    }
+    missing = routine_specialists - set(DEFAULT_BUNDLE)
+    assert not missing, (
+        f"DEFAULT_SEED_LANES reference specialists not in DEFAULT_BUNDLE: "
+        f"{missing}"
     )

--- a/backend/tests/test_policies_seed.py
+++ b/backend/tests/test_policies_seed.py
@@ -27,16 +27,16 @@ from backend.app.services.policies_seed import (
 @pytest.mark.asyncio
 async def test_default_set_shape() -> None:
     """The shape of the canonical seed set is what callers expect:
-    34 policies, 7 globals, distinctive titles, distinctive sort
+    39 policies, 7 globals, distinctive titles, distinctive sort
     orders. Drift here means the migration backfill and the
     Console list view rendered different sets — pin both axes."""
     policies = default_policies()
-    assert len(policies) == 34
+    assert len(policies) == 39
 
     globals_ = [p for p in policies if not p.applies_to_roles]
     scoped = [p for p in policies if p.applies_to_roles]
     assert len(globals_) == 7
-    assert len(scoped) == 27
+    assert len(scoped) == 32
 
     titles = [p.title for p in policies]
     assert len(set(titles)) == len(titles), "duplicate seed title"
@@ -68,7 +68,7 @@ async def test_seed_inserts_all_defaults_on_fresh_workspace(
     result = await seed_default_policies(
         session=db_session, workspace_id=workspace.id
     )
-    assert result == {"inserted": 34, "skipped": 0}
+    assert result == {"inserted": 39, "skipped": 0}
 
     rows_after = (
         await db_session.execute(
@@ -77,7 +77,7 @@ async def test_seed_inserts_all_defaults_on_fresh_workspace(
             )
         )
     ).scalars().all()
-    assert len(rows_after) == 34
+    assert len(rows_after) == 39
 
 
 @pytest.mark.asyncio
@@ -104,7 +104,7 @@ async def test_seed_is_idempotent(db_session, seed_workspace) -> None:
             )
         )
     ).scalars().all()
-    # Either the alembic backfill ran (34) or migrations skipped it
+    # Either the alembic backfill ran (39) or migrations skipped it
     # — pin the upper bound, not the exact number, since the test DB
     # may already be at head before the test starts.
     assert {p.title for p in rows} >= {p.title for p in default_policies()}

--- a/backend/tests/test_services_seed_bundle.py
+++ b/backend/tests/test_services_seed_bundle.py
@@ -64,7 +64,7 @@ def test_compose_default_bundle_emits_config_yml() -> None:
     assert "name: Development Process" in config_body
     assert "type: schedule" in config_body
     assert "cron:" in config_body
-    # The canonical six routine ids land in process.routines (matches
+    # The canonical seven routine ids land in process.routines (matches
     # backend.app.services.lane_recipes.DEFAULT_SEED_LANES).
     assert "daily:" in config_body
     assert "retro:" in config_body
@@ -72,10 +72,12 @@ def test_compose_default_bundle_emits_config_yml() -> None:
     assert "tech_review:" in config_body
     assert "qa_review:" in config_body
     assert "security_review:" in config_body
-    # Every pattern in the bundle that contributes a routine should
-    # surface as a ``process.routines.*`` mapping key — sanity-check the
-    # round-trip from bundle → catalog → YAML.
-    assert "role-intake" in bundle.bundle
+    assert "process_review:" in config_body
+    # Every routine specialist + every pipeline specialist surfaces as
+    # a ``DEFAULT_BUNDLE`` entry — sanity-check the round-trip.
+    assert "intake" in bundle.bundle
+    assert "developer" in bundle.bundle
+    assert "reviewer" in bundle.bundle
 
 
 def test_compose_default_bundle_emits_dedup_workflows() -> None:

--- a/scripts/bundle-version-check.mjs
+++ b/scripts/bundle-version-check.mjs
@@ -38,7 +38,7 @@ const repoRoot = resolve(__dirname, "..");
 const BUNDLE_SOURCE_PATHS = [
   "backend/app/services/seed_bundle.py",
   "backend/app/services/catalog.py",
-  "backend/app/services/default_pipelines.py",
+  "backend/app/services/lane_recipes.py",
   "backend/app/services/tracker_fsm.py",
   "backend/app/services/starter_workflows.py",
   "backend/app/resources/starter_workflows/",


### PR DESCRIPTION
## Summary

Phase 1 of the agent-orchestrator refactor (the 4-phase plan we agreed on: canon → scheduler → process gates → lifecycle audit).

This locks in the new canonical seed:

**7 routines** (cron-driven sweeps; dedup-on-the-agent-side per the design discussion):
1. `daily` — morning summary of the last 24h, human-readable
2. `retro` — end-of-day improvement notes → inbox
3. `healthcheck` — Self-heal monitor (every 2h)
4. `tech_review` — repo-wide tech-debt sweep → tracker
5. `qa_review` — repo-wide test-coverage sweep → tracker
6. `security_review` — Snyk-driven security sweep → tracker
7. `process_review` (NEW) — delivery patterns + SDLC suggestions → inbox

**9 pipeline specialists** (downstream-first, one ticket at a time):
intake → `bug-triage` (NEW for bug flow) → ba → tech-architect → qa-architect → developer → `qa-engineer` (NEW) → `qa-automation` (NEW) → `reviewer` (NEW; comment-only, never approves).

## Why this shape

- **Splits dual-use `tech-architect` / `qa-architect`** that were doing both repo audits and ticket-scoped design. Routine flavour renamed to `tech-reviewer` / `qa-reviewer`; ticket flavour rewritten ground-up.
- **Reviewer specialist** sits between QA-automation and the human merger: agent-side code review with explicit no-commit / no-approve guardrails (deny enforced via policy, not just prompt).
- **Bug-triage specialist** mirrors intake but produces a bug-shaped body (Steps / Expected / Actual / Env / Severity).
- **Dedup** for the three reviewer routines is left to the agent for now (per the discussion); we'll add a finding-hash gateway only if drift surfaces.

## Files

- `backend/app/resources/agent_roles/` — 5 new specialist files, 2 routine files renamed (tech/qa-reviewer), 2 specialist files rewritten ticket-scoped (tech/qa-architect).
- `backend/app/services/lane_recipes.py` — DEFAULT_SEED_LANES = 7, DEFAULT_BUNDLE = 16, DEFAULT_BUNDLE_REASONS + ROUTINE_DISPLAY_LABELS in sync.
- `backend/app/services/policies_seed.py` — _AUDIT_ROLES retargeted at -reviewer slugs, new _REVIEWER_POLICIES (no commit / no approve / one anchor) + _QA_PIPELINE_POLICIES (no defect fixes / anchored to plan).
- `backend/app/services/seed_bundle.py` — BUNDLE_VERSION 0.15 → 0.16.
- `scripts/bundle-version-check.mjs` — track `lane_recipes.py` (drop dead `default_pipelines.py`).
- `backend/tests/test_default_bundle.py` — rewritten against `agent_roles/*.md` (catalog/patterns retired in Phase 2.4 D, the file was already broken on `main`).
- `backend/tests/test_policies_seed.py` — counts updated 34 → 39, scoped 27 → 32.
- `backend/tests/test_services_seed_bundle.py` — assert new lane ids + drop legacy `role-intake` check.

## Out of scope (next phases)

- Phase 2 — `*/30` cadence, one-action-per-tick, `POST /pipeline-pick`, per-role mutex.
- Phase 3 — `process.gates: after_ba | after_arch | after_pr` schema + wizard radio.
- Phase 4 — shipctl preflight, mandatory kb-fetch first / kb-feedback last, reviewer `denied_tools` enforcement at the runner.

## Test plan

- [ ] `pytest backend/tests/test_policies_seed.py backend/tests/test_v1_agent_roles.py backend/tests/test_services_seed_bundle.py backend/tests/test_default_bundle.py backend/tests/test_policies_role_scope.py backend/tests/test_topic_assemble_policies.py backend/tests/test_v1_repo_home.py` — green locally (47 passed)
- [ ] Full backend suite — failure count went **down** (91 → 86) vs `main`; remaining failures are pre-existing Phase 2.4 D leftovers
- [ ] `node scripts/bundle-version-check.mjs --base origin/main` — passes (0.15 → 0.16)
- [ ] Spot-check a fresh wizard seed PR in staging (renders 7 process.routines block, no `lanes:` legacy)