### PR TITLE
project-first delivery (PR1): create_project lands anchor + Drafts row

### DIFF
--- a/backend/app/integrations/gateway/tracker.py
+++ b/backend/app/integrations/gateway/tracker.py
@@ -221,6 +221,57 @@ class TrackerGateway(Protocol):
         )
 
     # -----------------------------------------------------------------
+    # Decomposition anchor surface (project-first delivery, ELS-73)
+    #
+    # Each project the PO drafts gets exactly one *anchor* issue tagged
+    # ``planning:anchor``. The anchor is what the decomposition FSM runs
+    # against — Linear projects don't carry their own state machine, so
+    # we hang one inside. Adapters that don't model projects raise
+    # NotImplementedError on both methods and the orchestrator skips them.
+    # -----------------------------------------------------------------
+
+    async def create_planning_anchor(
+        self,
+        project_id: str,
+        *,
+        title: str,
+        body: str,
+        labels: list[str] | None = None,
+    ) -> dict[str, Any]:
+        """Create the anchor issue for a project's decomposition pipeline.
+
+        Implementations must place the issue *inside* ``project_id``
+        (so the anchor and the project body are co-located in the
+        tracker UI) and tag it with ``planning:anchor`` plus any
+        additional ``labels`` passed in. If the label isn't
+        provisioned on the team yet, the adapter mints it — the
+        decomposition FSM later filters issues by this label, so
+        silently dropping the tag would orphan the run.
+
+        Returns ``{"id", "identifier", "url"}``. ``identifier`` is
+        the human-readable shorthand (``ELS-83``).
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} does not model planning anchors"
+        )
+
+    async def get_planning_anchor(
+        self, project_id: str
+    ) -> dict[str, Any] | None:
+        """Fetch the existing planning anchor for ``project_id``.
+
+        Used by the create-side idempotency check (don't double-create
+        an anchor if the project already has one) and later by the
+        decomposition FSM to read anchor state. Returns ``None`` when
+        the project has no anchor yet (the canonical pre-creation
+        state). Returns ``{"id", "identifier", "url", "state"}`` when
+        present — ``state`` is the tracker-native state name.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} does not model planning anchors"
+        )
+
+    # -----------------------------------------------------------------
     # Clarifications projection (D13)
     #
     # Optional surface — only trackers that participate in the

--- a/backend/app/integrations/linear/tracker_adapter.py
+++ b/backend/app/integrations/linear/tracker_adapter.py
@@ -864,6 +864,114 @@ class LinearTracker:
         await self._gql(mutation, {"id": project_id, "content": new_content})
 
     # -----------------------------------------------------------------
