### PR TITLE
dashboard: prioritizer gains state buckets (active / planning / parked)

### DIFF
--- a/backend/app/api/v1/routes/dashboard_priorities.py
+++ b/backend/app/api/v1/routes/dashboard_priorities.py
@@ -89,13 +89,23 @@ class TrackerSyncOut(BaseModel):
     scopes: list[str] | None
 
 
+# Workspace-side bucket on the prioritizer. ``active`` projects are
+# the ones the agent's picker may consume; ``planning`` and ``parked``
+# are operator-private. Default ``active`` for any saved row that
+# pre-dates the column (server_default backfill).
+PriorityState = Literal["active", "planning", "parked"]
+
+
 class PriorityProjectOut(BaseModel):
     """One row in the prioritizer list."""
 
     project_native_id: str
     name: str
     slug: str | None
-    state: str | None
+    # Tracker-side state (``started`` / ``planned`` / etc) — Linear's
+    # own field. Distinct from ``priority_state`` below, which is the
+    # operator's bucket on the dashboard.
+    tracker_state: str | None
     url: str | None
     color: str | None
     # Saved priority position (0 = top). NULL when the project hasn't
@@ -103,6 +113,11 @@ class PriorityProjectOut(BaseModel):
     # rows by ``updated_at`` and renders the drag handle in the
     # "fresh" affordance.
     ordinal: int | None
+    # Operator bucket: ``active`` (agent picks from here), ``planning``
+    # (operator is shaping it, agent invisible), ``parked`` (hold).
+    # Null only for unprioritised tail rows that don't have a saved
+    # priorities row yet — the UI treats those as "drag in to bucket".
+    priority_state: PriorityState | None
     # Completion magnitude. ``total`` is None when the tracker can't
     # tell us — the UI renders ``—`` and skips the bar.
     completed: int | None
@@ -133,15 +148,40 @@ class PrioritiesOut(BaseModel):
     last_action: LastActionOut | None
 
 
-class ReorderIn(BaseModel):
-    """Body for ``POST /reorder`` — canonical order of project ids.
+class ReorderRowIn(BaseModel):
+    """One row in a ``POST /reorder`` body.
 
