### PR TITLE
console: wizard done card honours auto-merge result

### DIFF
--- a/console/src/app/onboarding/repo-card.tsx
+++ b/console/src/app/onboarding/repo-card.tsx
@@ -759,6 +759,31 @@ export function RepoCard({
               );
               return;
             }
+            // Done-page badge needs to know the merge actually
+            // landed (not just that the user *intended* to merge).
+            // Stash the activation result under its own
+            // sessionStorage key — separate from
+            // ``ship.wizard_seed_result.{id}`` whose invariant is
+            // "configure step writes, done page reads, nobody
+            // mutates after". Best-effort: a swallowed write means
+            // the badge falls back to OPENED, which is honest.
+            try {
+              const body = (await resp.json().catch(() => null)) as
+                | { merged?: unknown; sha?: unknown }
+                | null;
+              if (body && body.merged === true) {
+                window.sessionStorage.setItem(
+                  `ship.wizard_seed_activated.${initial.repo.id}`,
+                  JSON.stringify({
+                    merged: true,
+                    sha: typeof body.sha === "string" ? body.sha : null,
+                  }),
+                );
+              }
+            } catch {
+              // sessionStorage disabled / private browsing —
+              // navigate anyway; the badge degrades to OPENED.
+            }
             navigateToDone();
           }}
           onSkip={() => {

--- a/console/src/app/onboarding/repo-result-card.tsx
+++ b/console/src/app/onboarding/repo-result-card.tsx
@@ -8,6 +8,18 @@
  * (:component:`DoneResult`) hands in everything we need so the card
  * is trivial to unit-test and reuse in fallback paths.
  *
+ * The PR-state badge ("opened" vs "merged") is the one piece of
+ * state that *can* change between the wizard finishing and this
+ * card rendering: the configure step's "Activate Ship now" modal
+ * may have merged the PR via the App's installation token. The
+ * activation handler stashes the resulting ``{merged, sha}`` under
+ * ``ship.wizard_seed_activated.{repo_id}``; we read it once on
+ * mount. No GitHub round-trip — the source of truth is the
+ * activation API's response, captured at the moment the merge
+ * happened. The badge stays at "opened" when the operator picked
+ * "I'll merge it myself" (no activation key written) or when
+ * sessionStorage is unavailable (private browsing).
+ *
  * Pre-cleanup this card also surfaced CODEOWNERS-derived routing
  * rules and a repo-intel poll badge. Both fields became dead
  * post-P5-06: the wizard_seed route stopped dispatching either
@@ -17,6 +29,8 @@
  * Retry harvest →" buttons that wired to nothing. Cleanup keeps the
  * card to load-bearing facts only.
  */
+
+import { useEffect, useState } from "react";
 
 import type {
   ApiActivatedRepo,
@@ -70,7 +84,7 @@ export function RepoResultCard({
       </header>
 
       <div className="mt-4 space-y-3">
-        <PullRequestRow result={result} />
+        <PullRequestRow result={result} repoId={repo?.id ?? null} />
         <FileCountRow result={result} fileCount={fileCount} />
       </div>
     </article>
@@ -99,7 +113,15 @@ function Section({
   );
 }
 
-function PullRequestRow({ result }: { result: ApiWizardSeedOut }) {
+function PullRequestRow({
+  result,
+  repoId,
+}: {
+  result: ApiWizardSeedOut;
+  /** ``null`` when the parent only had the wizard payload, no repo row. */
+  repoId: string | null;
+}) {
+  const merged = useActivationMerged(repoId);
   return (
     <Section label="Pull request">
       <div className="flex flex-wrap items-center gap-2">
@@ -112,9 +134,21 @@ function PullRequestRow({ result }: { result: ApiWizardSeedOut }) {
         >
           → #{result.pr_number} Ship: bootstrap (open in GitHub)
         </a>
-        <span className="rounded-full border border-emerald-400/30 bg-emerald-500/[0.08] px-2 py-0.5 text-[10px] uppercase tracking-widest text-emerald-300">
-          opened
-        </span>
+        {merged ? (
+          <span
+            data-testid="onboarding-done-pr-state"
+            className="rounded-full border border-violet-400/30 bg-violet-500/[0.10] px-2 py-0.5 text-[10px] uppercase tracking-widest text-violet-300"
+          >
+            merged
+          </span>
+        ) : (
+          <span
+            data-testid="onboarding-done-pr-state"
+            className="rounded-full border border-emerald-400/30 bg-emerald-500/[0.08] px-2 py-0.5 text-[10px] uppercase tracking-widest text-emerald-300"
+          >
+            opened
+          </span>
+        )}
       </div>
       <div className="mt-2 text-[11px] text-white/55">
         Branch:{" "}
@@ -124,6 +158,44 @@ function PullRequestRow({ result }: { result: ApiWizardSeedOut }) {
       </div>
     </Section>
   );
+}
+
+
+/**
+ * Read the activation flag the configure step's "Activate Ship now"
+ * modal writes when the App's installation token successfully merged
+ * the seed PR. Returns ``true`` only on a successful merge; missing
+ * key, parse failure, ``merged !== true``, or storage error all
+ * collapse to ``false`` so the badge degrades to OPENED rather than
+ * lying.
+ *
+ * One-shot read on mount — the configure step navigates here right
+ * after writing, so there's no race window worth subscribing to.
+ */
+function useActivationMerged(repoId: string | null): boolean {
+  const [merged, setMerged] = useState(false);
+  useEffect(() => {
+    if (!repoId) return;
+    if (typeof window === "undefined") return;
+    let raw: string | null = null;
+    try {
+      raw = window.sessionStorage.getItem(
+        `ship.wizard_seed_activated.${repoId}`,
+      );
+    } catch {
+      return;
+    }
+    if (!raw) return;
+    try {
+      const parsed = JSON.parse(raw);
+      if (parsed && typeof parsed === "object" && parsed.merged === true) {
+        setMerged(true);
+      }
+    } catch {
+      // Tampered cache — ignore; badge stays OPENED.
+    }
+  }, [repoId]);
+  return merged;
 }
 
 function FileCountRow({


### PR DESCRIPTION
## Summary

Bug: after the configure step's "Activate Ship now" modal merges the seed PR via the App's installation token, the post-merge ``/done`` page still rendered the PR card with a hardcoded green ``opened`` pill. Same card showed the ``BUNDLE V0.x`` tag (which only stamps post-merge), so the two states contradicted each other.

Reported via screenshot in chat — PR #117 was actually MERGED on GitHub but the wizard kept showing OPENED.

## Fix

Persist the activation API's own response — no GitHub round-trip needed.

1. ``onActivate`` in ``repo-card.tsx`` writes ``ship.wizard_seed_activated.{repo_id}`` with ``{merged, sha}`` **only** when the response had ``merged: true``. A 409 branch-protection block doesn't write the key; the badge stays at OPENED.
2. ``PullRequestRow`` in ``repo-result-card.tsx`` reads the key on mount via the new ``useActivationMerged`` hook and renders a violet "merged" pill instead of the green "opened" one.

Honest fallbacks:
- "I'll merge it myself" path (``onSkip``) writes nothing → OPENED.
- sessionStorage disabled / private browsing → write swallowed, badge stays OPENED.
- Tampered cache / parse failure → ``merged !== true`` collapses to OPENED.

The configure step navigates straight to ``/done`` after writing, so a one-shot read on mount is enough — no subscription needed.

## Test plan

- [x] ``npx tsc --noEmit`` clean
- [x] ``npm run lint`` — no new warnings (pre-existing only)
- [ ] Manual: re-seed a workspace with auto-merge, verify card shows MERGED
- [ ] Manual: pick "I'll merge myself", verify card stays OPENED
- [ ] Manual: open ``/done`` URL on a different device (no sessionStorage entry), verify card shows OPENED — degrades honestly