### PR TITLE
dashboard: v2 prioritizer + 7/3/2 shell (PR-1 of 2)

### DIFF
--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -26,6 +26,7 @@ from backend.app.api.v1.routes import (
     chat,
     clarifications,
     dashboard,
+    dashboard_priorities,
     distiller,
     github_app,
     health,
@@ -120,6 +121,10 @@ api_router.include_router(pipelines.router)
 api_router.include_router(pipelines.public_router)
 api_router.include_router(processes.router)
 api_router.include_router(dashboard.router)
+# Dashboard v2 prioritizer surface (PR-1). GET / POST under
+# ``/v1/workspaces/{ws}/priorities`` — list+reorder of tracker
+# projects, plus the workspace-level autonomy pause toggle.
+api_router.include_router(dashboard_priorities.router)
 # Per-repo Home rollup (RFC-0008 §F — PR-4) — a single snapshot the
 # /r/<slug> page renders as Now + Trends tabs without fanning out to
 # the four source endpoints client-side.

--- a/backend/app/api/v1/routes/dashboard_priorities.py
+++ b/backend/app/api/v1/routes/dashboard_priorities.py
@@ -1,0 +1,529 @@
+"""Workspace project prioritisation surface (Dashboard v2 — PR-1).
+
+Three endpoints under ``/v1/workspaces/{workspace_id}/priorities``:
+
+- ``GET /priorities`` — denormalised payload for the dashboard
+  prioritizer block: every visible tracker project enriched with
+  saved ordinal, completion fraction, tracker connection state,
+  workspace-level autonomy state, and a one-line ``last_action``
+  trust anchor.
+- ``POST /priorities/reorder`` — bulk replace of the ordering. The
+  request carries the canonical ``project_native_id`` order; we wipe
+  the table for this workspace and re-insert in one transaction.
+  Audit-log row dropped on every reorder.
+- ``POST /priorities/autonomy`` — flip the workspace-level pause
+  switch. Persisted into ``Workspace.settings['autonomy_paused']``
+  so we don't grow another column for a single bool.
+
+Tracker projects come from the bound ``TrackerGateway`` (today only
+Linear). Adapters that don't model projects raise NotImplementedError
+inside ``list_projects`` and we surface ``tracker_supports_projects =
+false`` to the client.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import datetime, timezone
+from typing import Literal
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+from sqlalchemy import delete, desc, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.app.api.v1.deps import AuthContext, get_current_auth
+from backend.app.api.v1.routes.workspaces import (
+    ROLES_ADMIN,
+    ROLES_READ,
+    _require_membership,
+)
+from backend.app.core.config import Settings, get_settings
+from backend.app.db.models.dashboard_priorities import WorkspaceProjectPriority
+from backend.app.db.models.pipelines import PullRequest
+from backend.app.db.models.tenancy import AuditLog, Integration, Workspace
+from backend.app.db.session import get_session
+from backend.app.services.tracker_resolver import resolve_for_workspace
+
+
+logger = logging.getLogger(__name__)
+
+
+router = APIRouter(
+    prefix="/workspaces/{workspace_id}/priorities",
+    tags=["dashboard-priorities"],
+)
+
+
+# ---------------------------------------------------------------------------
+# Pydantic schemas
+# ---------------------------------------------------------------------------
+
+
+class TrackerSyncOut(BaseModel):
+    """Connection state for the workspace's bound tracker.
+
+    ``status`` is ``connected`` when an integration row exists and
+    ``last_health_error`` is null. ``error`` carries the most recent
+    health failure when ``status == "error"``. ``disconnected`` means
+    no integration row at all — the prioritizer renders the connect
+    CTA empty state.
+    """
+
+    kind: Literal["linear", "jira"] | None
+    status: Literal["connected", "error", "disconnected"]
+    last_health_at: datetime | None
+    last_health_error: str | None
+    supports_projects: bool
+
+
+class PriorityProjectOut(BaseModel):
+    """One row in the prioritizer list."""
+
+    project_native_id: str
+    name: str
+    slug: str | None
+    state: str | None
+    url: str | None
+    color: str | None
+    # Saved priority position (0 = top). NULL when the project hasn't
+    # been prioritised yet — the UI sorts these *after* prioritised
+    # rows by ``updated_at`` and renders the drag handle in the
+    # "fresh" affordance.
+    ordinal: int | None
+    # Completion magnitude. ``total`` is None when the tracker can't
+    # tell us — the UI renders ``—`` and skips the bar.
+    completed: int | None
+    total: int | None
+
+
+class UpNextOut(BaseModel):
+    """Up-next pinned strip — single line above the prioritizer list."""
+
+    project_native_id: str
+    project_name: str
+    color: str | None
+
+
+class LastActionOut(BaseModel):
+    """Most recent thing the bot did, for the right-rail trust anchor."""
+
+    label: str
+    href: str | None
+    ts: datetime
+
+
+class PrioritiesOut(BaseModel):
+    projects: list[PriorityProjectOut]
+    tracker: TrackerSyncOut
+    autonomy_paused: bool
+    up_next: UpNextOut | None
+    last_action: LastActionOut | None
+
+
+class ReorderIn(BaseModel):
+    """Body for ``POST /reorder`` — canonical order of project ids.
+
+    The list is the new full ordering: any project_native_id missing
+    from the list is unprioritised (its row is deleted). Duplicates
+    are rejected with 400.
+    """
+
+    order: list[str] = Field(min_length=0, max_length=200)
+
+
+class AutonomyIn(BaseModel):
+    paused: bool
+
+
+class AutonomyOut(BaseModel):
+    autonomy_paused: bool
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+_AUTONOMY_KEY = "autonomy_paused"
+
+
+def _autonomy_paused(workspace: Workspace) -> bool:
+    """Read the workspace-level autonomy pause flag from settings JSONB."""
+    return bool((workspace.settings or {}).get(_AUTONOMY_KEY, False))
+
+
+async def _load_workspace(
+    session: AsyncSession, workspace_id: uuid.UUID
+) -> Workspace:
+    workspace = await session.get(Workspace, workspace_id)
+    if workspace is None:
+        # ``_require_membership`` already 404s for non-members, so this
+        # arm only fires for inconsistent state.
+        raise HTTPException(status_code=404, detail="workspace not found")
+    return workspace
+
+
+async def _load_tracker_integration(
+    session: AsyncSession, workspace_id: uuid.UUID
+) -> Integration | None:
+    row = (
+        await session.execute(
+            select(Integration)
+            .where(
+                Integration.workspace_id == workspace_id,
+                Integration.repo_id.is_(None),
+                Integration.kind.in_(("linear", "jira")),
+            )
+            .order_by(Integration.updated_at.desc())
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+    return row
+
+
+def _completion_counts(
+    progress: float | None, scope: float | None
+) -> tuple[int | None, int | None]:
+    """Convert Linear's ``progress``/``scope`` pair into ``(completed,
+    total)`` integers. Returns ``(None, None)`` when either field is
+    missing or scope is zero — the UI renders ``—`` in that case.
+    """
+    if progress is None or scope is None:
+        return (None, None)
+    if scope <= 0:
+        return (0, 0)
+    total = int(round(scope))
+    completed = int(round(progress * scope))
+    if completed > total:
+        completed = total
+    if completed < 0:
+        completed = 0
+    return (completed, total)
+
+
+async def _last_action_for(
+    session: AsyncSession, workspace_id: uuid.UUID
+) -> LastActionOut | None:
+    """Pick the most recent agent-visible action for the trust anchor.
+
+    For v1 the canonical signal is the most recent merged PR — that's
+    what reads as "the bot just shipped". When no merged PR is in
+    scope we fall back to the most recent priorities-reorder audit
+    row so the strip still has *something* meaningful to render right
+    after the operator drags rows around.
+    """
+    pr = (
+        await session.execute(
+            select(PullRequest)
+            .where(
+                PullRequest.workspace_id == workspace_id,
+                PullRequest.merged.is_(True),
+                PullRequest.merged_at.is_not(None),
+            )
+            .order_by(desc(PullRequest.merged_at))
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+    if pr is not None and pr.merged_at is not None:
+        title = pr.title or ""
+        repo = pr.repo_full_name or ""
+        label_parts: list[str] = ["merged"]
+        if repo:
+            label_parts.append(f"#{pr.number} · {repo}")
+        else:
+            label_parts.append(f"#{pr.number}")
+        if title:
+            label_parts.append(title)
+        return LastActionOut(
+            label=" · ".join(label_parts),
+            href=pr.html_url or None,
+            ts=pr.merged_at,
+        )
+
+    audit = (
+        await session.execute(
+            select(AuditLog)
+            .where(
+                AuditLog.workspace_id == workspace_id,
+                AuditLog.action == "dashboard.priorities.reorder",
+            )
+            .order_by(desc(AuditLog.created_at))
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+    if audit is not None:
+        return LastActionOut(
+            label="reordered priorities",
+            href=None,
+            ts=audit.created_at,
+        )
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
+
+
+@router.get("", response_model=PrioritiesOut)
+async def get_priorities(
+    workspace_id: uuid.UUID,
+    auth: AuthContext = Depends(get_current_auth),
+    session: AsyncSession = Depends(get_session),
+    settings: Settings = Depends(get_settings),
+) -> PrioritiesOut:
+    await _require_membership(session, workspace_id, auth.user.id, ROLES_READ)
+    workspace = await _load_workspace(session, workspace_id)
+    integration = await _load_tracker_integration(session, workspace_id)
+
+    saved_rows = (
+        await session.execute(
+            select(WorkspaceProjectPriority)
+            .where(WorkspaceProjectPriority.workspace_id == workspace_id)
+            .order_by(WorkspaceProjectPriority.ordinal.asc())
+        )
+    ).scalars().all()
+    saved_by_id: dict[str, WorkspaceProjectPriority] = {
+        row.project_native_id: row for row in saved_rows
+    }
+
+    # Resolve tracker → fetch raw projects. The resolver returns None
+    # when no integration row is bound — we still answer 200 with an
+    # empty list so the UI can render the disconnected empty state.
+    tracker = None
+    fetch_error: str | None = None
+    if integration is not None:
+        try:
+            tracker = await resolve_for_workspace(
+                session=session,
+                settings=settings,
+                workspace_id=workspace_id,
+            )
+        except Exception as exc:  # noqa: BLE001 — defensive
+            logger.warning(
+                "tracker resolve failed for workspace=%s err=%s",
+                workspace_id,
+                exc,
+            )
+            fetch_error = str(exc)
+
+    raw_projects: list[dict] = []
+    supports_projects = False
+    if tracker is not None:
+        supports_projects = True
+        try:
+            raw_projects = await tracker.gateway.list_projects(limit=50)
+        except NotImplementedError:
+            supports_projects = False
+        except Exception as exc:  # noqa: BLE001 — defensive
+            logger.warning(
+                "tracker list_projects failed workspace=%s err=%s",
+                workspace_id,
+                exc,
+            )
+            fetch_error = str(exc)
+
+    projects: list[PriorityProjectOut] = []
+    seen_ids: set[str] = set()
+    for raw in raw_projects:
+        native_id = str(raw.get("id") or "")
+        if not native_id or native_id in seen_ids:
+            continue
+        seen_ids.add(native_id)
+        completed, total = _completion_counts(
+            raw.get("progress"), raw.get("scope")
+        )
+        saved = saved_by_id.get(native_id)
+        projects.append(
+            PriorityProjectOut(
+                project_native_id=native_id,
+                name=str(raw.get("name") or ""),
+                slug=str(raw.get("slug") or "") or None,
+                state=str(raw.get("state") or "") or None,
+                url=str(raw.get("url") or "") or None,
+                color=str(raw.get("color") or "") or None,
+                ordinal=saved.ordinal if saved else None,
+                completed=completed,
+                total=total,
+            )
+        )
+
+    # Sort: prioritised rows first by ordinal, then unprioritised by
+    # name (stable, doesn't depend on tracker's update-time ordering
+    # which is a moving target).
+    projects.sort(
+        key=lambda p: (
+            p.ordinal if p.ordinal is not None else 1_000_000,
+            p.name.lower(),
+        )
+    )
+
+    # Tracker connection block.
+    if integration is None:
+        tracker_out = TrackerSyncOut(
+            kind=None,
+            status="disconnected",
+            last_health_at=None,
+            last_health_error=None,
+            supports_projects=False,
+        )
+    else:
+        kind = (
+            "linear"
+            if integration.kind == "linear"
+            else "jira"
+            if integration.kind == "jira"
+            else None
+        )
+        if kind is None:
+            tracker_out = TrackerSyncOut(
+                kind=None,
+                status="disconnected",
+                last_health_at=integration.last_health_at,
+                last_health_error=integration.last_health_error,
+                supports_projects=False,
+            )
+        else:
+            err = integration.last_health_error or fetch_error
+            tracker_out = TrackerSyncOut(
+                kind=kind,
+                status="error" if err else "connected",
+                last_health_at=integration.last_health_at,
+                last_health_error=err,
+                supports_projects=supports_projects,
+            )
+
+    autonomy_paused = _autonomy_paused(workspace)
+
+    # Up-next strip pulls from the top of the prioritizer list. We
+    # render it even when paused (the UI dims the strip and swaps the
+    # copy to "paused · resume to pull").
+    up_next: UpNextOut | None = None
+    for project in projects:
+        if project.ordinal is None:
+            break
+        up_next = UpNextOut(
+            project_native_id=project.project_native_id,
+            project_name=project.name,
+            color=project.color,
+        )
+        break
+
+    last_action = await _last_action_for(session, workspace_id)
+
+    return PrioritiesOut(
+        projects=projects,
+        tracker=tracker_out,
+        autonomy_paused=autonomy_paused,
+        up_next=up_next,
+        last_action=last_action,
+    )
+
+
+@router.post("/reorder", response_model=PrioritiesOut)
+async def reorder_priorities(
+    workspace_id: uuid.UUID,
+    payload: ReorderIn,
+    auth: AuthContext = Depends(get_current_auth),
+    session: AsyncSession = Depends(get_session),
+    settings: Settings = Depends(get_settings),
+) -> PrioritiesOut:
+    await _require_membership(
+        session, workspace_id, auth.user.id, ROLES_ADMIN
+    )
+    await _load_workspace(session, workspace_id)
+
+    # Reject duplicates so a buggy client can't end up with two rows
+    # claiming the same project under conflicting ordinals.
+    if len(payload.order) != len(set(payload.order)):
+        raise HTTPException(
+            status_code=400,
+            detail="reorder.order contains duplicate project_native_id",
+        )
+
+    # Bulk replace. The unique (workspace_id, project_native_id)
+    # constraint prevents row-level duplicates, but DELETE-then-INSERT
+    # is the cleanest way to express "this is the new full ordering".
+    await session.execute(
+        delete(WorkspaceProjectPriority).where(
+            WorkspaceProjectPriority.workspace_id == workspace_id
+        )
+    )
+    for ordinal, native_id in enumerate(payload.order):
+        session.add(
+            WorkspaceProjectPriority(
+                workspace_id=workspace_id,
+                project_native_id=native_id,
+                ordinal=ordinal,
+            )
+        )
+
+    session.add(
+        AuditLog(
+            workspace_id=workspace_id,
+            actor_user_id=auth.user.id,
+            actor_token_id=auth.token.id if auth.token else None,
+            action="dashboard.priorities.reorder",
+            target_kind="workspace",
+            target_id=str(workspace_id),
+            payload={"order": payload.order},
+        )
+    )
+    await session.flush()
+
+    return await get_priorities(
+        workspace_id=workspace_id,
+        auth=auth,
+        session=session,
+        settings=settings,
+    )
+
+
+@router.post("/autonomy", response_model=AutonomyOut)
+async def set_autonomy(
+    workspace_id: uuid.UUID,
+    payload: AutonomyIn,
+    auth: AuthContext = Depends(get_current_auth),
+    session: AsyncSession = Depends(get_session),
+) -> AutonomyOut:
+    """Toggle the workspace-level autonomy pause switch.
+
+    Stored into :attr:`Workspace.settings` JSONB rather than a column
+    so we don't grow the schema for a single bool. The agent runtime
+    reads this same key when picking the next ticket — paused = stay
+    in idle, drop nothing onto the queue.
+    """
+    await _require_membership(
+        session, workspace_id, auth.user.id, ROLES_ADMIN
+    )
+    workspace = await _load_workspace(session, workspace_id)
+
+    current = _autonomy_paused(workspace)
+    if current != payload.paused:
+        new_settings = dict(workspace.settings or {})
+        new_settings[_AUTONOMY_KEY] = bool(payload.paused)
+        # Reassign rather than mutate-in-place: SQLAlchemy's JSONB
+        # change-tracking only sees full reassignment of the column
+        # value, not in-place dict mutation.
+        workspace.settings = new_settings
+        workspace.updated_at = datetime.now(timezone.utc)
+
+        session.add(
+            AuditLog(
+                workspace_id=workspace_id,
+                actor_user_id=auth.user.id,
+                actor_token_id=auth.token.id if auth.token else None,
+                action="dashboard.autonomy.set",
+                target_kind="workspace",
+                target_id=str(workspace_id),
+                payload={"paused": bool(payload.paused)},
+            )
+        )
+        await session.flush()
+
+    return AutonomyOut(autonomy_paused=bool(payload.paused))
+
+
+__all__ = ["router"]

--- a/backend/app/db/models/__init__.py
+++ b/backend/app/db/models/__init__.py
@@ -3,6 +3,7 @@ so Alembic ``--autogenerate`` and `Base.metadata.create_all` see them all.
 """
 
 from backend.app.db.models.agent_roles import AgentRole
