### PR TITLE
knowledge: tiebreaker uses vendor-default model, not hardcoded gpt-4o-mini

### DIFF
--- a/backend/app/services/knowledge_router.py
+++ b/backend/app/services/knowledge_router.py
@@ -453,12 +453,18 @@ async def _llm_tiebreaker(
         f"## Note body\n{body}"
     )
     try:
+        # Don't hardcode the model — pass ``None`` so the client uses its
+        # vendor-resolved fast model. ``Settings._validate_anthropic_models``
+        # already maps the OpenAI-shaped default (``gpt-4o-mini``) to the
+        # Anthropic equivalent when ``AGENT_VENDOR=anthropic``; hardcoding
+        # an OpenAI name here was sending the request to Anthropic with
+        # an unknown model id, which prod returned as a 4xx and we
+        # caught as ``llm_call_failed`` for every note.
         raw = await client.acomplete(
             messages=[
                 ChatMessage(role="system", content=_LLM_SYSTEM_PROMPT),
                 ChatMessage(role="user", content=user_msg),
             ],
-            model="gpt-4o-mini",
             max_tokens=200,
             temperature=0.0,
             response_format={"type": "json_object"},


### PR DESCRIPTION
## Summary

Telemetry from #115 revealed prod's ``no_fit_reason`` for all 77 stuck notes is **``llm_call_failed``** — meaning the LLM client exists but the HTTP call itself errors.

**Root cause:** the tiebreaker hardcoded ``model=\"gpt-4o-mini\"`` while prod runs ``AGENT_VENDOR=anthropic``. ``AnthropicAgentClient.acomplete`` happily forwards whatever model id it gets, and Anthropic's API rejects ``gpt-4o-mini`` as unknown. The 4xx surfaces as ``llm_call_failed`` — and no other code path in the router emits that label for every single note, so the diagnosis is unambiguous.

## Fix

Drop the hardcoded model. ``client.acomplete(model=None)`` falls back to ``self._default_fast_model``, which ``Settings._validate_anthropic_models`` already remaps from the OpenAI-shaped default (``gpt-4o-mini``) to the Anthropic equivalent at boot when vendor=anthropic. OpenAI deployments still get ``gpt-4o-mini`` via the same default. Chat / topic-shift / summariser callers already pass ``model=None``; the router was the outlier.

## Verification path

After deploy, the 20:30 UTC router tick (next one is current-hour:30) re-processes the stuck 77 because their ``routed_bucket_id`` is still NULL. Telemetry from #115 will show:
- ``no_fit_reason`` flips to ``llm_returned_null`` (genuine "doesn't fit") OR
- Many notes get ``source: \"llm_tiebreaker\"`` with a real bucket_slug

Either way the bug is fixed; the second outcome unblocks the synth tick at :40 and finally produces draft articles.

## Test plan

- [x] All 7 router tests still pass — the stub LLM client doesn't validate model ids, so the existing ``routed_via_llm`` / ``no_fit`` assertions are unchanged.
- [ ] After deploy: query ``audit_log`` after :30 tick, confirm ``no_fit_reason`` is no longer ``llm_call_failed``.