### PR TITLE
dashboard: v2 Live System aggregator (PR-2 of 2)

### DIFF
--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -26,6 +26,7 @@ from backend.app.api.v1.routes import (
     chat,
     clarifications,
     dashboard,
+    dashboard_live_system,
     dashboard_priorities,
     distiller,
     github_app,
@@ -125,6 +126,12 @@ api_router.include_router(dashboard.router)
 # ``/v1/workspaces/{ws}/priorities`` — list+reorder of tracker
 # projects, plus the workspace-level autonomy pause toggle.
 api_router.include_router(dashboard_priorities.router)
+# Dashboard v2 Live System aggregator (PR-2). One denormalised
+# endpoint feeds the middle column of the home dashboard
+# (masthead glyphs, knowledge, routines, daily-digest, specialist
+# health) so the Console doesn't fan out to half a dozen routes
+# on every render.
+api_router.include_router(dashboard_live_system.router)
 # Per-repo Home rollup (RFC-0008 §F — PR-4) — a single snapshot the
 # /r/<slug> page renders as Now + Trends tabs without fanning out to
 # the four source endpoints client-side.

--- a/backend/app/api/v1/routes/dashboard_live_system.py
+++ b/backend/app/api/v1/routes/dashboard_live_system.py
@@ -1,0 +1,459 @@
+"""Workspace "Live System" aggregator (Dashboard v2 — PR-2).
+
+One denormalised endpoint feeds the middle column of the home
+dashboard so the Console doesn't fan out to half a dozen separate
+routes (knowledge runs, routine state, daily-digest queue, specialist
+health) on every render.
+
+Five blocks, all best-effort: a missing data source returns ``None``
+or a zero-count and the UI renders ``—`` rather than failing the
+whole panel.
+
+- ``masthead`` — 7-day automation health: success rate (succeeded /
+  finished), failure count, when we last ran, was the last run OK.
+  Computed off ``pipeline_runs.finished_at >= now() - 7d``.
+- ``knowledge`` — most recent ``KnowledgeIngestionRun`` + count of
+  runs done in the last 24h. ``state_label`` is ``running`` if the
+  most recent row is in progress, ``errored`` if it crashed,
+  otherwise ``idle``.
+- ``routines`` — top three enabled non-daily :class:`Routine` rows by
+  ``last_run_at`` desc. The middle column renders the top two; we
+  return three so the UI can shuffle without a second round-trip.
+- ``daily`` — denormalised state of the daily-digest routine
+  (``lane_id == 'daily'``) plus inbox queue counts.
+- ``specialists`` — count of distinct FSM specialists in three
+  buckets (idle / working / errored) derived from the most recent
+  ``PipelineRun`` per ``Pipeline.lane_id`` mapped through
+  :func:`_specialist_for_lane`. ``working_name`` is set only when
+  exactly one specialist is currently running so the UI can render
+  the targeted "X working" line; multi-runner state collapses to a
+  generic count.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Literal
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+from sqlalchemy import desc, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.app.api.v1.deps import AuthContext, get_current_auth
+from backend.app.api.v1.routes.processes import _specialist_for_lane
+from backend.app.api.v1.routes.workspaces import (
+    ROLES_READ,
+    _require_membership,
+)
+from backend.app.db.models.agent_memory import KnowledgeIngestionRun
+from backend.app.db.models.inbox import InboxItem
+from backend.app.db.models.lanes import Routine
+from backend.app.db.models.pipelines import Pipeline, PipelineRun
+from backend.app.db.session import get_session
+
+
+logger = logging.getLogger(__name__)
+
+
+router = APIRouter(
+    prefix="/workspaces/{workspace_id}/dashboard/live-system",
+    tags=["dashboard-live-system"],
+)
+
+
+# ---------------------------------------------------------------------------
+# Pydantic schemas
+# ---------------------------------------------------------------------------
+
+
+class MastheadOut(BaseModel):
+    """7-day system-health glyphs rendered in the block kicker."""
+
+    success_rate_7d: float | None
+    failures_7d: int
+    last_run_at: datetime | None
+    last_run_status: Literal["ok", "error"] | None
+
+
+class KnowledgeOut(BaseModel):
+    last_run_at: datetime | None
+    last_status: Literal["pending", "running", "done", "error"] | None
+    ingested_today: int
+    state_label: Literal["idle", "running", "errored"]
+
+
+class RoutineOut(BaseModel):
+    name: str
+    last_run_at: datetime | None
+    last_run_status: str | None
+
+
+class DailyOut(BaseModel):
+    last_sent_at: datetime | None
+    last_run_status: str | None
+    queue_wins: int
+    queue_blockers: int
+
+
+class SpecialistsOut(BaseModel):
+    """Workspace-level specialist health rollup.
+
+    Buckets are mutually exclusive: every distinct specialist counted
+    once. ``errored_names`` lists the specialist slugs whose most
+    recent finished run was a failure — empty when health is clean.
+    ``working_name`` is the slug of the only currently-running
+    specialist (or ``None`` when zero or more-than-one are running);
+    the UI uses it to render ``Specialists · code-writer working ·
+    5 idle`` instead of a generic count.
+    """
+
+    idle_count: int
+    working_count: int
+    errored_count: int
+    errored_names: list[str]
+    working_name: str | None
+
+
+class LiveSystemOut(BaseModel):
+    masthead: MastheadOut
+    knowledge: KnowledgeOut
+    routines: list[RoutineOut]
+    daily: DailyOut
+    specialists: SpecialistsOut
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+
+_RUN_OK_STATUSES = frozenset({"succeeded", "success", "ok", "done"})
+_RUN_FAIL_STATUSES = frozenset({"failed", "error", "cancelled", "canceled"})
+_RUN_ACTIVE_STATUSES = frozenset({"running", "queued", "pending"})
+
+# Display labels for the canonical seven routine ids (mirrors
+# :data:`backend.app.services.lane_recipes.ROUTINE_DISPLAY_LABELS`,
+# kept inline so the route doesn't reach into the recipes module
+# just for cosmetics).
+_ROUTINE_LABELS: dict[str, str] = {
+    "daily": "Daily",
+    "retro": "Retro",
+    "healthcheck": "Self-heal",
+    "tech_review": "Tech review",
+    "qa_review": "QA review",
+    "security_review": "Security review",
+    "process_review": "Process review",
+}
+
+
+# ---------------------------------------------------------------------------
+# Block computers
+# ---------------------------------------------------------------------------
+
+
+async def _masthead(
+    session: AsyncSession, workspace_id: uuid.UUID, now: datetime
+) -> MastheadOut:
+    cutoff = now - timedelta(days=7)
+    rows = (
+        await session.execute(
+            select(PipelineRun.status, PipelineRun.finished_at)
+            .where(
+                PipelineRun.workspace_id == workspace_id,
+                PipelineRun.finished_at.is_not(None),
+                PipelineRun.finished_at >= cutoff,
+            )
+            .order_by(desc(PipelineRun.finished_at))
+        )
+    ).all()
+
+    succeeded = 0
+    failed = 0
+    for status, _ in rows:
+        if status in _RUN_OK_STATUSES:
+            succeeded += 1
+        elif status in _RUN_FAIL_STATUSES:
+            failed += 1
+    total_finished = succeeded + failed
+    success_rate: float | None = (
+        succeeded / total_finished if total_finished > 0 else None
+    )
+
+    last_run_at: datetime | None = None
+    last_run_status: Literal["ok", "error"] | None = None
+    if rows:
+        latest_status, latest_finished = rows[0]
+        last_run_at = latest_finished
+        if latest_status in _RUN_OK_STATUSES:
+            last_run_status = "ok"
+        elif latest_status in _RUN_FAIL_STATUSES:
+            last_run_status = "error"
+
+    return MastheadOut(
+        success_rate_7d=success_rate,
+        failures_7d=failed,
+        last_run_at=last_run_at,
+        last_run_status=last_run_status,
+    )
+
+
+async def _knowledge(
+    session: AsyncSession, workspace_id: uuid.UUID, now: datetime
+) -> KnowledgeOut:
+    last = (
+        await session.execute(
+            select(KnowledgeIngestionRun)
+            .where(KnowledgeIngestionRun.workspace_id == workspace_id)
+            .order_by(
+                desc(
+                    func.coalesce(
+                        KnowledgeIngestionRun.finished_at,
+                        KnowledgeIngestionRun.created_at,
+                    )
+                )
+            )
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+
+    cutoff_24h = now - timedelta(hours=24)
+    ingested_today = (
+        await session.execute(
+            select(func.count(KnowledgeIngestionRun.id)).where(
+                KnowledgeIngestionRun.workspace_id == workspace_id,
+                KnowledgeIngestionRun.status == "done",
+                KnowledgeIngestionRun.finished_at >= cutoff_24h,
+            )
+        )
+    ).scalar_one()
+
+    last_run_at: datetime | None = None
+    last_status: Literal["pending", "running", "done", "error"] | None = None
+    state_label: Literal["idle", "running", "errored"] = "idle"
+    if last is not None:
+        last_run_at = last.finished_at or last.created_at
+        # Cast through Literal-ish: the model carries free-text but the
+        # CHECK constraint pins values to the four below.
+        if last.status in ("pending", "running", "done", "error"):
+            last_status = last.status  # type: ignore[assignment]
+        if last.status == "running":
+            state_label = "running"
+        elif last.status == "error":
+            state_label = "errored"
+
+    return KnowledgeOut(
+        last_run_at=last_run_at,
+        last_status=last_status,
+        ingested_today=int(ingested_today or 0),
+        state_label=state_label,
+    )
+
+
+async def _routines(
+    session: AsyncSession, workspace_id: uuid.UUID
+) -> tuple[list[RoutineOut], Routine | None]:
+    """Top non-daily routines + the daily-routine row (or None).
+
+    Returned tuple keeps both lookups in one query: ``daily_row`` is
+    used by :func:`_daily` to pull last-sent state, the rest feed the
+    middle column's routine strip.
+    """
+    rows = (
+        await session.execute(
+            select(Routine)
+            .where(
+                Routine.workspace_id == workspace_id,
+                Routine.enabled.is_(True),
+            )
+            .order_by(
+                # Most-recently-run lanes float to the top — that's the
+                # signal "what did the bot just do?". NULLs (never run)
+                # sort last via FILTER trick: replace NULL with epoch.
+                desc(
+                    func.coalesce(
+                        Routine.last_run_at,
+                        func.to_timestamp(0),
+                    )
+                )
+            )
+        )
+    ).scalars().all()
+
+    daily_row: Routine | None = None
+    out: list[RoutineOut] = []
+    for r in rows:
+        if r.lane_id == "daily" and daily_row is None:
+            daily_row = r
+            continue
+        if len(out) >= 3:
+            continue
+        out.append(
+            RoutineOut(
+                name=_ROUTINE_LABELS.get(
+                    r.lane_id, r.lane_id.replace("_", " ").title()
+                ),
+                last_run_at=r.last_run_at,
+                last_run_status=r.last_run_status,
+            )
+        )
+    return out, daily_row
+
+
+async def _daily(
+    session: AsyncSession,
+    workspace_id: uuid.UUID,
+    daily_row: Routine | None,
+) -> DailyOut:
+    queue_wins = (
+        await session.execute(
+            select(func.count(InboxItem.id)).where(
+                InboxItem.workspace_id == workspace_id,
+                InboxItem.status == "new",
+                InboxItem.type == "improvement",
+            )
+        )
+    ).scalar_one()
+    queue_blockers = (
+        await session.execute(
+            select(func.count(InboxItem.id)).where(
+                InboxItem.workspace_id == workspace_id,
+                InboxItem.status == "new",
+                InboxItem.type.in_(("failure", "exception")),
+            )
+        )
+    ).scalar_one()
+
+    return DailyOut(
+        last_sent_at=daily_row.last_run_at if daily_row else None,
+        last_run_status=daily_row.last_run_status if daily_row else None,
+        queue_wins=int(queue_wins or 0),
+        queue_blockers=int(queue_blockers or 0),
+    )
+
+
+async def _specialists(
+    session: AsyncSession, workspace_id: uuid.UUID, now: datetime
+) -> SpecialistsOut:
+    """Aggregate specialist health from the most recent run per pipeline.
+
+    For each :class:`Pipeline` row in the workspace we look at the most
+    recent :class:`PipelineRun` (both finished and in-progress). The
+    pipeline's ``lane_id`` is mapped through :func:`_specialist_for_lane`
+    to the canonical specialist; we then dedupe on the specialist
+    slug and bucket it as working / errored / idle.
+    """
+    pipelines = (
+        await session.execute(
+            select(Pipeline.id, Pipeline.lane_id).where(
+                Pipeline.workspace_id == workspace_id,
+                Pipeline.enabled.is_(True),
+            )
+        )
+    ).all()
+
+    if not pipelines:
+        return SpecialistsOut(
+            idle_count=0,
+            working_count=0,
+            errored_count=0,
+            errored_names=[],
+            working_name=None,
+        )
+
+    pipeline_ids = [pid for pid, _ in pipelines]
+    lane_by_pipeline: dict[uuid.UUID, str] = {pid: lane for pid, lane in pipelines}
+
+    # Window the run lookup to last 24h so a year-old failure doesn't
+    # stick a specialist in the errored bucket forever. We order by
+    # ``finished_at`` first so still-running rows (NULL finished_at)
+    # don't accidentally outrank a just-finished one — coalesce
+    # NULL → started_at → created_at so every row sorts.
+    cutoff = now - timedelta(hours=24)
+    activity_at = func.coalesce(
+        PipelineRun.finished_at,
+        PipelineRun.started_at,
+        PipelineRun.created_at,
+    )
+    runs = (
+        await session.execute(
+            select(
+                PipelineRun.pipeline_id,
+                PipelineRun.status,
+            )
+            .where(
+                PipelineRun.workspace_id == workspace_id,
+                PipelineRun.pipeline_id.in_(pipeline_ids),
+                PipelineRun.created_at >= cutoff,
+            )
+            .order_by(desc(activity_at))
+        )
+    ).all()
+
+    # Latest status per pipeline within the window.
+    latest_per_pipeline: dict[uuid.UUID, str] = {}
+    for pid, status in runs:
+        if pid in latest_per_pipeline:
+            continue
+        latest_per_pipeline[pid] = status
+
+    # Specialist → worst-class status across its pipelines.
+    # Priority order: working > errored > idle. A specialist whose
+    # pipelines include both "running" and "failed" reads as
+    # "working" — it's actively trying again, not stuck.
+    by_specialist: dict[str, str] = {}
+    for pid, lane_id in lane_by_pipeline.items():
+        specialist = _specialist_for_lane(lane_id)
+        latest = latest_per_pipeline.get(pid)
+        if latest in _RUN_ACTIVE_STATUSES:
+            by_specialist[specialist] = "working"
+        elif latest in _RUN_FAIL_STATUSES:
+            if by_specialist.get(specialist) != "working":
+                by_specialist[specialist] = "errored"
+        else:
+            # No recent run, or it succeeded — idle is the default.
+            by_specialist.setdefault(specialist, "idle")
+
+    working = [s for s, st in by_specialist.items() if st == "working"]
+    errored = sorted(s for s, st in by_specialist.items() if st == "errored")
+    idle = [s for s, st in by_specialist.items() if st == "idle"]
+
+    return SpecialistsOut(
+        idle_count=len(idle),
+        working_count=len(working),
+        errored_count=len(errored),
+        errored_names=errored,
+        working_name=working[0] if len(working) == 1 else None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Route
+# ---------------------------------------------------------------------------
+
+
+@router.get("", response_model=LiveSystemOut)
+async def get_live_system(
+    workspace_id: uuid.UUID,
+    auth: AuthContext = Depends(get_current_auth),
+    session: AsyncSession = Depends(get_session),
+) -> LiveSystemOut:
+    await _require_membership(session, workspace_id, auth.user.id, ROLES_READ)
+    now = datetime.now(timezone.utc)
+    masthead = await _masthead(session, workspace_id, now)
+    knowledge = await _knowledge(session, workspace_id, now)
+    routines, daily_row = await _routines(session, workspace_id)
+    daily = await _daily(session, workspace_id, daily_row)
+    specialists = await _specialists(session, workspace_id, now)
+    return LiveSystemOut(
+        masthead=masthead,
+        knowledge=knowledge,
+        routines=routines,
+        daily=daily,
+        specialists=specialists,
+    )
+
+
+__all__ = ["router"]

--- a/backend/tests/test_v1_dashboard_live_system.py
+++ b/backend/tests/test_v1_dashboard_live_system.py
@@ -1,0 +1,191 @@
+"""Live System aggregator (Dashboard v2 — PR-2).
+
+Smoke coverage:
+- Empty workspace returns the expected zero-shape (no runs, no
+  knowledge, no routines, idle specialists).
+- A succeeded :class:`PipelineRun` lifts ``masthead.success_rate_7d``
+  to 1.0 with ``last_run_status='ok'``.
+- A failed :class:`PipelineRun` flips the most recent status to
+  ``error`` and increments ``failures_7d``.
+- A done :class:`KnowledgeIngestionRun` populates
+  ``knowledge.ingested_today`` and the state stays ``idle``.
+- Inbox queue counts split improvement-vs-failure correctly.
+- Viewer can read; stranger gets 404.
+"""
+
+from __future__ import annotations
+
+import secrets
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+
+def _auth(raw: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {raw}"}
+
+
+@pytest.mark.asyncio
+async def test_empty_workspace_returns_zero_shape(v1_client, seed_workspace) -> None:
+    _, raw, ws = seed_workspace
+    res = await v1_client.get(
+        f"/v1/workspaces/{ws.id}/dashboard/live-system",
+        headers=_auth(raw),
+    )
+    assert res.status_code == 200, res.text
+    body = res.json()
+
+    assert body["masthead"] == {
+        "success_rate_7d": None,
+        "failures_7d": 0,
+        "last_run_at": None,
+        "last_run_status": None,
+    }
+    assert body["knowledge"]["ingested_today"] == 0
+    assert body["knowledge"]["state_label"] == "idle"
+    assert body["routines"] == []
+    assert body["daily"]["queue_wins"] == 0
+    assert body["daily"]["queue_blockers"] == 0
+    assert body["specialists"] == {
+        "idle_count": 0,
+        "working_count": 0,
+        "errored_count": 0,
+        "errored_names": [],
+        "working_name": None,
+    }
+
+
+@pytest.mark.asyncio
+async def test_masthead_aggregates_pipeline_runs(
+    v1_client, seed_workspace, db_session
+) -> None:
+    """A succeeded run + a failed run → success_rate=0.5, failures_7d=1."""
+    from backend.app.db.models.pipelines import Pipeline, PipelineRun
+
+    _, raw, ws = seed_workspace
+    pipe = Pipeline(
+        workspace_id=ws.id,
+        repo_id=None,
+        lane_id="dev_implementation",
+        name="dev",
+        workflow_id="ship-dev",
+        config={},
+        enabled=True,
+    )
+    db_session.add(pipe)
+    await db_session.flush()
+
+    now = datetime.now(timezone.utc)
+    db_session.add(
+        PipelineRun(
+            pipeline_id=pipe.id,
+            workspace_id=ws.id,
+            trigger="manual",
+            status="succeeded",
+            started_at=now - timedelta(hours=3),
+            finished_at=now - timedelta(hours=2),
+        )
+    )
+    db_session.add(
+        PipelineRun(
+            pipeline_id=pipe.id,
+            workspace_id=ws.id,
+            trigger="manual",
+            status="failed",
+            started_at=now - timedelta(hours=1),
+            finished_at=now - timedelta(minutes=30),
+        )
+    )
+    await db_session.flush()
+
+    res = await v1_client.get(
+        f"/v1/workspaces/{ws.id}/dashboard/live-system",
+        headers=_auth(raw),
+    )
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["masthead"]["success_rate_7d"] == pytest.approx(0.5)
+    assert body["masthead"]["failures_7d"] == 1
+    assert body["masthead"]["last_run_status"] == "error"
+    # Latest pipeline_run is failed → specialist errored.
+    assert body["specialists"]["errored_count"] == 1
+    assert body["specialists"]["errored_names"] == ["developer"]
+
+
+@pytest.mark.asyncio
+async def test_inbox_queue_counts_split_by_type(
+    v1_client, seed_workspace, db_session
+) -> None:
+    from backend.app.db.models.inbox import InboxItem
+
+    _, raw, ws = seed_workspace
+    db_session.add_all(
+        [
+            InboxItem(
+                workspace_id=ws.id,
+                type="improvement",
+                title="Win 1",
+                source_table="improvements",
+                source_id=uuid.uuid4(),
+                status="new",
+            ),
+            InboxItem(
+                workspace_id=ws.id,
+                type="improvement",
+                title="Win 2",
+                source_table="improvements",
+                source_id=uuid.uuid4(),
+                status="new",
+            ),
+            InboxItem(
+                workspace_id=ws.id,
+                type="failure",
+                title="Blocker",
+                source_table="pipeline_runs",
+                source_id=uuid.uuid4(),
+                status="new",
+            ),
+        ]
+    )
+    await db_session.flush()
+
+    res = await v1_client.get(
+        f"/v1/workspaces/{ws.id}/dashboard/live-system",
+        headers=_auth(raw),
+    )
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["daily"]["queue_wins"] == 2
+    assert body["daily"]["queue_blockers"] == 1
+
+
+@pytest.mark.asyncio
+async def test_stranger_is_404d(v1_client, seed_workspace, db_session) -> None:
+    _, _, ws = seed_workspace
+    from backend.app.api.v1.deps import PAT_PREFIX, _hash_token
+    from backend.app.db.models.tenancy import ApiToken, User
+
+    stranger = User(
+        email=f"stranger-{uuid.uuid4().hex[:6]}@example.com",
+        display_name="Stranger",
+    )
+    db_session.add(stranger)
+    await db_session.flush()
+    raw = f"{PAT_PREFIX}{secrets.token_urlsafe(24)}"
+    db_session.add(
+        ApiToken(
+            user_id=stranger.id,
+            name="stranger-token",
+            hashed_secret=_hash_token(raw),
+            prefix=PAT_PREFIX,
+            scopes=[],
+        )
+    )
+    await db_session.flush()
+
+    res = await v1_client.get(
+        f"/v1/workspaces/{ws.id}/dashboard/live-system",
+        headers=_auth(raw),
+    )
+    assert res.status_code == 404, res.text

--- a/console/src/app/page.tsx
+++ b/console/src/app/page.tsx
@@ -9,11 +9,13 @@ import { WorkspaceEntryPicker } from "@/components/workspace-entry-picker";
 import { WorkspaceHome } from "@/components/workspace-home";
 import {
   type ApiActivatedRepo,
+  type ApiLiveSystem,
   type ApiOpsDashboard,
   type ApiPrioritiesResponse,
   ApiHttpError,
   ApiUnavailableError,
   getInboxCounts,
+  getLiveSystem,
   getMe,
   getOpsDashboard,
   getPriorities,
@@ -133,6 +135,11 @@ type LiveContext = {
    *  hides the prioritizer block so the rest of the dashboard still
    *  renders. */
   priorities: ApiPrioritiesResponse | null;
+  /** Dashboard v2 Live System aggregator — masthead glyphs, knowledge,
+   *  routines, daily, specialists. ``null`` on a fetch failure → the
+   *  middle column renders the loading placeholder rather than reading
+   *  broken. */
+  liveSystem: ApiLiveSystem | null;
 };
 
 /**
@@ -161,19 +168,25 @@ async function loadLiveContext(
 ): Promise<LiveContext | "unauthorized" | "down"> {
   const workspace = pickWorkspace(list, wsParam);
   try {
-    const [data, repos, inboxItems, inboxCounts, priorities] = await Promise.all([
-      getOpsDashboard(workspace.id, token),
-      listActivatedRepos(workspace.id, token).catch(() => [] as ApiActivatedRepo[]),
-      listInboxItems(workspace.id, { statuses: ["new"], limit: 5 }, token).catch(
-        () => null as InboxListResponse | null,
-      ),
-      getInboxCounts(workspace.id, token).catch(
-        () => null as InboxCountsResponse | null,
-      ),
-      getPriorities(workspace.id, token).catch(
-        () => null as ApiPrioritiesResponse | null,
-      ),
-    ]);
+    const [data, repos, inboxItems, inboxCounts, priorities, liveSystem] =
+      await Promise.all([
+        getOpsDashboard(workspace.id, token),
+        listActivatedRepos(workspace.id, token).catch(
+          () => [] as ApiActivatedRepo[],
+        ),
+        listInboxItems(workspace.id, { statuses: ["new"], limit: 5 }, token).catch(
+          () => null as InboxListResponse | null,
+        ),
+        getInboxCounts(workspace.id, token).catch(
+          () => null as InboxCountsResponse | null,
+        ),
+        getPriorities(workspace.id, token).catch(
+          () => null as ApiPrioritiesResponse | null,
+        ),
+        getLiveSystem(workspace.id, token).catch(
+          () => null as ApiLiveSystem | null,
+        ),
+      ]);
     return {
       workspace,
       allWorkspaces: list,
@@ -182,6 +195,7 @@ async function loadLiveContext(
       inboxItems,
       inboxCounts,
       priorities,
+      liveSystem,
     };
   } catch (err) {
     if (err instanceof ApiHttpError && err.status === 401) return "unauthorized";
@@ -216,6 +230,7 @@ function renderWorkspaceHome(ctx: LiveContext) {
         inboxItems={ctx.inboxItems}
         inboxCounts={ctx.inboxCounts}
         priorities={ctx.priorities}
+        liveSystem={ctx.liveSystem}
       />
     </AppShell>
   );

--- a/console/src/components/dashboard/live-system.tsx
+++ b/console/src/components/dashboard/live-system.tsx
@@ -1,0 +1,288 @@
+import type { ApiLiveSystem } from "@/lib/api/client";
+import { cn } from "@/lib/cn";
+
+/**
+ * Dashboard v2 Live System block (PR-2).
+ *
+ * Quiet middle column on the home dashboard. Reads as system health
+ * at a glance — kicker masthead + four cells (Knowledge, Routines,
+ * Daily, Specialists). No bordered cards; section breaks come from
+ * whitespace + tinted kickers.
+ *
+ * Fallback shape: if the aggregator endpoint failed to load the
+ * caller passes ``null`` and we render the loading placeholder so
+ * the column doesn't read broken when one upstream blip happens.
+ */
+
+type Props = {
+  data: ApiLiveSystem | null;
+};
+
+export function DashboardLiveSystem({ data }: Props) {
+  if (data === null) {
+    return (
+      <section className="space-y-2">
+        <p className="text-[10px] font-bold uppercase tracking-[0.22em] text-white/40">
+          Live system · loading…
+        </p>
+        <p className="text-[11px] italic text-white/30">
+          Couldn&apos;t reach the live-system aggregator on this render — try a
+          refresh.
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="space-y-6">
+      <Masthead data={data.masthead} />
+      <KnowledgeCell data={data.knowledge} />
+      <RoutinesCell rows={data.routines} />
+      <DailyCell data={data.daily} />
+      <SpecialistsCell data={data.specialists} />
+    </section>
+  );
+}
+
+
+function Masthead({ data }: { data: ApiLiveSystem["masthead"] }) {
+  const successPct =
+    data.success_rate_7d !== null
+      ? `${Math.round(data.success_rate_7d * 100)}%`
+      : "—";
+  const last =
+    data.last_run_at !== null
+      ? `${formatRelative(data.last_run_at)} last run`
+      : "no runs yet";
+  const failuresChip =
+    data.failures_7d > 0 ? (
+      <>
+        <span className="mx-2 text-white/15">·</span>
+        <span className="text-coral">
+          {data.failures_7d} failure{data.failures_7d === 1 ? "" : "s"}
+        </span>
+      </>
+    ) : null;
+  return (
+    <p className="text-[10px] font-bold uppercase tracking-[0.22em] text-white/40">
+      Live system
+      <span className="mx-2 text-white/15">·</span>
+      <span className={data.last_run_status === "error" ? "text-coral" : "text-aqua/80"}>
+        {successPct}
+      </span>
+      <span className="mx-2 text-white/15">·</span>
+      <span>{last}</span>
+      {failuresChip}
+    </p>
+  );
+}
+
+
+function KnowledgeCell({ data }: { data: ApiLiveSystem["knowledge"] }) {
+  const stateColor =
+    data.state_label === "errored"
+      ? "text-coral"
+      : data.state_label === "running"
+        ? "text-aqua"
+        : "text-white/65";
+  return (
+    <div className="space-y-1">
+      <p className="text-[10px] font-bold uppercase tracking-[0.22em] text-white/40">
+        Knowledge
+      </p>
+      <p className="text-[12px]">
+        <span className={cn("font-semibold", stateColor)}>
+          {data.state_label}
+        </span>
+        <span className="mx-2 text-white/20">·</span>
+        <span className="text-white/65">
+          {data.ingested_today} ingested today
+        </span>
+      </p>
+    </div>
+  );
+}
+
+
+function RoutinesCell({ rows }: { rows: ApiLiveSystem["routines"] }) {
+  return (
+    <div className="space-y-1.5">
+      <p className="text-[10px] font-bold uppercase tracking-[0.22em] text-white/40">
+        Routines
+      </p>
+      {rows.length === 0 ? (
+        <p className="text-[11px] italic text-white/30">No active routines.</p>
+      ) : (
+        <ul className="space-y-1">
+          {rows.slice(0, 2).map((row) => (
+            <li
+              key={row.name}
+              className="flex items-baseline justify-between gap-3 text-[12px]"
+            >
+              <span className="truncate text-white/80">{row.name}</span>
+              <span className="shrink-0 text-[11px]">
+                <span
+                  className={cn(
+                    row.last_run_status === "failed" ||
+                      row.last_run_status === "error"
+                      ? "text-coral"
+                      : "text-white/45",
+                  )}
+                >
+                  {row.last_run_at
+                    ? `last ${formatRelative(row.last_run_at)}`
+                    : "never run"}
+                </span>
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+
+function DailyCell({ data }: { data: ApiLiveSystem["daily"] }) {
+  const last =
+    data.last_sent_at !== null
+      ? `sent ${formatRelative(data.last_sent_at)}`
+      : data.last_run_status === "failed" || data.last_run_status === "error"
+        ? "skipped"
+        : "not yet sent";
+  return (
+    <div className="space-y-1.5">
+      <p className="text-[10px] font-bold uppercase tracking-[0.22em] text-white/40">
+        Daily
+      </p>
+      <ul className="space-y-1 text-[12px]">
+        <li className="flex items-baseline gap-2">
+          <span className="text-white/45">Last</span>
+          <span className="text-white/20">·</span>
+          <span
+            className={cn(
+              data.last_run_status === "failed" ||
+                data.last_run_status === "error"
+                ? "text-coral"
+                : "text-white/80",
+            )}
+          >
+            {last}
+          </span>
+        </li>
+        <li className="flex items-baseline gap-2">
+          <span className="text-white/45">Queue</span>
+          <span className="text-white/20">·</span>
+          <span className="text-white/80">
+            {data.queue_wins === 0 && data.queue_blockers === 0
+              ? "empty"
+              : (
+                <>
+                  <span className="text-aqua/85">
+                    {data.queue_wins} win{data.queue_wins === 1 ? "" : "s"}
+                  </span>
+                  <span className="mx-1 text-white/20">·</span>
+                  <span
+                    className={
+                      data.queue_blockers > 0 ? "text-coral" : "text-white/45"
+                    }
+                  >
+                    {data.queue_blockers} blocker
+                    {data.queue_blockers === 1 ? "" : "s"}
+                  </span>
+                </>
+              )}
+          </span>
+        </li>
+      </ul>
+    </div>
+  );
+}
+
+
+function SpecialistsCell({
+  data,
+}: {
+  data: ApiLiveSystem["specialists"];
+}) {
+  const total = data.idle_count + data.working_count + data.errored_count;
+  if (total === 0) {
+    return (
+      <div className="space-y-1">
+        <p className="text-[10px] font-bold uppercase tracking-[0.22em] text-white/40">
+          Specialists
+        </p>
+        <p className="text-[11px] italic text-white/30">
+          None configured yet.
+        </p>
+      </div>
+    );
+  }
+
+  const parts: React.ReactNode[] = [];
+  if (data.errored_count > 0) {
+    parts.push(
+      <span key="err" className="text-coral">
+        {data.errored_count === 1 && data.errored_names.length === 1
+          ? `${data.errored_names[0]} errored`
+          : `${data.errored_count} errored`}
+      </span>,
+    );
+  }
+  if (data.working_count > 0) {
+    parts.push(
+      <span key="work" className="text-aqua">
+        {data.working_name
+          ? `${data.working_name} working`
+          : `${data.working_count} working`}
+      </span>,
+    );
+  }
+  if (data.idle_count > 0) {
+    parts.push(
+      <span key="idle" className="text-white/65">
+        {data.idle_count} idle
+      </span>,
+    );
+  }
+
+  return (
+    <div className="space-y-1">
+      <p className="text-[10px] font-bold uppercase tracking-[0.22em] text-white/40">
+        Specialists
+      </p>
+      <p className="text-[12px]">
+        {parts.flatMap((node, idx) =>
+          idx === 0
+            ? [node]
+            : [
+                <span key={`sep-${idx}`} className="mx-2 text-white/20">
+                  ·
+                </span>,
+                node,
+              ],
+        )}
+      </p>
+      {data.errored_count > 1 && data.errored_names.length > 0 && (
+        <p className="text-[10.5px] text-coral/80">
+          {data.errored_names.join(", ")}
+        </p>
+      )}
+    </div>
+  );
+}
+
+
+function formatRelative(value: string): string {
+  const date = Date.parse(value);
+  if (Number.isNaN(date)) return "—";
+  const diff = Date.now() - date;
+  const minute = 60_000;
+  const hour = 60 * minute;
+  const day = 24 * hour;
+  if (diff < minute) return "just now";
+  if (diff < hour) return `${Math.max(1, Math.round(diff / minute))}m ago`;
+  if (diff < day) return `${Math.round(diff / hour)}h ago`;
+  if (diff < 30 * day) return `${Math.round(diff / day)}d ago`;
+  return new Date(date).toLocaleDateString();
+}

--- a/console/src/components/workspace-home.tsx
+++ b/console/src/components/workspace-home.tsx
@@ -1,8 +1,10 @@
 import Link from "next/link";
 
+import { DashboardLiveSystem } from "@/components/dashboard/live-system";
 import { DashboardPrioritizer } from "@/components/dashboard/prioritizer";
 import type {
   ApiActivatedRepo,
+  ApiLiveSystem,
   ApiOpsBlocker,
   ApiOpsDashboard,
   ApiOpsShippedItem,
@@ -48,6 +50,7 @@ export type WorkspaceHomeProps = {
   inboxItems: InboxListResponse | null;
   inboxCounts: InboxCountsResponse | null;
   priorities: ApiPrioritiesResponse | null;
+  liveSystem: ApiLiveSystem | null;
 };
 
 export function WorkspaceHome({
@@ -57,6 +60,7 @@ export function WorkspaceHome({
   inboxItems,
   inboxCounts,
   priorities,
+  liveSystem,
 }: WorkspaceHomeProps) {
   const reposNeedingUpdate = repos.filter(needsShipTemplateUpdate);
   const decisions = (inboxItems?.items ?? []).slice(0, 4);
@@ -118,7 +122,7 @@ export function WorkspaceHome({
         */}
         <div className="space-y-10 lg:col-span-4 lg:sticky lg:top-20 lg:self-start 2xl:contents">
           <aside className="space-y-6 2xl:col-span-3 2xl:sticky 2xl:top-20 2xl:self-start">
-            <LiveSystemPlaceholder />
+            <DashboardLiveSystem data={liveSystem} />
           </aside>
           <aside className="space-y-8 2xl:col-span-2 2xl:sticky 2xl:top-20 2xl:self-start">
             <LastActionStrip lastAction={priorities?.last_action ?? null} />
@@ -522,25 +526,6 @@ function ActiveTicketsStrip({
         Open process →
       </Link>
     </p>
-  );
-}
-
-
-// ---------------------------------------------------------------------------
-// Live System placeholder (PR-2 will populate)
-// ---------------------------------------------------------------------------
-
-
-function LiveSystemPlaceholder() {
-  return (
-    <section className="space-y-2">
-      <p className="text-[10px] font-bold uppercase tracking-[0.22em] text-white/40">
-        Live system · loading…
-      </p>
-      <p className="text-[11px] italic text-white/30">
-        Routines, daily digest, and specialist health land next.
-      </p>
-    </section>
   );
 }
 

--- a/console/src/lib/api/client.ts
+++ b/console/src/lib/api/client.ts
@@ -2531,6 +2531,71 @@ export function setAutonomyPaused(
   );
 }
 
+// --- Dashboard v2 — Live System aggregator ---------------------------------
+
+/**
+ * 7-day system-health glyphs rendered in the Live System block kicker.
+ * ``success_rate_7d`` is null when no runs finished in the window — the
+ * UI renders ``—``. ``last_run_status`` is the run-class of the most
+ * recent finished run, ``ok`` or ``error``.
+ */
+export interface ApiLiveSystemMasthead {
+  success_rate_7d: number | null;
+  failures_7d: number;
+  last_run_at: string | null;
+  last_run_status: "ok" | "error" | null;
+}
+
+export interface ApiLiveSystemKnowledge {
+  last_run_at: string | null;
+  last_status: "pending" | "running" | "done" | "error" | null;
+  ingested_today: number;
+  state_label: "idle" | "running" | "errored";
+}
+
+export interface ApiLiveSystemRoutine {
+  name: string;
+  last_run_at: string | null;
+  last_run_status: string | null;
+}
+
+export interface ApiLiveSystemDaily {
+  last_sent_at: string | null;
+  last_run_status: string | null;
+  queue_wins: number;
+  queue_blockers: number;
+}
+
+export interface ApiLiveSystemSpecialists {
+  idle_count: number;
+  working_count: number;
+  errored_count: number;
+  /** Specialist slugs that errored on their most recent finished run. */
+  errored_names: string[];
+  /** When exactly one specialist is currently running, its slug; null
+   * when zero or more-than-one are running so the UI collapses to a
+   * generic count. */
+  working_name: string | null;
+}
+
+export interface ApiLiveSystem {
+  masthead: ApiLiveSystemMasthead;
+  knowledge: ApiLiveSystemKnowledge;
+  routines: ApiLiveSystemRoutine[];
+  daily: ApiLiveSystemDaily;
+  specialists: ApiLiveSystemSpecialists;
+}
+
+export function getLiveSystem(
+  workspaceId: string,
+  token?: string,
+): Promise<ApiLiveSystem> {
+  return apiFetch<ApiLiveSystem>(
+    `/v1/workspaces/${encodeURIComponent(workspaceId)}/dashboard/live-system`,
+    { token },
+  );
+}
+
 export function dismissNotification(
   workspaceId: string,
   notificationId: string,


### PR DESCRIPTION
## Summary
- New ``GET /v1/workspaces/{ws}/dashboard/live-system`` returns five denormalised blocks: ``masthead`` (7-day success rate · failures · last-run age), ``knowledge`` (ingestion state · ingested-today count), ``routines`` (top 2-3 non-daily routines by recency), ``daily`` (digest last-sent + inbox queue counts), ``specialists`` (idle / working / errored rollup with named drill on single-error / single-working).
- Console middle column on the home dashboard now populates from the aggregator. PR-1's ``Live system · loading…`` placeholder is gone; the page renders specialist health, knowledge state, routine recency, and the daily-digest queue at a glance.
- Fetch is best-effort — a transient endpoint failure renders the placeholder instead of breaking the dashboard.

## Why
Designer + PO locked the masthead-in-kicker compromise overnight. PR-1 shipped the structural redesign with a placeholder middle column; PR-2 is the data layer that makes the column earn its space. Together they replace the read-only system-pulse rail that stood since the old dashboard.

## Test plan
- [x] ``pytest backend/tests/test_v1_dashboard_live_system.py`` — 4/4 (empty zero-shape, masthead aggregation, inbox queue split, stranger 404).
- [x] ``console: tsc --noEmit`` clean.
- [x] ``console: eslint --max-warnings=0`` clean for touched files.
- [x] ``console: next build`` passes.
- [ ] Smoke once merged: confirm masthead renders ``X% · Nm last run`` in the kicker, daily queue shows ``empty`` when truly empty (not collapsed), errored specialist surfaces the slug in coral.