### PR TITLE
project-first delivery (PR2): Navigator drafting UX + Continue shaping

### DIFF
--- a/backend/app/api/v1/routes/chat.py
+++ b/backend/app/api/v1/routes/chat.py
@@ -124,6 +124,10 @@ class ChatThreadOut(BaseModel):
     updated_at: datetime
     message_count: int
     messages: list[ChatMessageOut]
+    # Conversation purpose tag (``shape_project`` for drafting mode,
+    # null otherwise). Surfaced so the client can render mode-specific
+    # UI hints (e.g. a subtle "Drafting a project" banner).
+    intent: str | None = None
 
 
 class ChatThreadSummaryOut(BaseModel):
@@ -150,6 +154,12 @@ class ChatActiveNewIn(BaseModel):
     title: str | None = Field(default=None, max_length=512)
     pack_into_bucket_slug: str | None = Field(default=None, max_length=120)
     pack_into_bucket_name: str | None = Field(default=None, max_length=255)
+    # Conversation purpose. ``shape_project`` flips Navigator into
+    # drafting mode (system prompt biases toward shaping a brief and
+    # waiting for explicit confirmation before calling create_project).
+    # NULL = default chat. The dashboard's "+ New project" CTA passes
+    # ``shape_project``; everything else leaves it null.
+    intent: Literal["shape_project"] | None = None
 
 
 class ChatStreamIn(BaseModel):
@@ -309,6 +319,7 @@ def _thread_to_out(
         updated_at=thread.updated_at,
         message_count=len(messages),
         messages=[_msg_to_out(m) for m in messages],
+        intent=thread.intent,
     )
 
 
@@ -455,9 +466,11 @@ async def new_active_thread(
     fresh = ChatThread(
         workspace_id=workspace_id,
         created_by_user_id=auth.user.id,
-        title=payload.title or "New conversation",
+        title=payload.title
+        or ("Drafting a project" if payload.intent == "shape_project" else "New conversation"),
         status="active",
         last_user_activity_at=datetime.now(timezone.utc),
+        intent=payload.intent,
     )
     session.add(fresh)
     await session.flush()
@@ -702,6 +715,11 @@ async def _run_agent_turn(
         # so the tool can promote hits from the repo the user is
         # browsing into the top rank band even on a zero-arg tool call.
         active_repo_id=thread.repo_id,
+        # ELS-74 (drafting mode): pass the active thread context so
+        # ``create_project`` can stamp ``originating_thread_id`` on
+        # the priorities row for a future "Continue shaping" deep-link.
+        thread_id=thread.id,
+        thread_intent=thread.intent,
     )
 
     messages = await _thread_messages(session, thread.id)

--- a/backend/app/api/v1/routes/dashboard_priorities.py
+++ b/backend/app/api/v1/routes/dashboard_priorities.py
@@ -118,6 +118,11 @@ class PriorityProjectOut(BaseModel):
     # Null only for unprioritised tail rows that don't have a saved
     # priorities row yet — the UI treats those as "drag in to bucket".
     priority_state: PriorityState | None
+    # Backref to the Navigator thread the project was drafted in. The
+    # dashboard renders a "Continue shaping" link on Drafts rows when
+    # this is set; null for projects created outside Navigator or
+    # before the drafting flow shipped.
+    originating_thread_id: uuid.UUID | None
     # Completion magnitude. ``total`` is None when the tracker can't
     # tell us — the UI renders ``—`` and skips the bar.
     completed: int | None
@@ -392,6 +397,7 @@ async def get_priorities(
                 color=str(raw.get("color") or "") or None,
                 ordinal=saved.ordinal if saved else None,
                 priority_state=priority_state,
+                originating_thread_id=saved.originating_thread_id if saved else None,
                 completed=completed,
                 total=total,
             )

--- a/backend/app/db/models/agent_surface.py
+++ b/backend/app/db/models/agent_surface.py
@@ -299,6 +299,14 @@ class ChatThread(Base):
     )
     resolved_ticket_ref: Mapped[str | None] = mapped_column(String(255), nullable=True)
 