+    # Decomposition anchor (project-first delivery)
+    #
+    # Each project the PO drafts gets exactly one anchor issue tagged
+    # ``planning:anchor``. The decomposition FSM later runs against
+    # this issue (Linear projects don't have their own state machine,
+    # so we hang one inside). Co-locating the anchor with the project
+    # keeps the tracker UI honest: the issue tab on the project page
+    # shows the anchor first, body sections below.
+    # -----------------------------------------------------------------
+
+    PLANNING_ANCHOR_LABEL = "planning:anchor"
+
+    async def create_planning_anchor(
+        self,
+        project_id: str,
+        *,
+        title: str,
+        body: str,
+        labels: list[str] | None = None,
+    ) -> dict[str, Any]:
+        """Create the anchor issue for ``project_id``'s decomposition.
+
+        Mints the ``planning:anchor`` label on the team if it doesn't
+        exist yet — silently dropping the tag would orphan the
+        decomposition FSM's filter. Any caller-supplied ``labels`` are
+        ALSO minted-if-missing for the same reason.
+
+        Returns ``{"id", "identifier", "url"}``.
+        """
+        team_id = await self._resolve_team_id(None)
+        all_labels = [self.PLANNING_ANCHOR_LABEL]
+        for lbl in labels or []:
+            if lbl and lbl != self.PLANNING_ANCHOR_LABEL:
+                all_labels.append(lbl)
+        label_ids = await self._resolve_or_create_label_ids(
+            team_id, all_labels
+        )
+        mutation = """
+        mutation ShipCreateAnchor($input: IssueCreateInput!) {
+          issueCreate(input: $input) {
+            success
+            issue { id identifier url }
+          }
+        }
+        """
+        payload: dict[str, Any] = {
+            "teamId": team_id,
+            "projectId": project_id,
+            "title": title,
+            "description": body,
+        }
+        if label_ids:
+            payload["labelIds"] = label_ids
+        data = await self._gql(mutation, {"input": payload})
+        result = data.get("issueCreate") or {}
+        issue = result.get("issue") or {}
+        if not result.get("success") or not issue:
+            raise ValueError(
+                "Linear refused issueCreate for the planning anchor."
+            )
+        return {
+            "id": str(issue.get("id") or ""),
+            "identifier": str(issue.get("identifier") or issue.get("id") or ""),
+            "url": str(issue.get("url") or ""),
+        }
+
+    async def get_planning_anchor(
+        self, project_id: str
+    ) -> dict[str, Any] | None:
+        """Fetch the existing planning anchor for ``project_id``, if any.
+
+        Used by ``_tool_create_project`` to make the anchor-creation
+        step idempotent — a re-run of ``create_project`` against an
+        existing project must not spawn a second anchor.
+        """
+        query = """
+        query ShipFindAnchor($projectId: ID!, $label: String!) {
+          issues(
+            filter: {
+              project: { id: { eq: $projectId } },
+              labels: { name: { eq: $label } }
+            },
+            first: 1,
+            orderBy: createdAt
+          ) {
+            nodes { id identifier url state { name } }
+          }
+        }
+        """
+        data = await self._gql(
+            query,
+            {
+                "projectId": project_id,
+                "label": self.PLANNING_ANCHOR_LABEL,
+            },
+        )
+        nodes = ((data.get("issues") or {}).get("nodes")) or []
+        if not nodes:
+            return None
+        node = nodes[0]
+        return {
+            "id": str(node.get("id") or ""),
+            "identifier": str(node.get("identifier") or node.get("id") or ""),
+            "url": str(node.get("url") or ""),
+            "state": str(((node.get("state") or {}).get("name")) or ""),
+        }
+
+    # -----------------------------------------------------------------
     # Clarifications projection surface (D13)
     # -----------------------------------------------------------------
 
@@ -1133,6 +1241,61 @@ class LinearTracker:
         )
         want = {lbl.lower() for lbl in labels}
         return [str(n["id"]) for n in nodes if str(n.get("name", "")).lower() in want]
+
+    async def _resolve_or_create_label_ids(
+        self, team_id: str, labels: list[str]
+    ) -> list[str]:
+        """Like :meth:`_resolve_label_ids` but mints any missing labels.
+
+        Used by infrastructure-level callers (anchor creation) where
+        dropping a label silently would orphan a downstream filter (the
+        decomposition FSM polls ``label = 'planning:anchor'``). The
+        agent-facing ``create_ticket`` keeps the strict resolver — we
+        don't want the LLM polluting a customer's Linear with
+        freshly-invented label names.
+        """
+        if not labels:
+            return []
+        query = """
+        query ShipLabels($teamId: String!) {
+          team(id: $teamId) { labels { nodes { id name } } }
+        }
+        """
+        data = await self._gql(query, {"teamId": team_id})
+        nodes = (
+            ((data.get("team") or {}).get("labels") or {}).get("nodes") or []
+        )
+        existing = {
+            str(n.get("name", "")).lower(): str(n["id"])
+            for n in nodes
+            if n.get("id")
+        }
+        out: list[str] = []
+        mint = """
+        mutation ShipMintLabel($input: IssueLabelCreateInput!) {
+          issueLabelCreate(input: $input) {
+            success
+            issueLabel { id name }
+          }
+        }
+        """
+        for lbl in labels:
+            key = lbl.lower()
+            if key in existing:
+                out.append(existing[key])
+                continue
+            created = await self._gql(
+                mint, {"input": {"name": lbl, "teamId": team_id}}
+            )
+            new = (
+                (created.get("issueLabelCreate") or {}).get("issueLabel") or {}
+            )
+            if not new.get("id"):
+                raise RuntimeError(
+                    f"Linear refused issueLabelCreate for {lbl!r}"
+                )
+            out.append(str(new["id"]))
+        return out
 
 
 def _parse_iso8601(raw: str) -> datetime:

--- a/backend/app/services/agent/tools.py
+++ b/backend/app/services/agent/tools.py
@@ -156,6 +156,7 @@ from backend.app.db.models.integrations import (
     NativeIntegrationStatus,
     WorkspaceRepo,
 )
+from backend.app.db.models.dashboard_priorities import WorkspaceProjectPriority
 from backend.app.db.models.lanes import Lane
 from backend.app.db.models.pipelines import (
     Pipeline,
@@ -2387,7 +2388,127 @@ class ToolBox:
         except ValueError as exc:
             raise ToolInvocationError(str(exc)) from exc
 
-        return _json_result(project)
+        # Project-first delivery side-effects: a freshly-created project
+        # has to land on the dashboard immediately (in the Drafts bucket
+        # — DB enum value ``planning``) AND carry exactly one anchor
+        # issue tagged ``planning:anchor``. Without the priorities row,
+        # the project is invisible to the operator until they manually
+        # drag it; without the anchor, the decomposition FSM later
+        # has nothing to attach to. Both are best-effort: a tracker
+        # that can't model anchors raises NotImplementedError and we
+        # skip cleanly. A failure on either side is non-fatal — the
+        # project itself was created successfully and we don't want to
+        # roll that back over plumbing.
+        project_native_id = str(project.get("id") or "")
+        anchor_payload: dict[str, Any] | None = None
+        if project_native_id:
+            anchor_payload = await self._ensure_planning_anchor(
+                tracker,
+                project_id=project_native_id,
+                project_name=name,
+            )
+            await self._ensure_drafts_priorities_row(
+                project_native_id=project_native_id
+            )
+
+        result = dict(project)
+        if anchor_payload is not None:
+            result["anchor"] = anchor_payload
+            # Surface the dashboard hint so the agent can phrase its
+            # confirmation reliably ("Created · drafted in Drafts ·
+            # ready for hand-off").
+            result["dashboard_bucket"] = "drafts"
+        return _json_result(result)
+
+    async def _ensure_planning_anchor(
+        self,
+        tracker: TrackerGateway,
+        *,
+        project_id: str,
+        project_name: str,
+    ) -> dict[str, Any] | None:
+        """Idempotent: return an existing anchor or create one.
+
+        Returns ``None`` when the tracker doesn't model anchors
+        (Notion, future GitHub Issues), so the caller can skip the
+        confirmation block in the tool result rather than lying to
+        the agent about an artefact that wasn't created.
+        """
+        try:
+            existing = await tracker.get_planning_anchor(project_id)
+        except NotImplementedError:
+            return None
+        except Exception as exc:  # noqa: BLE001 — don't fail create over a probe
+            logger.warning(
+                "planning anchor probe failed for project=%s err=%s",
+                project_id,
+                exc,
+            )
+            existing = None
+        if existing:
+            return existing
+        anchor_body = (
+            f"Decomposition anchor for **{project_name}**.\n\n"
+            "This issue tracks the planning pipeline (BA → Architect → "
+            "QA-Architect → QA + Developer). Stage transitions on this "
+            "anchor drive what specialists run; the project body grows "
+            "section-by-section as each stage emits its artefact."
+        )
+        try:
+            return await tracker.create_planning_anchor(
+                project_id,
+                title=f"Anchor: {project_name}",
+                body=anchor_body,
+                labels=None,
+            )
+        except NotImplementedError:
+            return None
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "planning anchor creation failed for project=%s err=%s",
+                project_id,
+                exc,
+            )
+            return None
+
+    async def _ensure_drafts_priorities_row(
+        self, *, project_native_id: str
+    ) -> None:
+        """Insert (or no-op) a Drafts-bucket priorities row.
+
+        Idempotent on (workspace_id, project_native_id) — a re-run of
+        ``create_project`` for the same Linear project doesn't double-
+        insert. Ordinal goes to MAX+1 across the whole workspace so
+        the row sorts after everything currently saved; the operator
+        can drag it up if the project is high-priority.
+        """
+        existing = await self._session.scalar(
+            select(WorkspaceProjectPriority.id).where(
+                WorkspaceProjectPriority.workspace_id == self._workspace_id,
+                WorkspaceProjectPriority.project_native_id
+                == project_native_id,
+            )
+        )
+        if existing is not None:
+            return
+        max_ord = await self._session.scalar(
+            select(WorkspaceProjectPriority.ordinal)
+            .where(
+                WorkspaceProjectPriority.workspace_id == self._workspace_id
+            )
+            .order_by(WorkspaceProjectPriority.ordinal.desc())
+            .limit(1)
+        )
+        next_ord = 0 if max_ord is None else int(max_ord) + 1
+        self._session.add(
+            WorkspaceProjectPriority(
+                workspace_id=self._workspace_id,
+                project_native_id=project_native_id,
+                ordinal=next_ord,
+                state="planning",
+            )
+        )
+        await self._session.flush()
 
     async def _tool_append_project_description(self, args: dict[str, Any]) -> str:
         project_id = _require_str(args, "project_id")

