### PR TITLE
knowledge: synth survives LLM mis-decisions on slug/version collisions

### DIFF
--- a/backend/app/services/knowledge_synth.py
+++ b/backend/app/services/knowledge_synth.py
@@ -300,6 +300,30 @@ async def _synthesise_bucket(
             supersedes_id = prev.id
             new_version = (prev.version or 0) + 1
 
+    # Defensive: regardless of LLM verdict, query the actual max
+    # version live in the DB for ``(bucket_id, decision.slug)``. The
+    # LLM occasionally returns ``action='update'`` without a
+    # ``supersedes_slug``, or ``action='new'`` with a slug that
+    # already exists in the bucket — both blow up on the
+    # ``uq_bucket_articles_bucket_slug_version`` unique index when we
+    # blindly insert ``version=1``. Looking up the live max here makes
+    # the insert correct under either LLM mistake.
+    if supersedes_id is None:
+        live_max_stmt = (
+            select(BucketArticle)
+            .where(BucketArticle.bucket_id == bucket.id)
+            .where(BucketArticle.slug == decision.slug)
+            .where(BucketArticle.archived_at.is_(None))
+            .order_by(BucketArticle.version.desc())
+            .limit(1)
+        )
+        live_prev = (
+            await session.execute(live_max_stmt)
+        ).scalar_one_or_none()
+        if live_prev is not None:
+            supersedes_id = live_prev.id
+            new_version = (live_prev.version or 0) + 1
+
     # Embedding: best-effort. Missing key → article still useful.
     embedding = await _maybe_embed(decision.title, decision.body_md)
 


### PR DESCRIPTION
## Summary

Manual prod synth confirmed (after #123 unblocked routing): synth crashed with ``UniqueViolationError`` on the first bucket — ``(bucket_id, slug='agent-outcome-vocabulary', version=1)`` collided with an existing published article.

**Root cause:** the LLM returned ``action='update'`` but **no** ``supersedes_slug`` (or empty). The existing supersedes branch in ``_synthesise_bucket`` skipped, and ``new_version`` stayed at 1. Inserting a draft at the same ``(bucket_id, slug, version=1)`` as the live published row hits the ``uq_bucket_articles_bucket_slug_version`` index, the synth pass aborts mid-bucket, and the whole transaction rolls back — every other bucket in the tick loses its draft too.

That's why the user saw 0 drafts in inbox even with 75 routed notes ready.

## Fix

Defensive live-DB lookup for ``max(version) WHERE (bucket_id, slug)`` whenever the LLM-supplied ``supersedes_slug`` didn't pin a prior. If a prior article exists, treat the new draft as ``version+1`` with that prior as ``supersedes_id``; otherwise ``version=1`` (genuinely new slug). Catches:

- ``action='update'`` with missing/wrong ``supersedes_slug``
- ``action='new'`` with a slug that already exists in the bucket
- Any other LLM-side ``action``/``slug`` confusion

## Verified end-to-end on prod data

Manual run after the fix produced 4 drafts + 4 inbox items in askslayer's workspace:

```
✓ Draft update: Engineering standard: agent outcomes...    (v2, engineering-standards) ← my fix's path
✓ Draft article: Runbook: Local Testing and Routing...     (v1, runbooks-operations)
✓ Draft article: Understanding the Audit Log...            (v1, security-access)
✓ Draft article: Jira API Token: Authentication...         (v1, integration-playbooks)
```

The engineering-standards bucket correctly produced v2 of an existing slug instead of crashing — the exact behaviour the unique index expects.

## Test plan

- [x] Manual prod-DB verification — 4 drafts written, 4 inbox items linked, no UNIQUE violations.
- [ ] Existing synth test suite couldn't be run locally (pre-existing migration mismatch: DB pinned at ``0054_purge_legacy_pipelines`` which doesn't exist on this branch). Will run on CI.