+    # Conversation purpose tag. NULL means "default Navigator chat";
+    # ``shape_project`` flips the system prompt into drafting mode (the
+    # agent reflects scope, asks the sharpest open question, drafts the
+    # body inline, and waits for explicit confirmation before calling
+    # ``create_project``). Set once on creation by the dashboard's
+    # "+ New project" CTA; never mutated.
+    intent: Mapped[str | None] = mapped_column(String(32), nullable=True)
+
     # --- C12 single-window UX ---
     # Natural-language recap rendered as a sentinel "Packed → bucket X"
     # message in the chat UI when the thread is packed into a bucket.

--- a/backend/app/db/models/dashboard_priorities.py
+++ b/backend/app/db/models/dashboard_priorities.py
@@ -83,6 +83,17 @@ class WorkspaceProjectPriority(Base):
         nullable=False,
         server_default=text("'active'"),
     )
+    # Backref to the Navigator thread this project was drafted in.
+    # Powers the "Continue shaping" link on Drafts-bucket rows: clicking
+    # re-opens the originating conversation rather than spawning a new
+    # one (the agent then prefers ``append_project_description`` over
+    # creating a duplicate). Null for projects that predate the drafting
+    # flow or were created outside Navigator (e.g. directly in Linear).
+    originating_thread_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("chat_threads.id", ondelete="SET NULL"),
+        nullable=True,
+    )
 
     created_at: Mapped[datetime] = _ts_created()
     updated_at: Mapped[datetime] = _ts_updated()

--- a/backend/app/services/agent/tools.py
+++ b/backend/app/services/agent/tools.py
@@ -276,6 +276,8 @@ class ToolBox:
         workspace_id: uuid.UUID,
         user_id: uuid.UUID,
         active_repo_id: uuid.UUID | None = None,
+        thread_id: uuid.UUID | None = None,
+        thread_intent: str | None = None,
     ) -> None:
         self._session = session
         self._settings = settings
@@ -288,6 +290,16 @@ class ToolBox:
         # tool call. ``None`` means "workspace-wide, no preferred
         # repo" which is the pre-7C behaviour of every existing tool.
         self._active_repo_id = active_repo_id
+        # ELS-74 (drafting mode): ``_tool_create_project`` writes
+        # ``originating_thread_id`` onto the priorities row when these
+        # are set, so the dashboard can later render a "Continue
+        # shaping" link that re-opens the originating Navigator thread
+        # instead of fragmenting the conversation. ``thread_intent``
+        # is exposed so individual tools could specialise their copy
+        # in drafting mode (e.g. confirmation strings) — today only
+        # ``_tool_create_project`` reads it.
+        self._thread_id = thread_id
+        self._thread_intent = thread_intent
 
     # ------------------------------------------------------------------
     # Tool specs — the "what the LLM sees" side of the surface
@@ -2481,15 +2493,28 @@ class ToolBox:
         insert. Ordinal goes to MAX+1 across the whole workspace so
         the row sorts after everything currently saved; the operator
         can drag it up if the project is high-priority.
