### PR TITLE
knowledge: synth uses vendor-default model, not hardcoded gpt-4o-mini

### DIFF
--- a/backend/app/services/knowledge_synth.py
+++ b/backend/app/services/knowledge_synth.py
@@ -618,12 +618,19 @@ async def _ask_llm_synthesis(
     """One non-streaming completion. Returns ``None`` on failure / skip."""
     user_msg = _build_user_prompt(bucket=bucket, notes=notes, existing=existing)
     try:
+        # Don't hardcode the model — let the client use its
+        # vendor-resolved fast model. Same fix as #119 applied to
+        # the router: passing ``gpt-4o-mini`` to ``AnthropicAgentClient``
+        # on prod (``AGENT_VENDOR=anthropic``) returns a 4xx for an
+        # unknown model id, which we catch as a generic exception
+        # and convert to ``None`` — silently dropping every synth
+        # call. The cron then logs zero drafts created without any
+        # other signal of why.
         raw = await client.acomplete(
             messages=[
                 ChatMessage(role="system", content=_SYNTH_SYSTEM_PROMPT),
                 ChatMessage(role="user", content=user_msg),
             ],
-            model="gpt-4o-mini",
             max_tokens=4000,
             temperature=0.2,
             response_format={"type": "json_object"},


### PR DESCRIPTION
## Summary

Same bug shape as #119 (router fix), missed in synth. ``synth.py:626`` hardcoded ``model='gpt-4o-mini'`` in its single LLM call. Prod runs ``AGENT_VENDOR=anthropic`` — passing ``gpt-4o-mini`` to ``AnthropicAgentClient.acomplete`` returns a 4xx for an unknown model id, the synth function catches it as a generic exception and returns ``None``, the bucket pass logs ``drafts_skipped_no_llm``, and the cron writes zero drafts with no other signal of why.

**Surfaced today:** the 21:40 UTC synth tick ran post-#126 deploy but produced 0 drafts. Architecture-decisions still has 42 routed notes pending while every other bucket cleared (those drafts only exist because I ran synth manually with my local OpenAI client, bypassing the broken Anthropic path).

## Fix

Drop the hardcoded model. ``Settings._validate_anthropic_models`` already remaps the OpenAI-shaped ``agent_model_fast`` default to the Anthropic equivalent at boot, so passing ``model=None`` (i.e. omitting it) lets the client's vendor-resolved fast model take over. OpenAI deployments still get ``gpt-4o-mini`` via the same default.

``response_format={'type':'json_object'}`` stays — ``AnthropicAgentClient`` ignores it (the comment in client.py says "we rely on prompt engineering"), OpenAI honours it.

## Test plan

- [x] Diff matches #119 surgery exactly: only the ``model=...`` line removed.
- [ ] After deploy, the next synth tick (every hour at :40 UTC) processes the 42 stuck architecture-decisions notes.