### PR TITLE
process: render only what is in .ship/config.yml, drop legacy Pipeline drift

### DIFF
--- a/backend/app/api/v1/routes/processes.py
+++ b/backend/app/api/v1/routes/processes.py
@@ -1323,7 +1323,23 @@ def _placeholder_process_states(
 
 
 def _state_lane_ids(lanes: list[Lane], pipelines: list[Pipeline]) -> list[str]:
-    seen = {row.lane_id for row in lanes} | {row.lane_id for row in pipelines}
+    """Lane ids the canvas + routines columns project.
+
+    Source of truth is :class:`Lane` (the ``routines`` table), which
+    ``lanes_sync`` keeps in lockstep with the repo's
+    ``.ship/config.yml`` — rows for routines that disappear from the
+    config are hard-deleted on next sync. ``Pipeline`` rows are
+    deliberately ignored: they were auto-seeded on first repo
+    activation and never cleaned up, so they leak legacy ids
+    (``code_map``, ``tech_debt``, ``scan_*``, ``self_heal``, …) the
+    operator never declared. Showing them as drift was the old design;
+    the new design is "show what's actually in the repo, period".
+    The ``pipelines`` parameter stays so call sites that need
+    ``Pipeline`` for runtime data (last_run_status, run history) keep
+    working — we just don't pull lane ids from it.
+    """
+    del pipelines  # intentionally ignored; Lane is the source of truth
+    seen = {row.lane_id for row in lanes}
     ordered = list(_PROCESS_STATE_ORDER)
     extras = sorted(seen - set(ordered))
     return ordered + extras

--- a/console/src/app/(authed)/process/routine-catalog.ts
+++ b/console/src/app/(authed)/process/routine-catalog.ts
@@ -1,5 +1,5 @@
 /**
- * Canonical routine catalog — six routines, mirrored against backend
+ * Canonical routine catalog — seven routines, mirrored against backend
  * ``DEFAULT_SEED_LANES`` in ``backend/app/services/lane_recipes.py``.
  *
  * IDs are short verbs that match the backend seed exactly. They are
@@ -61,6 +61,15 @@ export const BUILTIN_ROUTINE_CATALOG: {
       "Scan dependencies and secrets policy; list actionable security follow-ups.",
     defaultCron: "0 6 * * *",
   },
+  {
+    id: "process_review",
+    name: "Process review",
+    description:
+      "Delivery patterns + SDLC suggestions to the inbox (PR previews, CI health, branch hygiene).",
+    prompt:
+      "Look at the last 7-30 days of repo activity; suggest concrete SDLC improvements as inbox items.",
+    defaultCron: "0 16 * * *",
+  },
 ];
 
 /**
@@ -68,26 +77,29 @@ export const BUILTIN_ROUTINE_CATALOG: {
  * clothing in older configs. These never belong in the routines list;
  * the FE filters them so the picker / summary stay clean.
  *
- * Pre-canonical routine ids (daily_security_review / code_map /
- * scan_*) used to be hidden too. They are no longer hidden — the
- * operator should SEE drift from the canonical six so they can clean
- * up DB orphans by hand. Hiding them masks "I have stale pipeline rows
- * from an old seed" which is exactly the kind of mismatch the editor
- * needs to surface, not paper over.
+ * The drift-orphan story changed: the backend projector now sources
+ * routines exclusively from :class:`Lane` rows (kept in lockstep with
+ * ``.ship/config.yml`` by ``lanes_sync``), so legacy ``Pipeline``
+ * orphans never reach the FE in the first place. The "show drift,
+ * clean by hand" design is gone; the page renders what's in the repo
+ * and nothing else.
  */
 export const HIDDEN_ROUTINE_IDS: ReadonlySet<string> = new Set([
   "task_intake",
+  "bug_triage",
   "ba_requirements",
   "tech_arch_plan",
   "qa_arch_plan",
   "dev_implementation",
   "qa_manual",
   "qa_automation",
+  "code_review",
 ]);
 
 /**
- * IDs the FE knows are routines but pre-date the canonical six. Used
- * to paint a "legacy" pill so the operator can spot drift.
+ * IDs the FE knows are routines but pre-date the canonical seven. Used
+ * to paint a "legacy" pill so the operator can spot drift on configs
+ * that haven't been re-seeded to the current canon yet.
  */
 export const CANONICAL_ROUTINE_IDS: ReadonlySet<string> = new Set(
   BUILTIN_ROUTINE_CATALOG.map((entry) => entry.id),


### PR DESCRIPTION
## Summary

Process page was showing nine LEGACY routines (`code_map`, `tech_debt`, `daily_standup`, `flow_release_notes`, `scan_docs_freshness`, `scan_license_deps`, `scan_security_deps`, `scan_tech_debt`, `self_heal`) that **don't exist** in the repo's `.ship/config.yml`. Plus `process_review` (the canonical seventh routine since Phase 1) was wrongly tagged LEGACY because the FE catalog still had six.

Operator's call: "show what's actually in the repo, period". This PR delivers that.

## Why those legacy entries existed

- They're stale `Pipeline` rows from a pre-canon auto-seed when the repo first activated. `lanes_sync` keeps `Lane` (routines table) in lockstep with `.ship/config.yml` — deletes rows for routines no longer declared — but it doesn't touch `Pipeline` rows. The projector at `_state_lane_ids` was unioning both tables, so legacy `Pipeline` ids leaked onto the canvas.
- The original design deliberately surfaced them as drift "so the operator can clean up DB orphans by hand". In practice that put unfixable junk in front of the user.

## Fix

**Backend** (`backend/app/api/v1/routes/processes.py`)
- `_state_lane_ids` ignores its `pipelines` parameter for the lane union. `Lane` is the sole source of truth.
- `Pipeline` rows still flow through downstream for runtime data (`last_run_status`, triggers) — they just no longer leak lane ids onto the canvas.

**FE** (`console/src/app/(authed)/process/routine-catalog.ts`)
- `BUILTIN_ROUTINE_CATALOG` gains `process_review` — the seventh canonical entry. Backend seeded it since Phase 1 but the FE catalog stayed at six, so `process_review` was wrongly tagged LEGACY.
- `HIDDEN_ROUTINE_IDS` extended for the Phase 1.5 stage ids (`bug_triage`, `code_review`) so they don't leak into the routines column when a repo's config carries them.
- Drift-cleanup comment dropped; new contract is "show repo, period".

## Test plan

- [x] Full backend: 86 failed, 937 passed — same regression count as `main` (pre-existing)
- [x] `npx tsc --noEmit` clean
- [ ] Deploy + reload Process page on Ship-on-Ship — should see exactly the seven canonical routines (Daily / Retro / Healthcheck / Tech review / QA review / Security review / Process review), no LEGACY pills.

## Out of scope

Stale `Pipeline` rows themselves stay in DB for now — the projector just stops surfacing them. If they ever become a real problem (cron-firing zombies, dashboard analytics inflated), we'd add a one-shot purge migration. For now, hidden = good enough.