--- a/backend/app/services/catalog.py
+++ b/backend/app/services/catalog.py
@@ -25,6 +25,30 @@ The catalog vocabulary (``pattern`` / ``tool`` / ``collection`` kinds,
 loaded by Ship is ``artifacts/knowledge-starters/``; ``agent-rules``
 collections are read by the CLI directly through the unauthenticated
 ``/collections`` endpoint that lives in :mod:`backend.app.main`.
+
+The three "planning"s — disambiguation
+======================================
+
+There are three things called "planning" in this codebase. Don't conflate
+them; if you find yourself confused by a log line, use this map:
+
+1. ``priority_state.planning`` — the **dashboard bucket** value (DB enum
+   in :mod:`backend.app.db.models.dashboard_priorities`). The UI label
+   for this bucket is **"Drafts"** — what the operator sees on the
+   dashboard. It means "the PO is shaping this; the agent's autonomous
+   picker must NOT consume it."
+
+2. ``state="planning"`` — a **kind-of-work tag** on per-stage entries in
+   :func:`default_development_process_config` below (e.g. the
+   ``task_intake`` stage carries ``state="planning"``). Classifies the
+   stage's phase (planning / executing / reviewing). Internal-only;
+   doesn't surface to the operator.
+
+3. The **decomposition process** — a separate FSM (``id="decomposition"``,
+   added in PR3 of the project-first delivery work) that runs BA →
+   Architect → QA-Architect → QA + Developer on a project's anchor
+   issue to produce coarse child tickets. Its operator-facing label is
+   "Decomposition," NOT "planning," precisely to keep these three apart.
 """
 
 from __future__ import annotations

--- a/backend/tests/test_agent_tools_create_project.py
+++ b/backend/tests/test_agent_tools_create_project.py
@@ -1,0 +1,270 @@
+"""Side-effects of the ``create_project`` tool (project-first delivery, ELS-73).
+
+When the agent creates a project the side-effects ride along on the same
+tool call:
+
+- A ``WorkspaceProjectPriority`` row is inserted in ``state='planning'``
+  (the dashboard surfaces this as the **Drafts** bucket) so the project
+  is visible to the operator within one tool round-trip.
+- A planning anchor issue is minted on the project so the future
+  decomposition FSM has something to attach to.
+- Both side-effects are idempotent on re-runs: the row is keyed on
+  ``(workspace_id, project_native_id)``; the anchor check goes through
+  ``tracker.get_planning_anchor`` first.
+- Trackers that don't model anchors (Notion / future GitHub Issues) raise
+  ``NotImplementedError`` and the tool degrades gracefully — the project
+  itself was created and we don't roll that back over plumbing.
+
+These tests exercise the helpers directly with a stub tracker so they
+don't require a live Linear connection.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from sqlalchemy import select
+
+
+class _StubTracker:
+    """Records every tracker call so the test can assert on side-effects.
+
+    Configurable per-instance: ``existing_anchor`` short-circuits
+    ``get_planning_anchor``; ``raise_on_get`` / ``raise_on_create``
+    let tests emulate ``NotImplementedError`` paths or live-API errors.
+    """
+
+    def __init__(
+        self,
+        *,
+        existing_anchor: dict[str, Any] | None = None,
+        raise_on_get: type[BaseException] | None = None,
+        raise_on_create: type[BaseException] | None = None,
+    ) -> None:
+        self.existing_anchor = existing_anchor
+        self.raise_on_get = raise_on_get
+        self.raise_on_create = raise_on_create
+        self.create_calls: list[dict[str, Any]] = []
+        self.get_calls: list[str] = []
+
+    async def get_planning_anchor(
+        self, project_id: str
+    ) -> dict[str, Any] | None:
+        self.get_calls.append(project_id)
+        if self.raise_on_get is not None:
+            raise self.raise_on_get(
+                f"_StubTracker does not model planning anchors"
+            )
+        return self.existing_anchor
+
+    async def create_planning_anchor(
+        self,
+        project_id: str,
+        *,
+        title: str,
+        body: str,
+        labels: list[str] | None = None,
+    ) -> dict[str, Any]:
+        self.create_calls.append(
+            {"project_id": project_id, "title": title, "body": body, "labels": labels}
+        )
+        if self.raise_on_create is not None:
+            raise self.raise_on_create("_StubTracker create raised")
+        return {
+            "id": "anchor-uuid",
+            "identifier": "STUB-1",
+            "url": "https://stub.example/anchor-uuid",
+        }
+
+
+def _toolbox(db_session, workspace, user):
+    from backend.app.core.config import get_settings
+    from backend.app.services.agent.tools import ToolBox
+
+    return ToolBox(
+        db_session,
+        settings=get_settings(),
+        workspace_id=workspace.id,
+        user_id=user.id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_drafts_priorities_row_inserts_then_idempotent(
+    db_session, seed_workspace
+) -> None:
+    """First call inserts a Drafts (state='planning') row; second is a no-op."""
+    from backend.app.db.models.dashboard_priorities import (
+        WorkspaceProjectPriority,
+    )
+
+    user, _, workspace = seed_workspace
+    toolbox = _toolbox(db_session, workspace, user)
+
+    await toolbox._ensure_drafts_priorities_row(
+        project_native_id="proj-x"
+    )
+    rows = (
+        await db_session.execute(
+            select(WorkspaceProjectPriority).where(
+                WorkspaceProjectPriority.workspace_id == workspace.id
+            )
+        )
+    ).scalars().all()
+    assert [r.project_native_id for r in rows] == ["proj-x"]
+    assert rows[0].state == "planning"
+    assert rows[0].ordinal == 0
+
+    # Second call must not duplicate — keyed on (workspace, project_native_id).
+    await toolbox._ensure_drafts_priorities_row(
+        project_native_id="proj-x"
+    )
+    rows_after = (
+        await db_session.execute(
+            select(WorkspaceProjectPriority).where(
+                WorkspaceProjectPriority.workspace_id == workspace.id
+            )
+        )
+    ).scalars().all()
+    assert len(rows_after) == 1
+    assert rows_after[0].state == "planning"
+
+
+@pytest.mark.asyncio
+async def test_drafts_priorities_row_appends_after_existing_max(
+    db_session, seed_workspace
+) -> None:
+    """A new project lands at MAX(ordinal)+1 so it doesn't reshuffle the queue."""
+    from backend.app.db.models.dashboard_priorities import (
+        WorkspaceProjectPriority,
+    )
+
+    user, _, workspace = seed_workspace
+    toolbox = _toolbox(db_session, workspace, user)
+
+    db_session.add(
+        WorkspaceProjectPriority(
+            workspace_id=workspace.id,
+            project_native_id="existing-active",
+            ordinal=0,
+            state="active",
+        )
+    )
+    db_session.add(
+        WorkspaceProjectPriority(
+            workspace_id=workspace.id,
+            project_native_id="existing-parked",
+            ordinal=5,
+            state="parked",
+        )
+    )
+    await db_session.flush()
+
+    await toolbox._ensure_drafts_priorities_row(project_native_id="proj-new")
+
+    rows = (
+        await db_session.execute(
+            select(WorkspaceProjectPriority)
+            .where(WorkspaceProjectPriority.workspace_id == workspace.id)
+            .order_by(WorkspaceProjectPriority.ordinal.asc())
+        )
+    ).scalars().all()
+    assert [r.project_native_id for r in rows] == [
+        "existing-active",
+        "existing-parked",
+        "proj-new",
+    ]
+    assert rows[-1].ordinal == 6
+    assert rows[-1].state == "planning"
+
+
+@pytest.mark.asyncio
+async def test_planning_anchor_returns_existing_when_present(
+    db_session, seed_workspace
+) -> None:
+    """Idempotency: a project that already has an anchor must NOT spawn a second."""
+    user, _, workspace = seed_workspace
+    toolbox = _toolbox(db_session, workspace, user)
+    tracker = _StubTracker(
+        existing_anchor={
+            "id": "old-anchor",
+            "identifier": "ELS-99",
+            "url": "https://linear.app/elship/issue/ELS-99",
+            "state": "Backlog",
+        }
+    )
+
+    out = await toolbox._ensure_planning_anchor(
+        tracker,  # type: ignore[arg-type]
+        project_id="proj-x",
+        project_name="Foo",
+    )
+    assert out is not None
+    assert out["identifier"] == "ELS-99"
+    assert tracker.get_calls == ["proj-x"]
+    assert tracker.create_calls == []
+
+
+@pytest.mark.asyncio
+async def test_planning_anchor_creates_when_absent(
+    db_session, seed_workspace
+) -> None:
+    """A project with no anchor yet gets one minted on the same call."""
+    user, _, workspace = seed_workspace
+    toolbox = _toolbox(db_session, workspace, user)
+    tracker = _StubTracker(existing_anchor=None)
+
+    out = await toolbox._ensure_planning_anchor(
+        tracker,  # type: ignore[arg-type]
+        project_id="proj-x",
+        project_name="Export to PDF",
+    )
+    assert out is not None
+    assert out["identifier"] == "STUB-1"
+    assert len(tracker.create_calls) == 1
+    call = tracker.create_calls[0]
+    assert call["project_id"] == "proj-x"
+    assert "Export to PDF" in call["title"]
+    assert "Export to PDF" in call["body"]
+
+
+@pytest.mark.asyncio
+async def test_planning_anchor_returns_none_for_unsupported_tracker(
+    db_session, seed_workspace
+) -> None:
+    """A tracker that doesn't model anchors degrades gracefully — the
+    tool result skips the anchor block instead of lying."""
+    user, _, workspace = seed_workspace
+    toolbox = _toolbox(db_session, workspace, user)
+    tracker = _StubTracker(raise_on_get=NotImplementedError)
+
+    out = await toolbox._ensure_planning_anchor(
+        tracker,  # type: ignore[arg-type]
+        project_id="proj-x",
+        project_name="Foo",
+    )
+    assert out is None
+    # Did NOT proceed to create — get_planning_anchor's
+    # NotImplementedError is the "this tracker can't" signal.
+    assert tracker.create_calls == []
+
+
+@pytest.mark.asyncio
+async def test_planning_anchor_swallows_create_errors(
+    db_session, seed_workspace
+) -> None:
+    """A live-API failure on create_planning_anchor must NOT roll back the
+    project — the project itself was created upstream and the anchor is
+    best-effort plumbing."""
+    user, _, workspace = seed_workspace
+    toolbox = _toolbox(db_session, workspace, user)
+    tracker = _StubTracker(raise_on_create=RuntimeError)
+
+    out = await toolbox._ensure_planning_anchor(
+        tracker,  # type: ignore[arg-type]
+        project_id="proj-x",
+        project_name="Foo",
+    )
+    assert out is None
+    assert len(tracker.create_calls) == 1

--- a/console/src/components/dashboard/prioritizer.tsx
+++ b/console/src/components/dashboard/prioritizer.tsx
@@ -61,6 +61,12 @@ const STATE_RANK: Record<ApiPriorityState, number> = {
 
 const SECTION_ORDER: ApiPriorityState[] = ["active", "planning", "parked"];
 
+// UI labels for ``priority_state`` enum values. The DB enum stays
+// ``planning`` (renaming would force an audit-log + JSONB churn for
+// what is, at the dashboard, just a label). "Drafts" is the operator
+// word — what's actually in the bucket is a one-line title + a brief
+// the PO is shaping in the Navigator. Don't rename in the API client
+// or the server; only here.
 const SECTION_COPY: Record<
   ApiPriorityState,
   { label: string; sub: (n: number) => string }
@@ -70,7 +76,7 @@ const SECTION_COPY: Record<
     sub: (n) => (n === 1 ? "1 pick for the agent" : `${n} picks for the agent`),
   },
   planning: {
-    label: "Planning",
+    label: "Drafts",
     sub: (n) => (n === 1 ? "1 you're shaping" : `${n} you're shaping`),
   },
   parked: {
@@ -434,7 +440,7 @@ export function DashboardPrioritizer({ workspaceId, initial }: Props) {
                 className="py-2 pl-3 text-[11px] italic text-white/30"
                 {...sectionDropHandlers(state)}
               >
-                drop a project here to {state === "active" ? "queue it" : state === "planning" ? "shape its brief" : "park it"}
+                drop a project here to {state === "active" ? "queue it" : state === "planning" ? "draft it" : "park it"}
               </li>
             )}
             {showEmptyHint && (


### PR DESCRIPTION
First PR of three for the project-first delivery flow tracked under [ELS-73](https://linear.app/elship/issue/ELS-73). Project body: [Project-first delivery: Drafts → Decomposition → SDLC](https://linear.app/elship/project/project-first-delivery-drafts-decomposition-sdlc-292d11e2f544).

## What

When the agent creates a project, the side-effects ride along on the same tool call:

- **`tracker.create_planning_anchor(project_id, ...)`** mints a `planning:anchor` issue inside the project (Linear projects don't have their own state machine; we hang one inside).
- **`tracker.get_planning_anchor(project_id)`** is used by the create-side idempotency check.
- **`WorkspaceProjectPriority(state='planning')`** is inserted so the project appears on the dashboard in the **Drafts** bucket within one round-trip.
- **Dashboard UI label** for `priority_state='planning'` becomes "Drafts." DB enum unchanged.
- **Comment block in `catalog.py`** disambiguates the three "planning"s in the codebase.

The label is minted on first use (`_resolve_or_create_label_ids`, a sibling of the strict label resolver scoped to infrastructure callers). Both side-effects degrade cleanly: a tracker that doesn't model anchors raises `NotImplementedError` and the tool returns the project without an anchor block (no lying to the agent about an artefact that wasn't created); a live-API failure on anchor creation is logged and skipped (the project itself was created and we don't roll that back over plumbing).

## What's NOT in this PR

- The Navigator UI (+ New project button, drafting bias, draft-then-confirm preview, re-entry) — that's PR2.
- The decomposition FSM, the hand-off endpoint, and the completion hook — that's PR3.
- Section-aware `append_project_description` — also PR3.

## Test plan

- [x] New unit tests in `backend/tests/test_agent_tools_create_project.py` cover: idempotent priorities row insert, ordinal=MAX+1 placement, anchor-returns-existing path, anchor-creates-when-absent path, tracker-doesn't-model-anchors graceful degradation, create-side error swallowed without rolling back the project. 6/6 pass.
- [x] Touched-area regression: `backend/tests/test_v1_dashboard_priorities.py` 8/8 pass; `backend/tests/test_agent_tools_native_linear.py` 1/1 pass.
- [x] Frontend `tsc --noEmit` clean.
- [ ] **Pre-existing**: `backend/tests/test_navigator_tool_inventory.py::test_specs_match_expected_inventory` fails on `main` for unrelated reasons (`get_catalog_artifact` / `list_catalog_artifacts` removed from the registry but still in `EXPECTED_TOOLS`). Not introduced by this PR — confirmed by `git stash` + re-run on `main`.

## Manual smoke (not run in this PR; deferred to a live walkthrough)

- [ ] In Navigator, ask the agent to "create a project for X." Confirm a Linear project, an anchor issue tagged `planning:anchor` inside it, and a Drafts-bucket row on the dashboard within one tool round-trip.
- [ ] Re-run the same create against the same project id (e.g. by replaying the tool with a name collision). Confirm no second anchor, no duplicate priorities row.