+
+        When the toolbox knows the thread that drove this call (i.e.
+        the Navigator was in drafting mode) we stamp it onto the row
+        as ``originating_thread_id`` so the dashboard can render a
+        **Continue shaping** link straight back to that conversation.
         """
         existing = await self._session.scalar(
-            select(WorkspaceProjectPriority.id).where(
+            select(WorkspaceProjectPriority).where(
                 WorkspaceProjectPriority.workspace_id == self._workspace_id,
                 WorkspaceProjectPriority.project_native_id
                 == project_native_id,
             )
         )
         if existing is not None:
+            # Backfill the thread link if the row was created earlier
+            # without one (e.g. the agent created the project in a
+            # default thread, then later re-created in a drafting
+            # thread). Don't overwrite an existing link — first thread
+            # wins so the deep-link doesn't drift.
+            if existing.originating_thread_id is None and self._thread_id is not None:
+                existing.originating_thread_id = self._thread_id
+                await self._session.flush()
             return
         max_ord = await self._session.scalar(
             select(WorkspaceProjectPriority.ordinal)
@@ -2506,6 +2531,7 @@ class ToolBox:
                 project_native_id=project_native_id,
                 ordinal=next_ord,
                 state="planning",
+                originating_thread_id=self._thread_id,
             )
         )
         await self._session.flush()

--- a/backend/app/services/agent/topic.py
+++ b/backend/app/services/agent/topic.py
@@ -99,6 +99,39 @@ def _load_navigator_prompt() -> str:
     return default.prompt.strip()
 
 
+_PROJECT_DRAFTING_MODE_PROMPT = (
+    "## Mode: Project drafting\n"
+    "\n"
+    "This thread was opened from the dashboard's **+ New project** "
+    "CTA. The user is here to shape ONE feature vision into a "
+    "Linear project (or Jira epic). Run the conversation like this:\n"
+    "\n"
+    "1. **Reflect** the user's idea back in 3 short bullets — who it's "
+    "for, why it matters, what's explicitly out of scope. Don't pad.\n"
+    "2. **Ask the single sharpest open question** that closes the "
+    "biggest ambiguity. ONE question per turn — not a checklist.\n"
+    "3. As the brief firms up, **draft the project body inline as a "
+    "preview** (a markdown block titled `## Project draft`). Sections: "
+    "**Goal**, **Scope**, **Non-goals**, **Open questions**. Edit the "
+    "preview across turns; don't rewrite the whole thing each time.\n"
+    "4. **Do NOT call `create_project` until the user explicitly "
+    "confirms** ('save it', 'looks good', 'ship it', equivalent). "
+    "Premature commit is the failure mode this mode exists to "
+    "prevent — the project ends up on the dashboard before the brief "
+    "is ready, then sits there as noise.\n"
+    "5. After `create_project` lands, **prefer "
+    "`append_project_description`** over chatter for any further body "
+    "edits. NEVER spawn a second `create_project` for the same idea — "
+    "that produces ghost projects on the dashboard.\n"
+    "\n"
+    "The dashboard places the new project in the **Drafts** bucket "
+    "(internal enum value `priority_state='planning'`). The agent's "
+    "autonomous picker does not consume Drafts — the user has to "
+    "explicitly hand the project off to decomposition before any "
+    "specialist runs. You don't need to tell the user this; just "
+    "don't promise immediate work."
+)
+
 _NAVIGATOR_FALLBACK_PROMPT = (
     "You are Ship Navigator, a software-engineering agent in a single "
     "chat window. Be concrete, accurate, concise. Use tools whenever "
@@ -898,6 +931,21 @@ class TopicService:
         if policies_preamble:
             out.append(
                 ChatMessage(role="system", content=policies_preamble)
+            )
+        # ELS-74: drafting mode. When the thread carries
+        # ``intent='shape_project'`` the dashboard's "+ New project" CTA
+        # opened it; bias Navigator toward shaping a brief and waiting
+        # for explicit confirmation before calling ``create_project``.
+        # The block lives here (after policies, before per-thread
+        # warmed memory) so workspace-level rules still take precedence
+        # but the mode override beats the topic summary, which can
+        # drift across turns.
+        if thread.intent == "shape_project":
+            out.append(
+                ChatMessage(
+                    role="system",
+                    content=_PROJECT_DRAFTING_MODE_PROMPT,
+                )
             )
         if thread.topic_summary:
             out.append(

--- a/backend/migrations/versions/0058_drafting_intent.py
+++ b/backend/migrations/versions/0058_drafting_intent.py
@@ -1,0 +1,59 @@
+"""chat thread intent + project originating thread (project-first delivery, ELS-74)
+
+Two columns drop in for PR2 of the project-first delivery flow:
+
+- ``chat_threads.intent`` — tags a thread with its conversation purpose.
+  Today only ``shape_project`` is meaningful (the Navigator drafting
+  mode); NULL means "default conversation," matching every existing
+  thread. The system-prompt assembler injects a "Project drafting mode"
+  block when this is set so the agent biases toward shaping a brief
+  rather than calling ``create_project`` immediately.
+
+- ``workspace_project_priorities.originating_thread_id`` — backref to
+  the thread the PO drafted the project in. Lets the dashboard render
+  a "Continue shaping" link on each Drafts row that re-opens the same
+  Navigator thread instead of fragmenting the conversation. Nullable
+  because projects predating this work (and projects created outside
+  Navigator) won't have one.
+
+Revision ID: 0058_drafting_intent
+Revises: 0057_priority_state
+Create Date: 2026-05-05
+"""
+
+from __future__ import annotations
+
+from typing import Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision: str = "0058_drafting_intent"
+down_revision: Union[str, None] = "0057_priority_state"
+branch_labels: Union[str, tuple[str, ...], None] = None
+depends_on: Union[str, tuple[str, ...], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "chat_threads",
+        sa.Column("intent", sa.String(length=32), nullable=True),
+    )
+    op.add_column(
+        "workspace_project_priorities",
+        sa.Column(
+            "originating_thread_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("chat_threads.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column(
+        "workspace_project_priorities", "originating_thread_id"
+    )
+    op.drop_column("chat_threads", "intent")

--- a/backend/tests/test_agent_tools_create_project.py
+++ b/backend/tests/test_agent_tools_create_project.py
@@ -78,7 +78,14 @@ class _StubTracker:
         }
 
 
-def _toolbox(db_session, workspace, user):
+def _toolbox(
+    db_session,
+    workspace,
+    user,
+    *,
+    thread_id=None,
+    thread_intent=None,
+):
     from backend.app.core.config import get_settings
     from backend.app.services.agent.tools import ToolBox
 
@@ -87,6 +94,8 @@ def _toolbox(db_session, workspace, user):
         settings=get_settings(),
         workspace_id=workspace.id,
         user_id=user.id,
+        thread_id=thread_id,
+        thread_intent=thread_intent,
     )
 
 
@@ -248,6 +257,137 @@ async def test_planning_anchor_returns_none_for_unsupported_tracker(
     # Did NOT proceed to create — get_planning_anchor's
     # NotImplementedError is the "this tracker can't" signal.
     assert tracker.create_calls == []
+
+
+@pytest.mark.asyncio
+async def test_drafts_row_stamps_originating_thread_when_provided(
+    db_session, seed_workspace
+) -> None:
+    """When the toolbox knows the active thread (drafting mode) the new
+    priorities row carries ``originating_thread_id`` so the dashboard
+    can deep-link a "Continue shaping" affordance back to the
+    conversation."""
+    import uuid as _uuid
+    from datetime import datetime, timezone
+
+    from backend.app.db.models.agent_surface import ChatThread
+    from backend.app.db.models.dashboard_priorities import (
+        WorkspaceProjectPriority,
+    )
+
+    user, _, workspace = seed_workspace
+    thread = ChatThread(
+        workspace_id=workspace.id,
+        created_by_user_id=user.id,
+        title="Drafting a project",
+        status="active",
+        intent="shape_project",
+        last_user_activity_at=datetime.now(timezone.utc),
+    )
+    db_session.add(thread)
+    await db_session.flush()
+
+    toolbox = _toolbox(
+        db_session,
+        workspace,
+        user,
+        thread_id=thread.id,
+        thread_intent="shape_project",
+    )
+    await toolbox._ensure_drafts_priorities_row(
+        project_native_id="proj-drafted"
+    )
+
+    row = (
+        await db_session.execute(
+            select(WorkspaceProjectPriority).where(
+                WorkspaceProjectPriority.workspace_id == workspace.id,
+                WorkspaceProjectPriority.project_native_id == "proj-drafted",
+            )
+        )
+    ).scalar_one()
+    assert row.originating_thread_id == thread.id
+    assert row.state == "planning"
+
+
+@pytest.mark.asyncio
+async def test_drafts_row_backfills_thread_link_on_existing_row(
+    db_session, seed_workspace
+) -> None:
+    """A project that already has a priorities row but no thread link
+    (e.g. created from a default chat first) gets backfilled when the
+    same project is touched from a drafting thread. The reverse path —
+    overwriting an existing thread link — is rejected so deep-links
+    don't drift."""
+    from datetime import datetime, timezone
+
+    from backend.app.db.models.agent_surface import ChatThread
+    from backend.app.db.models.dashboard_priorities import (
+        WorkspaceProjectPriority,
+    )
+
+    user, _, workspace = seed_workspace
+
+    # Pre-existing priorities row (no thread link).
+    db_session.add(
+        WorkspaceProjectPriority(
+            workspace_id=workspace.id,
+            project_native_id="proj-x",
+            ordinal=0,
+            state="planning",
+        )
+    )
+    await db_session.flush()
+
+    thread = ChatThread(
+        workspace_id=workspace.id,
+        created_by_user_id=user.id,
+        title="Drafting a project",
+        status="active",
+        intent="shape_project",
+        last_user_activity_at=datetime.now(timezone.utc),
+    )
+    db_session.add(thread)
+    await db_session.flush()
+
+    toolbox = _toolbox(
+        db_session, workspace, user, thread_id=thread.id
+    )
+    await toolbox._ensure_drafts_priorities_row(
+        project_native_id="proj-x"
+    )
+
+    row = (
+        await db_session.execute(
+            select(WorkspaceProjectPriority).where(
+                WorkspaceProjectPriority.workspace_id == workspace.id,
+                WorkspaceProjectPriority.project_native_id == "proj-x",
+            )
+        )
+    ).scalar_one()
+    assert row.originating_thread_id == thread.id
+
+    # Second drafting thread — the link must NOT change. First
+    # thread wins so the deep-link doesn't drift.
+    second_thread = ChatThread(
+        workspace_id=workspace.id,
+        created_by_user_id=user.id,
+        title="Different drafting",
+        status="active",
+        intent="shape_project",
+        last_user_activity_at=datetime.now(timezone.utc),
+    )
+    db_session.add(second_thread)
+    await db_session.flush()
+
+    toolbox2 = _toolbox(
+        db_session, workspace, user, thread_id=second_thread.id
+    )
+    await toolbox2._ensure_drafts_priorities_row(
+        project_native_id="proj-x"
+    )
+    await db_session.refresh(row)
+    assert row.originating_thread_id == thread.id
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_v1_chat_active.py
+++ b/backend/tests/test_v1_chat_active.py
@@ -59,3 +59,69 @@ async def test_new_active_archives_previous(v1_client, seed_workspace) -> None:
         f"/v1/workspaces/{workspace.id}/chat/active", headers=auth
     )
     assert resp.json()["id"] == fresh["id"]