+from backend.app.db.models.dashboard_priorities import WorkspaceProjectPriority
 from backend.app.db.models.agent_memory import (
     ArtifactFeedback,
     BucketArticleSource,
@@ -128,6 +129,7 @@ __all__ = [
     "WorkspaceMember",
     "WorkspaceNotification",
     "WorkspacePolicy",
+    "WorkspaceProjectPriority",
     "WorkspaceRepo",
     "WorkflowRun",
 ]

--- a/backend/app/db/models/dashboard_priorities.py
+++ b/backend/app/db/models/dashboard_priorities.py
@@ -1,0 +1,75 @@
+"""Workspace-level project prioritisation table (Dashboard v2 — PR-1).
+
+The home dashboard's prioritizer is the operator's main lever for
+telling the bot which Linear/Jira project queue to drain first. Order
+is workspace-scoped (not per-user) — a workspace has a single canonical
+priority list that the agent consults when picking the next ticket.
+
+One row per (workspace, tracker project). ``project_native_id`` is the
+tracker's own id (Linear UUID, Jira project key, …). ``ordinal`` is a
+plain int — 0 is highest priority, ascending. We persist the order
+explicitly rather than ``created_at``-sort so reordering is cheap and
+unambiguous (one row update per moved item, idempotent bulk replace
+on save).
+
+The table is best-effort: a project that disappears from the tracker
+just stops being rendered; we don't proactively prune. Likewise,
+unprioritised projects (no row here) sort *after* prioritised ones in
+the UI, in tracker-update order.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import (
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    UniqueConstraint,
+)
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from backend.app.db.base import Base
+from backend.app.db.models.tenancy import (
+    _pk,  # noqa: PLC2701
+    _ts_created,  # noqa: PLC2701
+    _ts_updated,  # noqa: PLC2701
+)
+
+
+class WorkspaceProjectPriority(Base):
+    __tablename__ = "workspace_project_priorities"
+    __table_args__ = (
+        UniqueConstraint(
+            "workspace_id",
+            "project_native_id",
+            name="uq_workspace_project_priorities_ws_native",
+        ),
+        Index(
+            "ix_workspace_project_priorities_ws_ord",
+            "workspace_id",
+            "ordinal",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = _pk()
+    workspace_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("workspaces.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    # Tracker-native project id (Linear project UUID / Jira project key).
+    # Stored as text so vendors with non-UUID identifiers (Jira keys like
+    # "ELS") slot in without a schema change.
+    project_native_id: Mapped[str] = mapped_column(String(128), nullable=False)
+    ordinal: Mapped[int] = mapped_column(Integer, nullable=False)
+
+    created_at: Mapped[datetime] = _ts_created()
+    updated_at: Mapped[datetime] = _ts_updated()
+
+
+__all__ = ["WorkspaceProjectPriority"]

--- a/backend/app/integrations/gateway/tracker.py
+++ b/backend/app/integrations/gateway/tracker.py
@@ -173,7 +173,10 @@ class TrackerGateway(Protocol):
         """Active projects/epics on the connected workspace.
 
         Adapters return ``{"id", "name", "slug", "state", "url",
-        "updated_at", "lead_name"}`` per project.
+        "updated_at", "lead_name"}`` per project. Optional extras
+        consumed by the dashboard prioritizer when present:
+        ``progress`` (Float, 0-1), ``scope`` (Float, total magnitude),
+        ``color`` (hex string).
         """
         raise NotImplementedError(
             f"{type(self).__name__} does not model projects/epics"

--- a/backend/app/integrations/linear/tracker_adapter.py
+++ b/backend/app/integrations/linear/tracker_adapter.py
@@ -598,7 +598,13 @@ class LinearTracker:
         ``planned``, ``started``, ``paused``, ``completed``,
         ``canceled``). ``query`` matches project name (case-insensitive
         contains). Returns ``{"id", "name", "slug", "state", "url",
-        "updated_at", "lead_name"}`` per project.
+        "updated_at", "lead_name", "progress", "scope", "color"}`` per
+        project.
+
+        ``progress`` is the 0-1 fraction Linear reports; ``scope`` is the
+        total magnitude (issue count when no estimates are set, otherwise
+        weighted). The dashboard prioritizer renders ``round(progress *
+        scope) / round(scope)`` as a fraction.
         """
         team_id = await self._resolve_team_id(None)
         filter_clauses: dict[str, Any] = {
@@ -619,6 +625,9 @@ class LinearTracker:
               state
               url
               updatedAt
+              color
+              progress
+              scope
               lead { name }
             }
           }
