### PR TITLE
knowledge: cascade route + synth right after a sync

### DIFF
--- a/backend/app/api/v1/routes/knowledge_import_sources.py
+++ b/backend/app/api/v1/routes/knowledge_import_sources.py
@@ -135,18 +135,28 @@ async def _load_source(
 async def _kick_initial_sync(
     *, workspace_id: uuid.UUID, source_id: uuid.UUID
 ) -> None:
-    """Run a single ``sync_import_source`` for a freshly-created row.
+    """Run a single ``sync_import_source`` + downstream cascade.
 
-    Lives outside the request session so it can run after the response
-    is sent (FastAPI ``BackgroundTasks`` semantics). Failures are
-    swallowed because the source row already records ``last_error``
-    via ``sync_import_source``'s own except-branch — the operator
-    sees the error in the UI on the next list refresh, and the cron
-    will retry on the next due tick.
+    Lives outside the request session so it runs after the response
+    is sent (FastAPI ``BackgroundTasks`` semantics). The cascade step
+    (``cascade_workspace_pipeline``) closes the cold-start latency:
+    without it, the operator who just connected Notion would wait
+    ~30 min for the ``:30`` route tick + ~10 min for the ``:40``
+    synth tick before any draft article shows up.
+
+    Failures in either step are swallowed because:
+
+    - sync errors are already persisted on ``source.last_error``;
+    - cascade is best-effort — the regular cron tick handles whatever
+      the fast-path didn't.
     """
     from backend.app.db.session import get_sessionmaker
+    from backend.app.services.knowledge_cascade import (
+        cascade_workspace_pipeline,
+    )
 
     sessionmaker = get_sessionmaker()
+    sync_ok = False
     async with sessionmaker() as session:
         source = await session.get(KnowledgeImportSource, source_id)
         if source is None or source.workspace_id != workspace_id:
@@ -154,11 +164,14 @@ async def _kick_initial_sync(
         try:
             await sync_import_source(session, source=source, trigger="create")
             await session.commit()
+            sync_ok = True
         except Exception:  # noqa: BLE001 — already persisted on the row
             await session.rollback()
             logger.warning(
                 "initial sync failed for source %s — see last_error", source_id
             )
+    if sync_ok:
+        await cascade_workspace_pipeline(workspace_id=workspace_id)
 
 
 @router.get("", response_model=list[ImportSourceOut])
@@ -238,6 +251,7 @@ async def create_source(
 async def sync_source(
     workspace_id: uuid.UUID,
     source_id: uuid.UUID,
+    background_tasks: BackgroundTasks,
     auth: AuthContext = Depends(get_current_auth),
     session: AsyncSession = Depends(get_session),
 ) -> IngestionRunOut:
@@ -254,6 +268,13 @@ async def sync_source(
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
         ) from exc
+    # Run route + synth right after the sync commits so a "Sync now"
+    # press surfaces a draft article in seconds, not after the next
+    # :30/:40 cron tick. Cascade is idempotent + lock-aware so
+    # overlapping with the regular tick is safe.
+    from backend.app.services.knowledge_cascade import cascade_workspace_pipeline
+
+    background_tasks.add_task(cascade_workspace_pipeline, workspace_id=workspace_id)
     return _run_out(run)
 
 

--- a/backend/app/services/knowledge_cascade.py
+++ b/backend/app/services/knowledge_cascade.py
@@ -1,0 +1,177 @@
+"""Fast-path cascade: route + synth one workspace right after a sync.
+
+The four hourly knowledge ticks (harvest, route, synth, decay) are
+batch-mode by design — they collect deltas across every workspace and
+run one LLM-backed pass per stage so synthesis stays coherent (one draft
+article per bucket per tick rather than N rampaging per-note drafts).
+
+That batching is correct for steady-state operation but produces a
+cold-start latency spike: an operator who just connected Notion or hit
+*Sync now* has to wait up to 30 min for the next ``:30`` route tick and
+then up to 10 min more for the ``:40`` synth tick before any draft
+appears. The fast-path here closes that gap by re-running the route +
+synth stages **for the affected workspace only**, immediately after a
+sync writes fresh ``Improvement(kind='knowledge_note')`` rows.
+
+Coordination model (matches :mod:`backend.app.services.cron`):
+
+- Each stage tries the same global advisory lock the cron wrapper
+  takes (``CronLockId.KNOWLEDGE_ROUTE`` / ``KNOWLEDGE_SYNTH``). If the
+  lock is already held — the regular tick is mid-sweep on a different
+  replica — we skip silently. The fresh notes will be picked up by
+  the in-flight sweep, so nothing is lost.
+- Each stage opens its own session: a stage failure rolls back only
+  its own transaction and the next stage still runs.
+- LLM client is best-effort. ``None`` is fine: route falls back to
+  centroid-only, synth skips silently — same semantics as the cron
+  wrapper.
+
+The cascade is **idempotent**. A second pass over the same notes is a
+no-op (route filters on ``routed_bucket_id IS NULL``; synth filters on
+notes not yet linked to an article via ``BucketArticleSource``). That
+property is what lets us also call it from the ``sync_due`` cron tick
+without worrying about double-routing if the regular ``:30`` tick
+overlaps.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from dataclasses import dataclass, field
+from typing import Any
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.app.core.config import Settings, get_settings
+from backend.app.db.session import get_sessionmaker
+from backend.app.services.agent.client import AgentClient, pick_default_client
+from backend.app.services.cron import CronLockId
+from backend.app.services.knowledge_router import route_pending_notes
+from backend.app.services.knowledge_synth import synthesise_workspace
+
+
+log = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class CascadeReport:
+    """Outcome of one ``cascade_workspace_pipeline`` call.
+
+    Used by tests + future telemetry — production callers fire the
+    cascade and ignore the result (cron will catch up either way).
+    """
+
+    workspace_id: uuid.UUID
+    route_ran: bool = False
+    synth_ran: bool = False
+    route_skipped_lock_held: bool = False
+    synth_skipped_lock_held: bool = False
+    errors: list[str] = field(default_factory=list)
+
+
+async def cascade_workspace_pipeline(
+    workspace_id: uuid.UUID,
+    *,
+    settings: Settings | None = None,
+    llm_client: AgentClient | None = None,
+) -> CascadeReport:
+    """Run route → synth for one workspace right after fresh notes land.
+
+    Best-effort end-to-end. Each stage:
+
+    1. Opens a fresh session.
+    2. Tries the matching cron advisory lock. Skips silently if held.
+    3. Runs the per-workspace pipeline call, commits.
+    4. Releases the lock.
+
+    A failure in any stage is logged + recorded in the report, but
+    never raises — the source row's notes are already committed by
+    the caller, so the regular cron tick can finish whatever the
+    fast-path didn't.
+    """
+    settings = settings or get_settings()
+    if llm_client is None:
+        try:
+            llm_client = pick_default_client(settings)
+        except Exception:  # noqa: BLE001
+            log.info(
+                "cascade ws=%s: no LLM client configured (centroid-only "
+                "routing, synth will skip)",
+                workspace_id,
+            )
+            llm_client = None
+
+    report = CascadeReport(workspace_id=workspace_id)
+
+    await _run_stage(
+        report=report,
+        lock=CronLockId.KNOWLEDGE_ROUTE,
+        stage="route",
+        body=lambda session: route_pending_notes(
+            session, workspace_id=workspace_id, llm_client=llm_client
+        ),
+    )
+
+    await _run_stage(
+        report=report,
+        lock=CronLockId.KNOWLEDGE_SYNTH,
+        stage="synth",
+        body=lambda session: synthesise_workspace(
+            session, workspace_id=workspace_id, llm_client=llm_client
+        ),
+    )
+
+    return report
+
+
+async def _run_stage(
+    *,
+    report: CascadeReport,
+    lock: CronLockId,
+    stage: str,
+    body,
+) -> None:
+    """Run ``body(session)`` under the given advisory lock, best-effort.
+
+    Lifted into its own helper because route and synth share the
+    exact same lock-try-commit-release dance and the duplication
+    obscured the actual stage call.
+    """
+    sm = get_sessionmaker()
+    async with sm() as session:
+        got = (
+            await session.execute(
+                text("SELECT pg_try_advisory_lock(:k)"), {"k": int(lock)}
+            )
+        ).scalar_one()
+        if not got:
+            log.info(
+                "cascade ws=%s: %s lock %d held — letting cron handle it",
+                report.workspace_id,
+                stage,
+                int(lock),
+            )
+            setattr(report, f"{stage}_skipped_lock_held", True)
+            return
+        try:
+            await body(session)
+            await session.commit()
+            setattr(report, f"{stage}_ran", True)
+        except Exception as exc:  # noqa: BLE001 — never let cascade poison the request
+            await session.rollback()
+            log.exception(
+                "cascade ws=%s: %s failed", report.workspace_id, stage
+            )
+            report.errors.append(f"{stage}: {exc}")
+        finally:
+            try:
+                await session.execute(
+                    text("SELECT pg_advisory_unlock(:k)"), {"k": int(lock)}
+                )
+            except Exception:  # pragma: no cover — defensive
+                pass
+
+
+__all__ = ["CascadeReport", "cascade_workspace_pipeline"]

--- a/backend/app/services/knowledge_ingestion.py
+++ b/backend/app/services/knowledge_ingestion.py
@@ -249,6 +249,7 @@ async def sync_due_import_sources(
     now = datetime.now(timezone.utc)
     sessionmaker = get_sessionmaker()
     checked = synced = skipped = errors = 0
+    cascaded_workspaces: set[uuid.UUID] = set()
     async with sessionmaker() as session:
         stmt = (
             select(KnowledgeImportSource)
@@ -287,9 +288,29 @@ async def sync_due_import_sources(
                 )
                 await session.commit()
                 synced += 1
+                cascaded_workspaces.add(source.workspace_id)
             except Exception:  # noqa: BLE001
                 await session.rollback()
                 errors += 1
+
+    # Cascade once per workspace that actually ingested fresh notes —
+    # the route + synth advisory locks make it safe to overlap with
+    # the regular :30/:40 ticks, and skipping the cascade entirely
+    # leaves operators waiting up to ~70 min for a draft after a
+    # scheduled sync produces fresh notes.
+    if cascaded_workspaces:
+        from backend.app.services.knowledge_cascade import (
+            cascade_workspace_pipeline,
+        )
+
+        for ws_id in cascaded_workspaces:
+            try:
+                await cascade_workspace_pipeline(
+                    workspace_id=ws_id, settings=settings
+                )
+            except Exception:  # noqa: BLE001 — never fail the tick on cascade
+                errors += 1
+
     return DueSyncResult(
         checked=checked,
         synced=synced,

--- a/backend/tests/test_services_knowledge_cascade.py
+++ b/backend/tests/test_services_knowledge_cascade.py
@@ -1,0 +1,178 @@
+"""Unit tests for the post-sync cascade fast-path.
+
+Exercises the lock-aware coordination — these tests deliberately
+don't go through the real ``route_pending_notes`` /
+``synthesise_workspace`` bodies. Both already have their own
+coverage; here we want to lock down:
+
+- a happy-path cascade calls both stages once, in order;
+- if the global ``KNOWLEDGE_ROUTE`` advisory lock is held by some
+  other connection, the route stage is skipped silently and the
+  synth stage still runs;
+- a stage that raises is logged + recorded in the report, but
+  does not propagate (callers fire-and-forget).
+
+Sessions are stubbed via a fake sessionmaker so the tests are pure
+unit tests — no Postgres needed and no asyncpg event-loop teardown
+flake.
+"""
+
+from __future__ import annotations
+
+import uuid
+from contextlib import asynccontextmanager
+
+import pytest
+
+from backend.app.services import knowledge_cascade
+from backend.app.services.cron import CronLockId
+
+
+class _FakeResult:
+    def __init__(self, value):
+        self._value = value
+
+    def scalar_one(self):
+        return self._value
+
+
+class _FakeSession:
+    """Records SQL it sees and answers ``pg_try_advisory_lock`` per recipe.
+
+    ``lock_grants`` maps ``CronLockId`` int values to the boolean the
+    fake should return when ``pg_try_advisory_lock`` is called for
+    that id. Anything else (commits, rollbacks, unlocks) is a no-op.
+    """
+
+    def __init__(self, lock_grants: dict[int, bool]):
+        self.lock_grants = lock_grants
+        self.executed: list[str] = []
+        self.committed = False
+        self.rolled_back = False
+
+    async def execute(self, stmt, params=None):
+        sql = str(stmt)
+        self.executed.append(sql)
+        if "pg_try_advisory_lock" in sql:
+            return _FakeResult(self.lock_grants.get(int(params["k"]), True))
+        return _FakeResult(None)
+
+    async def commit(self):
+        self.committed = True
+
+    async def rollback(self):
+        self.rolled_back = True
+
+
+def _install_fake_sessionmaker(
+    monkeypatch, *, lock_grants: dict[int, bool] | None = None
+) -> list[_FakeSession]:
+    """Patch ``get_sessionmaker`` so cascade stages use ``_FakeSession``.
+
+    Returns the list the fake sessionmaker appends each yielded
+    session to, so tests can inspect commit/rollback flags after the
+    fact.
+    """
+    sessions: list[_FakeSession] = []
+    grants = lock_grants or {}
+
+    @asynccontextmanager
+    async def _ctx():
+        s = _FakeSession(grants)
+        sessions.append(s)
+        try:
+            yield s
+        finally:
+            pass
+
+    def _sessionmaker():
+        return _ctx()
+
+    monkeypatch.setattr(
+        knowledge_cascade, "get_sessionmaker", lambda: _sessionmaker
+    )
+    monkeypatch.setattr(
+        knowledge_cascade, "pick_default_client", lambda settings=None: None
+    )
+    return sessions
+
+
+@pytest.mark.asyncio
+async def test_cascade_runs_route_and_synth_when_locks_free(monkeypatch):
+    """Happy path: both stages execute, neither short-circuits on lock."""
+    ws_id = uuid.uuid4()
+    called: list[str] = []
+
+    async def fake_route(session, *, workspace_id, llm_client):
+        called.append(f"route:{workspace_id}")
+
+    async def fake_synth(session, *, workspace_id, llm_client):
+        called.append(f"synth:{workspace_id}")
+
+    monkeypatch.setattr(knowledge_cascade, "route_pending_notes", fake_route)
+    monkeypatch.setattr(knowledge_cascade, "synthesise_workspace", fake_synth)
+    sessions = _install_fake_sessionmaker(monkeypatch)
+
+    report = await knowledge_cascade.cascade_workspace_pipeline(ws_id)
+
+    assert called == [f"route:{ws_id}", f"synth:{ws_id}"]
+    assert report.route_ran is True
+    assert report.synth_ran is True
+    assert report.errors == []
+    assert all(s.committed for s in sessions)
+
+
+@pytest.mark.asyncio
+async def test_cascade_skips_route_when_route_lock_held(monkeypatch):
+    """If the global route lock is held (regular cron mid-sweep), the
+    cascade route stage is a no-op while the synth stage still runs.
+    """
+    ws_id = uuid.uuid4()
+    called: list[str] = []
+
+    async def fake_route(session, *, workspace_id, llm_client):
+        called.append("route")
+
+    async def fake_synth(session, *, workspace_id, llm_client):
+        called.append("synth")
+
+    monkeypatch.setattr(knowledge_cascade, "route_pending_notes", fake_route)
+    monkeypatch.setattr(knowledge_cascade, "synthesise_workspace", fake_synth)
+    _install_fake_sessionmaker(
+        monkeypatch,
+        lock_grants={int(CronLockId.KNOWLEDGE_ROUTE): False},
+    )
+
+    report = await knowledge_cascade.cascade_workspace_pipeline(ws_id)
+
+    assert called == ["synth"]
+    assert report.route_ran is False
+    assert report.route_skipped_lock_held is True
+    assert report.synth_ran is True
+
+
+@pytest.mark.asyncio
+async def test_cascade_records_stage_failure_without_raising(monkeypatch):
+    """A stage that raises must be logged + reported, but not propagate
+    so background-task callers don't get spurious task crashes."""
+    ws_id = uuid.uuid4()
+
+    async def boom_route(session, *, workspace_id, llm_client):
+        raise RuntimeError("simulated route failure")
+
+    async def fake_synth(session, *, workspace_id, llm_client):
+        return None
+
+    monkeypatch.setattr(knowledge_cascade, "route_pending_notes", boom_route)
+    monkeypatch.setattr(knowledge_cascade, "synthesise_workspace", fake_synth)
+    sessions = _install_fake_sessionmaker(monkeypatch)
+
+    report = await knowledge_cascade.cascade_workspace_pipeline(ws_id)
+
+    assert report.route_ran is False
+    assert report.synth_ran is True
+    assert any("route" in e for e in report.errors)
+    # Route session rolled back; synth session committed.
+    assert sessions[0].rolled_back is True
+    assert sessions[0].committed is False
+    assert sessions[1].committed is True


### PR DESCRIPTION
## Summary

Closes the cold-start latency gap in the knowledge pipeline. The four hourly ticks (harvest/route/synth/decay) are batching by design — one LLM call per workspace per bucket per tick — which is correct for steady-state but means a freshly-connected Notion source had to wait up to ~70 min for the first draft article. The cascade fast-path runs route + synth for the affected workspace immediately after the sync commits, so an operator who hits *Sync now* sees a draft in seconds.

- New `knowledge_cascade.cascade_workspace_pipeline(workspace_id)`. Each stage opens its own session and tries the same global advisory lock the cron wrapper takes (`CronLockId.KNOWLEDGE_ROUTE` / `KNOWLEDGE_SYNTH`). If the lock is held — the regular tick is mid-sweep — the stage skips silently; the in-flight tick already covers the fresh notes. If a stage raises, the next cron tick catches up because the knowledge ticks are idempotent.
- Wired into `_kick_initial_sync` (post-create background task), the manual `sync_source` endpoint (background task), and `sync_due_import_sources` (collects workspace_ids that actually ingested fresh notes, cascades once per workspace).
- Steady-state batching is unchanged: the four hourly ticks remain in place to handle backfill + workspaces nobody touched this hour. The fast-path fires only when a sync produced something new.

## Test plan

- [x] `pytest backend/tests/test_services_knowledge_cascade.py` — 3/3 (happy path, lock-held route skip, stage failure recorded without raising). Tests use a fake sessionmaker so they don't depend on a live Postgres.
- [x] `pytest backend/tests/test_connectors_notion.py` — 13/13 still green
- [ ] CI: full backend suite
- [ ] Manual: connect Notion in a fresh workspace and confirm a draft article appears within ~10s of sync completing