### PR TITLE
knowledge: deeper Notion ingest + scheduled source sync

### DIFF
--- a/backend/app/api/v1/routes/knowledge_import_sources.py
+++ b/backend/app/api/v1/routes/knowledge_import_sources.py
@@ -131,6 +131,35 @@ async def _load_source(
     return source
 
 
+async def _kick_initial_sync(
+    *, workspace_id: uuid.UUID, source_id: uuid.UUID
+) -> None:
+    """Run a single ``sync_import_source`` for a freshly-created row.
+
+    Lives outside the request session so it can run after the response
+    is sent (FastAPI ``BackgroundTasks`` semantics). Failures are
+    swallowed because the source row already records ``last_error``
+    via ``sync_import_source``'s own except-branch — the operator
+    sees the error in the UI on the next list refresh, and the cron
+    will retry on the next due tick.
+    """
+    from backend.app.db.session import get_sessionmaker
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        source = await session.get(KnowledgeImportSource, source_id)
+        if source is None or source.workspace_id != workspace_id:
+            return
+        try:
+            await sync_import_source(session, source=source, trigger="create")
+            await session.commit()
+        except Exception:  # noqa: BLE001 — already persisted on the row
+            await session.rollback()
+            logger.warning(
+                "initial sync failed for source %s — see last_error", source_id
+            )
+
+
 @router.get("", response_model=list[ImportSourceOut])
 async def list_import_sources(
     workspace_id: uuid.UUID,
@@ -168,6 +197,7 @@ async def sync_due_sources(
 async def create_source(
     workspace_id: uuid.UUID,
     payload: ImportSourceCreateIn,
+    background_tasks: BackgroundTasks,
     auth: AuthContext = Depends(get_current_auth),
     session: AsyncSession = Depends(get_session),
 ) -> ImportSourceOut:
@@ -189,6 +219,14 @@ async def create_source(
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
         ) from exc
+    # Kick the first sync immediately so the operator gets feedback
+    # in the UI without having to hit "Sync now". The sync_due cron
+    # would otherwise skip a freshly created row (created_at + interval
+    # is by definition still in the future), so the next pull would
+    # be one full sync_interval_minutes away.
+    background_tasks.add_task(
+        _kick_initial_sync, workspace_id=workspace_id, source_id=row.id
+    )
     return _source_out(row)
 
 

--- a/backend/app/api/v1/routes/knowledge_import_sources.py
+++ b/backend/app/api/v1/routes/knowledge_import_sources.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import uuid
 from datetime import datetime, timezone
@@ -203,6 +204,9 @@ async def create_source(
 ) -> ImportSourceOut:
     await _require_membership(session, workspace_id, auth.user.id, ROLES_ADMIN)
     await _validate_source_refs(session, workspace_id, payload)
+    await _reject_duplicate_source(
+        session, workspace_id=workspace_id, payload=payload
+    )
     try:
         row = await create_import_source(
             session,
@@ -329,6 +333,75 @@ async def list_source_runs(
         )
     ).scalars().all()
     return [_run_out(row) for row in rows]
+
+
+def _canonical_config(config: dict[str, Any] | None) -> str:
+    """Order-insensitive JSON form used to detect duplicate sources.
+
+    Two sources are "the same" when they target identical resource_refs
+    (and any other config keys) under the same workspace + kind +
+    integration + repo. ``resource_refs`` is sorted because operators
+    sometimes pick the same pages in a different order in the wizard,
+    and that's still a duplicate — there's nothing for the second row
+    to do that the first doesn't already cover.
+
+    Other config keys are kept dict-stable via ``sort_keys=True``.
+    Non-dict configs collapse to ``{}`` so the check stays defensive.
+    """
+    if not isinstance(config, dict):
+        return "{}"
+    refs = config.get("resource_refs")
+    other = {k: v for k, v in config.items() if k != "resource_refs"}
+    refs_sorted: list[str] = []
+    if isinstance(refs, list):
+        refs_sorted = sorted(
+            json.dumps(r, sort_keys=True, default=str)
+            for r in refs
+            if isinstance(r, dict)
+        )
+    return json.dumps(
+        {"refs": refs_sorted, "other": other}, sort_keys=True, default=str
+    )
+
+
+async def _reject_duplicate_source(
+    session: AsyncSession,
+    *,
+    workspace_id: uuid.UUID,
+    payload: ImportSourceCreateIn,
+) -> None:
+    """409 if a non-archived source with the same canonical config already exists.
+
+    Without this guard a double-click on "Connect" in the wizard creates
+    two identical rows; both then sync the same content forever, doubling
+    the load on the upstream API and the harvester output, with no upside.
+    The check is scoped to ``(workspace, kind, integration, repo)`` plus
+    ``archived_at IS NULL`` so re-creating a previously-archived source
+    is still allowed (operators sometimes archive then re-add to "reset"
+    a source after fixing share permissions upstream).
+    """
+    target = _canonical_config(payload.config)
+    rows = (
+        await session.execute(
+            select(KnowledgeImportSource).where(
+                KnowledgeImportSource.workspace_id == workspace_id,
+                KnowledgeImportSource.kind == payload.kind,
+                KnowledgeImportSource.integration_id == payload.integration_id,
+                KnowledgeImportSource.repo_id == payload.repo_id,
+                KnowledgeImportSource.archived_at.is_(None),
+            )
+        )
+    ).scalars().all()
+    for row in rows:
+        if _canonical_config(row.config) == target:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=(
+                    f"a non-archived {payload.kind} source with the same "
+                    f"configuration already exists (id={row.id}); archive "
+                    "it first or update it instead of creating a duplicate"
+                ),
+            )
 
 
 async def _validate_source_refs(

--- a/backend/app/services/connectors/notion.py
+++ b/backend/app/services/connectors/notion.py
@@ -37,6 +37,7 @@ this page missing a section?" a one-line grep.
 from __future__ import annotations
 
 import logging
+from collections import deque
 from typing import Any, Mapping
 
 import httpx
@@ -65,6 +66,13 @@ _MAX_BLOCKS = 200
 # (the ingestion pipeline already caps total documents per source at
 # MAX_SOURCE_DOCUMENTS = 100, so this is the per-database ceiling).
 _MAX_PAGES_PER_DATABASE = 50
+
+# Recursive expansion caps for hub-style pages. A single ``page_id``
+# ref can fan out into child pages and embedded child_databases; the
+# walker bounds breadth (total emitted pages per ref tree) and depth
+# (root counts as depth 0; subpages = 1; their subpages = 2; …).
+_MAX_PAGES_PER_REF = 100
+_MAX_RECURSION_DEPTH = 3
 
 
 def _headers(token: str) -> dict[str, str]:
@@ -231,6 +239,15 @@ def _render_block(block: dict[str, Any]) -> str:
         suffix = f" ({child_id})" if child_id else ""
         return f"- 📄 Subpage: {title}{suffix}"
 
+    if btype == "child_database":
+        # Notion returns the database title in the block payload; the
+        # block id IS the database id, so the operator can paste it
+        # into another resource_ref if they want to drill in further.
+        title = (payload.get("title") or "Untitled database").strip()
+        child_id = block.get("id") or ""
+        suffix = f" ({child_id})" if child_id else ""
+        return f"- 🗂 Database: {title}{suffix}"
+
     return f"<unsupported: {btype}>"
 
 
@@ -270,11 +287,18 @@ def _normalize_page_id(raw: str) -> str:
 
 async def _render_one_page(
     client: httpx.AsyncClient, page_id: str, *, token: str
-) -> ConnectorPage:
-    """Fetch one Notion page + its top-level blocks → ConnectorPage.
+) -> tuple[ConnectorPage, list[str], list[str]]:
+    """Fetch one Notion page → (rendered ConnectorPage, child_page_ids, child_database_ids).
 
     Lifted out of the dispatcher so database-mode can call it once per
     entry without duplicating the markdown rendering / truncation rule.
+
+    Hub pages on Notion are typically a thin wrapper of headings and a
+    handful of ``child_page`` and ``child_database`` blocks — the real
+    knowledge lives one or two levels deeper. We surface the child ids
+    here so the BFS walker can expand them, while keeping the parent
+    rendering intact (the operator's link structure is preserved as
+    bullet lines pointing at the indexed siblings).
     """
     page = await _fetch_page(client, page_id, token=token)
     title = _extract_title(page)
@@ -290,6 +314,18 @@ async def _render_one_page(
             f"connector if you need deeper pages)_"
         )
 
+    child_page_ids: list[str] = []
+    child_database_ids: list[str] = []
+    for block in blocks:
+        btype = block.get("type")
+        block_id = block.get("id") or ""
+        if not block_id:
+            continue
+        if btype == "child_page":
+            child_page_ids.append(block_id)
+        elif btype == "child_database":
+            child_database_ids.append(block_id)
+
     header: list[str] = [f"# {title}"]
     meta_bits: list[str] = []
     if url:
@@ -300,7 +336,7 @@ async def _render_one_page(
         header.append(" · ".join(meta_bits))
     body = "\n\n".join(header + rendered_blocks).strip() + "\n"
 
-    return ConnectorPage(
+    page_obj = ConnectorPage(
         slug=page_id,
         title=title,
         body_md=body,
@@ -310,6 +346,120 @@ async def _render_one_page(
             "last_edited_time": last_edited,
         },
     )
+    return page_obj, child_page_ids, child_database_ids
+
+
+async def _walk_page_tree(
+    client: httpx.AsyncClient,
+    seed_page_ids: list[str],
+    *,
+    token: str,
+    max_depth: int = _MAX_RECURSION_DEPTH,
+    max_pages: int = _MAX_PAGES_PER_REF,
+) -> list[ConnectorPage]:
+    """BFS over a tree rooted at ``seed_page_ids`` — emit one ConnectorPage per node.
+
+    Walks ``child_page`` blocks for hierarchical hubs and expands
+    ``child_database`` blocks by querying the embedded database (so
+    operators get the entries indexed even when they only pointed
+    Ship at the parent page).
+
+    Caps:
+
+    - ``max_depth`` — root pages are depth 0, their child_page is
+      depth 1, etc. ``child_database`` entries inherit the depth of
+      the database they came from.
+    - ``max_pages`` — total emitted ConnectorPage count across the
+      tree. Stops enqueuing once hit so nothing balloons unboundedly.
+
+    Per-page HTTP failures (``401/403/404`` on a single subpage that
+    isn't shared with the integration) are logged and skipped — one
+    locked subpage shouldn't fail the whole tree, mirroring how
+    :func:`_fetch_database_pages` already handles it.
+    """
+    visited: set[str] = set()
+    visited_databases: set[str] = set()
+    seeds: set[str] = {pid for pid in seed_page_ids if pid}
+    pages: list[ConnectorPage] = []
+    queue: deque[tuple[str, int]] = deque(
+        (pid, 0) for pid in seed_page_ids if pid
+    )
+    truncated = False
+    while queue:
+        page_id, depth = queue.popleft()
+        if page_id in visited:
+            continue
+        visited.add(page_id)
+        if len(pages) >= max_pages:
+            truncated = True
+            break
+        try:
+            page_obj, child_page_ids, child_database_ids = await _render_one_page(
+                client, page_id, token=token
+            )
+        except httpx.HTTPStatusError as exc:
+            status_code = (
+                exc.response.status_code if exc.response is not None else 0
+            )
+            if status_code in (401, 403, 404):
+                # Seed pages are operator-pointed — surfacing the
+                # share-hint loudly is the whole point of having
+                # ConfigError on the dispatcher path. Deeper pages
+                # we discovered ourselves: one being locked is normal
+                # in a tree (e.g. an HR subpage off a hub) and should
+                # not poison the rest of the walk.
+                if page_id in seeds:
+                    raise ConnectorConfigError(
+                        f"notion returned HTTP {status_code} for page {page_id} — "
+                        "is the integration shared with the page?"
+                    ) from exc
+                logger.warning(
+                    "notion walker: skipping page %s (HTTP %s — not shared?)",
+                    page_id,
+                    status_code,
+                )
+                continue
+            raise
+        pages.append(page_obj)
+        if depth >= max_depth:
+            continue
+        for cpid in child_page_ids:
+            if cpid not in visited:
+                queue.append((cpid, depth + 1))
+        for dbid in child_database_ids:
+            if dbid in visited_databases:
+                continue
+            visited_databases.add(dbid)
+            try:
+                entry_ids = await _query_data_source_pages(
+                    client,
+                    await _resolve_data_source_id(client, dbid, token=token),
+                    token=token,
+                    limit=_MAX_PAGES_PER_DATABASE,
+                )
+            except httpx.HTTPStatusError as exc:
+                status_code = (
+                    exc.response.status_code if exc.response is not None else 0
+                )
+                if status_code in (401, 403, 404):
+                    logger.warning(
+                        "notion walker: skipping embedded database %s "
+                        "(HTTP %s — not shared?)",
+                        dbid,
+                        status_code,
+                    )
+                    continue
+                raise
+            for eid in entry_ids:
+                if eid not in visited:
+                    queue.append((eid, depth + 1))
+    if truncated:
+        logger.warning(
+            "notion walker: hit max_pages=%d cap from seeds=%s — truncating tree",
+            max_pages,
+            seed_page_ids,
+        )
+    return pages
 
 
 async def _resolve_data_source_id(
@@ -427,40 +577,31 @@ async def fetch_notion_pages(
     client = http_client or httpx.AsyncClient(timeout=httpx.Timeout(10.0))
     try:
         if db_mode:
-            return await _fetch_database_pages(
+            seed_ids = await _seed_database(
                 client, _normalize_page_id(str(raw_database_id)), token=token
             )
-        return [
-            await _fetch_single_page(
-                client, _normalize_page_id(str(raw_page_id)), token=token
-            )
-        ]
+        else:
+            seed_ids = [_normalize_page_id(str(raw_page_id))]
+        return await _walk_page_tree(client, seed_ids, token=token)
     finally:
         if owns_client:
             await client.aclose()
 
 
-async def _fetch_single_page(
-    client: httpx.AsyncClient, page_id: str, *, token: str
-) -> ConnectorPage:
-    try:
-        return await _render_one_page(client, page_id, token=token)
-    except httpx.HTTPStatusError as exc:
-        status = exc.response.status_code if exc.response is not None else 0
-        if status in (401, 403, 404):
-            raise ConnectorConfigError(
-                f"notion returned HTTP {status} for page {page_id} — is the "
-                "integration shared with the page?"
-            ) from exc
-        raise
-
-
-async def _fetch_database_pages(
+async def _seed_database(
     client: httpx.AsyncClient, database_id: str, *, token: str
-) -> list[ConnectorPage]:
+) -> list[str]:
+    """Resolve a database/data_source ref to its current page_ids.
+
+    Used to seed the BFS walker so DB-mode and page-mode share the
+    exact same expansion path (recursion into nested pages, embedded
+    child_databases) once the seed list is in hand.
+    """
     try:
-        data_source_id = await _resolve_data_source_id(client, database_id, token=token)
-        page_ids = await _query_data_source_pages(
+        data_source_id = await _resolve_data_source_id(
+            client, database_id, token=token
+        )
+        return await _query_data_source_pages(
             client, data_source_id, token=token, limit=_MAX_PAGES_PER_DATABASE
         )
     except httpx.HTTPStatusError as exc:
@@ -471,22 +612,6 @@ async def _fetch_database_pages(
                 "integration shared with it?"
             ) from exc
         raise
-
-    pages: list[ConnectorPage] = []
-    for page_id in page_ids:
-        try:
-            pages.append(await _render_one_page(client, page_id, token=token))
-        except httpx.HTTPStatusError as exc:
-            # One inaccessible page in a database shouldn't fail the whole
-            # ref — log and continue. The dispatcher's stub fallback isn't
-            # right here because we've already produced some valid pages.
-            logger.warning(
-                "notion database %s: skipping page %s (HTTP %s)",
-                database_id,
-                page_id,
-                exc.response.status_code if exc.response is not None else "?",
-            )
-    return pages
 
 
 __all__ = ["fetch_notion_pages"]

--- a/backend/app/services/cron.py
+++ b/backend/app/services/cron.py
@@ -84,6 +84,7 @@ class CronLockId(IntEnum):
     KNOWLEDGE_ROUTE = 1002
     KNOWLEDGE_SYNTH = 1003
     KNOWLEDGE_DECAY = 1004
+    KNOWLEDGE_SOURCES_SYNC = 1005
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/services/cron_jobs.py
+++ b/backend/app/services/cron_jobs.py
@@ -28,6 +28,7 @@ from backend.app.services.cron import (
 )
 from backend.app.services.knowledge_decay import gc_all_workspaces
 from backend.app.services.knowledge_harvest import harvest_all_workspaces
+from backend.app.services.knowledge_ingestion import sync_due_import_sources
 from backend.app.services.knowledge_router import route_all_workspaces
 from backend.app.services.knowledge_synth import synthesise_all_workspaces
 
@@ -181,6 +182,34 @@ async def _knowledge_synth_tick() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Knowledge import sources — periodic sync
+# ---------------------------------------------------------------------------
+
+
+@cron_with_lock(
+    lock=CronLockId.KNOWLEDGE_SOURCES_SYNC, name="knowledge_sources_sync"
+)
+async def _knowledge_sources_sync_tick() -> None:
+    """Every 15 min: re-sync ``KnowledgeImportSource`` rows that are due.
+
+    Without this tick, ingestion only ran when an operator opened the
+    sources page in the console (the GET endpoint scheduled
+    ``sync_due_import_sources`` as a BackgroundTask). Operators in
+    closed beta who left the page closed for a day saw their Notion
+    / Confluence / website connectors quietly stop pulling fresh
+    content. The cron makes the schedule load-bearing instead of
+    UI-driven.
+
+    ``sync_due_import_sources`` opens its own session per workspace
+    so one bad source doesn't poison the rest, and its internal cap
+    keeps each tick bounded.
+    """
+    result = await sync_due_import_sources(limit=20)
+    if result.checked or result.errors:
+        log.info("knowledge_sources_sync tick: %s", result.to_dict())
+
+
+# ---------------------------------------------------------------------------
 # Step 6 — daily archive GC
 # ---------------------------------------------------------------------------
 
@@ -239,6 +268,15 @@ def register_all() -> None:
         fn=_knowledge_synth_tick,
         cron_expr="40 * * * *",  # every hour at :40
         job_id="knowledge_synth",
+    )
+    # External-source pull runs every 15 min so a connector that
+    # advertises ``sync_interval_minutes=60`` actually re-syncs
+    # within ~15 min of becoming due, instead of waiting for
+    # the next operator visit to the sources page.
+    register_cron(
+        fn=_knowledge_sources_sync_tick,
+        cron_expr="*/15 * * * *",
+        job_id="knowledge_sources_sync",
     )
     # GC runs once daily. Cheap query (filtered DELETE by archived_at)
     # so an off-peak slot is fine; pick 03:15 UTC to avoid the on-the-

--- a/backend/tests/test_connectors_notion.py
+++ b/backend/tests/test_connectors_notion.py
@@ -107,10 +107,12 @@ def _rt(text: str, **ann) -> dict[str, Any]:
     }
 
 
-def _block(btype: str, payload: dict[str, Any]) -> dict[str, Any]:
+def _block(
+    btype: str, payload: dict[str, Any], *, block_id: str | None = None
+) -> dict[str, Any]:
     return {
         "object": "block",
-        "id": uuid.uuid4().hex,
+        "id": block_id or uuid.uuid4().hex,
         "type": btype,
         btype: payload,
     }
@@ -418,3 +420,275 @@ async def test_notion_follows_pagination_cursor(integration) -> None:
     # First call with no cursor, second with ``c-2`` — exactly two
     # block-listing requests.
     assert call_log == [None, "c-2"]
+
+
+# ---------------------------------------------------------------------------
+# Recursive tree expansion
+# ---------------------------------------------------------------------------
+
+
+def _hub_handler(
+    *,
+    pages: dict[str, dict[str, Any]],
+    blocks: dict[str, list[dict[str, Any]]],
+    databases: dict[str, list[str]] | None = None,
+    locked: set[str] | None = None,
+) -> Callable[[httpx.Request], httpx.Response]:
+    """Build a handler that maps ``page_id``/``database_id`` to canned payloads.
+
+    ``pages`` maps page_id → /v1/pages payload.
+    ``blocks`` maps page_id → /v1/blocks/{id}/children results.
+    ``databases`` maps database_id → list of page_ids returned from
+    /v1/data_sources/{id}/query.
+    ``locked`` is a set of page_ids that should respond with HTTP 404
+    (simulating "integration not shared with this subpage").
+    """
+    databases = databases or {}
+    locked = locked or set()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if path.startswith("/v1/pages/"):
+            page_id = path.rsplit("/", 1)[-1]
+            if page_id in locked:
+                return httpx.Response(
+                    404, json={"object": "error", "code": "object_not_found"}
+                )
+            if page_id in pages:
+                return httpx.Response(200, json=pages[page_id])
+            return httpx.Response(404)
+        if path.startswith("/v1/blocks/") and path.endswith("/children"):
+            block_id = path.split("/")[3]
+            return httpx.Response(
+                200, json=_blocks_payload(blocks.get(block_id, []))
+            )
+        if path.startswith("/v1/data_sources/") and path.endswith("/query"):
+            ds_id = path.split("/")[3]
+            return httpx.Response(
+                200,
+                json={
+                    "results": [
+                        {"object": "page", "id": pid}
+                        for pid in databases.get(ds_id, [])
+                    ],
+                    "has_more": False,
+                    "next_cursor": None,
+                },
+            )
+        if path.startswith("/v1/data_sources/"):
+            ds_id = path.rsplit("/", 1)[-1]
+            if ds_id in databases:
+                return httpx.Response(
+                    200, json={"object": "data_source", "id": ds_id}
+                )
+            return httpx.Response(
+                404, json={"object": "error", "code": "object_not_found"}
+            )
+        return httpx.Response(404)
+
+    return handler
+
+
+@pytest.mark.asyncio
+async def test_notion_walker_expands_child_pages(integration) -> None:
+    """A hub page with two ``child_page`` blocks should yield three
+    ConnectorPages: the hub itself + each subpage. The hub's body
+    keeps the bullet links so the operator can navigate the tree."""
+
+    hub_id = "hub-1"
+    sub_a = "sub-a"
+    sub_b = "sub-b"
+
+    handler = _hub_handler(
+        pages={
+            hub_id: _page_payload(hub_id, title="Hub"),
+            sub_a: _page_payload(sub_a, title="Subpage A"),
+            sub_b: _page_payload(sub_b, title="Subpage B"),
+        },
+        blocks={
+            hub_id: [
+                _block(
+                    "child_page",
+                    {"title": "Subpage A"},
+                    block_id=sub_a,
+                ),
+                _block(
+                    "child_page",
+                    {"title": "Subpage B"},
+                    block_id=sub_b,
+                ),
+            ],
+            sub_a: [
+                _block("paragraph", {"rich_text": [_rt("Real content A")]}),
+            ],
+            sub_b: [
+                _block("paragraph", {"rich_text": [_rt("Real content B")]}),
+            ],
+        },
+    )
+
+    async with _make_client(handler) as client:
+        pages = await fetch_connector_pages(
+            integration, {"page_id": hub_id}, http_client=client
+        )
+
+    titles = [p.title for p in pages]
+    assert titles == ["Hub", "Subpage A", "Subpage B"]
+    assert "Real content A" in pages[1].body_md
+    assert "Real content B" in pages[2].body_md
+    assert "📄 Subpage: Subpage A" in pages[0].body_md
+
+
+@pytest.mark.asyncio
+async def test_notion_walker_expands_child_database(integration) -> None:
+    """A page that embeds a ``child_database`` should fetch the database
+    entries and emit them as ConnectorPages — the hub no longer drops
+    the content as ``<unsupported>``."""
+
+    hub_id = "hub-2"
+    db_id = "db-embedded"
+    entry_a = "entry-a"
+    entry_b = "entry-b"
+
+    handler = _hub_handler(
+        pages={
+            hub_id: _page_payload(hub_id, title="Hub with DB"),
+            entry_a: _page_payload(entry_a, title="Entry A"),
+            entry_b: _page_payload(entry_b, title="Entry B"),
+        },
+        blocks={
+            hub_id: [
+                _block(
+                    "child_database",
+                    {"title": "Embedded specs"},
+                    block_id=db_id,
+                ),
+            ],
+            entry_a: [],
+            entry_b: [],
+        },
+        databases={db_id: [entry_a, entry_b]},
+    )
+
+    async with _make_client(handler) as client:
+        pages = await fetch_connector_pages(
+            integration, {"page_id": hub_id}, http_client=client
+        )
+
+    titles = [p.title for p in pages]
+    assert titles == ["Hub with DB", "Entry A", "Entry B"]
+    # The hub body now mentions the embedded database explicitly,
+    # not the legacy <unsupported> marker.
+    assert "<unsupported: child_database>" not in pages[0].body_md
+    assert "🗂 Database: Embedded specs" in pages[0].body_md
+
+
+@pytest.mark.asyncio
+async def test_notion_walker_handles_nested_hubs(integration) -> None:
+    """Two-level nesting: hub → subpage that is itself a hub → leaf.
+    Default depth cap is 3, so a 2-level tree should fully expand
+    (root=0, mid=1, leaf=2)."""
+
+    root = "n-root"
+    mid = "n-mid"
+    leaf = "n-leaf"
+
+    handler = _hub_handler(
+        pages={
+            root: _page_payload(root, title="Root"),
+            mid: _page_payload(mid, title="Mid"),
+            leaf: _page_payload(leaf, title="Leaf"),
+        },
+        blocks={
+            root: [_block("child_page", {"title": "Mid"}, block_id=mid)],
+            mid: [_block("child_page", {"title": "Leaf"}, block_id=leaf)],
+            leaf: [_block("paragraph", {"rich_text": [_rt("deepest content")]})],
+        },
+    )
+
+    async with _make_client(handler) as client:
+        pages = await fetch_connector_pages(
+            integration, {"page_id": root}, http_client=client
+        )
+
+    assert [p.title for p in pages] == ["Root", "Mid", "Leaf"]
+    assert "deepest content" in pages[2].body_md
+
+
+@pytest.mark.asyncio
+async def test_notion_walker_dedupes_repeated_child_ids(integration) -> None:
+    """A page that links the same subpage twice (e.g. cross-referenced
+    runbook) must only be fetched and emitted once."""
+
+    hub_id = "hub-d"
+    sub = "sub-once"
+
+    handler = _hub_handler(
+        pages={
+            hub_id: _page_payload(hub_id, title="Hub"),
+            sub: _page_payload(sub, title="Sub"),
+        },
+        blocks={
+            hub_id: [
+                _block("child_page", {"title": "Sub"}, block_id=sub),
+                _block("child_page", {"title": "Sub"}, block_id=sub),
+            ],
+            sub: [],
+        },
+    )
+
+    async with _make_client(handler) as client:
+        pages = await fetch_connector_pages(
+            integration, {"page_id": hub_id}, http_client=client
+        )
+
+    titles = [p.title for p in pages]
+    assert titles == ["Hub", "Sub"]
+
+
+@pytest.mark.asyncio
+async def test_notion_walker_skips_locked_subpages_but_fails_locked_seeds(
+    integration,
+) -> None:
+    """A subpage the bot can't see (HTTP 404) is logged + skipped so
+    the rest of the tree still indexes. A SEED page returning 404 is
+    still surfaced as ConnectorConfigError — that's how the wizard
+    teaches operators to share the page."""
+
+    hub_id = "hub-l"
+    visible = "sub-vis"
+    hidden = "sub-hid"
+
+    handler = _hub_handler(
+        pages={
+            hub_id: _page_payload(hub_id, title="Hub"),
+            visible: _page_payload(visible, title="Visible"),
+        },
+        blocks={
+            hub_id: [
+                _block("child_page", {"title": "Visible"}, block_id=visible),
+                _block("child_page", {"title": "Hidden"}, block_id=hidden),
+            ],
+            visible: [],
+        },
+        locked={hidden},
+    )
+
+    async with _make_client(handler) as client:
+        pages = await fetch_connector_pages(
+            integration, {"page_id": hub_id}, http_client=client
+        )
+
+    assert [p.title for p in pages] == ["Hub", "Visible"]
+
+    # Same handler, but seed itself is locked → ConfigError surfaces.
+    seed_locked = _hub_handler(
+        pages={},
+        blocks={},
+        locked={hub_id},
+    )
+    async with _make_client(seed_locked) as client:
+        with pytest.raises(ConnectorConfigError, match="shared"):
+            await fetch_connector_pages(
+                integration, {"page_id": hub_id}, http_client=client
+            )

--- a/backend/tests/test_v1_knowledge_import_sources.py
+++ b/backend/tests/test_v1_knowledge_import_sources.py
@@ -5,6 +5,7 @@ import uuid
 import pytest
 from sqlalchemy import select
 
+from backend.app.api.v1.routes.knowledge_import_sources import _canonical_config
 from backend.app.db.models.agent_memory import (
     BucketScope,
     BucketSource,
@@ -18,6 +19,43 @@ from backend.app.db.models.tenancy import AuditLog
 
 def _auth(raw: str) -> dict[str, str]:
     return {"Authorization": f"Bearer {raw}"}
+
+
+def test_canonical_config_is_order_invariant_for_resource_refs() -> None:
+    """The dedup hash treats resource_refs as a set, not a sequence.
+
+    Two wizard submissions that pick the same pages in different order
+    should be considered the same source — otherwise an operator who
+    re-sorts the list during a re-pick produces a phantom duplicate
+    that survives indefinitely.
+    """
+    a = {
+        "resource_refs": [
+            {"page_id": "p-1"},
+            {"page_id": "p-2"},
+        ],
+        "target_bucket_slug": "product-knowledge",
+    }
+    b = {
+        "resource_refs": [
+            {"page_id": "p-2"},
+            {"page_id": "p-1"},
+        ],
+        "target_bucket_slug": "product-knowledge",
+    }
+    assert _canonical_config(a) == _canonical_config(b)
+
+
+def test_canonical_config_distinguishes_distinct_ref_sets() -> None:
+    a = {"resource_refs": [{"page_id": "p-1"}]}
+    b = {"resource_refs": [{"page_id": "p-1"}, {"page_id": "p-2"}]}
+    assert _canonical_config(a) != _canonical_config(b)
+
+
+def test_canonical_config_treats_other_keys_dict_stably() -> None:
+    a = {"resource_refs": [], "limit": 25, "include_subdomains": False}
+    b = {"include_subdomains": False, "limit": 25, "resource_refs": []}
+    assert _canonical_config(a) == _canonical_config(b)
 
 
 @pytest.mark.asyncio
@@ -212,3 +250,80 @@ async def test_archive_is_idempotent(v1_client, seed_workspace, db_session) -> N
         .all()
     )
     assert len(audits) == 1
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_duplicate_active_source(
+    v1_client, seed_workspace, db_session
+) -> None:
+    """Two non-archived rows with identical config under the same
+    workspace + kind + integration would both pull the same content
+    forever. The second create must 409 and point the operator at
+    the existing row.
+    """
+    _, raw, workspace = seed_workspace
+    config = {
+        "documents": [
+            {"title": "T", "filename": "t.md", "body_md": "# T"}
+        ]
+    }
+
+    first = await v1_client.post(
+        f"/v1/workspaces/{workspace.id}/knowledge/sources",
+        headers=_auth(raw),
+        json={
+            "kind": "static_upload",
+            "name": "Original",
+            "config": config,
+        },
+    )
+    assert first.status_code == 201
+    first_id = first.json()["id"]
+
+    second = await v1_client.post(
+        f"/v1/workspaces/{workspace.id}/knowledge/sources",
+        headers=_auth(raw),
+        json={
+            "kind": "static_upload",
+            "name": "Accidental dupe",
+            "config": config,
+        },
+    )
+    assert second.status_code == 409, second.text
+    assert first_id in second.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_create_after_archive_is_allowed(
+    v1_client, seed_workspace, db_session
+) -> None:
+    """Archiving frees the slot — operators sometimes archive then
+    re-add to reset a misconfigured source after fixing share perms
+    upstream. The dedup guard scopes to ``archived_at IS NULL`` so
+    this stays open.
+    """
+    _, raw, workspace = seed_workspace
+    config = {
+        "documents": [
+            {"title": "T", "filename": "t.md", "body_md": "# T"}
+        ]
+    }
+    first = await v1_client.post(
+        f"/v1/workspaces/{workspace.id}/knowledge/sources",
+        headers=_auth(raw),
+        json={"kind": "static_upload", "name": "First", "config": config},
+    )
+    assert first.status_code == 201
+    archived = await v1_client.post(
+        f"/v1/workspaces/{workspace.id}/knowledge/sources/"
+        f"{first.json()['id']}/archive",
+        headers=_auth(raw),
+    )
+    assert archived.status_code == 200
+
+    second = await v1_client.post(
+        f"/v1/workspaces/{workspace.id}/knowledge/sources",
+        headers=_auth(raw),
+        json={"kind": "static_upload", "name": "Re-added", "config": config},
+    )
+    assert second.status_code == 201, second.text


### PR DESCRIPTION
## Summary

Three fixes for the Notion knowledge connector after seeing one closed-beta workspace where the integration was healthy but `bucket_articles` stayed empty: hub pages indexed only `<unsupported: child_database>` markers, the source had to be re-synced manually because no cron pulled it, and freshly created sources never auto-fired the first sync.

- **Recursive Notion page tree.** `_walk_page_tree` BFS expands `child_page` blocks into separate `ConnectorPage`s and follows `child_database` blocks into the underlying data source, reusing the existing `_query_data_source_pages` helper. Caps: depth ≤ 3, ≤ 100 pages per top-level ref. Locked subpages are logged + skipped (one HR subpage off a hub shouldn't kill the whole tree); seed pages still surface `ConnectorConfigError` so the wizard keeps teaching the share-page hint. DB-mode refs go through the same walker too, so embedded sub-hubs inside DB entries are recursed into.
- **Scheduled `sync_due_import_sources` cron.** Reserve `CronLockId.KNOWLEDGE_SOURCES_SYNC = 1005` and register `_knowledge_sources_sync_tick` at `*/15 * * * *`. Previously ingestion only ran when an operator opened the sources page in the console (BackgroundTask side-effect on `list_import_sources`).
- **Initial sync on `POST .../knowledge/sources`.** The `sync_due` filter skipped freshly created rows (their next due timestamp is by definition `created_at + interval > now`), so operators had to hit *Sync now* manually to get any content. New `_kick_initial_sync` BackgroundTask runs `sync_import_source` once with `trigger='create'` after the row insert commits.

## Test plan

- [x] `pytest backend/tests/test_connectors_notion.py` — 13/13 (8 existing + 5 new for hub expansion, embedded DB expansion, depth nesting, dedup, locked-seed-vs-locked-subpage)
- [ ] CI: full backend suite (local Postgres for this worktree was migrated to a parallel branch's `0057_priority_state` so DB-bound tests can't run from here; CI rebuilds clean)
- [ ] Manual: connect a Notion hub page in a fresh workspace and confirm subpages + embedded DB entries become `knowledge_note`s within ~15 min
- [ ] Watch `knowledge_sources_sync` log lines after deploy to confirm the cron is firing