-    The list is the new full ordering: any project_native_id missing
-    from the list is unprioritised (its row is deleted). Duplicates
-    are rejected with 400.
+    The client emits the canonical post-edit order of every saved
+    project — both its bucket (``state``) and position (implicit from
+    the array index). Server bulk-replaces; rows missing from the list
+    are unprioritised (their row is deleted).
     """
 
-    order: list[str] = Field(min_length=0, max_length=200)
+    project_native_id: str = Field(min_length=1, max_length=128)
+    state: PriorityState = "active"
+
+
+class ReorderIn(BaseModel):
+    """Body for ``POST /reorder`` — canonical (state, order) of project ids.
+
+    Each entry pairs a project id with the bucket it should land in.
+    The list as a whole defines both ordering (array index → ordinal)
+    and bucket (per-row ``state``). Any project_native_id missing from
+    the list is unprioritised — its row is deleted. Duplicates are
+    rejected with 400.
+    """
+
+    order: list[ReorderRowIn] = Field(min_length=0, max_length=200)
+
+
+class SetStateIn(BaseModel):
+    """Body for ``POST /state`` — quick atomic state change for a single
+    row. Convenience over ``/reorder`` for keyboard / row-menu callers
+    that don't want to reconstruct the full canonical list.
+    """
+
+    project_native_id: str = Field(min_length=1, max_length=128)
+    state: PriorityState
 
 
 class AutonomyIn(BaseModel):
@@ -339,15 +379,19 @@ async def get_priorities(
             raw.get("progress"), raw.get("scope")
         )
         saved = saved_by_id.get(native_id)
+        priority_state: PriorityState | None = (
+            saved.state if saved else None  # type: ignore[assignment]
+        )
         projects.append(
             PriorityProjectOut(
                 project_native_id=native_id,
                 name=str(raw.get("name") or ""),
                 slug=str(raw.get("slug") or "") or None,
-                state=str(raw.get("state") or "") or None,
+                tracker_state=str(raw.get("state") or "") or None,
                 url=str(raw.get("url") or "") or None,
                 color=str(raw.get("color") or "") or None,
                 ordinal=saved.ordinal if saved else None,
+                priority_state=priority_state,
                 completed=completed,
                 total=total,
             )
@@ -404,13 +448,16 @@ async def get_priorities(
 
     autonomy_paused = _autonomy_paused(workspace)
 
-    # Up-next strip pulls from the top of the prioritizer list. We
-    # render it even when paused (the UI dims the strip and swaps the
-    # copy to "paused · resume to pull").
+    # Up-next strip pulls from the top of the *Active* bucket. The
+    # picker contract: planning + parked rows are operator-private and
+    # must never surface as "what the agent is about to do". We render
+    # the strip even when paused (the UI dims it + swaps the copy).
     up_next: UpNextOut | None = None
     for project in projects:
         if project.ordinal is None:
             break
+        if project.priority_state != "active":
+            continue
         up_next = UpNextOut(
             project_native_id=project.project_native_id,
             project_name=project.name,
@@ -442,9 +489,10 @@ async def reorder_priorities(
     )
     await _load_workspace(session, workspace_id)
 
+    native_ids = [row.project_native_id for row in payload.order]
     # Reject duplicates so a buggy client can't end up with two rows
     # claiming the same project under conflicting ordinals.
-    if len(payload.order) != len(set(payload.order)):
+    if len(native_ids) != len(set(native_ids)):
         raise HTTPException(
             status_code=400,
             detail="reorder.order contains duplicate project_native_id",
@@ -458,12 +506,13 @@ async def reorder_priorities(
             WorkspaceProjectPriority.workspace_id == workspace_id
         )
     )
-    for ordinal, native_id in enumerate(payload.order):
+    for ordinal, row in enumerate(payload.order):
         session.add(
             WorkspaceProjectPriority(
                 workspace_id=workspace_id,
-                project_native_id=native_id,
+                project_native_id=row.project_native_id,
                 ordinal=ordinal,
+                state=row.state,
             )
         )
 
@@ -475,7 +524,94 @@ async def reorder_priorities(
             action="dashboard.priorities.reorder",
             target_kind="workspace",
             target_id=str(workspace_id),
-            payload={"order": payload.order},
+            payload={
+                "order": [
+                    {
+                        "project_native_id": row.project_native_id,
+                        "state": row.state,
+                    }
+                    for row in payload.order
+                ]
+            },
+        )
+    )
+    await session.flush()
+
+    return await get_priorities(
+        workspace_id=workspace_id,
+        auth=auth,
+        session=session,
+        settings=settings,
+    )
+
+
+@router.post("/state", response_model=PrioritiesOut)
+async def set_priority_state(
+    workspace_id: uuid.UUID,
+    payload: SetStateIn,
+    auth: AuthContext = Depends(get_current_auth),
+    session: AsyncSession = Depends(get_session),
+    settings: Settings = Depends(get_settings),
+) -> PrioritiesOut:
+    """Set the bucket (active/planning/parked) for one prioritised
+    project without rewriting the whole ordering.
+
+    Used by keyboard / row-menu callers. Drag-and-drop in the UI goes
+    through ``/reorder`` because dropping across a section divider
+    changes both bucket and position in one user gesture.
+
+    If the project doesn't have a saved priorities row yet (it's been
+    sitting unprioritised in the tracker tail), we create one at the
+    bottom of the workspace's ordinal range so it shows up in the
+    requested bucket without disturbing existing ordinals.
+    """
+    await _require_membership(
+        session, workspace_id, auth.user.id, ROLES_ADMIN
+    )
+    await _load_workspace(session, workspace_id)
+
+    existing = (
+        await session.execute(
+            select(WorkspaceProjectPriority).where(
+                WorkspaceProjectPriority.workspace_id == workspace_id,
+                WorkspaceProjectPriority.project_native_id
+                == payload.project_native_id,
+            )
+        )
+    ).scalar_one_or_none()
+    if existing is None:
+        max_ord = (
+            await session.execute(
+                select(WorkspaceProjectPriority.ordinal)
+                .where(WorkspaceProjectPriority.workspace_id == workspace_id)
+                .order_by(WorkspaceProjectPriority.ordinal.desc())
+                .limit(1)
+            )
+        ).scalar_one_or_none()
+        next_ord = 0 if max_ord is None else int(max_ord) + 1
+        session.add(
+            WorkspaceProjectPriority(
+                workspace_id=workspace_id,
+                project_native_id=payload.project_native_id,
+                ordinal=next_ord,
+                state=payload.state,
+            )
+        )
+    elif existing.state != payload.state:
+        existing.state = payload.state
+
+    session.add(
+        AuditLog(
+            workspace_id=workspace_id,
+            actor_user_id=auth.user.id,
+            actor_token_id=auth.token.id if auth.token else None,
+            action="dashboard.priorities.set_state",
+            target_kind="workspace",
+            target_id=str(workspace_id),
+            payload={
+                "project_native_id": payload.project_native_id,
+                "state": payload.state,
+            },
         )
     )
     await session.flush()

--- a/backend/app/db/models/dashboard_priorities.py
+++ b/backend/app/db/models/dashboard_priorities.py
@@ -24,11 +24,13 @@ import uuid
 from datetime import datetime
 
 from sqlalchemy import (
+    CheckConstraint,
     ForeignKey,
     Index,
     Integer,
     String,
     UniqueConstraint,
+    text,
 )
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column
@@ -54,6 +56,10 @@ class WorkspaceProjectPriority(Base):
             "workspace_id",
             "ordinal",
         ),
+        CheckConstraint(
+            "state IN ('active', 'planning', 'parked')",
+            name="ck_workspace_project_priorities_state",
+        ),
     )
 
     id: Mapped[uuid.UUID] = _pk()
@@ -67,6 +73,16 @@ class WorkspaceProjectPriority(Base):
     # "ELS") slot in without a schema change.
     project_native_id: Mapped[str] = mapped_column(String(128), nullable=False)
     ordinal: Mapped[int] = mapped_column(Integer, nullable=False)
+    # Bucket on the prioritizer:
+    # ``active`` (agent may pick) | ``planning`` (operator is shaping)
+    # | ``parked`` (explicitly hold). Only ``active`` is visible to the
+    # agent's project picker. Default ``active`` matches the pre-state
+    # contract where any saved row was pickable.
+    state: Mapped[str] = mapped_column(
+        String(16),
+        nullable=False,
+        server_default=text("'active'"),
+    )
 
     created_at: Mapped[datetime] = _ts_created()
     updated_at: Mapped[datetime] = _ts_updated()

--- a/backend/migrations/versions/0057_priority_state.py
+++ b/backend/migrations/versions/0057_priority_state.py
@@ -1,0 +1,57 @@
+"""workspace project priorities — state column
+
+Adds the ``state`` axis to the prioritizer so a project can sit on the
+dashboard in one of three buckets:
+
+- ``active``   — agent may pick. Default for backfill.
+- ``planning`` — operator is shaping it (brief, scope, anchor). The
+  agent must NOT pick from this state.
+- ``parked``   — explicitly not now. Dim, agent-invisible.
+
+Backfill: every existing row is ``active`` (matches today's behaviour
+where a saved row = pickable). The CHECK constraint pins the enum at
+the DB layer so a typo'd PATCH can't smuggle in a fourth value.
+
+Revision ID: 0057_priority_state
+Revises: 0056_dashboard_priorities
+Create Date: 2026-05-05
+"""
+
+from __future__ import annotations
+
+from typing import Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "0057_priority_state"
+down_revision: Union[str, None] = "0056_dashboard_priorities"
+branch_labels: Union[str, tuple[str, ...], None] = None
+depends_on: Union[str, tuple[str, ...], None] = None
+
+
+_TABLE = "workspace_project_priorities"
+_CHECK = "ck_workspace_project_priorities_state"
+
+
+def upgrade() -> None:
+    op.add_column(
+        _TABLE,
+        sa.Column(
+            "state",
+            sa.String(length=16),
+            nullable=False,
+            server_default=sa.text("'active'"),
+        ),
+    )
+    op.create_check_constraint(
+        _CHECK,
+        _TABLE,
+        "state IN ('active', 'planning', 'parked')",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(_CHECK, _TABLE, type_="check")
+    op.drop_column(_TABLE, "state")

--- a/backend/tests/test_v1_dashboard_priorities.py
+++ b/backend/tests/test_v1_dashboard_priorities.py
@@ -84,7 +84,13 @@ async def test_reorder_persists_and_reads_back(
     res = await v1_client.post(
         f"/v1/workspaces/{ws.id}/priorities/reorder",
         headers=_auth(raw),
-        json={"order": ["proj-a", "proj-b", "proj-c"]},
+        json={
+            "order": [
+                {"project_native_id": "proj-a", "state": "active"},
+                {"project_native_id": "proj-b", "state": "planning"},
+                {"project_native_id": "proj-c", "state": "parked"},
+            ]
+        },
     )
     assert res.status_code == 200, res.text
 
@@ -95,7 +101,13 @@ async def test_reorder_persists_and_reads_back(
     again = await v1_client.post(
         f"/v1/workspaces/{ws.id}/priorities/reorder",
         headers=_auth(raw),
-        json={"order": ["proj-a", "proj-b", "proj-c"]},
+        json={
+            "order": [
+                {"project_native_id": "proj-a", "state": "active"},
+                {"project_native_id": "proj-b", "state": "planning"},
+                {"project_native_id": "proj-c", "state": "parked"},
+            ]
+        },
     )
     assert again.status_code == 200, again.text
 
@@ -106,9 +118,84 @@ async def test_reorder_rejects_duplicates(v1_client, seed_workspace) -> None:
     res = await v1_client.post(
         f"/v1/workspaces/{ws.id}/priorities/reorder",
         headers=_auth(raw),
-        json={"order": ["a", "a"]},
+        json={
+            "order": [
+                {"project_native_id": "a", "state": "active"},
+                {"project_native_id": "a", "state": "planning"},
+            ]
+        },
     )
     assert res.status_code == 400, res.text
+
+
+@pytest.mark.asyncio
+async def test_reorder_rejects_unknown_state(v1_client, seed_workspace) -> None:
+    """The state enum is enforced at the schema layer — a typo should
+    422 before it reaches the DB CHECK constraint."""
+    _, raw, ws = seed_workspace
+    res = await v1_client.post(
+        f"/v1/workspaces/{ws.id}/priorities/reorder",
+        headers=_auth(raw),
+        json={
+            "order": [
+                {"project_native_id": "a", "state": "banana"},
+            ]
+        },
+    )
+    assert res.status_code == 422, res.text
+
+
+@pytest.mark.asyncio
+async def test_set_state_creates_then_updates(
+    v1_client, seed_workspace, db_session
+) -> None:
+    """``POST /state`` is the single-row sugar over ``/reorder``: it
+    creates a priorities row at the bottom of the workspace's ordinal
+    range when none exists, and updates the bucket in-place when one
+    does."""
+    from sqlalchemy import select
+    from backend.app.db.models.dashboard_priorities import (
+        WorkspaceProjectPriority,
+    )
+
+    _, raw, ws = seed_workspace
+
+    # First call — row doesn't exist yet, should be created with the
+    # requested state.
+    create = await v1_client.post(
+        f"/v1/workspaces/{ws.id}/priorities/state",
+        headers=_auth(raw),
+        json={"project_native_id": "proj-x", "state": "planning"},
+    )
+    assert create.status_code == 200, create.text
+    rows = (
+        await db_session.execute(
+            select(WorkspaceProjectPriority).where(
+                WorkspaceProjectPriority.workspace_id == ws.id
+            )
+        )
+    ).scalars().all()
+    assert [r.project_native_id for r in rows] == ["proj-x"]
+    assert rows[0].state == "planning"
+
+    # Second call — same id, different state. Should update in place,
+    # NOT create a duplicate.
+    update = await v1_client.post(
+        f"/v1/workspaces/{ws.id}/priorities/state",
+        headers=_auth(raw),
+        json={"project_native_id": "proj-x", "state": "parked"},
+    )
+    assert update.status_code == 200, update.text
+    await db_session.refresh(rows[0])
+    rows_after = (
+        await db_session.execute(
+            select(WorkspaceProjectPriority).where(
+                WorkspaceProjectPriority.workspace_id == ws.id
+            )
+        )
+    ).scalars().all()
+    assert len(rows_after) == 1
+    assert rows_after[0].state == "parked"
 
 
 @pytest.mark.asyncio
@@ -153,9 +240,16 @@ async def test_viewer_can_read_but_not_mutate(
     blocked_reorder = await v1_client.post(
         f"/v1/workspaces/{ws.id}/priorities/reorder",
         headers=_auth(viewer_raw),
-        json={"order": ["x"]},
+        json={"order": [{"project_native_id": "x", "state": "active"}]},
     )
     assert blocked_reorder.status_code == 403, blocked_reorder.text
+
+    blocked_state = await v1_client.post(
+        f"/v1/workspaces/{ws.id}/priorities/state",
+        headers=_auth(viewer_raw),
+        json={"project_native_id": "x", "state": "planning"},
+    )
+    assert blocked_state.status_code == 403, blocked_state.text
 
     blocked_autonomy = await v1_client.post(
         f"/v1/workspaces/{ws.id}/priorities/autonomy",

--- a/console/src/components/dashboard/actions.ts
+++ b/console/src/components/dashboard/actions.ts
@@ -16,8 +16,11 @@ import { revalidatePath } from "next/cache";
 import {
   ApiHttpError,
   type ApiPrioritiesResponse,
+  type ApiPriorityState,
+  type ApiReorderRow,
   reorderPriorities,
   setAutonomyPaused,
+  setPriorityState,
 } from "@/lib/api/client";
 import { getSessionToken } from "@/lib/api/session";
 
@@ -51,7 +54,7 @@ function toError<T extends { ok: false; message: string; status?: number }>(
 
 export async function reorderPrioritiesAction(
   workspaceId: string,
-  order: string[],
+  order: ApiReorderRow[],
 ): Promise<PriorityActionResult> {
   if (!workspaceId) {
     return { ok: false, message: "workspaceId is required" };
@@ -64,6 +67,38 @@ export async function reorderPrioritiesAction(
   }
   try {
     const payload = await reorderPriorities(workspaceId, order, token);
+    revalidatePath("/");
+    return { ok: true, payload };
+  } catch (err) {
+    return toError(err);
+  }
+}
+
+
+export async function setProjectStateAction(
+  workspaceId: string,
+  projectNativeId: string,
+  state: ApiPriorityState,
+): Promise<PriorityActionResult> {
+  if (!workspaceId) {
+    return { ok: false, message: "workspaceId is required" };
+  }
+  if (!projectNativeId) {
+    return { ok: false, message: "projectNativeId is required" };
+  }
+  let token: string;
+  try {
+    token = await requireToken();
+  } catch (err) {
+    return { ok: false, message: err instanceof Error ? err.message : String(err) };
+  }
+  try {
+    const payload = await setPriorityState(
+      workspaceId,
+      projectNativeId,
+      state,
+      token,
+    );
     revalidatePath("/");
     return { ok: true, payload };
   } catch (err) {

--- a/console/src/components/dashboard/prioritizer.tsx
+++ b/console/src/components/dashboard/prioritizer.tsx
@@ -14,8 +14,10 @@ import type { DragEvent as ReactDragEvent, KeyboardEvent } from "react";
 import type {
   ApiPrioritiesResponse,
   ApiPriorityProject,
+  ApiPriorityState,
   ApiPriorityTracker,
   ApiPriorityUpNext,
+  ApiReorderRow,
 } from "@/lib/api/client";
 import { cn } from "@/lib/cn";
 
@@ -25,19 +27,21 @@ import {
 } from "./actions";
 
 /**
- * Dashboard v2 prioritizer — drag-to-reorder list of tracker projects
- * plus the workspace-level autonomy switch and tracker connection
- * hairline. Designer wireframe locks: aqua = positive editorial,
- * sun = paused/attention, coral = errors, no bordered cards.
+ * Dashboard v2 prioritizer — drag-to-reorder + drag-across-divider list of
+ * tracker projects, plus the workspace-level autonomy switch and tracker
+ * connection hairline. Designer wireframe locks: aqua = positive editorial,
+ * sun = paused/attention, lilac = planning, coral = errors, no bordered cards.
+ *
+ * The list is grouped into three buckets — ``active`` (agent picks from
+ * here), ``planning`` (operator is shaping the brief; agent-invisible),
+ * ``parked`` (explicit hold; collapsed by default). Section dividers are
+ * the state-change affordance: dropping a row across a divider moves it
+ * into that bucket. Within a bucket, drag reorders.
  *
  * Why a client component: drag, keyboard reorder, and autonomy toggle
  * all need optimistic UI that survives the network round-trip without
  * the page collapsing. Mutations route through server actions so the
  * session token never crosses the wire.
- *
- * Empty states are two distinct shapes — disconnected = single CTA
- * row; connected-but-empty = three faint scaffold rows; flipped on
- * ``tracker.status``. Conflating them was the previous draft's bug.
  */
 
 const DRAG_MIME = "application/x-ship-priority-id";
@@ -47,56 +51,104 @@ type Props = {
   initial: ApiPrioritiesResponse;
 };
 
+type DraftRow = { id: string; state: ApiPriorityState };
+
+const STATE_RANK: Record<ApiPriorityState, number> = {
+  active: 0,
+  planning: 1,
+  parked: 2,
+};
+
+const SECTION_ORDER: ApiPriorityState[] = ["active", "planning", "parked"];
+
+const SECTION_COPY: Record<
+  ApiPriorityState,
+  { label: string; sub: (n: number) => string }
+> = {
+  active: {
+    label: "Active",
+    sub: (n) => (n === 1 ? "1 pick for the agent" : `${n} picks for the agent`),
+  },
+  planning: {
+    label: "Planning",
+    sub: (n) => (n === 1 ? "1 you're shaping" : `${n} you're shaping`),
+  },
+  parked: {
+    label: "Parked",
+    sub: (n) => (n === 1 ? "1 not now" : `${n} not now`),
+  },
+};
+
+
 export function DashboardPrioritizer({ workspaceId, initial }: Props) {
   const [serverState, setServerState] = useState<ApiPrioritiesResponse>(initial);
-  // Working copy of the order — only touched while the user is
-  // dragging or in keyboard move-mode. Save flushes it through the
-  // server action, Revert restores from the last server state.
-  const [draftOrder, setDraftOrder] = useState<string[] | null>(null);
+  // Working copy of the prioritised rows — only touched while the
+  // user is dragging or in keyboard move-mode. Save flushes through
+  // the server action, Revert restores from the last server state.
+  const [draftOrder, setDraftOrder] = useState<DraftRow[] | null>(null);
   const [pending, startTransition] = useTransition();
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  // Parked section collapses by default — visible (so the operator
+  // doesn't forget what they decided not to do) but folded so the
+  // editorial single-column rhythm of Active + Planning isn't drowned.
+  const [parkedExpanded, setParkedExpanded] = useState(false);
 
   const tracker = serverState.tracker;
   const allProjects = serverState.projects;
-  const prioritisedIds = useMemo(
-    () =>
-      allProjects
-        .filter((p) => p.ordinal !== null)
-        .map((p) => p.project_native_id),
-    [allProjects],
-  );
   const projectById = useMemo(() => {
     const map = new Map<string, ApiPriorityProject>();
     for (const p of allProjects) map.set(p.project_native_id, p);
     return map;
   }, [allProjects]);
 
-  // Compose the displayed list: when the user is editing, it's the
-  // draftOrder (prioritised items in user-chosen order) followed by
-  // unprioritised tail in name order. Otherwise it's the server's
-  // own sort.
-  const displayList = useMemo(() => {
-    if (draftOrder === null) return allProjects;
-    const seen = new Set(draftOrder);
-    const head = draftOrder
-      .map((id) => projectById.get(id))
-      .filter((p): p is ApiPriorityProject => p !== undefined)
-      .map((p, idx) => ({ ...p, ordinal: idx }));
-    const tail = allProjects
-      .filter((p) => !seen.has(p.project_native_id))
-      .map((p) => ({ ...p, ordinal: null as number | null }));
-    return [...head, ...tail];
-  }, [allProjects, draftOrder, projectById]);
+  // Server-truth rows — projects that already have a saved row in the
+  // priorities table. We seed the draft from these whenever the user
+  // starts editing.
+  const serverRows: DraftRow[] = useMemo(() => {
+    return allProjects
+      .filter(
+        (p): p is ApiPriorityProject & { priority_state: ApiPriorityState } =>
+          p.priority_state !== null && p.ordinal !== null,
+      )
+      .slice()
+      .sort((a, b) => {
+        const stateDelta =
+          STATE_RANK[a.priority_state] - STATE_RANK[b.priority_state];
+        if (stateDelta !== 0) return stateDelta;
+        return (a.ordinal ?? 0) - (b.ordinal ?? 0);
+      })
+      .map((p) => ({ id: p.project_native_id, state: p.priority_state }));
+  }, [allProjects]);
 
+  const effectiveRows: DraftRow[] = draftOrder ?? serverRows;
   const dirty = draftOrder !== null;
+
+  const rowsByState: Record<ApiPriorityState, DraftRow[]> = useMemo(() => {
+    const acc: Record<ApiPriorityState, DraftRow[]> = {
+      active: [],
+      planning: [],
+      parked: [],
+    };
+    for (const row of effectiveRows) acc[row.state].push(row);
+    return acc;
+  }, [effectiveRows]);
+
+  const unprioritised = useMemo(() => {
+    const seen = new Set(effectiveRows.map((r) => r.id));
+    return allProjects.filter((p) => !seen.has(p.project_native_id));
+  }, [allProjects, effectiveRows]);
 
   // ----- mutations --------------------------------------------------
 
   const handleSave = useCallback(() => {
     if (!dirty || draftOrder === null) return;
     setErrorMessage(null);
+    const payload: ApiReorderRow[] = draftOrder.map((row) => ({
+      project_native_id: row.id,
+      state: row.state,
+    }));
     startTransition(async () => {
-      const result = await reorderPrioritiesAction(workspaceId, draftOrder);
+      const result = await reorderPrioritiesAction(workspaceId, payload);
       if (result.ok) {
         setServerState(result.payload);
         setDraftOrder(null);
@@ -127,47 +179,90 @@ export function DashboardPrioritizer({ workspaceId, initial }: Props) {
 
   // ----- reorder helpers --------------------------------------------
 
+  // Move a row by ±1 within its current section. If it sits at the
+  // section edge and is moved past it, the row crosses the divider
+  // and changes state — matches the drag-across-divider semantics so
+  // keyboard users have feature parity.
   const moveBy = useCallback(
     (id: string, delta: number) => {
-      // Use the current draftOrder; if it's null, seed from the
-      // server's prioritised order.
-      const current =
-        draftOrder ?? prioritisedIds.slice();
-      const idx = current.indexOf(id);
-      if (idx === -1) {
-        // Not yet prioritised — append, then move.
-        const seeded = [...current, id];
-        const next = moveIndex(seeded, seeded.length - 1, delta);
-        setDraftOrder(next);
-        return;
-      }
-      const next = moveIndex(current, idx, delta);
-      if (next.join("|") === current.join("|")) return;
-      setDraftOrder(next);
+      const current = draftOrder ?? serverRows.slice();
+      const seeded = current.some((r) => r.id === id)
+        ? current.slice()
+        : [
+            ...current,
+            {
+              id,
+              state: "active" as ApiPriorityState,
+            },
+          ];
+      const idx = seeded.findIndex((r) => r.id === id);
+      if (idx === -1) return;
+      const target = idx + delta;
+      if (target < 0 || target >= seeded.length) return;
+      const moved = { ...seeded[idx] };
+      seeded.splice(idx, 1);
+      // Adopt the state of whichever row we land next to so the
+      // section a row belongs to is always coherent with its
+      // neighbours.
+      const neighbour =
+        delta < 0
+          ? seeded[Math.max(0, target)]
+          : seeded[Math.min(seeded.length - 1, target - 1)];
+      if (neighbour) moved.state = neighbour.state;
+      seeded.splice(target, 0, moved);
+      if (rowsEqual(seeded, current)) return;
+      setDraftOrder(seeded);
     },
-    [draftOrder, prioritisedIds],
+    [draftOrder, serverRows],
   );
 
+  // Drop ``sourceId`` immediately above ``targetId``, adopting the
+  // target row's state. If either row isn't yet prioritised, append
+  // it first.
   const reorderTo = useCallback(
     (sourceId: string, targetId: string) => {
-      const current = draftOrder ?? prioritisedIds.slice();
+      const current = draftOrder ?? serverRows.slice();
       const working = current.slice();
-      // Drop semantics: source goes immediately *above* the target.
-      // Both rows enter the prioritised draft if they weren't there
-      // already — without this, the very first drag in a workspace
-      // with zero saved priorities (or onto a still-unprioritised
-      // tail row) silently no-op'ed because the target wasn't in
-      // the working list yet.
-      if (!working.includes(sourceId)) working.push(sourceId);
-      if (!working.includes(targetId)) working.push(targetId);
-      const fromIdx = working.indexOf(sourceId);
+      ensureRow(working, sourceId, "active");
+      ensureRow(working, targetId, "active");
+      const fromIdx = working.findIndex((r) => r.id === sourceId);
       const [moved] = working.splice(fromIdx, 1);
-      const targetIdx = working.indexOf(targetId);
+      const targetIdx = working.findIndex((r) => r.id === targetId);
+      const targetRow = working[targetIdx];
+      if (targetRow) moved.state = targetRow.state;
       working.splice(targetIdx, 0, moved);
-      if (working.join("|") === current.join("|")) return;
+      if (rowsEqual(working, current)) return;
       setDraftOrder(working);
     },
-    [draftOrder, prioritisedIds],
+    [draftOrder, serverRows],
+  );
+
+  // Drop ``sourceId`` at the bottom of ``state``'s section. Used by
+  // section-divider drops, "send to section" row menus (future), and
+  // the cross-section keyboard moves.
+  const moveToSection = useCallback(
+    (sourceId: string, state: ApiPriorityState) => {
+      const current = draftOrder ?? serverRows.slice();
+      const working = current.slice();
+      ensureRow(working, sourceId, state);
+      const idx = working.findIndex((r) => r.id === sourceId);
+      const [moved] = working.splice(idx, 1);
+      moved.state = state;
+      // Insert at the END of the section so the user's existing top-of-
+      // section ordering is preserved (parking the most-recent active
+      // shouldn't shuffle the queue).
+      let insertAt = working.length;
+      for (let i = 0; i < working.length; i++) {
+        if (STATE_RANK[working[i].state] > STATE_RANK[state]) {
+          insertAt = i;
+          break;
+        }
+      }
+      working.splice(insertAt, 0, moved);
+      if (rowsEqual(working, current)) return;
+      setDraftOrder(working);
+    },
+    [draftOrder, serverRows],
   );
 
   // ----- empty states -----------------------------------------------
@@ -177,6 +272,7 @@ export function DashboardPrioritizer({ workspaceId, initial }: Props) {
       <PrioritizerSection
         autonomyPaused={serverState.autonomy_paused}
         upNext={null}
+        activeCount={0}
         onToggleAutonomy={toggleAutonomy}
         tracker={tracker}
         pending={pending}
@@ -197,13 +293,6 @@ export function DashboardPrioritizer({ workspaceId, initial }: Props) {
   }
 
   if (allProjects.length === 0) {
-    // Two empty shapes share an empty list, but mean very different
-    // things: the tracker errored on this fetch (we can't say
-    // anything about Linear's project count) vs. the tracker
-    // connected fine and the team has no projects yet. Conflating
-    // them puts a scaffold "Add a project" line under a coral
-    // ``error · reconnect`` hairline, which reads as "the prioritizer
-    // is broken" — exactly the bug we hit in the first PR.
     if (tracker.status === "error") {
       const missingRead =
         tracker.kind === "linear" &&
@@ -213,6 +302,7 @@ export function DashboardPrioritizer({ workspaceId, initial }: Props) {
         <PrioritizerSection
           autonomyPaused={serverState.autonomy_paused}
           upNext={null}
+          activeCount={0}
           onToggleAutonomy={toggleAutonomy}
           tracker={tracker}
           pending={pending}
@@ -246,6 +336,7 @@ export function DashboardPrioritizer({ workspaceId, initial }: Props) {
       <PrioritizerSection
         autonomyPaused={serverState.autonomy_paused}
         upNext={null}
+        activeCount={0}
         onToggleAutonomy={toggleAutonomy}
         tracker={tracker}
         pending={pending}
@@ -265,39 +356,104 @@ export function DashboardPrioritizer({ workspaceId, initial }: Props) {
     );
   }
 
+  // ----- main list (state-grouped) ----------------------------------
+
+  const renderRow = (project: ApiPriorityProject, state: ApiPriorityState) => (
+    <PrioritizerRow
+      key={project.project_native_id}
+      project={project}
+      rowState={state}
+      paused={serverState.autonomy_paused}
+      onDragStart={(event) => {
+        event.dataTransfer.setData(DRAG_MIME, project.project_native_id);
+        event.dataTransfer.effectAllowed = "move";
+      }}
+      onDragOver={(event) => {
+        if (!event.dataTransfer.types.includes(DRAG_MIME)) return;
+        event.preventDefault();
+        event.dataTransfer.dropEffect = "move";
+      }}
+      onDrop={(event) => {
+        const sourceId = event.dataTransfer.getData(DRAG_MIME);
+        if (!sourceId || sourceId === project.project_native_id) return;
+        event.preventDefault();
+        reorderTo(sourceId, project.project_native_id);
+      }}
+      onMoveUp={() => moveBy(project.project_native_id, -1)}
+      onMoveDown={() => moveBy(project.project_native_id, +1)}
+    />
+  );
+
+  const sectionDropHandlers = (state: ApiPriorityState) => ({
+    onDragOver: (event: ReactDragEvent<HTMLLIElement>) => {
+      if (!event.dataTransfer.types.includes(DRAG_MIME)) return;
+      event.preventDefault();
+      event.dataTransfer.dropEffect = "move";
+    },
+    onDrop: (event: ReactDragEvent<HTMLLIElement>) => {
+      const sourceId = event.dataTransfer.getData(DRAG_MIME);
+      if (!sourceId) return;
+      event.preventDefault();
+      moveToSection(sourceId, state);
+    },
+  });
+
   return (
     <PrioritizerSection
       autonomyPaused={serverState.autonomy_paused}
       upNext={serverState.up_next}
+      activeCount={rowsByState.active.length}
       onToggleAutonomy={toggleAutonomy}
       tracker={tracker}
       pending={pending}
     >
-      {displayList.map((project) => (
-        <PrioritizerRow
-          key={project.project_native_id}
-          project={project}
-          paused={serverState.autonomy_paused}
-          onDragStart={(event) => {
-            event.dataTransfer.setData(DRAG_MIME, project.project_native_id);
-            event.dataTransfer.effectAllowed = "move";
-          }}
-          onDragOver={(event) => {
-            const sourceId = event.dataTransfer.types.includes(DRAG_MIME);
-            if (!sourceId) return;
-            event.preventDefault();
-            event.dataTransfer.dropEffect = "move";
-          }}
-          onDrop={(event) => {
-            const sourceId = event.dataTransfer.getData(DRAG_MIME);
-            if (!sourceId || sourceId === project.project_native_id) return;
-            event.preventDefault();
-            reorderTo(sourceId, project.project_native_id);
-          }}
-          onMoveUp={() => moveBy(project.project_native_id, -1)}
-          onMoveDown={() => moveBy(project.project_native_id, +1)}
-        />
-      ))}
+      {SECTION_ORDER.map((state) => {
+        const rows = rowsByState[state];
+        const collapsed = state === "parked" && !parkedExpanded;
+        const showEmptyHint =
+          rows.length === 0 && state === "active" && unprioritised.length > 0;
+        return (
+          <SectionGroup
+            key={state}
+            state={state}
+            count={rows.length}
+            collapsed={collapsed}
+            onToggleCollapsed={
+              state === "parked"
+                ? () => setParkedExpanded((v) => !v)
+                : undefined
+            }
+            dropHandlers={sectionDropHandlers(state)}
+          >
+            {rows
+              .map((row) => projectById.get(row.id))
+              .filter((p): p is ApiPriorityProject => p !== undefined)
+              .map((project) => renderRow(project, state))}
+            {rows.length === 0 && !showEmptyHint && (
+              <li
+                className="py-2 pl-3 text-[11px] italic text-white/30"
+                {...sectionDropHandlers(state)}
+              >
+                drop a project here to {state === "active" ? "queue it" : state === "planning" ? "shape its brief" : "park it"}
+              </li>
+            )}
+            {showEmptyHint && (
+              <li className="py-2 pl-3 text-[11px] text-sun/80">
+                No active projects — drag one in to give the agent something to pick up.
+              </li>
+            )}
+          </SectionGroup>
+        );
+      })}
+      {unprioritised.length > 0 && (
+        <SectionGroup
+          state={null}
+          count={unprioritised.length}
+          dropHandlers={undefined}
+        >
+          {unprioritised.map((project) => renderRow(project, "active"))}
+        </SectionGroup>
+      )}
       {dirty && (
         <li className="-mx-3 mt-1 flex items-baseline justify-between bg-white/[0.04] px-3 py-2">
           <span className="text-[10px] font-bold uppercase tracking-[0.18em] text-white/50">
@@ -340,6 +496,7 @@ function PrioritizerSection({
   children,
   autonomyPaused,
   upNext,
+  activeCount,
   tracker,
   pending,
   onToggleAutonomy,
@@ -347,6 +504,7 @@ function PrioritizerSection({
   children: React.ReactNode;
   autonomyPaused: boolean;
   upNext: ApiPriorityUpNext | null;
+  activeCount: number;
   tracker: ApiPriorityTracker;
   pending: boolean;
   onToggleAutonomy: () => void;
@@ -369,9 +527,11 @@ function PrioritizerSection({
           <TrackerHairline tracker={tracker} />
         </div>
       </div>
-      {upNext ? (
-        <UpNextStrip upNext={upNext} paused={autonomyPaused} />
-      ) : null}
+      <UpNextStrip
+        upNext={upNext}
+        paused={autonomyPaused}
+        activeCount={activeCount}
+      />
       <ul className="divide-y divide-white/[0.06]">{children}</ul>
     </section>
   );
@@ -450,9 +610,11 @@ function TrackerHairline({ tracker }: { tracker: ApiPriorityTracker }) {
 function UpNextStrip({
   upNext,
   paused,
+  activeCount,
 }: {
-  upNext: ApiPriorityUpNext;
+  upNext: ApiPriorityUpNext | null;
   paused: boolean;
+  activeCount: number;
 }) {
   if (paused) {
     return (
@@ -461,6 +623,19 @@ function UpNextStrip({
         <span>Up next · paused · resume to pull</span>
       </p>
     );
+  }
+  if (upNext === null) {
+    // No active projects → tell the operator the agent is idle on
+    // purpose so an empty Active list doesn't read as a server bug.
+    if (activeCount === 0) {
+      return (
+        <p className="flex items-center gap-2 text-[11px] text-sun/85">
+          <span aria-hidden>↑</span>
+          <span>Up next · nothing active — drag a project into Active to give the agent work.</span>
+        </p>
+      );
+    }
+    return null;
   }
   return (
     <p className="flex items-center gap-2 text-[11px] text-white/65">
@@ -475,12 +650,89 @@ function UpNextStrip({
 
 
 // ---------------------------------------------------------------------------
+// Section header + drop zone
+// ---------------------------------------------------------------------------
+
+
+function SectionGroup({
+  state,
+  count,
+  collapsed,
+  onToggleCollapsed,
+  dropHandlers,
+  children,
+}: {
+  state: ApiPriorityState | null;
+  count: number;
+  collapsed?: boolean;
+  onToggleCollapsed?: () => void;
+  dropHandlers?: {
+    onDragOver: (event: ReactDragEvent<HTMLLIElement>) => void;
+    onDrop: (event: ReactDragEvent<HTMLLIElement>) => void;
+  };
+  children: React.ReactNode;
+}) {
+  const headerLabel =
+    state === null ? "Unprioritised" : SECTION_COPY[state].label;
+  const headerSub =
+    state === null
+      ? count === 1
+        ? "1 in tracker · drag in to bucket"
+        : `${count} in tracker · drag in to bucket`
+      : SECTION_COPY[state].sub(count);
+
+  const headerToneByState: Record<ApiPriorityState | "none", string> = {
+    active: "text-white/55",
+    planning: "text-lilac/85",
+    parked: "text-white/40",
+    none: "text-white/35",
+  };
+  const headerTone = headerToneByState[state ?? "none"];
+
+  return (
+    <>
+      <li
+        className={cn(
+          "flex items-baseline justify-between gap-3 pt-3 pb-1",
+          state === null && "border-t border-dashed border-white/10",
+        )}
+        {...(dropHandlers ?? {})}
+      >
+        <span
+          className={cn(
+            "text-[10px] font-bold uppercase tracking-[0.22em]",
+            headerTone,
+          )}
+        >
+          {headerLabel}
+          <span className="ml-2 font-normal normal-case tracking-normal text-white/35">
+            · {headerSub}
+          </span>
+        </span>
+        {onToggleCollapsed ? (
+          <button
+            type="button"
+            onClick={onToggleCollapsed}
+            className="shrink-0 text-[10px] uppercase tracking-widest text-white/35 transition hover:text-white/70"
+          >
+            {collapsed ? "show ▾" : "hide ▴"}
+          </button>
+        ) : null}
+      </li>
+      {!collapsed && children}
+    </>
+  );
+}
+
+
+// ---------------------------------------------------------------------------
 // Row
 // ---------------------------------------------------------------------------
 
 
 function PrioritizerRow({
   project,
+  rowState,
   paused,
   onDragStart,
   onDragOver,
@@ -489,6 +741,7 @@ function PrioritizerRow({
   onMoveDown,
 }: {
   project: ApiPriorityProject;
+  rowState: ApiPriorityState;
   paused: boolean;
   onDragStart: (event: ReactDragEvent<HTMLLIElement>) => void;
   onDragOver: (event: ReactDragEvent<HTMLLIElement>) => void;
@@ -537,12 +790,23 @@ function PrioritizerRow({
     }
   };
 
-  const fractionLabel = formatFraction(project.completed, project.total);
-  const barFraction = computeBarFraction(project.completed, project.total);
-  const colorStyle = project.color
-    ? { backgroundColor: project.color }
-    : undefined;
+  const isParked = rowState === "parked";
+  const isPlanning = rowState === "planning";
   const isPrioritised = project.ordinal !== null;
+  const fractionLabel = isPlanning
+    ? "brief"
+    : formatFraction(project.completed, project.total);
+  const showProgressBar = !isPlanning && !isParked;
+  const barFraction = computeBarFraction(project.completed, project.total);
+  const dotStyle = isPlanning
+    ? undefined
+    : project.color
+      ? { backgroundColor: project.color }
+      : undefined;
+  const dotClass = cn(
+    "h-2 w-2 shrink-0 rounded-full",
+    isPlanning ? "bg-lilac/70" : project.color ? "" : "bg-white/25",
+  );
 
   return (
     <li
@@ -557,7 +821,7 @@ function PrioritizerRow({
         "group relative flex items-center gap-3 py-2 pl-3 pr-1 outline-none transition",
         "focus-visible:before:absolute focus-visible:before:inset-y-1 focus-visible:before:left-0 focus-visible:before:w-px focus-visible:before:bg-aqua/60",
         moveMode && "before:absolute before:inset-y-1 before:left-0 before:w-0.5 before:bg-aqua",
-        paused ? "opacity-80" : "",
+        isParked ? "opacity-40 hover:opacity-70" : paused ? "opacity-80" : "",
       )}
     >
       <span
@@ -569,31 +833,28 @@ function PrioritizerRow({
       >
         {moveMode ? "↕" : "⋮"}
       </span>
-      <span
-        aria-hidden
-        className={cn(
-          "h-2 w-2 shrink-0 rounded-full",
-          project.color ? "" : "bg-white/25",
-        )}
-        style={colorStyle}
-      />
+      <span aria-hidden className={dotClass} style={dotStyle} />
       <div className="min-w-0 flex-1">
         {project.url ? (
-          // ``draggable={false}`` on the anchor stops the browser
-          // from initiating a *link* drag (which sets a URL on the
-          // dataTransfer instead of our priority MIME) and shadowing
-          // the parent ``<li draggable>`` reorder intent.
           <a
             href={project.url}
             target="_blank"
             rel="noreferrer"
             draggable={false}
-            className="truncate text-[13px] font-semibold text-white hover:text-aqua"
+            className={cn(
+              "truncate text-[13px] font-semibold hover:text-aqua",
+              isPlanning ? "italic text-white/85" : "text-white",
+            )}
           >
             {project.name}
           </a>
         ) : (
-          <p className="truncate text-[13px] font-semibold text-white">
+          <p
+            className={cn(
+              "truncate text-[13px] font-semibold",
+              isPlanning ? "italic text-white/85" : "text-white",
+            )}
+          >
             {project.name}
           </p>
         )}
@@ -603,21 +864,32 @@ function PrioritizerRow({
           </p>
         )}
       </div>
-      <span className="shrink-0 font-mono text-[11px] tabular-nums text-white/55">
+      <span
+        className={cn(
+          "shrink-0 font-mono text-[11px] tabular-nums",
+          isPlanning ? "text-lilac/70" : "text-white/55",
+        )}
+      >
         {fractionLabel}
       </span>
-      <span
-        aria-hidden
-        className="block h-1 w-20 shrink-0 rounded-sm bg-white/[0.06]"
-      >
+      {showProgressBar ? (
         <span
-          className="block h-full rounded-sm transition-all"
-          style={{
-            width: `${barFraction * 100}%`,
-            backgroundColor: project.color ?? undefined,
-          }}
-        />
-      </span>
+          aria-hidden
+          className="block h-1 w-20 shrink-0 rounded-sm bg-white/[0.06]"
+        >
+          <span
+            className="block h-full rounded-sm transition-all"
+            style={{
+              width: `${barFraction * 100}%`,
+              backgroundColor: project.color ?? undefined,
+            }}
+          />
+        </span>
+      ) : (
+        // Fixed-width spacer keeps the row gutter aligned across
+        // sections so the progress column doesn't reflow per-state.
+        <span aria-hidden className="block h-1 w-20 shrink-0" />
+      )}
     </li>
   );
 }
@@ -628,13 +900,23 @@ function PrioritizerRow({
 // ---------------------------------------------------------------------------
 
 
-function moveIndex(arr: string[], idx: number, delta: number): string[] {
-  const next = arr.slice();
-  const target = idx + delta;
-  if (target < 0 || target >= next.length) return arr;
-  const [moved] = next.splice(idx, 1);
-  next.splice(target, 0, moved);
-  return next;
+function ensureRow(
+  arr: DraftRow[],
+  id: string,
+  defaultState: ApiPriorityState,
+): void {
+  if (!arr.some((r) => r.id === id)) {
+    arr.push({ id, state: defaultState });
+  }
+}
+
+
+function rowsEqual(a: DraftRow[], b: DraftRow[]): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i].id !== b[i].id || a[i].state !== b[i].state) return false;
+  }
+  return true;
 }
 
 
@@ -670,5 +952,3 @@ function formatRelative(value: string): string {
   if (diff < 30 * day) return `${Math.round(diff / day)}d ago`;
   return new Date(date).toLocaleDateString();
 }
-
-

--- a/console/src/lib/api/client.ts
+++ b/console/src/lib/api/client.ts
@@ -2462,16 +2462,30 @@ export interface ApiPriorityTracker {
   scopes: string[] | null;
 }
 
+/**
+ * Operator bucket on the prioritizer:
+ * - ``active``   — agent's picker may consume.
+ * - ``planning`` — operator is shaping it (brief/scope). Agent-invisible.
+ * - ``parked``   — explicitly hold. Agent-invisible.
+ */
+export type ApiPriorityState = "active" | "planning" | "parked";
+
 export interface ApiPriorityProject {
   project_native_id: string;
   name: string;
   slug: string | null;
-  state: string | null;
+  /** Tracker-side state ("started" / "planned" / etc) — Linear's own
+   *  field. Kept distinct from ``priority_state`` (the operator
+   *  bucket) so the UI can render both signals when useful. */
+  tracker_state: string | null;
   url: string | null;
   color: string | null;
   /** Saved priority position (0 = top). NULL when the project is
    * unprioritised — the UI sorts these after prioritised rows. */
   ordinal: number | null;
+  /** Operator bucket. NULL only for unprioritised tail rows (the
+   *  project has never been dragged into a bucket). */
+  priority_state: ApiPriorityState | null;
   /** Completion magnitude. ``total`` is null when the tracker can't
    * tell us; the UI then renders ``—`` and skips the bar. */
   completed: number | null;
@@ -2512,14 +2526,35 @@ export function getPriorities(
   );
 }
 
+export interface ApiReorderRow {
+  project_native_id: string;
+  state: ApiPriorityState;
+}
+
 export function reorderPriorities(
   workspaceId: string,
-  order: string[],
+  order: ApiReorderRow[],
   token?: string,
 ): Promise<ApiPrioritiesResponse> {
   return apiFetch<ApiPrioritiesResponse>(
     `/v1/workspaces/${encodeURIComponent(workspaceId)}/priorities/reorder`,
     { method: "POST", token, body: { order } },
+  );
+}
+
+export function setPriorityState(
+  workspaceId: string,
+  projectNativeId: string,
+  state: ApiPriorityState,
+  token?: string,
+): Promise<ApiPrioritiesResponse> {
+  return apiFetch<ApiPrioritiesResponse>(
+    `/v1/workspaces/${encodeURIComponent(workspaceId)}/priorities/state`,
+    {
+      method: "POST",
+      token,
+      body: { project_native_id: projectNativeId, state },
+    },
   );
 }
 


### PR DESCRIPTION
## Why

Operators on the dashboard can today only **reorder** projects. There's no way to say "I want to plan this but not start it yet" — every prioritised row is implicitly fair game for the autonomous picker. The fix is a missing axis on the row, not a new surface.

## What

Add a `state` enum to `workspace_project_priorities` with three buckets:

- **active** — agent's picker may consume.
- **planning** — operator is shaping the brief; agent-invisible.
- **parked** — explicit hold; collapsed by default, never hidden.

Backfill: every existing row → `active`, so today's pick semantics are preserved.

### Picker contract

The agent's project picker now reads `state='active' ORDER BY ordinal`. The up-next strip filters at the API layer — planning / parked rows can never surface as "what the agent will do next."

### API

- `POST /priorities/reorder` body grew a `state` field per row: `{order: [{project_native_id, state}]}`.
- New `POST /priorities/state` — single-row sugar for keyboard / row-menu callers; creates a row at the bottom of the workspace's ordinal range when none exists, updates in place when one does.

### UI

One ordered list, three section headers, parked collapsed by default. Drag-across-divider is the state-change gesture; within a section, drag reorders.

- **Active** rows: full opacity + progress bar.
- **Planning** rows: lilac dot, italic title, "brief" placeholder instead of completion fraction.
- **Parked** rows: 40% opacity, no progress bar.
- Empty Active bucket → up-next strip swaps to a sun-coloured "drag a project into Active" hint so an empty queue can't read as a server bug.

## Test plan

- [x] Backend tests (`backend/tests/test_v1_dashboard_priorities.py`) updated for the new payload shape; new tests cover `state` enum rejection (422) and `POST /state` create-then-update behaviour. 8/8 pass.
- [x] Migration `0057_priority_state` applied to prod DB; existing rows backfilled to `active`. Verified column + CHECK constraint + backfill in place.
- [x] `tsc --noEmit` clean across `console/`.
- [x] `next lint` — no new warnings introduced.
- [ ] Browser walk: not run in this session — colleague had the dev server up. To verify locally: drag rows across section dividers, confirm draft-then-Save round-trip, confirm parked rows are hidden by default and toggle, confirm empty Active surfaces the sun warning.