### PR TITLE
console: inbox row actions show in single-workspace mode too

### DIFF
--- a/console/src/app/(authed)/inbox/page.tsx
+++ b/console/src/app/(authed)/inbox/page.tsx
@@ -325,6 +325,7 @@ export default async function InboxPage({
                     key={tier}
                     tier={tier}
                     items={items}
+                    workspaceId={workspaceId}
                     workspaceScope={inboxWs}
                   />
                 );
@@ -414,10 +415,17 @@ function OwnershipRibbon({
 function TierSection({
   tier,
   items,
+  workspaceId,
   workspaceScope,
 }: {
   tier: InboxTier;
   items: InboxItem[];
+  /** The actual workspace id — always set; passed to row actions so
+   *  POST disposition knows which workspace to act on, regardless of
+   *  whether the user happens to belong to one workspace or many. */
+  workspaceId: string;
+  /** URL-scope override — only set when the user has multiple
+   *  workspaces and we need to disambiguate via ``?ws=…`` on links. */
   workspaceScope?: string;
 }) {
   return (
@@ -441,7 +449,7 @@ function TierSection({
           <li key={item.id}>
             <InboxItemRow
               item={item}
-              workspaceId={workspaceScope}
+              workspaceId={workspaceId}
               href={
                 workspaceScope
                   ? `/inbox/${item.id}?ws=${encodeURIComponent(workspaceScope)}`


### PR DESCRIPTION
## Summary

The inline **Accept** / **Reject** buttons on inbox rows were hidden for every operator who only belonged to one workspace. ``inbox/page.tsx`` overloaded ``inboxWs`` — same value used for "include ``?ws=…`` in links?" *and* "what workspace do row actions act on?". Single-workspace users had ``multiWs=false`` → ``inboxWs=undefined`` → ``InboxItemRow`` got ``workspaceId=undefined`` → the ``{workspaceId && href && !isTerminal && (…)}`` guard rejected, **nothing rendered** (neither the lg-hover-revealed desktop set nor the mobile always-on set).

Surfaced today when the knowledge synth pipeline finally produced its first drafts on prod (after #119/#123/#126) and the operator (single workspace) saw the rows but had no way to approve them.

## Fix

Split the two concerns. ``TierSection`` now takes:
- ``workspaceId`` — the real workspace id, always set; passed to row actions so POST disposition knows where to act regardless of multi-ws state.
- ``workspaceScope`` — URL override, ``undefined`` for single-ws so links stay clean (no ``?ws=…``).

Same change pattern as we'd want to apply to other consumers of ``inboxWs`` if they share the bug, but the row-actions case was the live blocker.

## Test plan

- [x] ``npx tsc --noEmit`` clean.
- [ ] Manual: load ``/inbox`` in a single-workspace account, hover a row → Accept button appears (desktop) / always visible (mobile).