### PR TITLE
dashboard: surface Linear OAuth scopes in the prioritizer error

### DIFF
--- a/backend/app/api/v1/routes/dashboard_priorities.py
+++ b/backend/app/api/v1/routes/dashboard_priorities.py
@@ -81,6 +81,12 @@ class TrackerSyncOut(BaseModel):
     last_health_at: datetime | None
     last_health_error: str | None
     supports_projects: bool
+    # OAuth scopes the stored token was issued with. We render them in
+    # the error empty-state so an admin can eyeball whether ``read``
+    # is actually granted (a 401 from ``projects`` without ``read`` is
+    # the same Linear error string as a revoked token, but a different
+    # fix — re-OAuth with a wider scope set vs. reconnect).
+    scopes: list[str] | None
 
 
 class PriorityProjectOut(BaseModel):
@@ -359,6 +365,7 @@ async def get_priorities(
             last_health_at=None,
             last_health_error=None,
             supports_projects=False,
+            scopes=None,
         )
     else:
         kind = (
@@ -383,6 +390,7 @@ async def get_priorities(
             last_health_at=last_health_at,  # type: ignore[arg-type]
             last_health_error=fetch_error or tracker.last_health_error,
             supports_projects=supports_projects,
+            scopes=list(tracker.scopes) if tracker.scopes else [],
         )
 
     autonomy_paused = _autonomy_paused(workspace)

--- a/backend/app/services/tracker_resolver.py
+++ b/backend/app/services/tracker_resolver.py
@@ -69,6 +69,10 @@ class ResolvedTracker:
     source: Literal["native", "legacy"] | None = None
     last_health_at: object | None = None
     last_health_error: str | None = None
+    # OAuth scopes the stored token was issued with. Surfaced into
+    # the dashboard so an admin can eyeball whether ``read`` is
+    # actually granted before chasing 401 ghosts.
+    scopes: tuple[str, ...] = ()
 
 
 async def resolve_for_workspace(
@@ -195,6 +199,7 @@ async def _resolve_native_linear(
         source="native",
         last_health_at=install.last_health_at,
         last_health_error=install.last_health_error,
+        scopes=tuple(install.scopes or ()),
     )
 
 
@@ -205,12 +210,17 @@ def _resolve_from_legacy_row(
         token = _decrypt_legacy_token(row, decrypt)
         if token is None:
             return None
+        scope_raw = (row.config or {}).get("scope")
+        scopes = tuple(
+            s.strip() for s in str(scope_raw or "").split(",") if s.strip()
+        )
         return _build_linear_resolved(
             token,
             row.config or {},
             source="legacy",
             last_health_at=row.last_health_at,
             last_health_error=row.last_health_error,
+            scopes=scopes,
         )
 
     # Jira / others — wire when needed.
@@ -227,6 +237,7 @@ def _build_linear_resolved(
     source: Literal["native", "legacy"],
     last_health_at: object | None,
     last_health_error: str | None,
+    scopes: tuple[str, ...] = (),
 ) -> ResolvedTracker:
     """Hydrate a ``ResolvedTracker`` from a Linear token + config blob.
 
@@ -254,6 +265,7 @@ def _build_linear_resolved(
         source=source,
         last_health_at=last_health_at,
         last_health_error=last_health_error,
+        scopes=scopes,
     )
 
 

--- a/console/src/components/dashboard/prioritizer.tsx
+++ b/console/src/components/dashboard/prioritizer.tsx
@@ -202,6 +202,10 @@ export function DashboardPrioritizer({ workspaceId, initial }: Props) {
     // ``error · reconnect`` hairline, which reads as "the prioritizer
     // is broken" — exactly the bug we hit in the first PR.
     if (tracker.status === "error") {
+      const missingRead =
+        tracker.kind === "linear" &&
+        tracker.scopes !== null &&
+        !tracker.scopes.includes("read");
       return (
         <PrioritizerSection
           autonomyPaused={serverState.autonomy_paused}
@@ -215,6 +219,17 @@ export function DashboardPrioritizer({ workspaceId, initial }: Props) {
               Couldn&apos;t fetch projects from{" "}
               {tracker.kind === "linear" ? "Linear" : "the tracker"}.
             </p>
+            {missingRead ? (
+              <p className="text-[11px] text-sun/85">
+                Token scopes don&apos;t include <span className="font-mono">read</span> — re-authorize Linear with{" "}
+                <span className="font-mono">read,write,issues:create,comments:create</span>.
+              </p>
+            ) : null}
+            {tracker.scopes && tracker.scopes.length > 0 ? (
+              <p className="text-[10.5px] text-white/45">
+                scopes: {tracker.scopes.join(", ")}
+              </p>
+            ) : null}
             {tracker.last_health_error ? (
               <p className="font-mono text-[10.5px] text-coral/60">
                 {tracker.last_health_error}

--- a/console/src/lib/api/client.ts
+++ b/console/src/lib/api/client.ts
@@ -2457,6 +2457,9 @@ export interface ApiPriorityTracker {
   last_health_at: string | null;
   last_health_error: string | null;
   supports_projects: boolean;
+  /** OAuth scopes the stored token was issued with. Useful in the
+   *  error empty state to confirm whether ``read`` is granted. */
+  scopes: string[] | null;
 }
 
 export interface ApiPriorityProject {


### PR DESCRIPTION
## Summary
After PR #136 the team-resolution probe is gone, but the workspace is still seeing the same Linear ``Authentication required`` error — now from the ``projects`` query directly. The most likely cause is a narrow OAuth scope set (``issues:create,comments:create`` only) on the stored token. Linear returns the same error for "missing scope" and "revoked token", so we need to see the actual scopes.

This PR pipes the stored OAuth scopes from the source row (native installation or legacy ``Integration``) all the way to the error empty-state:

- ``ResolvedTracker`` carries ``scopes``.
- ``TrackerSyncOut`` and the TS ``ApiPriorityTracker`` mirror them.
- The prioritizer error UI lists the scopes the token has and, when ``read`` is missing, surfaces a clear one-liner pointing the operator at re-authorising.

Once this is live the screenshot itself will tell us whether to re-OAuth (scope issue) or chase a different cause (token actually invalid).

## Test plan
- [x] ``pytest backend/tests/test_v1_dashboard_priorities.py`` — 6/6.
- [x] ``console: tsc --noEmit`` clean.
- [x] ``console: eslint --max-warnings=0`` clean.
- [ ] After merge: refresh the dashboard, screenshot the scopes line.