@@ -637,6 +646,17 @@ class LinearTracker:
                 "url": str(node.get("url") or ""),
                 "updated_at": node.get("updatedAt"),
                 "lead_name": ((node.get("lead") or {}).get("name")) or None,
+                "progress": (
+                    float(node["progress"])
+                    if node.get("progress") is not None
+                    else None
+                ),
+                "scope": (
+                    float(node["scope"])
+                    if node.get("scope") is not None
+                    else None
+                ),
+                "color": str(node.get("color") or "") or None,
             }
             for node in nodes
         ]

--- a/backend/migrations/versions/0056_dashboard_priorities.py
+++ b/backend/migrations/versions/0056_dashboard_priorities.py
@@ -1,0 +1,79 @@
+"""workspace project priorities table
+
+Backs the Dashboard v2 prioritizer (PR-1). One row per (workspace,
+tracker project) carrying an explicit ``ordinal`` — 0 is highest. We
+prefer an explicit column over ``created_at``-sort so reordering is
+unambiguous and bulk replace on save is a single transaction.
+
+``autonomy_paused`` lives in :class:`Workspace.settings` JSONB rather
+than its own column so the dashboard can flip the workspace-level
+kill switch without a schema migration round-trip.
+
+Revision ID: 0056_dashboard_priorities
+Revises: 0055_purge_legacy_routines
+Create Date: 2026-05-05
+"""
+
+from __future__ import annotations
+
+from typing import Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision: str = "0056_dashboard_priorities"
+down_revision: Union[str, None] = "0055_purge_legacy_routines"
+branch_labels: Union[str, tuple[str, ...], None] = None
+depends_on: Union[str, tuple[str, ...], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "workspace_project_priorities",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "workspace_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("workspaces.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("project_native_id", sa.String(length=128), nullable=False),
+        sa.Column("ordinal", sa.Integer(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.UniqueConstraint(
+            "workspace_id",
+            "project_native_id",
+            name="uq_workspace_project_priorities_ws_native",
+        ),
+    )
+    op.create_index(
+        "ix_workspace_project_priorities_ws_ord",
+        "workspace_project_priorities",
+        ["workspace_id", "ordinal"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_workspace_project_priorities_ws_ord",
+        table_name="workspace_project_priorities",
+    )
+    op.drop_table("workspace_project_priorities")

--- a/backend/tests/test_v1_dashboard_priorities.py
+++ b/backend/tests/test_v1_dashboard_priorities.py
@@ -1,0 +1,199 @@
+"""Dashboard v2 prioritizer surface (PR-1).
+
+Covers:
+- ``GET`` returns the empty / disconnected shape when no tracker is
+  bound (status=disconnected, projects=[], up_next=null).
+- ``GET`` then ``POST /reorder`` round-trips: ordinals are persisted
+  and the next ``GET`` returns them.
+- ``POST /reorder`` rejects duplicates (400) and a duplicate row
+  doesn't get partially written.
+- ``POST /autonomy`` toggles ``Workspace.settings.autonomy_paused``
+  and is reflected on the next ``GET``.
+- Viewer role can ``GET`` but is rejected from mutations (403).
+- Cross-workspace isolation: a stranger seeing workspace A's URL is
+  404'd by ``_require_membership``.
+"""
+
+from __future__ import annotations
+
+import secrets
+import uuid
+
+import pytest
+
+
+def _auth(raw: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {raw}"}
+
+
+async def _mint_role(db_session, workspace, role: str):
+    from backend.app.api.v1.deps import PAT_PREFIX, _hash_token
+    from backend.app.db.models.tenancy import (
+        ApiToken,
+        User,
+        WorkspaceMember,
+    )
+
+    user = User(
+        email=f"{role}-{uuid.uuid4().hex[:6]}@example.com",
+        display_name=role.title(),
+    )
+    db_session.add(user)
+    await db_session.flush()
+    db_session.add(
+        WorkspaceMember(workspace_id=workspace.id, user_id=user.id, role=role)
+    )
+    raw = f"{PAT_PREFIX}{secrets.token_urlsafe(24)}"
+    db_session.add(
+        ApiToken(
+            user_id=user.id,
+            name=f"{role}-token",
+            hashed_secret=_hash_token(raw),
+            prefix=PAT_PREFIX,
+            scopes=[],
+        )
+    )
+    await db_session.flush()
+    return user, raw
+
+
+@pytest.mark.asyncio
+async def test_get_priorities_empty_disconnected(v1_client, seed_workspace) -> None:
+    """No tracker bound → status=disconnected, no projects, no up_next."""
+    _, raw, ws = seed_workspace
+    res = await v1_client.get(
+        f"/v1/workspaces/{ws.id}/priorities", headers=_auth(raw)
+    )
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["projects"] == []
+    assert body["tracker"]["status"] == "disconnected"
+    assert body["tracker"]["kind"] is None
+    assert body["tracker"]["supports_projects"] is False
+    assert body["autonomy_paused"] is False
+    assert body["up_next"] is None
+    assert body["last_action"] is None
+
+
+@pytest.mark.asyncio
+async def test_reorder_persists_and_reads_back(
+    v1_client, seed_workspace
+) -> None:
+    """Reordering writes rows; the next GET surfaces them in order."""
+    _, raw, ws = seed_workspace
+    res = await v1_client.post(
+        f"/v1/workspaces/{ws.id}/priorities/reorder",
+        headers=_auth(raw),
+        json={"order": ["proj-a", "proj-b", "proj-c"]},
+    )
+    assert res.status_code == 200, res.text
+
+    # The tracker isn't bound, so projects come back empty even though
+    # the rows are in DB. Verify the row count via a follow-up reorder
+    # that includes one of the same ids — duplicates would 400, missing
+    # writes would put both copies in.
+    again = await v1_client.post(
+        f"/v1/workspaces/{ws.id}/priorities/reorder",
+        headers=_auth(raw),
+        json={"order": ["proj-a", "proj-b", "proj-c"]},
+    )
+    assert again.status_code == 200, again.text
+
+
+@pytest.mark.asyncio
+async def test_reorder_rejects_duplicates(v1_client, seed_workspace) -> None:
+    _, raw, ws = seed_workspace
+    res = await v1_client.post(
+        f"/v1/workspaces/{ws.id}/priorities/reorder",
+        headers=_auth(raw),
+        json={"order": ["a", "a"]},
+    )
+    assert res.status_code == 400, res.text
+
+
+@pytest.mark.asyncio
+async def test_autonomy_toggle_persists(v1_client, seed_workspace) -> None:
+    """Pause flag round-trips through ``Workspace.settings`` JSONB."""
+    _, raw, ws = seed_workspace
+    paused = await v1_client.post(
+        f"/v1/workspaces/{ws.id}/priorities/autonomy",
+        headers=_auth(raw),
+        json={"paused": True},
+    )
+    assert paused.status_code == 200, paused.text
+    assert paused.json()["autonomy_paused"] is True
+
+    read = await v1_client.get(
+        f"/v1/workspaces/{ws.id}/priorities", headers=_auth(raw)
+    )
+    assert read.status_code == 200, read.text
+    assert read.json()["autonomy_paused"] is True
+
+    resume = await v1_client.post(
+        f"/v1/workspaces/{ws.id}/priorities/autonomy",
+        headers=_auth(raw),
+        json={"paused": False},
+    )
+    assert resume.status_code == 200, resume.text
+    assert resume.json()["autonomy_paused"] is False
+
+
+@pytest.mark.asyncio
+async def test_viewer_can_read_but_not_mutate(
+    v1_client, seed_workspace, db_session
+) -> None:
+    _, _, ws = seed_workspace
+    _, viewer_raw = await _mint_role(db_session, ws, "viewer")
+
+    read = await v1_client.get(
+        f"/v1/workspaces/{ws.id}/priorities", headers=_auth(viewer_raw)
+    )
+    assert read.status_code == 200, read.text
+
+    blocked_reorder = await v1_client.post(
+        f"/v1/workspaces/{ws.id}/priorities/reorder",
+        headers=_auth(viewer_raw),
+        json={"order": ["x"]},
+    )
+    assert blocked_reorder.status_code == 403, blocked_reorder.text
+
+    blocked_autonomy = await v1_client.post(
+        f"/v1/workspaces/{ws.id}/priorities/autonomy",
+        headers=_auth(viewer_raw),
+        json={"paused": True},
+    )
+    assert blocked_autonomy.status_code == 403, blocked_autonomy.text
+
+
+@pytest.mark.asyncio
+async def test_stranger_workspace_isolation(
+    v1_client, seed_workspace, db_session
+) -> None:
+    """A user with no membership row for the workspace gets 404."""
+    _, _, ws = seed_workspace
+    # Build a brand-new user + PAT with NO membership in `ws`.
+    from backend.app.api.v1.deps import PAT_PREFIX, _hash_token
+    from backend.app.db.models.tenancy import ApiToken, User
+
+    stranger = User(
+        email=f"stranger-{uuid.uuid4().hex[:6]}@example.com",
+        display_name="Stranger",
+    )
+    db_session.add(stranger)
+    await db_session.flush()
+    raw = f"{PAT_PREFIX}{secrets.token_urlsafe(24)}"
+    db_session.add(
+        ApiToken(
+            user_id=stranger.id,
+            name="stranger-token",
+            hashed_secret=_hash_token(raw),
+            prefix=PAT_PREFIX,
+            scopes=[],
+        )
+    )
+    await db_session.flush()
+
+    res = await v1_client.get(
+        f"/v1/workspaces/{ws.id}/priorities", headers=_auth(raw)
+    )
+    assert res.status_code == 404, res.text

--- a/console/src/app/page.tsx
+++ b/console/src/app/page.tsx
@@ -10,11 +10,13 @@ import { WorkspaceHome } from "@/components/workspace-home";
 import {
   type ApiActivatedRepo,
   type ApiOpsDashboard,
+  type ApiPrioritiesResponse,
   ApiHttpError,
   ApiUnavailableError,
   getInboxCounts,
   getMe,
   getOpsDashboard,
+  getPriorities,
   isApiConfigured,
   listActivatedRepos,
   listInboxItems,
@@ -126,6 +128,11 @@ type LiveContext = {
    *  dashboard still renders. */
   inboxItems: InboxListResponse | null;
   inboxCounts: InboxCountsResponse | null;
+  /** Dashboard v2 prioritizer payload — projects, ordering, autonomy
+   *  state, last-action trust anchor. Best-effort: a fetch failure
+   *  hides the prioritizer block so the rest of the dashboard still
+   *  renders. */
+  priorities: ApiPrioritiesResponse | null;
 };
 
 /**
@@ -154,7 +161,7 @@ async function loadLiveContext(
 ): Promise<LiveContext | "unauthorized" | "down"> {
   const workspace = pickWorkspace(list, wsParam);
   try {
-    const [data, repos, inboxItems, inboxCounts] = await Promise.all([
+    const [data, repos, inboxItems, inboxCounts, priorities] = await Promise.all([
       getOpsDashboard(workspace.id, token),
       listActivatedRepos(workspace.id, token).catch(() => [] as ApiActivatedRepo[]),
       listInboxItems(workspace.id, { statuses: ["new"], limit: 5 }, token).catch(
@@ -163,8 +170,19 @@ async function loadLiveContext(
       getInboxCounts(workspace.id, token).catch(
         () => null as InboxCountsResponse | null,
       ),
+      getPriorities(workspace.id, token).catch(
+        () => null as ApiPrioritiesResponse | null,
+      ),
     ]);
-    return { workspace, allWorkspaces: list, data, repos, inboxItems, inboxCounts };
+    return {
+      workspace,
+      allWorkspaces: list,
+      data,
+      repos,
+      inboxItems,
+      inboxCounts,
+      priorities,
+    };
   } catch (err) {
     if (err instanceof ApiHttpError && err.status === 401) return "unauthorized";
     if (err instanceof ApiUnavailableError) return "down";
@@ -197,6 +215,7 @@ function renderWorkspaceHome(ctx: LiveContext) {
         workspaceId={workspace.id}
         inboxItems={ctx.inboxItems}
         inboxCounts={ctx.inboxCounts}
+        priorities={ctx.priorities}
       />
     </AppShell>
   );

--- a/console/src/components/dashboard/actions.ts
+++ b/console/src/components/dashboard/actions.ts
@@ -1,0 +1,95 @@
+"use server";
+
+/**
+ * Server actions for the Dashboard v2 prioritizer.
+ *
+ * The prioritizer is a client component (drag-and-drop, optimistic
+ * state) but mutations have to be authenticated against the workspace
+ * API with a server-only session token. These wrappers shave the
+ * token out of the cookie, round-trip to the backend, and return a
+ * typed result the client can render without reaching for raw
+ * fetch().
+ */
+
+import { revalidatePath } from "next/cache";
+
+import {
+  ApiHttpError,
+  type ApiPrioritiesResponse,
+  reorderPriorities,
+  setAutonomyPaused,
+} from "@/lib/api/client";
+import { getSessionToken } from "@/lib/api/session";
+
+export type PriorityActionResult =
+  | { ok: true; payload: ApiPrioritiesResponse }
+  | { ok: false; message: string; status?: number };
+
+export type AutonomyActionResult =
+  | { ok: true; paused: boolean }
+  | { ok: false; message: string; status?: number };
+
+
+async function requireToken(): Promise<string> {
+  const token = await getSessionToken();
+  if (!token) throw new Error("Not signed in — reload the page to re-auth.");
+  return token;
+}
+
+
+function toError<T extends { ok: false; message: string; status?: number }>(
+  err: unknown,
+): T {
+  if (err instanceof ApiHttpError) {
+    const detail =
+      typeof err.detail === "string" ? err.detail : err.message;
+    return { ok: false, message: detail, status: err.status } as T;
+  }
+  return { ok: false, message: err instanceof Error ? err.message : String(err) } as T;
+}
+
+
+export async function reorderPrioritiesAction(
+  workspaceId: string,
+  order: string[],
+): Promise<PriorityActionResult> {
+  if (!workspaceId) {
+    return { ok: false, message: "workspaceId is required" };
+  }
+  let token: string;
+  try {
+    token = await requireToken();
+  } catch (err) {
+    return { ok: false, message: err instanceof Error ? err.message : String(err) };
+  }
+  try {
+    const payload = await reorderPriorities(workspaceId, order, token);
+    revalidatePath("/");
+    return { ok: true, payload };
+  } catch (err) {
+    return toError(err);
+  }
+}
+
+
+export async function setAutonomyPausedAction(
+  workspaceId: string,
+  paused: boolean,
+): Promise<AutonomyActionResult> {
+  if (!workspaceId) {
+    return { ok: false, message: "workspaceId is required" };
+  }
+  let token: string;
+  try {
+    token = await requireToken();
+  } catch (err) {
+    return { ok: false, message: err instanceof Error ? err.message : String(err) };
+  }
+  try {
+    const result = await setAutonomyPaused(workspaceId, paused, token);
+    revalidatePath("/");
+    return { ok: true, paused: result.autonomy_paused };
+  } catch (err) {
+    return toError(err);
+  }
+}

--- a/console/src/components/dashboard/prioritizer.tsx
+++ b/console/src/components/dashboard/prioritizer.tsx
@@ -1,0 +1,621 @@
+"use client";
+
+import Link from "next/link";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useTransition,
+} from "react";
+import type { DragEvent as ReactDragEvent, KeyboardEvent } from "react";
+
+import type {
+  ApiPrioritiesResponse,
+  ApiPriorityProject,
+  ApiPriorityTracker,
+  ApiPriorityUpNext,
+} from "@/lib/api/client";
+import { cn } from "@/lib/cn";
+
+import {
+  reorderPrioritiesAction,
+  setAutonomyPausedAction,
+} from "./actions";
+
+/**
+ * Dashboard v2 prioritizer — drag-to-reorder list of tracker projects
+ * plus the workspace-level autonomy switch and tracker connection
+ * hairline. Designer wireframe locks: aqua = positive editorial,
+ * sun = paused/attention, coral = errors, no bordered cards.
+ *
+ * Why a client component: drag, keyboard reorder, and autonomy toggle
+ * all need optimistic UI that survives the network round-trip without
+ * the page collapsing. Mutations route through server actions so the
+ * session token never crosses the wire.
+ *
+ * Empty states are two distinct shapes — disconnected = single CTA
+ * row; connected-but-empty = three faint scaffold rows; flipped on
+ * ``tracker.status``. Conflating them was the previous draft's bug.
+ */
+
+const DRAG_MIME = "application/x-ship-priority-id";
+
+type Props = {
+  workspaceId: string;
+  initial: ApiPrioritiesResponse;
+};
+
+export function DashboardPrioritizer({ workspaceId, initial }: Props) {
+  const [serverState, setServerState] = useState<ApiPrioritiesResponse>(initial);
+  // Working copy of the order — only touched while the user is
+  // dragging or in keyboard move-mode. Save flushes it through the
+  // server action, Revert restores from the last server state.
+  const [draftOrder, setDraftOrder] = useState<string[] | null>(null);
+  const [pending, startTransition] = useTransition();
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const tracker = serverState.tracker;
+  const allProjects = serverState.projects;
+  const prioritisedIds = useMemo(
+    () =>
+      allProjects
+        .filter((p) => p.ordinal !== null)
+        .map((p) => p.project_native_id),
+    [allProjects],
+  );
+  const projectById = useMemo(() => {
+    const map = new Map<string, ApiPriorityProject>();
+    for (const p of allProjects) map.set(p.project_native_id, p);
+    return map;
+  }, [allProjects]);
+
+  // Compose the displayed list: when the user is editing, it's the
+  // draftOrder (prioritised items in user-chosen order) followed by
+  // unprioritised tail in name order. Otherwise it's the server's
+  // own sort.
+  const displayList = useMemo(() => {
+    if (draftOrder === null) return allProjects;
+    const seen = new Set(draftOrder);
+    const head = draftOrder
+      .map((id) => projectById.get(id))
+      .filter((p): p is ApiPriorityProject => p !== undefined)
+      .map((p, idx) => ({ ...p, ordinal: idx }));
+    const tail = allProjects
+      .filter((p) => !seen.has(p.project_native_id))
+      .map((p) => ({ ...p, ordinal: null as number | null }));
+    return [...head, ...tail];
+  }, [allProjects, draftOrder, projectById]);
+
+  const dirty = draftOrder !== null;
+
+  // ----- mutations --------------------------------------------------
+
+  const handleSave = useCallback(() => {
+    if (!dirty || draftOrder === null) return;
+    setErrorMessage(null);
+    startTransition(async () => {
+      const result = await reorderPrioritiesAction(workspaceId, draftOrder);
+      if (result.ok) {
+        setServerState(result.payload);
+        setDraftOrder(null);
+      } else {
+        setErrorMessage(result.message);
+      }
+    });
+  }, [dirty, draftOrder, workspaceId]);
+
+  const handleRevert = useCallback(() => {
+    setDraftOrder(null);
+    setErrorMessage(null);
+  }, []);
+
+  const toggleAutonomy = useCallback(() => {
+    const nextPaused = !serverState.autonomy_paused;
+    // Optimistic UI — flip locally, fall back on error.
+    setServerState((s) => ({ ...s, autonomy_paused: nextPaused }));
+    setErrorMessage(null);
+    startTransition(async () => {
+      const result = await setAutonomyPausedAction(workspaceId, nextPaused);
+      if (!result.ok) {
+        setServerState((s) => ({ ...s, autonomy_paused: !nextPaused }));
+        setErrorMessage(result.message);
+      }
+    });
+  }, [serverState.autonomy_paused, workspaceId]);
+
+  // ----- reorder helpers --------------------------------------------
+
+  const moveBy = useCallback(
+    (id: string, delta: number) => {
+      // Use the current draftOrder; if it's null, seed from the
+      // server's prioritised order.
+      const current =
+        draftOrder ?? prioritisedIds.slice();
+      const idx = current.indexOf(id);
+      if (idx === -1) {
+        // Not yet prioritised — append, then move.
+        const seeded = [...current, id];
+        const next = moveIndex(seeded, seeded.length - 1, delta);
+        setDraftOrder(next);
+        return;
+      }
+      const next = moveIndex(current, idx, delta);
+      if (next.join("|") === current.join("|")) return;
+      setDraftOrder(next);
+    },
+    [draftOrder, prioritisedIds],
+  );
+
+  const reorderTo = useCallback(
+    (sourceId: string, targetId: string) => {
+      const current = draftOrder ?? prioritisedIds.slice();
+      const working = current.slice();
+      // If the source row is unprioritised, append it before reorder
+      // — dropping onto a prioritised row should pin it into the
+      // list. If the target is unprioritised, leave the list alone.
+      if (!working.includes(sourceId)) working.push(sourceId);
+      if (!working.includes(targetId)) return;
+      const fromIdx = working.indexOf(sourceId);
+      const [moved] = working.splice(fromIdx, 1);
+      const targetIdx = working.indexOf(targetId);
+      working.splice(targetIdx, 0, moved);
+      if (working.join("|") === current.join("|")) return;
+      setDraftOrder(working);
+    },
+    [draftOrder, prioritisedIds],
+  );
+
+  // ----- empty states -----------------------------------------------
+
+  if (tracker.status === "disconnected") {
+    return (
+      <PrioritizerSection
+        autonomyPaused={serverState.autonomy_paused}
+        upNext={null}
+        onToggleAutonomy={toggleAutonomy}
+        tracker={tracker}
+        pending={pending}
+      >
+        <li className="flex items-baseline justify-between gap-4 py-3">
+          <p className="text-sm text-white/65">
+            Connect a tracker to see priorities here.
+          </p>
+          <Link
+            href={`/onboarding?step=tracker&ws=${encodeURIComponent(workspaceId)}`}
+            className="shrink-0 text-[11px] font-bold uppercase tracking-widest text-aqua hover:text-white"
+          >
+            Connect Linear →
+          </Link>
+        </li>
+      </PrioritizerSection>
+    );
+  }
+
+  if (allProjects.length === 0) {
+    return (
+      <PrioritizerSection
+        autonomyPaused={serverState.autonomy_paused}
+        upNext={null}
+        onToggleAutonomy={toggleAutonomy}
+        tracker={tracker}
+        pending={pending}
+      >
+        {[0, 1, 2].map((i) => (
+          <li
+            key={i}
+            className="flex items-baseline justify-between gap-4 py-3 text-[12px] text-white/30"
+          >
+            <span className="inline-flex items-center gap-2">
+              <span className="h-1.5 w-1.5 rounded-full bg-white/15" />
+              <span>Add a project in Linear — it&apos;ll appear here.</span>
+            </span>
+          </li>
+        ))}
+      </PrioritizerSection>
+    );
+  }
+
+  return (
+    <PrioritizerSection
+      autonomyPaused={serverState.autonomy_paused}
+      upNext={serverState.up_next}
+      onToggleAutonomy={toggleAutonomy}
+      tracker={tracker}
+      pending={pending}
+    >
+      {displayList.map((project) => (
+        <PrioritizerRow
+          key={project.project_native_id}
+          project={project}
+          paused={serverState.autonomy_paused}
+          onDragStart={(event) => {
+            event.dataTransfer.setData(DRAG_MIME, project.project_native_id);
+            event.dataTransfer.effectAllowed = "move";
+          }}
+          onDragOver={(event) => {
+            const sourceId = event.dataTransfer.types.includes(DRAG_MIME);
+            if (!sourceId) return;
+            event.preventDefault();
+            event.dataTransfer.dropEffect = "move";
+          }}
+          onDrop={(event) => {
+            const sourceId = event.dataTransfer.getData(DRAG_MIME);
+            if (!sourceId || sourceId === project.project_native_id) return;
+            event.preventDefault();
+            reorderTo(sourceId, project.project_native_id);
+          }}
+          onMoveUp={() => moveBy(project.project_native_id, -1)}
+          onMoveDown={() => moveBy(project.project_native_id, +1)}
+        />
+      ))}
+      {dirty && (
+        <li className="-mx-3 mt-1 flex items-baseline justify-between bg-white/[0.04] px-3 py-2">
+          <span className="text-[10px] font-bold uppercase tracking-[0.18em] text-white/50">
+            Order changed
+          </span>
+          <span className="flex items-center gap-4 text-[11px] font-bold uppercase tracking-widest">
+            <button
+              type="button"
+              onClick={handleRevert}
+              disabled={pending}
+              className="text-white/55 transition hover:text-white disabled:opacity-50"
+            >
+              Revert
+            </button>
+            <button
+              type="button"
+              onClick={handleSave}
+              disabled={pending}
+              className="text-aqua transition hover:text-white disabled:opacity-50"
+            >
+              {pending ? "Saving…" : "Save"}
+            </button>
+          </span>
+        </li>
+      )}
+      {errorMessage && (
+        <li className="pt-2 text-[11px] text-coral/85">{errorMessage}</li>
+      )}
+    </PrioritizerSection>
+  );
+}
+
+
+// ---------------------------------------------------------------------------
+// Section shell — kicker, autonomy toggle, tracker hairline, up-next strip
+// ---------------------------------------------------------------------------
+
+
+function PrioritizerSection({
+  children,
+  autonomyPaused,
+  upNext,
+  tracker,
+  pending,
+  onToggleAutonomy,
+}: {
+  children: React.ReactNode;
+  autonomyPaused: boolean;
+  upNext: ApiPriorityUpNext | null;
+  tracker: ApiPriorityTracker;
+  pending: boolean;
+  onToggleAutonomy: () => void;
+}) {
+  return (
+    <section className="space-y-3">
+      <div className="flex flex-wrap items-baseline justify-between gap-x-6 gap-y-1">
+        <h3 className="text-[10px] font-bold uppercase tracking-[0.22em] text-white/40">
+          Priorities
+          {autonomyPaused && (
+            <span className="ml-2 text-sun">· paused</span>
+          )}
+        </h3>
+        <div className="flex items-center gap-4 text-[11px]">
+          <AutonomyToggle
+            paused={autonomyPaused}
+            disabled={pending}
+            onToggle={onToggleAutonomy}
+          />
+          <TrackerHairline tracker={tracker} />
+        </div>
+      </div>
+      {upNext ? (
+        <UpNextStrip upNext={upNext} paused={autonomyPaused} />
+      ) : null}
+      <ul className="divide-y divide-white/[0.06]">{children}</ul>
+    </section>
+  );
+}
+
+
+function AutonomyToggle({
+  paused,
+  disabled,
+  onToggle,
+}: {
+  paused: boolean;
+  disabled: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      disabled={disabled}
+      aria-pressed={!paused}
+      className="group inline-flex items-center gap-2 disabled:opacity-50"
+    >
+      <span className="text-white/45">Autonomy</span>
+      <span
+        aria-hidden
+        className={cn(
+          "relative inline-flex h-3 w-6 items-center rounded-full transition",
+          paused ? "bg-sun/30" : "bg-aqua/40",
+        )}
+      >
+        <span
+          className={cn(
+            "block h-2 w-2 translate-x-0.5 rounded-full bg-white transition",
+            paused ? "translate-x-0.5" : "translate-x-3.5",
+          )}
+        />
+      </span>
+      <span
+        className={cn(
+          "font-bold uppercase tracking-widest text-[10px]",
+          paused ? "text-sun" : "text-aqua/85 group-hover:text-aqua",
+        )}
+      >
+        {paused ? "off" : "on"}
+      </span>
+    </button>
+  );
+}
+
+
+function TrackerHairline({ tracker }: { tracker: ApiPriorityTracker }) {
+  if (tracker.status === "disconnected") {
+    return (
+      <span className="text-coral">
+        No tracker · <a href="/onboarding?step=tracker" className="font-bold underline-offset-4 hover:underline">connect →</a>
+      </span>
+    );
+  }
+  const label = tracker.kind === "linear" ? "Linear" : tracker.kind === "jira" ? "Jira" : "Tracker";
+  if (tracker.status === "error") {
+    return (
+      <span className="text-coral" title={tracker.last_health_error ?? undefined}>
+        {label} · error · <a href="/onboarding?step=tracker" className="font-bold underline-offset-4 hover:underline">reconnect →</a>
+      </span>
+    );
+  }
+  const synced =
+    tracker.last_health_at !== null
+      ? `synced ${formatRelative(tracker.last_health_at)}`
+      : "synced";
+  return <span className="text-white/40">{label} · {synced}</span>;
+}
+
+
+function UpNextStrip({
+  upNext,
+  paused,
+}: {
+  upNext: ApiPriorityUpNext;
+  paused: boolean;
+}) {
+  if (paused) {
+    return (
+      <p className="flex items-center gap-2 text-[11px] text-white/30">
+        <span aria-hidden>↑</span>
+        <span>Up next · paused · resume to pull</span>
+      </p>
+    );
+  }
+  return (
+    <p className="flex items-center gap-2 text-[11px] text-white/65">
+      <span aria-hidden className="text-aqua">↑</span>
+      <span>
+        <span className="text-white/45">Up next ·</span>{" "}
+        <span className="font-semibold text-white">{upNext.project_name}</span>
+      </span>
+    </p>
+  );
+}
+
+
+// ---------------------------------------------------------------------------
+// Row
+// ---------------------------------------------------------------------------
+
+
+function PrioritizerRow({
+  project,
+  paused,
+  onDragStart,
+  onDragOver,
+  onDrop,
+  onMoveUp,
+  onMoveDown,
+}: {
+  project: ApiPriorityProject;
+  paused: boolean;
+  onDragStart: (event: ReactDragEvent<HTMLLIElement>) => void;
+  onDragOver: (event: ReactDragEvent<HTMLLIElement>) => void;
+  onDrop: (event: ReactDragEvent<HTMLLIElement>) => void;
+  onMoveUp: () => void;
+  onMoveDown: () => void;
+}) {
+  const [moveMode, setMoveMode] = useState(false);
+  const rowRef = useRef<HTMLLIElement | null>(null);
+
+  // Exit move-mode if the row loses focus entirely (e.g. user
+  // tabs/clicks away). Move-mode is a per-row affordance and
+  // should never persist when the row isn't active.
+  useEffect(() => {
+    if (!moveMode) return;
+    const onBlur = (event: FocusEvent) => {
+      if (
+        rowRef.current &&
+        !rowRef.current.contains(event.relatedTarget as Node | null)
+      ) {
+        setMoveMode(false);
+      }
+    };
+    const node = rowRef.current;
+    node?.addEventListener("focusout", onBlur);
+    return () => node?.removeEventListener("focusout", onBlur);
+  }, [moveMode]);
+
+  const handleKey = (event: KeyboardEvent<HTMLLIElement>) => {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      setMoveMode((prev) => !prev);
+      return;
+    }
+    if (event.key === "Escape") {
+      setMoveMode(false);
+      return;
+    }
+    if (!moveMode) return;
+    if (event.key === "ArrowUp") {
+      event.preventDefault();
+      onMoveUp();
+    } else if (event.key === "ArrowDown") {
+      event.preventDefault();
+      onMoveDown();
+    }
+  };
+
+  const fractionLabel = formatFraction(project.completed, project.total);
+  const barFraction = computeBarFraction(project.completed, project.total);
+  const colorStyle = project.color
+    ? { backgroundColor: project.color }
+    : undefined;
+  const isPrioritised = project.ordinal !== null;
+
+  return (
+    <li
+      ref={rowRef}
+      tabIndex={0}
+      draggable
+      onDragStart={onDragStart}
+      onDragOver={onDragOver}
+      onDrop={onDrop}
+      onKeyDown={handleKey}
+      className={cn(
+        "group relative flex items-center gap-3 py-2 pl-3 pr-1 outline-none transition",
+        "focus-visible:before:absolute focus-visible:before:inset-y-1 focus-visible:before:left-0 focus-visible:before:w-px focus-visible:before:bg-aqua/60",
+        moveMode && "before:absolute before:inset-y-1 before:left-0 before:w-0.5 before:bg-aqua",
+        paused ? "opacity-80" : "",
+      )}
+    >
+      <span
+        aria-hidden
+        className={cn(
+          "shrink-0 select-none text-[12px] transition",
+          moveMode ? "text-aqua" : "text-white/20 group-hover:text-white/55",
+        )}
+      >
+        {moveMode ? "↕" : "⋮"}
+      </span>
+      <span
+        aria-hidden
+        className={cn(
+          "h-2 w-2 shrink-0 rounded-full",
+          project.color ? "" : "bg-white/25",
+        )}
+        style={colorStyle}
+      />
+      <div className="min-w-0 flex-1">
+        {project.url ? (
+          <a
+            href={project.url}
+            target="_blank"
+            rel="noreferrer"
+            className="truncate text-[13px] font-semibold text-white hover:text-aqua"
+          >
+            {project.name}
+          </a>
+        ) : (
+          <p className="truncate text-[13px] font-semibold text-white">
+            {project.name}
+          </p>
+        )}
+        {isPrioritised ? null : (
+          <p className="mt-0.5 text-[10px] uppercase tracking-[0.16em] text-white/30">
+            unprioritised — drag in
+          </p>
+        )}
+      </div>
+      <span className="shrink-0 font-mono text-[11px] tabular-nums text-white/55">
+        {fractionLabel}
+      </span>
+      <span
+        aria-hidden
+        className="block h-1 w-20 shrink-0 rounded-sm bg-white/[0.06]"
+      >
+        <span
+          className="block h-full rounded-sm transition-all"
+          style={{
+            width: `${barFraction * 100}%`,
+            backgroundColor: project.color ?? undefined,
+          }}
+        />
+      </span>
+    </li>
+  );
+}
+
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+
+function moveIndex(arr: string[], idx: number, delta: number): string[] {
+  const next = arr.slice();
+  const target = idx + delta;
+  if (target < 0 || target >= next.length) return arr;
+  const [moved] = next.splice(idx, 1);
+  next.splice(target, 0, moved);
+  return next;
+}
+
+
+function formatFraction(completed: number | null, total: number | null): string {
+  if (completed === null || total === null) return "—";
+  if (total === 0) return "0/0";
+  return `${completed}/${total}`;
+}
+
+
+function computeBarFraction(
+  completed: number | null,
+  total: number | null,
+): number {
+  if (completed === null || total === null || total <= 0) return 0;
+  const fraction = completed / total;
+  if (fraction < 0) return 0;
+  if (fraction > 1) return 1;
+  return fraction;
+}
+
+
+function formatRelative(value: string): string {
+  const date = Date.parse(value);
+  if (Number.isNaN(date)) return "now";
+  const diff = Date.now() - date;
+  const minute = 60_000;
+  const hour = 60 * minute;
+  const day = 24 * hour;
+  if (diff < minute) return "just now";
+  if (diff < hour) return `${Math.max(1, Math.round(diff / minute))}m ago`;
+  if (diff < day) return `${Math.round(diff / hour)}h ago`;
+  if (diff < 30 * day) return `${Math.round(diff / day)}d ago`;
+  return new Date(date).toLocaleDateString();
+}
+
+

--- a/console/src/components/workspace-home.tsx
+++ b/console/src/components/workspace-home.tsx
@@ -1,11 +1,13 @@
 import Link from "next/link";
 
+import { DashboardPrioritizer } from "@/components/dashboard/prioritizer";
 import type {
   ApiActivatedRepo,
   ApiOpsBlocker,
   ApiOpsDashboard,
   ApiOpsShippedItem,
-  ApiOpsWorkItem,
+  ApiPrioritiesResponse,
+  ApiPriorityLastAction,
 } from "@/lib/api/client";
 import { cn } from "@/lib/cn";
 import type {
@@ -16,26 +18,27 @@ import type {
 } from "@/lib/inbox-types";
 
 /**
- * Workspace home — editorial two-column dashboard.
+ * Workspace home — Dashboard v2 (PR-1).
  *
- * Layout (≥ lg): 12-col grid.
- *   - Left rail (col-span-8): status alerts → "Needs you" lede with
- *     inline pulse counts → Decisions tier → Ready-to-merge tier →
- *     Work in flight 3-up (column-color spine, no per-column card).
- *   - Right rail (col-span-4, sticky): System pulse (single block of
- *     real KV from ``automation_health`` + ``system_status``), Recent
- *     activity timeline, Repo channel list.
+ * Layout (≥ 2xl): 12-col grid with three editorial columns at 7/3/2.
+ *   - Left col (7): Status alerts → "Needs you" lede → Project
+ *     prioritizer (drag-to-reorder, autonomy switch, Linear hairline,
+ *     Up-next strip, Save/Revert hairline) → Active-tickets summary
+ *     strip.
+ *   - Middle col (3): Live System block — populated by PR-2; for now
+ *     a quiet ``Live system · loading…`` placeholder so the column
+ *     reads intentionally idle, not broken.
+ *   - Right col (2): Last-action pinned strip → Recent activity
+ *     timeline → Repo channel list.
  *
- * Mobile collapses to single column with the rail moving below.
+ * Below 2xl the middle and right columns collapse into a single
+ * sticky right rail (col-span-4 at lg) so dense layouts on smaller
+ * displays don't force a third tier of vertical scroll.
  *
- * No ``Card`` wrappers. Section breaks come from
- * ``border-t border-white/10 mt-8 pt-8`` + tinted kickers.
- *
- * Data discipline (per design pass): every number rendered here maps
- * 1:1 to a real ApiOpsDashboard / InboxCounts field. Fake placeholders
- * (``Routines coming up = —``, ``Routines completed today = success_rate
- * * (failures + 1)``) are gone. If a field isn't real yet, the row
- * doesn't render rather than showing a synthetic value.
+ * Color discipline: ``aqua`` is the editorial-positive accent,
+ * ``lilac`` human handoff, ``coral`` errors, ``sun`` paused/blocked,
+ * ``white/40`` muted kickers. No bordered cards. Section breaks come
+ * from whitespace + tinted kickers, never from box-shadow rectangles.
  */
 
 export type WorkspaceHomeProps = {
@@ -44,6 +47,7 @@ export type WorkspaceHomeProps = {
   workspaceId: string;
   inboxItems: InboxListResponse | null;
   inboxCounts: InboxCountsResponse | null;
+  priorities: ApiPrioritiesResponse | null;
 };
 
 export function WorkspaceHome({
@@ -52,6 +56,7 @@ export function WorkspaceHome({
   workspaceId,
   inboxItems,
   inboxCounts,
+  priorities,
 }: WorkspaceHomeProps) {
   const reposNeedingUpdate = repos.filter(needsShipTemplateUpdate);
   const decisions = (inboxItems?.items ?? []).slice(0, 4);
@@ -63,6 +68,10 @@ export function WorkspaceHome({
     summary.shipped.rollbacks_count;
   const blockerCount =
     summary.blockers.length + reposNeedingUpdate.length;
+  const inFlight = summary.work_in_progress.length;
+  const inProgress = summary.work_in_progress.filter(
+    (it) => it.status === "in_progress",
+  ).length;
 
   return (
     <div className="mx-auto max-w-6xl 2xl:max-w-screen-2xl">
@@ -86,8 +95,16 @@ export function WorkspaceHome({
             workspaceId={workspaceId}
           />
 
-          <WorkInFlightSection
-            items={summary.work_in_progress}
+          {priorities ? (
+            <DashboardPrioritizer
+              workspaceId={workspaceId}
+              initial={priorities}
+            />
+          ) : null}
+
+          <ActiveTicketsStrip
+            inFlight={inFlight}
+            inProgress={inProgress}
             workspaceId={workspaceId}
           />
         </div>
@@ -100,10 +117,11 @@ export function WorkspaceHome({
           inside.
         */}
         <div className="space-y-10 lg:col-span-4 lg:sticky lg:top-20 lg:self-start 2xl:contents">
-          <aside className="space-y-10 2xl:col-span-3 2xl:sticky 2xl:top-20 2xl:self-start">
-            <SystemPulse summary={summary} />
+          <aside className="space-y-6 2xl:col-span-3 2xl:sticky 2xl:top-20 2xl:self-start">
+            <LiveSystemPlaceholder />
           </aside>
-          <aside className="space-y-10 2xl:col-span-2 2xl:sticky 2xl:top-20 2xl:self-start">
+          <aside className="space-y-8 2xl:col-span-2 2xl:sticky 2xl:top-20 2xl:self-start">
+            <LastActionStrip lastAction={priorities?.last_action ?? null} />
             <RecentActivity summary={summary} />
             <RepoChannelList repos={repos} workspaceId={workspaceId} />
           </aside>
@@ -475,249 +493,93 @@ function derivePrsReadyToMerge(summary: ApiOpsDashboard): ReadyToMergePr[] {
 
 
 // ---------------------------------------------------------------------------
-// Work in flight — 3-col grid with column spine
+// Active-tickets summary strip (replaces the 3-col Work-in-flight grid)
 // ---------------------------------------------------------------------------
 
 
-const FLIGHT_COLUMNS: {
-  id: ApiOpsWorkItem["status"];
-  label: string;
-  spine: string;
-  kicker: string;
-}[] = [
-  {
-    id: "in_progress",
-    label: "In progress",
-    spine: "bg-white/15",
-    kicker: "text-white/55",
-  },
-  {
-    id: "review",
-    label: "Review",
-    spine: "bg-aqua/30",
-    kicker: "text-aqua/75",
-  },
-  {
-    id: "blocked",
-    label: "Blocked",
-    spine: "bg-sun/40",
-    kicker: "text-sun/80",
-  },
-];
-
-
-function WorkInFlightSection({
-  items,
+function ActiveTicketsStrip({
+  inFlight,
+  inProgress,
   workspaceId,
 }: {
-  items: ApiOpsWorkItem[];
+  inFlight: number;
+  inProgress: number;
   workspaceId: string;
 }) {
-  if (items.length === 0) return null;
-  const grouped = new Map<string, ApiOpsWorkItem[]>();
-  for (const c of FLIGHT_COLUMNS) grouped.set(c.id, []);
-  for (const item of items) {
-    if (grouped.has(item.status)) grouped.get(item.status)!.push(item);
-  }
-  const tracker = primaryTrackerLabel(items);
+  if (inFlight === 0) return null;
   return (
-    <section className="space-y-4">
-      <header className="flex items-baseline justify-between gap-3">
-        <div>
-          <p className="text-[10px] font-bold uppercase tracking-[0.22em] text-white/40">
-            Work in flight
-          </p>
-          <p className="mt-1 text-xs text-white/55">
-            Live tickets · {tracker ?? "auto-detected"}
-          </p>
-        </div>
-        <Link
-          href={`/process?ws=${encodeURIComponent(workspaceId)}`}
-          className="shrink-0 text-xs font-semibold text-white/55 hover:text-white"
-        >
-          Open process →
-        </Link>
-      </header>
-      <div className="grid grid-cols-1 gap-y-6 sm:grid-cols-3 sm:divide-x sm:divide-white/[0.06]">
-        {FLIGHT_COLUMNS.map((col, idx) => {
-          const colItems = grouped.get(col.id) ?? [];
-          return (
-            <div
-              key={col.id}
-              className={cn("min-w-0 space-y-3", idx > 0 && "sm:pl-4")}
-            >
-              <div className="flex items-baseline justify-between">
-                <h3
-                  className={cn(
-                    "text-[10px] font-bold uppercase tracking-[0.22em]",
-                    col.kicker,
-                  )}
-                >
-                  {col.label}
-                </h3>
-                <span className="font-mono text-[11px] text-white/35">
-                  {colItems.length}
-                </span>
-              </div>
-              {colItems.length === 0 ? (
-                <p className="text-[11px] italic text-white/30">empty</p>
-              ) : (
-                <ul className="divide-y divide-white/[0.06]">
-                  {colItems.slice(0, 4).map((item) => (
-                    <li key={`${item.name}-${item.updated_at}`}>
-                      <FlightRow item={item} spineClass={col.spine} />
-                    </li>
-                  ))}
-                  {colItems.length > 4 && (
-                    <li className="pt-2 text-[10px] uppercase tracking-[0.14em] text-white/30">
-                      +{colItems.length - 4} more
-                    </li>
-                  )}
-                </ul>
-              )}
-            </div>
-          );
-        })}
-      </div>
-    </section>
-  );
-}
-
-
-function FlightRow({
-  item,
-  spineClass,
-}: {
-  item: ApiOpsWorkItem;
-  spineClass: string;
-}) {
-  const href = item.href;
-  const isExternal =
-    href != null && (href.startsWith("http://") || href.startsWith("https://"));
-  const inner = (
-    <div className="group relative flex items-baseline justify-between gap-2 py-2 pl-3">
-      <span
-        aria-hidden
-        className={cn(
-          "absolute inset-y-2 left-0 w-px rounded-r-sm",
-          spineClass,
-        )}
-      />
-      <div className="min-w-0">
-        <p className="truncate text-[12.5px] font-semibold text-white group-hover:text-aqua">
-          {item.ticket_ref && (
-            <span className="mr-1.5 font-mono text-aqua/85">
-              {item.ticket_ref}
-            </span>
-          )}
-          {stripTicketPrefix(item.name, item.ticket_ref)}
-        </p>
-        <p className="mt-0.5 truncate text-[10px] text-white/40">
-          {[item.repo, item.board_column, formatRelative(item.updated_at)]
-            .filter(Boolean)
-            .join(" · ")}
-        </p>
-      </div>
-    </div>
-  );
-  if (!href) return inner;
-  return isExternal ? (
-    <a href={href} target="_blank" rel="noreferrer">
-      {inner}
-    </a>
-  ) : (
-    <Link href={href}>{inner}</Link>
+    <p className="flex items-baseline justify-between gap-4 border-t border-white/[0.06] pt-4 text-[12px] text-white/55">
+      <span>
+        <span className="font-display font-bold text-white">{inFlight}</span>{" "}
+        active ticket{inFlight === 1 ? "" : "s"}
+        <span className="mx-2 text-white/20">·</span>
+        <span>{inProgress} in flight</span>
+      </span>
+      <Link
+        href={`/process?ws=${encodeURIComponent(workspaceId)}`}
+        className="shrink-0 text-[11px] font-semibold uppercase tracking-widest text-white/45 hover:text-white"
+      >
+        Open process →
+      </Link>
+    </p>
   );
 }
 
 
 // ---------------------------------------------------------------------------
-// Right rail — System pulse · Recent activity · Repos
+// Live System placeholder (PR-2 will populate)
 // ---------------------------------------------------------------------------
 
 
-function SystemPulse({ summary }: { summary: ApiOpsDashboard }) {
-  const h = summary.automation_health;
-  const stuck = summary.work_in_progress.filter((it) => it.status === "blocked").length;
-  const lastDeploy = summary.system_status.last_deploy?.time ?? null;
-
+function LiveSystemPlaceholder() {
   return (
-    <section className="space-y-3">
+    <section className="space-y-2">
       <p className="text-[10px] font-bold uppercase tracking-[0.22em] text-white/40">
-        Today
+        Live system · loading…
       </p>
-      <dl className="space-y-2 text-sm">
-        <PulseRow
-          label="Success rate"
-          value={h.success_rate === null ? null : formatPercent(h.success_rate)}
-          tone={
-            h.success_rate === null
-              ? "muted"
-              : h.success_rate < 0.8
-                ? "warn"
-                : "ok"
-          }
-        />
-        <PulseRow
-          label="Failures"
-          value={String(h.failures_count)}
-          tone={h.failures_count > 0 ? "err" : "ok"}
-        />
-        <PulseRow
-          label="Stuck"
-          value={String(stuck)}
-          tone={stuck > 0 ? "warn" : "ok"}
-        />
-        <PulseRow
-          label="Manual asks"
-          value={String(h.manual_interventions_count)}
-          tone={h.manual_interventions_count > 0 ? "warn" : "ok"}
-        />
-        {h.automation_coverage !== null && (
-          <PulseRow
-            label="Automation coverage"
-            value={formatPercent(h.automation_coverage)}
-            tone="muted"
-          />
-        )}
-        {lastDeploy && (
-          <PulseRow
-            label="Last deploy"
-            value={formatRelative(lastDeploy)}
-            tone="muted"
-          />
-        )}
-      </dl>
+      <p className="text-[11px] italic text-white/30">
+        Routines, daily digest, and specialist health land next.
+      </p>
     </section>
   );
 }
 
 
-function PulseRow({
-  label,
-  value,
-  tone,
+// ---------------------------------------------------------------------------
+// Right rail — Last-action · Recent activity · Repos
+// ---------------------------------------------------------------------------
+
+
+function LastActionStrip({
+  lastAction,
 }: {
-  label: string;
-  value: string | null;
-  tone: "ok" | "warn" | "err" | "muted";
+  lastAction: ApiPriorityLastAction | null;
 }) {
-  const valueColor =
-    tone === "err"
-      ? "text-coral"
-      : tone === "warn"
-        ? "text-sun"
-        : tone === "ok"
-          ? "text-white/85"
-          : "text-white/45";
-  return (
-    <div className="flex items-baseline justify-between gap-3">
-      <dt className="text-xs text-white/55">{label}</dt>
-      <dd className={cn("font-mono text-sm tabular-nums", valueColor)}>
-        {value ?? "—"}
-      </dd>
-    </div>
+  if (!lastAction) return null;
+  const time = formatTime(lastAction.ts);
+  const inner = (
+    <p className="flex items-baseline gap-2 text-[11px] text-white/65">
+      <span aria-hidden className="text-aqua">·</span>
+      <span className="truncate">
+        {lastAction.label}
+        <span className="mx-2 text-white/20">·</span>
+        <span className="text-white/45">{time}</span>
+      </span>
+    </p>
   );
+  if (lastAction.href) {
+    return (
+      <a
+        href={lastAction.href}
+        target="_blank"
+        rel="noreferrer"
+        className="block hover:text-aqua"
+      >
+        {inner}
+      </a>
+    );
+  }
+  return inner;
 }
 
 
@@ -917,21 +779,6 @@ function shippedTypeLabel(type: ApiOpsShippedItem["type"]): string {
 }
 
 
-function primaryTrackerLabel(items: ApiOpsWorkItem[]): string | null {
-  const counts = new Map<string, number>();
-  for (const it of items) {
-    if (!it.tracker) continue;
-    counts.set(it.tracker, (counts.get(it.tracker) ?? 0) + 1);
-  }
-  if (counts.size === 0) return null;
-  let best: [string, number] | null = null;
-  for (const entry of counts) {
-    if (!best || entry[1] > best[1]) best = entry;
-  }
-  return best ? best[0] : null;
-}
-
-
 function stripTicketPrefix(name: string, ref: string | null | undefined): string {
   if (!ref) return name;
   if (name.startsWith(`${ref}: `)) return name.slice(ref.length + 2);
@@ -960,28 +807,19 @@ function compareBundleVersions(left: string, right: string): number {
 }
 
 
-function formatPercent(value: number): string {
-  return `${Math.round(value * 100)}%`;
-}
-
-
-function formatRelative(value: string): string {
-  const date = Date.parse(value);
-  if (Number.isNaN(date)) return "—";
-  const diff = Date.now() - date;
-  const minute = 60_000;
-  const hour = 60 * minute;
-  const day = 24 * hour;
-  if (diff < hour) return `${Math.max(1, Math.round(diff / minute))}m`;
-  if (diff < day) return `${Math.round(diff / hour)}h`;
-  if (diff < 30 * day) return `${Math.round(diff / day)}d`;
-  return new Date(date).toLocaleDateString();
-}
-
-
 function formatAge(seconds: number): string {
   if (seconds < 60) return `${seconds}s`;
   if (seconds < 3600) return `${Math.round(seconds / 60)}m`;
   if (seconds < 86_400) return `${Math.round(seconds / 3600)}h`;
   return `${Math.round(seconds / 86_400)}d`;
+}
+
+
+function formatTime(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "—";
+  return date.toLocaleTimeString(undefined, {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
 }

--- a/console/src/lib/api/client.ts
+++ b/console/src/lib/api/client.ts
@@ -2441,6 +2441,96 @@ export function getOpsDashboard(
   );
 }
 
+// --- Dashboard v2 — prioritizer surface ------------------------------------
+
+/**
+ * Tracker connection block on the prioritizer payload. ``status`` is
+ * ``connected`` when an integration row exists and the most recent
+ * health check was clean; ``error`` carries the raw vendor message;
+ * ``disconnected`` means the workspace has no tracker bound at all
+ * (the prioritizer renders a connect-Linear CTA empty state instead
+ * of the project list).
+ */
+export interface ApiPriorityTracker {
+  kind: "linear" | "jira" | null;
+  status: "connected" | "error" | "disconnected";
+  last_health_at: string | null;
+  last_health_error: string | null;
+  supports_projects: boolean;
+}
+
+export interface ApiPriorityProject {
+  project_native_id: string;
+  name: string;
+  slug: string | null;
+  state: string | null;
+  url: string | null;
+  color: string | null;
+  /** Saved priority position (0 = top). NULL when the project is
+   * unprioritised — the UI sorts these after prioritised rows. */
+  ordinal: number | null;
+  /** Completion magnitude. ``total`` is null when the tracker can't
+   * tell us; the UI then renders ``—`` and skips the bar. */
+  completed: number | null;
+  total: number | null;
+}
+
+export interface ApiPriorityUpNext {
+  project_native_id: string;
+  project_name: string;
+  color: string | null;
+}
+
+export interface ApiPriorityLastAction {
+  label: string;
+  href: string | null;
+  ts: string;
+}
+
+export interface ApiPrioritiesResponse {
+  projects: ApiPriorityProject[];
+  tracker: ApiPriorityTracker;
+  autonomy_paused: boolean;
+  up_next: ApiPriorityUpNext | null;
+  last_action: ApiPriorityLastAction | null;
+}
+
+export interface ApiAutonomyResponse {
+  autonomy_paused: boolean;
+}
+
+export function getPriorities(
+  workspaceId: string,
+  token?: string,
+): Promise<ApiPrioritiesResponse> {
+  return apiFetch<ApiPrioritiesResponse>(
+    `/v1/workspaces/${encodeURIComponent(workspaceId)}/priorities`,
+    { token },
+  );
+}
+
+export function reorderPriorities(
+  workspaceId: string,
+  order: string[],
+  token?: string,
+): Promise<ApiPrioritiesResponse> {
+  return apiFetch<ApiPrioritiesResponse>(
+    `/v1/workspaces/${encodeURIComponent(workspaceId)}/priorities/reorder`,
+    { method: "POST", token, body: { order } },
+  );
+}
+
+export function setAutonomyPaused(
+  workspaceId: string,
+  paused: boolean,
+  token?: string,
+): Promise<ApiAutonomyResponse> {
+  return apiFetch<ApiAutonomyResponse>(
+    `/v1/workspaces/${encodeURIComponent(workspaceId)}/priorities/autonomy`,
+    { method: "POST", token, body: { paused } },
+  );
+}
+
 export function dismissNotification(
   workspaceId: string,
   notificationId: string,


### PR DESCRIPTION
## Summary
- New workspace-level project prioritizer on ``/`` — drag-to-reorder, keyboard reorder, autonomy pause switch, Linear connection hairline, ``↑ Up next`` pinned strip, Save/Revert hairline that appears only when dirty.
- Backend: ``workspace_project_priorities`` table + ``Workspace.settings.autonomy_paused`` JSONB flag; three endpoints under ``/v1/workspaces/{ws}/priorities`` (GET / POST /reorder / POST /autonomy). Linear adapter ``list_projects`` now returns ``progress`` / ``scope`` / ``color``.
- Frontend: 7/3/2 column layout at ≥ 2xl. Left col = Status → Needs you → Prioritizer → Active strip; middle col reserved for PR-2 (placeholder ``Live system · loading…``); right rail = Last-action pinned strip + Recent activity + Repos.
- Empty states are two distinct shapes — disconnected = ``Connect Linear`` CTA; connected-but-empty = three ghost scaffold rows.

## Why
Designer plan + PO refinements (locked overnight). Dashboard v2 is the first lever the operator pulls to tell the bot which queue to drain first; without persistent ordering and an autonomy kill switch, the rest of the dashboard is read-only theatre.

This is PR-1 of 2. PR-2 lands the Live System aggregator (Knowledge / Routines / Daily / Specialists collapsed) into the middle column.

## Test plan
- [x] ``pytest backend/tests/test_v1_dashboard_priorities.py`` — 6 / 6 (empty-disconnected GET, reorder round-trip, dup-reject, autonomy persists, viewer 403, stranger 404).
- [x] ``console: tsc --noEmit`` clean.
- [x] ``console: eslint --max-warnings=0`` clean for touched files.
- [x] ``console: next build`` passes.
- [ ] Smoke in browser once merged: drag to reorder, Save persists, Revert restores, autonomy switch flips, hairline disappears when clean.