### PR TITLE
knowledge: synth honours LLM 'skip' as a real decision

### DIFF
--- a/backend/app/services/knowledge_synth.py
+++ b/backend/app/services/knowledge_synth.py
@@ -116,6 +116,7 @@ class SynthReport:
     drafts_skipped_no_notes: int = 0
     drafts_skipped_no_llm: int = 0
     drafts_skipped_dup_content: int = 0
+    drafts_skipped_llm_skip: int = 0
     # Number of ``auto_routed_archive_proposal`` inbox rows emitted
     # this pass. They sit alongside ``drafts_created`` in the cron
     # log so an operator can tell at a glance whether the pipeline
@@ -237,6 +238,17 @@ async def _synthesise_bucket(
     )
     if decision is None:
         report.drafts_skipped_no_llm += 1
+        return
+
+    if decision.action == "skip":
+        # LLM looked at the notes and decided they don't form an
+        # article. Mark them consumed so the next tick stops
+        # re-presenting the same notes (otherwise we burn one LLM
+        # call per bucket per hour forever on the same skip
+        # verdict).
+        await _mark_notes_consumed(session, pending, article_id=None)
+        report.notes_consumed += len(pending)
+        report.drafts_skipped_llm_skip += 1
         return
 
     if decision.action == "archive":
@@ -456,12 +468,23 @@ async def _existing_published_articles(
 async def _mark_notes_consumed(
     session: AsyncSession,
     notes: list[Improvement],
-    article_id: uuid.UUID,
+    article_id: uuid.UUID | None,
 ) -> None:
+    """Stamp notes with ``synthesised_into_article_id`` so the next
+    tick stops re-fetching them.
+
+    ``article_id`` may be ``None`` when the LLM decided ``skip`` — the
+    notes are still consumed (the model looked at them and chose
+    nothing), but there's no article to point at. We persist the
+    sentinel string ``"skipped"`` so the JSON path predicate
+    ``IS NULL`` in :func:`_pending_notes_for_bucket` excludes them
+    just the same.
+    """
     now = datetime.now(timezone.utc).isoformat()
+    target = str(article_id) if article_id is not None else "skipped"
     for n in notes:
         ctx = dict(n.context or {})
-        ctx["synthesised_into_article_id"] = str(article_id)
+        ctx["synthesised_into_article_id"] = target
         ctx["synthesised_at"] = now
         n.context = ctx
 
@@ -646,8 +669,23 @@ async def _ask_llm_synthesis(
         return None
 
     action = obj.get("action")
-    if action not in ("new", "update", "archive"):
+    if action not in ("new", "update", "archive", "skip"):
         return None
+
+    if action == "skip":
+        # Surface the verdict so the caller can mark notes consumed
+        # and bump the right counter — without dropping into the
+        # ``decision is None`` branch that's reserved for genuine
+        # LLM failures.
+        return _SynthDecision(
+            action="skip",
+            slug="",
+            title="",
+            body_md="",
+            supersedes_slug=None,
+            archive_slug=None,
+            archive_reason=None,
+        )
 
     if action == "archive":
         # Archive proposals only need a slug + reason; body fields


### PR DESCRIPTION
## Summary

Architecture-decisions had 42 routed notes the LLM kept rejecting as off-topic (they're reference docs about Ship's artifact system, routed there only by cosine fallback when no better bucket scored). Two follow-on bugs in synth:

1. **Parser whitelist refused ``action='skip'``** — it dropped to ``return None``, which the caller treated identically to ``llm_call_failed`` (incrementing ``drafts_skipped_no_llm``). Telemetry told us "LLM is broken" when actually the model was making a deliberate, documented choice.

2. **Notes were never marked consumed on skip** — every cron tick re-fetched the same 20 notes, called the LLM, watched it skip, logged the wrong counter, and moved on. One bucket producing the same skip verdict in perpetuity costs ~24 LLM calls a day on identical input. The synthesiser docstring already says ``action='skip' — notes are too thin / off-topic to act on yet; consumed without writing`` — implementation just didn't do the "consumed" half.

## Fix

- Recognise ``'skip'`` in ``_ask_llm_synthesis``; build a ``_SynthDecision(action='skip', …)`` so the caller can distinguish from genuine LLM failure.
- New ``drafts_skipped_llm_skip`` counter on ``SynthReport``.
- ``_synthesise_bucket`` handles ``action='skip'`` by marking pending notes consumed (no article_id) and bumping the new counter.
- ``_mark_notes_consumed`` accepts ``article_id=None`` and writes the sentinel string ``'skipped'`` so the existing ``IS NULL`` predicate in ``_pending_notes_for_bucket`` excludes them just the same.

## Verified manually against prod

Before: architecture-decisions 42 pending forever; engineering-standards 1 pending forever.
After one manual run with the fix: 21 notes exited the pool with ``synthesised_into_article_id='skipped'`` (20 architecture + 1 engineering-standards). The remaining 22 architecture notes will hit the next tick and get the same skip-and-consume treatment in groups of 20.

## Test plan

- [x] Manual prod-DB verification — 21 notes flipped to ``synthesised_into_article_id='skipped'``; ``drafts_skipped_no_llm`` is no longer wrongly incremented for skip verdicts.
- [ ] Existing synth test suite: pre-existing migration mismatch on this branch's local DB; will run on CI.