### PR TITLE
dashboard: drop blind team-resolution probe from list_projects

### DIFF
--- a/backend/app/integrations/linear/tracker_adapter.py
+++ b/backend/app/integrations/linear/tracker_adapter.py
@@ -639,10 +639,19 @@ class LinearTracker:
         weighted). The dashboard prioritizer renders ``round(progress *
         scope) / round(scope)`` as a fraction.
         """
-        team_id = await self._resolve_team_id(None)
-        filter_clauses: dict[str, Any] = {
-            "accessibleTeams": {"some": {"id": {"eq": team_id}}},
-        }
+        # Only narrow to a specific team when one is actually
+        # configured. Calling ``_resolve_team_id(None)`` blindly used
+        # to fire a ``teams(first: 2)`` probe against Linear — fine
+        # for tokens with the ``read`` scope but a 401 with
+        # ``Authentication required`` for narrower OAuth scopes that
+        # don't grant team-listing access. The dashboard prioritizer
+        # is fine showing every project the OAuth user can see, so
+        # we drop the filter when no default team is bound.
+        filter_clauses: dict[str, Any] = {}
+        if self._team_id:
+            filter_clauses["accessibleTeams"] = {
+                "some": {"id": {"eq": self._team_id}}
+            }
         if state:
             filter_clauses["state"] = {"eq": state}
         if query:
@@ -681,7 +690,13 @@ class LinearTracker:
           }
         }
         """
-        variables = {"filter": filter_clauses, "first": min(limit, 100)}
+        variables = {
+            # GraphQL accepts a null filter when no narrowing is
+            # needed; sending ``{}`` works in current Linear builds
+            # but ``null`` is the canonical "no filter" shape.
+            "filter": filter_clauses or None,
+            "first": min(limit, 100),
+        }
         try:
             data = await self._gql(rich_query, variables)
         except RuntimeError as exc:

--- a/backend/app/services/tracker_resolver.py
+++ b/backend/app/services/tracker_resolver.py
@@ -91,16 +91,46 @@ async def resolve_for_workspace(
     del settings  # No vendor-specific knobs needed here yet.
     from backend.app.security.encryption import decrypt
 
-    native = await _resolve_native_linear(session, workspace_id, decrypt)
+    # Native carries the live token; legacy carries the FSM-provisioned
+    # config (team_id / team_key / state_id_by_name / label_id_by_stage)
+    # that ``linear_oauth.py`` writes only on the legacy row. We pull
+    # the legacy config blob up front so the native path can layer it
+    # under the native token without a second resolve pass.
+    legacy_row = await _load_legacy_linear_row(session, workspace_id)
+    legacy_config = (legacy_row.config or {}) if legacy_row else {}
+
+    native = await _resolve_native_linear(
+        session, workspace_id, decrypt, legacy_config=legacy_config
+    )
     if native is not None:
         return native
-    return await _resolve_legacy_linear(session, workspace_id, decrypt)
+    if legacy_row is None:
+        return None
+    return _resolve_from_legacy_row(legacy_row, decrypt)
+
+
+async def _load_legacy_linear_row(
+    session: AsyncSession, workspace_id: uuid.UUID
+) -> Integration | None:
+    return (
+        await session.execute(
+            select(Integration).where(
+                Integration.workspace_id == workspace_id,
+                Integration.repo_id.is_(None),
+                Integration.kind.in_(("linear", "jira")),
+            )
+            .order_by(Integration.updated_at.desc())
+            .limit(1)
+        )
+    ).scalar_one_or_none()
 
 
 async def _resolve_native_linear(
     session: AsyncSession,
     workspace_id: uuid.UUID,
     decrypt,
+    *,
+    legacy_config: dict | None = None,
 ) -> ResolvedTracker | None:
     install = (
         await session.execute(
@@ -142,34 +172,35 @@ async def _resolve_native_linear(
     if not token:
         return None
 
+    # ``linear_oauth.py`` writes the FSM-provisioned config (team_id /
+    # team_key / state_id_by_name / label_id_by_stage / signal_label_ids)
+    # to the *legacy* ``Integration.config`` row. The native row only
+    # gets ``{scope, token_type}``. Layering the legacy blob under
+    # native lets the dashboard scope ``list_projects`` to the right
+    # team and the agent transition tickets without a second lookup.
+    config = dict(install.config or {})
+    if legacy_config:
+        for key in (
+            "team_id",
+            "team_key",
+            "label_id_by_stage",
+            "state_id_by_name",
+            "signal_label_ids",
+        ):
+            if key not in config and key in legacy_config:
+                config[key] = legacy_config[key]
     return _build_linear_resolved(
         token,
-        install.config or {},
+        config,
         source="native",
         last_health_at=install.last_health_at,
         last_health_error=install.last_health_error,
     )
 
 
-async def _resolve_legacy_linear(
-    session: AsyncSession,
-    workspace_id: uuid.UUID,
-    decrypt,
+def _resolve_from_legacy_row(
+    row: Integration, decrypt
 ) -> ResolvedTracker | None:
-    row = (
-        await session.execute(
-            select(Integration).where(
-                Integration.workspace_id == workspace_id,
-                Integration.repo_id.is_(None),
-                Integration.kind.in_(("linear", "jira")),
-            )
-            .order_by(Integration.updated_at.desc())
-            .limit(1)
-        )
-    ).scalar_one_or_none()
-    if row is None:
-        return None
-
     if row.kind == "linear":
         token = _decrypt_legacy_token(row, decrypt)
         if token is None:
@@ -184,7 +215,7 @@ async def _resolve_legacy_linear(
 
     # Jira / others — wire when needed.
     logger.warning(
-        "workspace %s has tracker kind=%s, not yet wired", workspace_id, row.kind
+        "workspace has tracker kind=%s, not yet wired", row.kind
     )
     return None
 


### PR DESCRIPTION
## Summary
This is the actual root cause behind the persistent 401:

``LinearTracker.list_projects`` was calling ``_resolve_team_id(None)`` before issuing the projects query. With no team cached on the adapter that fell through to a ``teams(first: 2)`` probe — and that probe is what 401-ed Linear, not ``projects`` itself.

The probe needs a broader OAuth scope than the rest of the integration. ``linear_oauth.py`` writes the FSM-provisioned ``team_id`` / ``team_key`` / label-state maps onto the **legacy** ``Integration.config`` row only. The native installation gets ``{scope, token_type}``. After PR #134 we (correctly) read the live token from the native row, but the config side trail was empty, so the adapter had no team and fired the probe. Tokens scoped to ``issues:create,comments:create`` 401 on ``teams``.

Two coupled fixes:

1. ``list_projects`` skips ``_resolve_team_id`` entirely when no team is configured. An empty ``ProjectFilter`` returns every project the OAuth user can see — exactly what the dashboard prioritizer wants, with no privileged probe.
2. ``tracker_resolver`` layers the legacy ``Integration.config`` blob (``team_id``/``team_key``/state+label maps) under the native token whenever both rows exist. Adapter methods that DO need team scope (``transition``, ``create_ticket``) keep working without a second lookup.

## Test plan
- [x] ``pytest backend/tests/test_v1_dashboard_priorities.py`` — 6/6.
- [ ] Smoke once merged: dashboard prioritizer renders the user's Linear projects, hairline goes ``Linear · synced …``, no coral.