### PR TITLE
dashboard: stop a stale Linear health-error masking as a live fault

### DIFF
--- a/backend/app/api/v1/routes/dashboard_priorities.py
+++ b/backend/app/api/v1/routes/dashboard_priorities.py
@@ -386,12 +386,20 @@ async def get_priorities(
                 supports_projects=False,
             )
         else:
-            err = integration.last_health_error or fetch_error
+            # Status reflects the result of the *current* fetch, not
+            # whatever ``last_health_error`` happens to be sitting in
+            # the integration row. The OAuth callback and the
+            # provisioner both write to ``last_health_error`` from
+            # entirely separate code paths; mixing it with the live
+            # fetch state turns "I just resolved a stale provisioning
+            # blip" into "Linear is broken" on the dashboard. Surface
+            # the stored error in ``last_health_error`` for ops/audit,
+            # but only flip ``status`` when the live fetch failed.
             tracker_out = TrackerSyncOut(
                 kind=kind,
-                status="error" if err else "connected",
+                status="error" if fetch_error else "connected",
                 last_health_at=integration.last_health_at,
-                last_health_error=err,
+                last_health_error=fetch_error or integration.last_health_error,
                 supports_projects=supports_projects,
             )
 

--- a/backend/app/integrations/linear/tracker_adapter.py
+++ b/backend/app/integrations/linear/tracker_adapter.py
@@ -15,8 +15,12 @@ enough that re-fetching the token costs nothing.
 
 from __future__ import annotations
 
+import logging
 from datetime import datetime
 from typing import Any
+
+
+logger = logging.getLogger(__name__)
 
 import httpx
 
@@ -599,7 +603,12 @@ class LinearTracker:
         ``canceled``). ``query`` matches project name (case-insensitive
         contains). Returns ``{"id", "name", "slug", "state", "url",
         "updated_at", "lead_name", "progress", "scope", "color"}`` per
-        project.
+        project — the last three are dashboard-only enrichment that
+        Linear may reject on certain workspace tiers; we fall back to
+        the basic shape (``progress``/``scope``/``color`` = ``None``)
+        rather than fail the call when they error out, so a connected
+        Linear that can't serve the rich fields still renders the
+        prioritizer list.
 
         ``progress`` is the 0-1 fraction Linear reports; ``scope`` is the
         total magnitude (issue count when no estimates are set, otherwise
@@ -615,7 +624,7 @@ class LinearTracker:
         if query:
             filter_clauses["name"] = {"containsIgnoreCase": query}
 
-        gql_query = """
+        rich_query = """
         query ShipListProjects($filter: ProjectFilter, $first: Int!) {
           projects(filter: $filter, first: $first, orderBy: updatedAt) {
             nodes {
@@ -633,9 +642,35 @@ class LinearTracker:
           }
         }
         """
-        data = await self._gql(
-            gql_query, {"filter": filter_clauses, "first": min(limit, 100)}
-        )
+        basic_query = """
+        query ShipListProjects($filter: ProjectFilter, $first: Int!) {
+          projects(filter: $filter, first: $first, orderBy: updatedAt) {
+            nodes {
+              id
+              name
+              slugId
+              state
+              url
+              updatedAt
+              lead { name }
+            }
+          }
+        }
+        """
+        variables = {"filter": filter_clauses, "first": min(limit, 100)}
+        try:
+            data = await self._gql(rich_query, variables)
+        except RuntimeError as exc:
+            # Linear rejected one of the enrichment fields (the only
+            # way ``_gql`` raises here is a ``errors[0].message`` from
+            # the GraphQL response). Re-issue the call with the basic
+            # shape and let the dashboard render without bars.
+            logger.warning(
+                "linear list_projects rich query rejected, falling back: %s",
+                exc,
+            )
+            data = await self._gql(basic_query, variables)
+
         nodes = ((data.get("projects") or {}).get("nodes")) or []
         return [
             {

--- a/console/src/components/dashboard/prioritizer.tsx
+++ b/console/src/components/dashboard/prioritizer.tsx
@@ -194,6 +194,36 @@ export function DashboardPrioritizer({ workspaceId, initial }: Props) {
   }
 
   if (allProjects.length === 0) {
+    // Two empty shapes share an empty list, but mean very different
+    // things: the tracker errored on this fetch (we can't say
+    // anything about Linear's project count) vs. the tracker
+    // connected fine and the team has no projects yet. Conflating
+    // them puts a scaffold "Add a project" line under a coral
+    // ``error · reconnect`` hairline, which reads as "the prioritizer
+    // is broken" — exactly the bug we hit in the first PR.
+    if (tracker.status === "error") {
+      return (
+        <PrioritizerSection
+          autonomyPaused={serverState.autonomy_paused}
+          upNext={null}
+          onToggleAutonomy={toggleAutonomy}
+          tracker={tracker}
+          pending={pending}
+        >
+          <li className="space-y-1 py-3 text-[12px]">
+            <p className="text-coral/85">
+              Couldn&apos;t fetch projects from{" "}
+              {tracker.kind === "linear" ? "Linear" : "the tracker"}.
+            </p>
+            {tracker.last_health_error ? (
+              <p className="font-mono text-[10.5px] text-coral/60">
+                {tracker.last_health_error}
+              </p>
+            ) : null}
+          </li>
+        </PrioritizerSection>
+      );
+    }
     return (
       <PrioritizerSection
         autonomyPaused={serverState.autonomy_paused}


### PR DESCRIPTION
## Summary
Fix for the ``Linear · error · reconnect →`` strip + ``Add a project in Linear`` ghost rows that fired on a healthy, linked Linear:

1. **Backend** — ``GET /v1/workspaces/{ws}/priorities`` no longer flips ``tracker.status`` to ``error`` based on a stale ``Integration.last_health_error``. The OAuth callback + provisioner write that field from independent code paths and can leave a resolved string in the row; status now reflects the live fetch only. The error string still rides through ``last_health_error`` for ops/audit visibility.
2. **Linear adapter** — ``list_projects`` tries a rich query (``color`` / ``progress`` / ``scope``) first and falls back to the basic shape if Linear rejects any of them. Previously a single-field rejection killed the entire fetch; now we degrade gracefully and the prioritizer renders without bars.
3. **Frontend** — the empty-list view used to be the same for "tracker errored" and "tracker connected, no projects yet" (three ``Add a project`` ghost rows). Error case now surfaces the actual reason + captured GraphQL message, so the screenshot doesn't read as ``Linear is broken — go add a project``.

## Test plan
- [x] ``pytest backend/tests/test_v1_dashboard_priorities.py`` — 6/6.
- [x] ``console: tsc --noEmit`` clean for touched files.
- [x] ``console: eslint --max-warnings=0`` clean.
- [ ] Smoke once merged: connected Linear renders ``Linear · synced …`` (white/40), prioritizer shows real projects (or a clear error reason if Linear actually rejects the GraphQL).