+
+
+@pytest.mark.asyncio
+async def test_new_active_persists_intent_shape_project(
+    v1_client, seed_workspace
+) -> None:
+    """The dashboard "+ New project" CTA POSTs ``intent='shape_project'``.
+    The new thread has to carry that intent on read so the system-prompt
+    assembler can inject the drafting-mode block on every turn, and so
+    the client can surface a "drafting" UI hint."""
+    _, raw, workspace = seed_workspace
+    auth = {"Authorization": f"Bearer {raw}"}
+
+    resp = await v1_client.post(
+        f"/v1/workspaces/{workspace.id}/chat/active/new",
+        headers=auth,
+        json={"intent": "shape_project"},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["intent"] == "shape_project"
+    # Default title is mode-specific so the archive list disambiguates
+    # without the operator having to type one.
+    assert body["title"] == "Drafting a project"
+
+    # GET /chat/active also surfaces the intent — the prompt
+    # assembler reads it on every turn, not just at creation.
+    active = await v1_client.get(
+        f"/v1/workspaces/{workspace.id}/chat/active", headers=auth
+    )
+    assert active.json()["intent"] == "shape_project"
+
+
+@pytest.mark.asyncio
+async def test_new_active_intent_defaults_to_null(
+    v1_client, seed_workspace
+) -> None:
+    """A regular "New conversation" click leaves intent null, so the
+    drafting-mode prompt block is NOT injected for default chats."""
+    _, raw, workspace = seed_workspace
+    auth = {"Authorization": f"Bearer {raw}"}
+
+    resp = await v1_client.post(
+        f"/v1/workspaces/{workspace.id}/chat/active/new",
+        headers=auth,
+        json={"title": "Hello"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["intent"] is None
+
+
+@pytest.mark.asyncio
+async def test_new_active_rejects_unknown_intent(
+    v1_client, seed_workspace
+) -> None:
+    """Pydantic Literal guards the enum at the schema layer — a typo'd
+    intent never reaches the DB."""
+    _, raw, workspace = seed_workspace
+    auth = {"Authorization": f"Bearer {raw}"}
+
+    resp = await v1_client.post(
+        f"/v1/workspaces/{workspace.id}/chat/active/new",
+        headers=auth,
+        json={"intent": "shape_banana"},
+    )
+    assert resp.status_code == 422, resp.text

--- a/console/src/app/api/chat/new-thread/route.ts
+++ b/console/src/app/api/chat/new-thread/route.ts
@@ -32,14 +32,20 @@ export async function POST(req: Request): Promise<Response> {
     title?: string | null;
     pack_into_bucket_slug?: string | null;
     pack_into_bucket_name?: string | null;
+    intent?: "shape_project" | null;
   } = {};
   try {
     body = await req.json();
   } catch {
     return NextResponse.json({ error: "bad_json" }, { status: 400 });
   }
-  const { workspace_id, title, pack_into_bucket_slug, pack_into_bucket_name } =
-    body;
+  const {
+    workspace_id,
+    title,
+    pack_into_bucket_slug,
+    pack_into_bucket_name,
+    intent,
+  } = body;
   if (!workspace_id || typeof workspace_id !== "string") {
     return NextResponse.json(
       { error: "workspace_id_required" },
@@ -59,6 +65,7 @@ export async function POST(req: Request): Promise<Response> {
         title: title ?? null,
         pack_into_bucket_slug: pack_into_bucket_slug ?? null,
         pack_into_bucket_name: pack_into_bucket_name ?? null,
+        intent: intent ?? null,
       }),
       cache: "no-store",
     },

--- a/console/src/components/dashboard/prioritizer.tsx
+++ b/console/src/components/dashboard/prioritizer.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import {
   useCallback,
   useEffect,
@@ -87,17 +88,59 @@ const SECTION_COPY: Record<
 
 
 export function DashboardPrioritizer({ workspaceId, initial }: Props) {
+  const router = useRouter();
   const [serverState, setServerState] = useState<ApiPrioritiesResponse>(initial);
   // Working copy of the prioritised rows — only touched while the
   // user is dragging or in keyboard move-mode. Save flushes through
   // the server action, Revert restores from the last server state.
   const [draftOrder, setDraftOrder] = useState<DraftRow[] | null>(null);
   const [pending, startTransition] = useTransition();
+  const [draftingPending, setDraftingPending] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   // Parked section collapses by default — visible (so the operator
   // doesn't forget what they decided not to do) but folded so the
   // editorial single-column rhythm of Active + Planning isn't drowned.
   const [parkedExpanded, setParkedExpanded] = useState(false);
+
+  // ELS-74: dashboard "+ New project" CTA. Opens a fresh Navigator
+  // thread tagged ``intent=shape_project`` and navigates the user
+  // there. The drafting-mode system prompt then biases the agent
+  // toward shaping a brief and waiting for explicit confirmation
+  // before ``create_project`` fires. Errors fall through to the
+  // existing errorMessage band — there's no separate failure surface
+  // for this CTA because failure means "the API is down," which the
+  // tracker hairline already conveys.
+  const startProjectDrafting = useCallback(async () => {
+    if (draftingPending) return;
+    setDraftingPending(true);
+    setErrorMessage(null);
+    try {
+      const res = await fetch("/api/chat/new-thread", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          workspace_id: workspaceId,
+          intent: "shape_project",
+          title: "Drafting a project",
+        }),
+      });
+      if (!res.ok) {
+        setErrorMessage(
+          res.status === 401
+            ? "Session expired — reload to sign in again."
+            : `Couldn't start drafting (HTTP ${res.status}).`,
+        );
+        return;
+      }
+      router.push("/chat");
+    } catch (err) {
+      setErrorMessage(
+        err instanceof Error ? err.message : "Couldn't start drafting.",
+      );
+    } finally {
+      setDraftingPending(false);
+    }
+  }, [draftingPending, router, workspaceId]);
 
   const tracker = serverState.tracker;
   const allProjects = serverState.projects;
@@ -282,6 +325,8 @@ export function DashboardPrioritizer({ workspaceId, initial }: Props) {
         onToggleAutonomy={toggleAutonomy}
         tracker={tracker}
         pending={pending}
+        onStartDrafting={startProjectDrafting}
+        draftingPending={draftingPending}
       >
         <li className="flex items-baseline justify-between gap-4 py-3">
           <p className="text-sm text-white/65">
@@ -312,6 +357,8 @@ export function DashboardPrioritizer({ workspaceId, initial }: Props) {
           onToggleAutonomy={toggleAutonomy}
           tracker={tracker}
           pending={pending}
+          onStartDrafting={startProjectDrafting}
+          draftingPending={draftingPending}
         >
           <li className="space-y-1 py-3 text-[12px]">
             <p className="text-coral/85">
@@ -346,6 +393,8 @@ export function DashboardPrioritizer({ workspaceId, initial }: Props) {
         onToggleAutonomy={toggleAutonomy}
         tracker={tracker}
         pending={pending}
+        onStartDrafting={startProjectDrafting}
+        draftingPending={draftingPending}
       >
         {[0, 1, 2].map((i) => (
           <li
@@ -412,6 +461,8 @@ export function DashboardPrioritizer({ workspaceId, initial }: Props) {
       onToggleAutonomy={toggleAutonomy}
       tracker={tracker}
       pending={pending}
+      onStartDrafting={startProjectDrafting}
+      draftingPending={draftingPending}
     >
       {SECTION_ORDER.map((state) => {
         const rows = rowsByState[state];
@@ -506,6 +557,8 @@ function PrioritizerSection({
   tracker,
   pending,
   onToggleAutonomy,
+  onStartDrafting,
+  draftingPending,
 }: {
   children: React.ReactNode;
   autonomyPaused: boolean;
@@ -514,6 +567,8 @@ function PrioritizerSection({
   tracker: ApiPriorityTracker;
   pending: boolean;
   onToggleAutonomy: () => void;
+  onStartDrafting: () => void;
+  draftingPending: boolean;
 }) {
   return (
     <section className="space-y-3">
@@ -525,6 +580,14 @@ function PrioritizerSection({
           )}
         </h3>
         <div className="flex items-center gap-4 text-[11px]">
+          <button
+            type="button"
+            onClick={onStartDrafting}
+            disabled={draftingPending}
+            className="font-bold uppercase tracking-widest text-aqua transition hover:text-white disabled:opacity-50"
+          >
+            {draftingPending ? "Opening…" : "+ New project"}
+          </button>
           <AutonomyToggle
             paused={autonomyPaused}
             disabled={pending}
@@ -755,6 +818,12 @@ function PrioritizerRow({
   onMoveUp: () => void;
   onMoveDown: () => void;
 }) {
+  // Continue shaping → re-open the originating Navigator thread when
+  // the project was drafted in chat. Only surface on Drafts rows
+  // (rowState=='planning'); a project that's already Active/Parked
+  // doesn't benefit from "shaping" affordance.
+  const showContinueShaping =
+    rowState === "planning" && Boolean(project.originating_thread_id);
   const [moveMode, setMoveMode] = useState(false);
   const rowRef = useRef<HTMLLIElement | null>(null);
 
@@ -891,6 +960,19 @@ function PrioritizerRow({
             }}
           />
         </span>
+      ) : showContinueShaping ? (
+        // The Drafts row gets a "continue shaping" deep-link in the
+        // slot the progress bar would otherwise occupy. Same width so
+        // the row gutter stays aligned with rows in other sections.
+        <Link
+          href="/chat"
+          className="block w-20 shrink-0 text-right text-[10px] font-bold uppercase tracking-widest text-lilac/85 transition hover:text-white"
+          // ``draggable={false}`` prevents the anchor from claiming the
+          // drag intent and shadowing the parent <li draggable> reorder.
+          draggable={false}
+        >
+          Continue →
+        </Link>
       ) : (
         // Fixed-width spacer keeps the row gutter aligned across
         // sections so the progress column doesn't reflow per-state.

--- a/console/src/lib/api/client.ts
+++ b/console/src/lib/api/client.ts
@@ -1072,6 +1072,16 @@ export interface ApiChatMessage {
   created_at: string;
 }
 
+/**
+ * Conversation purpose tag on a chat thread:
+ * - ``shape_project`` — the dashboard's "+ New project" CTA opened
+ *   this thread; Navigator runs in drafting mode (system prompt biases
+ *   toward shaping a brief, waits for explicit confirmation before
+ *   ``create_project`` fires).
+ * Null = default Navigator chat.
+ */
+export type ApiChatThreadIntent = "shape_project";
+
 export interface ApiChatThread {
   id: string;
   title: string;
@@ -1084,6 +1094,7 @@ export interface ApiChatThread {
   updated_at: string;
   message_count: number;
   messages: ApiChatMessage[];
+  intent: ApiChatThreadIntent | null;
 }
 
 // Trimmed shape returned by ``GET /v1/workspaces/{ws}/chat/threads``;
@@ -1134,6 +1145,7 @@ export function newActiveChatThread(
     title?: string | null;
     pack_into_bucket_slug?: string | null;
     pack_into_bucket_name?: string | null;
+    intent?: ApiChatThreadIntent | null;
   } = {},
   options: { token?: string } = {},
 ): Promise<ApiChatThread> {
@@ -2486,6 +2498,11 @@ export interface ApiPriorityProject {
   /** Operator bucket. NULL only for unprioritised tail rows (the
    *  project has never been dragged into a bucket). */
   priority_state: ApiPriorityState | null;
+  /** Backref to the Navigator thread the project was drafted in.
+   *  Powers the "Continue shaping" link on Drafts rows; null for
+   *  projects that pre-date the drafting flow or were created
+   *  outside Navigator. */
+  originating_thread_id: string | null;
   /** Completion magnitude. ``total`` is null when the tracker can't
    * tell us; the UI then renders ``—`` and skips the bar. */
   completed: number | null;


### PR DESCRIPTION
Second PR of three for the project-first delivery flow tracked under [ELS-74](https://linear.app/elship/issue/ELS-74). Project body: [Project-first delivery: Drafts → Decomposition → SDLC](https://linear.app/elship/project/project-first-delivery-drafts-decomposition-sdlc-292d11e2f544). Builds on the side-effects from PR1 (#142, merged).

## What

The dashboard's priorities header gains a **+ New project** CTA. Clicks open a fresh Navigator thread tagged `intent='shape_project'`; the system-prompt assembler conditionally injects a **Mode: Project drafting** block that biases the agent toward shaping a brief and waiting for explicit confirmation before calling `create_project`. When the tool fires from inside a drafting thread, the priorities row that lands on the dashboard carries `originating_thread_id`, and the row renders a lilac **Continue →** deep-link in the slot the progress bar would otherwise occupy — clicking it re-opens the originating conversation so `append_project_description` can accumulate edits onto the same project body.

## Schema (migration 0058)

- `chat_threads.intent` — `String(32) NULL`. Today only `shape_project` is meaningful; null = default chat.
- `workspace_project_priorities.originating_thread_id` — `UUID NULL` with `ON DELETE SET NULL` so archiving the originating thread (idle sweeper) doesn't cascade-delete the priorities row.

## Backfill semantics

If a project already has a priorities row but no thread link (e.g. created from a default chat, then revisited from a drafting thread), the link gets stamped on the next touch. A subsequent drafting thread does **not** overwrite an existing link — first thread wins so the deep-link doesn't drift across re-entries.

## What's NOT in this PR

- **Decomposition FSM** + section-aware `append_project_description` + the hand-off endpoint + the completion hook that flips Drafts → Active. That's PR3.
- A Navigator left-rail "+ New project" CTA. The dashboard CTA covers the discoverability path the PO actually walks (open Ship → Dashboard → click). Adding a second door in the chat sidebar is polish for later.
- A bespoke `<ProjectDraftCard>` chat-renderer affordance. The system-prompt biased markdown preview pattern is enough for v1; the agent renders `## Project draft` inline and the user types "save it" / "ship it" to release the tool call. We can promote the preview to a structured renderer in a polish iteration.

## Test plan

- [x] **Backend** — new tests in `backend/tests/test_v1_chat_active.py` cover: intent persists on the create endpoint, default-null path, Pydantic 422 on typo'd intents. Existing tests still pass.
- [x] New tests in `backend/tests/test_agent_tools_create_project.py` cover: `originating_thread_id` stamp on a fresh row, backfill on existing row, **first thread wins** on second drafting touch.
- [x] **Frontend** — `tsc --noEmit` clean. Type-checked the four `PrioritizerSection` call-sites (disconnected, error, empty, populated) for the new props.
- [x] **Migration 0058** applied to prod DB; existing rows backfilled (intent stays null on every existing thread; `originating_thread_id` stays null on every existing priorities row).
- [ ] **Pre-existing**: `backend/tests/test_navigator_tool_inventory.py::test_specs_match_expected_inventory` continues to fail on `main` for unrelated reasons (`get_catalog_artifact` / `list_catalog_artifacts` removed from the registry but still in `EXPECTED_TOOLS`). Not introduced by this PR.

## Manual smoke (deferred to a live walkthrough)

- [ ] Click **+ New project** on the dashboard → Navigator opens on a fresh thread titled "Drafting a project," system message contains the **Mode: Project drafting** block.
- [ ] Describe a feature in 2-3 turns; confirm the agent drafts a `## Project draft` markdown preview inline before calling any tool.
- [ ] Say "save it" → `create_project` fires; row appears on the dashboard in the **Drafts** bucket within one round-trip; row shows the **Continue →** link.
- [ ] Click **Continue →** → routes back to `/chat`; `append_project_description` accumulates onto the same project body.