### PR TITLE
dashboard: actually move rows on drop + hide completed Linear projects

### DIFF
--- a/backend/app/api/v1/routes/dashboard_priorities.py
+++ b/backend/app/api/v1/routes/dashboard_priorities.py
@@ -325,6 +325,15 @@ async def get_priorities(
         native_id = str(raw.get("id") or "")
         if not native_id or native_id in seen_ids:
             continue
+        # Don't surface terminal projects in the prioritizer — Linear
+        # exposes ``completed`` / ``canceled`` as project states, and
+        # showing them under "Priorities" with no marker reads as a
+        # bug ("why is the bot still working on this?"). The "Done
+        # · last 14d" group the designer parked for v2 will absorb
+        # the completed list later; for now they're hidden.
+        state_raw = str(raw.get("state") or "").lower()
+        if state_raw in {"completed", "canceled", "cancelled"}:
+            continue
         seen_ids.add(native_id)
         completed, total = _completion_counts(
             raw.get("progress"), raw.get("scope")

--- a/console/src/components/dashboard/prioritizer.tsx
+++ b/console/src/components/dashboard/prioritizer.tsx
@@ -152,11 +152,14 @@ export function DashboardPrioritizer({ workspaceId, initial }: Props) {
     (sourceId: string, targetId: string) => {
       const current = draftOrder ?? prioritisedIds.slice();
       const working = current.slice();
-      // If the source row is unprioritised, append it before reorder
-      // — dropping onto a prioritised row should pin it into the
-      // list. If the target is unprioritised, leave the list alone.
+      // Drop semantics: source goes immediately *above* the target.
+      // Both rows enter the prioritised draft if they weren't there
+      // already — without this, the very first drag in a workspace
+      // with zero saved priorities (or onto a still-unprioritised
+      // tail row) silently no-op'ed because the target wasn't in
+      // the working list yet.
       if (!working.includes(sourceId)) working.push(sourceId);
-      if (!working.includes(targetId)) return;
+      if (!working.includes(targetId)) working.push(targetId);
       const fromIdx = working.indexOf(sourceId);
       const [moved] = working.splice(fromIdx, 1);
       const targetIdx = working.indexOf(targetId);
@@ -576,10 +579,15 @@ function PrioritizerRow({
       />
       <div className="min-w-0 flex-1">
         {project.url ? (
+          // ``draggable={false}`` on the anchor stops the browser
+          // from initiating a *link* drag (which sets a URL on the
+          // dataTransfer instead of our priority MIME) and shadowing
+          // the parent ``<li draggable>`` reorder intent.
           <a
             href={project.url}
             target="_blank"
             rel="noreferrer"
+            draggable={false}
             className="truncate text-[13px] font-semibold text-white hover:text-aqua"
           >
             {project.name}


### PR DESCRIPTION
## Summary
Two prioritizer bugs the user flagged:

1. **Drag-and-drop didn't actually reorder.** The inner ``<a href={project.url}>`` link was hijacking HTML5 DnD — browsers initiate a *link* drag from inside an anchor, set a URL on ``dataTransfer``, and shadow the parent ``<li draggable>`` reorder intent. The drop handler then bails because our priority-MIME payload was never written. ``draggable={false}`` on the anchor cedes the intent back to the row.

2. **First drop in an empty / still-unprioritised list silently no-op'ed.** ``reorderTo`` returned early when the drop target wasn't already in the working list. Now both source and target are appended into the working draft before splice; the source still lands one slot above the target, which matches the natural drop semantic.

Plus a separate paper-cut: completed / canceled Linear projects were rendering alongside active ones with no marker. Filtered out at the route layer — Linear's project state is the authoritative "done" signal, no UI badge needed. The designer's "Done · last 14d" group will absorb them once that surface lands.

## Test plan
- [x] ``pytest backend/tests/test_v1_dashboard_priorities.py`` — 6/6.
- [x] ``console: tsc --noEmit`` clean.
- [x] ``console: eslint --max-warnings=0`` clean.
- [ ] After merge: drag a row onto another, see it move; Save/Revert hairline appears; completed Linear projects no longer appear in the list.