### PR TITLE
dashboard: prefer native Linear installation over legacy Integration row

### DIFF
--- a/backend/app/api/v1/routes/dashboard_priorities.py
+++ b/backend/app/api/v1/routes/dashboard_priorities.py
@@ -42,7 +42,7 @@ from backend.app.api.v1.routes.workspaces import (
 from backend.app.core.config import Settings, get_settings
 from backend.app.db.models.dashboard_priorities import WorkspaceProjectPriority
 from backend.app.db.models.pipelines import PullRequest
-from backend.app.db.models.tenancy import AuditLog, Integration, Workspace
+from backend.app.db.models.tenancy import AuditLog, Workspace
 from backend.app.db.session import get_session
 from backend.app.services.tracker_resolver import resolve_for_workspace
 
@@ -165,24 +165,6 @@ async def _load_workspace(
     return workspace
 
 
-async def _load_tracker_integration(
-    session: AsyncSession, workspace_id: uuid.UUID
-) -> Integration | None:
-    row = (
-        await session.execute(
-            select(Integration)
-            .where(
-                Integration.workspace_id == workspace_id,
-                Integration.repo_id.is_(None),
-                Integration.kind.in_(("linear", "jira")),
-            )
-            .order_by(Integration.updated_at.desc())
-            .limit(1)
-        )
-    ).scalar_one_or_none()
-    return row
-
-
 def _completion_counts(
     progress: float | None, scope: float | None
 ) -> tuple[int | None, int | None]:
@@ -276,7 +258,6 @@ async def get_priorities(
 ) -> PrioritiesOut:
     await _require_membership(session, workspace_id, auth.user.id, ROLES_READ)
     workspace = await _load_workspace(session, workspace_id)
-    integration = await _load_tracker_integration(session, workspace_id)
 
     saved_rows = (
         await session.execute(
@@ -289,25 +270,27 @@ async def get_priorities(
         row.project_native_id: row for row in saved_rows
     }
 
-    # Resolve tracker → fetch raw projects. The resolver returns None
-    # when no integration row is bound — we still answer 200 with an
-    # empty list so the UI can render the disconnected empty state.
+    # Resolve tracker via the canonical helper (native installation
+    # first, then legacy ``Integration`` row) so the dashboard reads
+    # the same token the agent's runtime authenticates with. A
+    # workspace with a fresh native install + a stale legacy row
+    # used to surface the legacy 401 here even though the agent kept
+    # working — the resolver fix flips the precedence.
     tracker = None
     fetch_error: str | None = None
-    if integration is not None:
-        try:
-            tracker = await resolve_for_workspace(
-                session=session,
-                settings=settings,
-                workspace_id=workspace_id,
-            )
-        except Exception as exc:  # noqa: BLE001 — defensive
-            logger.warning(
-                "tracker resolve failed for workspace=%s err=%s",
-                workspace_id,
-                exc,
-            )
-            fetch_error = str(exc)
+    try:
+        tracker = await resolve_for_workspace(
+            session=session,
+            settings=settings,
+            workspace_id=workspace_id,
+        )
+    except Exception as exc:  # noqa: BLE001 — defensive
+        logger.warning(
+            "tracker resolve failed for workspace=%s err=%s",
+            workspace_id,
+            exc,
+        )
+        fetch_error = str(exc)
 
     raw_projects: list[dict] = []
     supports_projects = False
@@ -360,8 +343,11 @@ async def get_priorities(
         )
     )
 
-    # Tracker connection block.
-    if integration is None:
+    # Tracker connection block. We trust the resolver: a non-None
+    # ``ResolvedTracker`` means *some* storage shape (native install
+    # or legacy Integration row) handed back a usable token, so
+    # surface ``connected`` even when no legacy row exists.
+    if tracker is None:
         tracker_out = TrackerSyncOut(
             kind=None,
             status="disconnected",
@@ -372,36 +358,27 @@ async def get_priorities(
     else:
         kind = (
             "linear"
-            if integration.kind == "linear"
+            if tracker.kind == "linear"
             else "jira"
-            if integration.kind == "jira"
+            if tracker.kind == "jira"
             else None
         )
-        if kind is None:
-            tracker_out = TrackerSyncOut(
-                kind=None,
-                status="disconnected",
-                last_health_at=integration.last_health_at,
-                last_health_error=integration.last_health_error,
-                supports_projects=False,
-            )
-        else:
-            # Status reflects the result of the *current* fetch, not
-            # whatever ``last_health_error`` happens to be sitting in
-            # the integration row. The OAuth callback and the
-            # provisioner both write to ``last_health_error`` from
-            # entirely separate code paths; mixing it with the live
-            # fetch state turns "I just resolved a stale provisioning
-            # blip" into "Linear is broken" on the dashboard. Surface
-            # the stored error in ``last_health_error`` for ops/audit,
-            # but only flip ``status`` when the live fetch failed.
-            tracker_out = TrackerSyncOut(
-                kind=kind,
-                status="error" if fetch_error else "connected",
-                last_health_at=integration.last_health_at,
-                last_health_error=fetch_error or integration.last_health_error,
-                supports_projects=supports_projects,
-            )
+        # Status reflects the result of the *current* fetch, not
+        # whatever ``last_health_error`` happens to be sitting in the
+        # source row. The OAuth callback and provisioner write to
+        # ``last_health_error`` from independent code paths; mixing
+        # them into ``status`` turned a long-resolved blip into a
+        # coral "Linear is broken" hairline. Surface the stored error
+        # in ``last_health_error`` for ops visibility but only flip
+        # ``status`` when the live fetch failed.
+        last_health_at = tracker.last_health_at  # type: ignore[assignment]
+        tracker_out = TrackerSyncOut(
+            kind=kind,
+            status="error" if fetch_error else "connected",
+            last_health_at=last_health_at,  # type: ignore[arg-type]
+            last_health_error=fetch_error or tracker.last_health_error,
+            supports_projects=supports_projects,
+        )
 
     autonomy_paused = _autonomy_paused(workspace)
 

--- a/backend/app/services/tracker_resolver.py
+++ b/backend/app/services/tracker_resolver.py
@@ -8,8 +8,20 @@ the lookup of the bound tracker so every write-side route resolves
 the same way.
 
 Today's catalog:
-- ``linear``  — workspace-level Linear OAuth row.
+- ``linear``  — native installation (preferred) or legacy
+  workspace-level Linear OAuth row.
 - ``jira``    — same shape, deferred until needed.
+
+Two storage shapes coexist while the native-integration migration
+is in flight: the legacy ``Integration`` table (with
+``secret_ciphertext`` inline) and the newer
+``NativeIntegrationInstallation`` + ``NativeIntegrationCredential``
+pair. The agent's runtime
+(:meth:`backend.app.services.agent.tools.AgentToolset._resolve_tracker`)
+prefers the native pair when both exist; this resolver mirrors that
+ordering so dashboards and the agent don't accidentally read different
+tokens — the symptom of the old (legacy-only) behaviour was the
+dashboard 401-ing on Linear while the agent kept working.
 
 Returns ``None`` when no tracker is bound — callers map that to
 ``no_tracker_bound`` and the agent surfaces ``blocked`` cleanly.
@@ -26,6 +38,12 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.app.core.config import Settings
+from backend.app.db.models.integrations import (
+    NativeIntegrationCredential,
+    NativeIntegrationInstallation,
+    NativeIntegrationProvider,
+    NativeIntegrationStatus,
+)
 from backend.app.db.models.tenancy import Integration
 from backend.app.integrations.gateway.tracker import TrackerGateway
 from backend.app.integrations.linear.tracker_adapter import LinearTracker
@@ -44,6 +62,13 @@ class ResolvedTracker:
     # Vendor-specific scope hint (Linear team key, Jira project key).
     # Adapters fall back to "the only available scope" when unset.
     scope_hint: str | None
+    # Provenance + health pass-through so the dashboard can render
+    # "Linear · synced 2m" without a second query against the same
+    # row. ``source`` reflects which storage shape carried the token
+    # — native installation row vs. legacy Integration row.
+    source: Literal["native", "legacy"] | None = None
+    last_health_at: object | None = None
+    last_health_error: str | None = None
 
 
 async def resolve_for_workspace(
@@ -52,9 +77,85 @@ async def resolve_for_workspace(
     settings: Settings,
     workspace_id: uuid.UUID,
 ) -> ResolvedTracker | None:
-    """Return the workspace's bound tracker, if any."""
-    from backend.app.api.v1.routes.integrations import decrypt  # lazy
+    """Return the workspace's bound tracker, if any.
 
+    Resolution order matches
+    :meth:`AgentToolset._resolve_tracker` so dashboard-side reads
+    pick the same row the agent is actually authenticating with:
+
+    1. Native ``LINEAR`` installation in ``READY`` state with a live
+       ``access_token`` credential.
+    2. Legacy ``Integration(kind='linear', repo_id IS NULL)`` row with
+       a stored ``secret_ciphertext``.
+    """
+    del settings  # No vendor-specific knobs needed here yet.
+    from backend.app.security.encryption import decrypt
+
+    native = await _resolve_native_linear(session, workspace_id, decrypt)
+    if native is not None:
+        return native
+    return await _resolve_legacy_linear(session, workspace_id, decrypt)
+
+
+async def _resolve_native_linear(
+    session: AsyncSession,
+    workspace_id: uuid.UUID,
+    decrypt,
+) -> ResolvedTracker | None:
+    install = (
+        await session.execute(
+            select(NativeIntegrationInstallation)
+            .where(
+                NativeIntegrationInstallation.workspace_id == workspace_id,
+                NativeIntegrationInstallation.provider
+                == NativeIntegrationProvider.LINEAR,
+                NativeIntegrationInstallation.status
+                == NativeIntegrationStatus.READY,
+                NativeIntegrationInstallation.disabled_at.is_(None),
+            )
+            .order_by(NativeIntegrationInstallation.updated_at.desc())
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+    if install is None:
+        return None
+
+    credential = (
+        await session.execute(
+            select(NativeIntegrationCredential).where(
+                NativeIntegrationCredential.installation_id == install.id,
+                NativeIntegrationCredential.kind == "access_token",
+                NativeIntegrationCredential.revoked_at.is_(None),
+            )
+        )
+    ).scalar_one_or_none()
+    if credential is None or not credential.secret_ciphertext:
+        return None
+
+    try:
+        token = decrypt(credential.secret_ciphertext)
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "native linear token unreadable for installation=%s", install.id
+        )
+        return None
+    if not token:
+        return None
+
+    return _build_linear_resolved(
+        token,
+        install.config or {},
+        source="native",
+        last_health_at=install.last_health_at,
+        last_health_error=install.last_health_error,
+    )
+
+
+async def _resolve_legacy_linear(
+    session: AsyncSession,
+    workspace_id: uuid.UUID,
+    decrypt,
+) -> ResolvedTracker | None:
     row = (
         await session.execute(
             select(Integration).where(
@@ -70,33 +171,62 @@ async def resolve_for_workspace(
         return None
 
     if row.kind == "linear":
-        token = await _decrypt_token(row, decrypt)
+        token = _decrypt_legacy_token(row, decrypt)
         if token is None:
             return None
-        cfg = row.config or {}
-        team_id = cfg.get("team_id")
-        team_key = cfg.get("team_key")
-        label_id_by_stage = cfg.get("label_id_by_stage") or {}
-        state_id_by_name = cfg.get("state_id_by_name") or {}
-        signal_label_ids = cfg.get("signal_label_ids") or {}
-        from backend.app.services.linear_provisioner import FSM_TO_LINEAR_STATE
-        gateway = LinearTracker(
+        return _build_linear_resolved(
             token,
-            team_id=team_id,
-            team_key=team_key,
-            label_id_by_stage=label_id_by_stage,
-            state_id_by_name=state_id_by_name,
-            fsm_to_linear_state=FSM_TO_LINEAR_STATE,
-            signal_label_ids=signal_label_ids,
+            row.config or {},
+            source="legacy",
+            last_health_at=row.last_health_at,
+            last_health_error=row.last_health_error,
         )
-        return ResolvedTracker(kind="linear", gateway=gateway, scope_hint=team_key)
 
     # Jira / others — wire when needed.
-    logger.warning("workspace %s has tracker kind=%s, not yet wired", workspace_id, row.kind)
+    logger.warning(
+        "workspace %s has tracker kind=%s, not yet wired", workspace_id, row.kind
+    )
     return None
 
 
-async def _decrypt_token(row: Integration, decrypt) -> str | None:
+def _build_linear_resolved(
+    token: str,
+    config: dict,
+    *,
+    source: Literal["native", "legacy"],
+    last_health_at: object | None,
+    last_health_error: str | None,
+) -> ResolvedTracker:
+    """Hydrate a ``ResolvedTracker`` from a Linear token + config blob.
+
+    Both the native and legacy code paths converge here so the
+    workspace's configured default team / FSM mapping reach the
+    adapter regardless of which storage shape carried the token.
+    """
+    from backend.app.services.linear_provisioner import FSM_TO_LINEAR_STATE
+
+    team_id = config.get("team_id")
+    team_key = config.get("team_key")
+    gateway = LinearTracker(
+        token,
+        team_id=team_id,
+        team_key=team_key,
+        label_id_by_stage=config.get("label_id_by_stage") or {},
+        state_id_by_name=config.get("state_id_by_name") or {},
+        fsm_to_linear_state=FSM_TO_LINEAR_STATE,
+        signal_label_ids=config.get("signal_label_ids") or {},
+    )
+    return ResolvedTracker(
+        kind="linear",
+        gateway=gateway,
+        scope_hint=team_key,
+        source=source,
+        last_health_at=last_health_at,
+        last_health_error=last_health_error,
+    )
+
+
+def _decrypt_legacy_token(row: Integration, decrypt) -> str | None:
     if not row.secret_ciphertext:
         return None
     try:


### PR DESCRIPTION
## Summary
Root cause of the ``401 Unauthorized`` from ``api.linear.app/graphql`` on the prioritizer:

The agent's runtime resolver (``AgentToolset._resolve_tracker`` in ``services/agent/tools.py``) reads the **native** Linear installation first (``NativeIntegrationInstallation`` + ``NativeIntegrationCredential``) and only falls back to the legacy ``Integration`` table. Workspaces that re-OAuth'd into the native flow still have the old legacy row sitting around with a stale token — the agent kept working off the fresh native one, so the user never saw a problem; the dashboard's ``tracker_resolver`` was hard-coded to read the legacy table only and grabbed the stale token.

Fix:
- ``tracker_resolver.resolve_for_workspace`` now mirrors the agent's ordering — native installation first, legacy second.
- ``ResolvedTracker`` carries ``source`` + ``last_health_at`` + ``last_health_error`` so the dashboard renders ``Linear · synced 2m`` without an extra round-trip against the same row it authenticated through.
- ``dashboard_priorities.get_priorities`` no longer requires a legacy ``Integration`` row to consider a tracker bound; a workspace whose only Linear linkage is in the native installation reads as ``connected`` instead of ``disconnected``.

## Test plan
- [x] ``pytest backend/tests/test_v1_dashboard_priorities.py`` — 6/6 (existing scenarios still pass under the new resolver path).
- [ ] Smoke once merged: dashboard prioritizer renders Linear projects on a workspace whose token lives only in the native installation. ``Linear · synced …`` (white/40), no coral hairline, no ghost ``Add a project`` rows.

## Why not "just delete the legacy row"
The native migration is in flight; some legacy callsites still write to ``Integration``. Mirroring the agent's precedence means the dashboard adapts to whichever shape carried the live token, without forcing a coordinated cutover.