### PR TITLE
knowledge: claim store + source-document extractor (P0+P1)

### DIFF
--- a/backend/app/db/models/agent_memory.py
+++ b/backend/app/db/models/agent_memory.py
@@ -31,6 +31,7 @@ from pgvector.sqlalchemy import Vector
 from sqlalchemy import (
     CheckConstraint,
     DateTime,
+    Float,
     ForeignKey,
     Index,
     Integer,
@@ -39,7 +40,7 @@ from sqlalchemy import (
     UniqueConstraint,
     text,
 )
-from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.dialects.postgresql import ARRAY, JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
 from backend.app.db.base import Base
@@ -395,6 +396,14 @@ class KnowledgeSourceItem(Base):
         DateTime(timezone=True), nullable=True
     )
     deleted_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    # Lifted out of ``Improvement.body`` (which is an event queue, not a
+    # corpus) so the claim extractor can re-run idempotently keyed on
+    # ``body_md_sha``. NULL for legacy rows synced before migration 0059.
+    body_md: Mapped[str | None] = mapped_column(Text, nullable=True)
+    body_md_sha: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    extracted_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True
     )
     created_at: Mapped[datetime] = _ts_created()
@@ -874,6 +883,147 @@ class DistillerRun(Base):
     updated_at: Mapped[datetime] = _ts_updated()
 
 
+class ClaimStatus:
+    """Lifecycle status of a :class:`KnowledgeClaim` row.
+
+    Mirrors the CHECK constraint in migration 0059. Plain string
+    constants (not ``enum.Enum``) match the rest of this module's
+    convention so ``psql`` and ``grep`` show the wire value verbatim.
+
+    - ``ACTIVE`` — current canon. The claim hasn't been replaced and
+      at least one source has confirmed it within the decay window.
+    - ``SUPERSEDED`` — replaced by a newer claim via
+      ``superseded_by_id``. Kept for the history graph; not returned
+      from default search.
+    - ``STALE`` — no source has confirmed this claim for N decay-cron
+      ticks. Operator can revive (flip back to active) if it was a
+      false positive.
+    - ``DISPUTED`` — reconciliation engine flagged a conflict that
+      needs operator review (hits the inbox).
+    - ``ARCHIVED`` — operator-killed, terminal.
+    """
+
+    ACTIVE = "active"
+    SUPERSEDED = "superseded"
+    STALE = "stale"
+    DISPUTED = "disputed"
+    ARCHIVED = "archived"
+
+    ALL = frozenset({ACTIVE, SUPERSEDED, STALE, DISPUTED, ARCHIVED})
+
+
+class ClaimKind:
+    """Coarse type tag on a claim — drives nothing critical, but makes
+    operator review and search filters readable.
+
+    Mirrors the CHECK constraint in migration 0059. The extractor
+    picks one per claim; mismatches don't poison anything (we'd
+    prefer ``other`` over forcing a wrong bucket).
+    """
+
+    FACT = "fact"
+    RULE = "rule"
+    DECISION = "decision"
+    EXAMPLE = "example"
+    GLOSSARY = "glossary"
+    OTHER = "other"
+
+    ALL = frozenset({FACT, RULE, DECISION, EXAMPLE, GLOSSARY, OTHER})
+
+
+class KnowledgeClaim(Base):
+    """One atomic, verifiable assertion extracted from sources.
+
+    The unit of canonical truth in the post-0059 knowledge model.
+    Articles (``BucketArticle``) become a derived view rendered on
+    top of the active claim set per topic; reconciliation operates
+    here, at the fact level, so a stale architecture decision can
+    be marked ``superseded`` without rewriting an entire article.
+
+    Multi-tag is on purpose: a claim about Linear FSM is legitimately
+    both ``integrations`` and ``architecture-decisions``. The single-
+    bucket model forced a false choice and pushed the synth engine
+    toward "skip" decisions.
+
+    Idempotency on re-extract is the ``(workspace_id, claim_md_sha)``
+    unique index — a second run that produces the same exact text
+    no-ops at the DB level. The reconciliation engine handles
+    near-duplicates with different wording via embedding cosine.
+    """
+
+    __tablename__ = "knowledge_claim"
+    __table_args__ = (
+        UniqueConstraint(
+            "workspace_id",
+            "claim_md_sha",
+            name="uq_knowledge_claim_workspace_sha",
+        ),
+        Index("ix_knowledge_claim_workspace_id", "workspace_id"),
+        Index("ix_knowledge_claim_status", "status"),
+        Index("ix_knowledge_claim_supersedes_id", "supersedes_id"),
+        Index("ix_knowledge_claim_superseded_by_id", "superseded_by_id"),
+        CheckConstraint(
+            "status IN ('active', 'superseded', 'stale', 'disputed', 'archived')",
+            name="ck_knowledge_claim_status",
+        ),
+        CheckConstraint(
+            "kind IN ('fact', 'rule', 'decision', 'example', 'glossary', 'other')",
+            name="ck_knowledge_claim_kind",
+        ),
+        CheckConstraint(
+            "confidence >= 0.0 AND confidence <= 1.0",
+            name="ck_knowledge_claim_confidence_range",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = _pk()
+    workspace_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("workspaces.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    claim_md: Mapped[str] = mapped_column(Text, nullable=False)
+    claim_md_sha: Mapped[str] = mapped_column(String(64), nullable=False)
+    embedding: Mapped[list[float] | None] = mapped_column(
+        Vector(EMBED_DIM), nullable=True
+    )
+    topic_tags: Mapped[list[str]] = mapped_column(
+        ARRAY(Text),
+        nullable=False,
+        server_default=text("ARRAY[]::text[]"),
+    )
+    kind: Mapped[str] = mapped_column(
+        String(24), nullable=False, server_default=text("'fact'")
+    )
+    status: Mapped[str] = mapped_column(
+        String(16), nullable=False, server_default=text("'active'")
+    )
+    supersedes_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("knowledge_claim.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    superseded_by_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("knowledge_claim.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    confidence: Mapped[float] = mapped_column(
+        Float, nullable=False, server_default=text("1.0")
+    )
+    source_links: Mapped[list[dict[str, Any]]] = mapped_column(
+        JSONB, nullable=False, server_default=text("'[]'::jsonb")
+    )
+    first_seen_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=text("now()")
+    )
+    last_seen_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=text("now()")
+    )
+    created_at: Mapped[datetime] = _ts_created()
+    updated_at: Mapped[datetime] = _ts_updated()
+
+
 __all__ = [
     "ArtifactFeedback",
     "BucketArticle",
@@ -882,12 +1032,15 @@ __all__ = [
     "BucketScope",
     "BucketSource",
     "BucketSummary",
+    "ClaimKind",
+    "ClaimStatus",
     "DistillerRun",
     "DistillerRunDecision",
     "DistillerRunStatus",
     "EMBED_DIM",
     "KbChunk",
     "KnowledgeBucket",
+    "KnowledgeClaim",
     "KnowledgeImportSource",
     "KnowledgeImportSourceKind",
     "KnowledgeIngestionRun",

--- a/backend/app/services/knowledge_claim_extractor.py
+++ b/backend/app/services/knowledge_claim_extractor.py
@@ -1,0 +1,475 @@
+"""Source-document → :class:`KnowledgeClaim` extractor.
+
+The pre-claim pipeline treated each source document as a single
+``Improvement(kind='knowledge_note')`` that the synth engine would
+later try to digest into an article. That meant the LLM saw raw
+mixed signal (architecture decisions, runbook steps, meeting notes,
+jokes, stale bits from two years ago) all bundled together and had
+to do signal extraction *and* article-level reconciliation in one
+pass — which is why operators saw 50 docs collapse to 4 articles
+with 43/74 notes ignored as "skip".
+
+This module separates those concerns. It does **signal extraction
+only**: read one source item body, ask an LLM to produce a list of
+atomic claims, persist each as a :class:`KnowledgeClaim` row with
+``status='active'``. Reconciliation (dedupe / supersede / contradict-
+detect) lives in the next phase and operates on the claim store
+after this module has finished.
+
+Note: the existing :mod:`backend.app.services.knowledge_extractor`
+operates on resolved-clarification Q&A pairs and emits
+``KnowledgeAtom`` records for the legacy harvester. It is unrelated
+to this module — both can coexist while the old pipeline runs in
+parallel behind a feature flag.
+
+Why a separate cheap LLM call per item instead of inline in the
+ingestion path:
+
+- Source ingestion is bandwidth-bound (Notion / GitHub fetches).
+  Bolting an LLM call onto every fetch would multiply the latency
+  budget per page and starve the rest of the sync.
+- Idempotency. We hash ``body_md`` and skip un-changed items, so a
+  re-run of the cron is free for items the operator hasn't touched.
+- Extractor-vendor / model can change without touching ingestion.
+
+Caps + safety:
+
+- ``_MAX_BODY_CHARS`` clamps the body sent to the LLM. A 100k-char
+  Notion runbook turns extraction into a per-call cost spike with
+  diminishing returns; the synthesis-stage rendering still has
+  access to the full body via ``source_item.body_md``.
+- ``_MAX_CLAIMS_PER_ITEM`` clamps how many claims one document can
+  emit. Hub pages with 200 bullet items would otherwise flood the
+  store with low-signal claims.
+- Extractor failure is per-item: one malformed LLM response or one
+  oversized body marks ``extracted_at = now()`` with zero claims and
+  moves on. The next ingestion that *changes* ``body_md_sha`` will
+  trigger a re-try.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.app.core.config import Settings, get_settings
+from backend.app.db.models.agent_memory import (
+    ClaimKind,
+    ClaimStatus,
+    KnowledgeClaim,
+    KnowledgeSourceItem,
+)
+from backend.app.services.agent.client import AgentClient, ChatMessage
+from backend.app.services.agent.embedding import embed_text
+
+
+log = logging.getLogger(__name__)
+
+
+# Trim very long source bodies. Long-tail Notion / Confluence runbooks
+# would otherwise blow the per-call token budget without improving
+# extraction quality much (LLMs hit diminishing returns past ~10k
+# chars of mixed-purpose prose).
+_MAX_BODY_CHARS = 24_000
+
+# Per-document fan-out cap. Pages with 200 bullet items would flood
+# the store with low-signal "Bob said X" claims and starve the
+# reconciliation engine.
+_MAX_CLAIMS_PER_ITEM = 30
+
+# Per-cron-tick batch — how many un-extracted items the worker pulls
+# per workspace. Bounded so a 5000-doc backfill doesn't single-thread
+# a tick.
+_EXTRACTOR_BATCH_LIMIT = 25
+
+
+_SYSTEM_PROMPT = """\
+You extract atomic, verifiable claims from a workspace document and
+discard noise. The output feeds a knowledge base that operators and
+agents will search to answer questions about the system.
+
+Rules:
+
+- One claim per output item. Claims must be self-contained sentences
+  that can stand without the surrounding document.
+- DROP noise: meeting attendance, "who said what" gossip, personal
+  status, scheduling chatter, "let's circle back" notes.
+- DROP claims that are explicitly outdated by the document itself
+  ("we used to do X but switched to Y" → emit only the Y claim).
+- PREFER concrete decisions, rules, facts, and examples. If the
+  document is *only* noise, return zero claims.
+- Tag each claim with one or more topic_tags — short kebab-case
+  topical labels (e.g. ``linear-fsm``, ``oauth-flow``,
+  ``runbooks-deploy``). Topic tags are free-form, NOT a fixed list.
+- Pick the closest ``kind`` from: fact, rule, decision, example,
+  glossary, other.
+
+Output ONLY a JSON object of shape:
+
+  {"claims":[
+    {"text": "...", "kind": "fact|rule|decision|example|glossary|other",
+     "topic_tags": ["tag1","tag2"]},
+    ...
+  ]}
+
+No commentary, no markdown fences, just JSON.
+"""
+
+
+@dataclass(slots=True)
+class ExtractionReport:
+    """Outcome of one extractor pass over a source item."""
+
+    source_item_id: uuid.UUID
+    claims_created: int = 0
+    claims_skipped_duplicate: int = 0
+    skipped_no_body: bool = False
+    skipped_unchanged: bool = False
+    llm_failed: bool = False
+    errors: list[str] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class BatchReport:
+    """Outcome of one extractor batch over a workspace's pending items."""
+
+    inspected: int = 0
+    extracted: int = 0
+    skipped_unchanged: int = 0
+    skipped_no_body: int = 0
+    failed: int = 0
+    claims_created: int = 0
+
+
+def _sha256(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _excerpt(body: str, max_chars: int = 400) -> str:
+    """Tight body excerpt for the claim's ``source_links`` payload.
+
+    Search results show this excerpt next to the source link so the
+    operator can eyeball provenance without re-opening the doc.
+    """
+    body = (body or "").strip()
+    if len(body) <= max_chars:
+        return body
+    return body[: max_chars - 1].rstrip() + "…"
+
+
+# ---------------------------------------------------------------------------
+# LLM call + parse
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class _ExtractedClaim:
+    text: str
+    kind: str
+    topic_tags: tuple[str, ...]
+
+
+async def _call_extractor_llm(
+    *,
+    client: AgentClient,
+    title: str,
+    body_md: str,
+) -> list[_ExtractedClaim]:
+    """Invoke the LLM, parse the JSON response, return validated claims.
+
+    Returns an empty list rather than raising on malformed responses —
+    one bad doc shouldn't fail the whole batch. Validation rejects
+    individual claims with empty text, unknown ``kind``, or non-list
+    ``topic_tags`` rather than dropping the whole batch.
+    """
+    user_msg = (
+        f"# {title}\n\n{body_md[:_MAX_BODY_CHARS]}"
+        + (
+            "\n\n[document truncated for extraction]"
+            if len(body_md) > _MAX_BODY_CHARS
+            else ""
+        )
+    )
+    raw = await client.acomplete(
+        messages=[
+            ChatMessage(role="system", content=_SYSTEM_PROMPT),
+            ChatMessage(role="user", content=user_msg),
+        ],
+        max_tokens=2000,
+        temperature=0.0,
+        response_format={"type": "json_object"},
+    )
+    return _parse_extractor_json(raw)
+
+
+def _parse_extractor_json(raw: str) -> list[_ExtractedClaim]:
+    """Tolerant parser for the extractor's JSON envelope.
+
+    Handles the two common LLM misbehaviours:
+    - wrapping the JSON in a markdown code fence
+    - producing a top-level array instead of ``{"claims": [...]}``.
+    """
+    cleaned = (raw or "").strip()
+    if cleaned.startswith("```"):
+        cleaned = cleaned.strip("`")
+        if cleaned.lower().startswith("json"):
+            cleaned = cleaned[4:].lstrip()
+        cleaned = cleaned.strip("`").strip()
+    try:
+        obj: Any = json.loads(cleaned)
+    except json.JSONDecodeError:
+        return []
+    raw_items = obj.get("claims") if isinstance(obj, dict) else obj
+    if not isinstance(raw_items, list):
+        return []
+    out: list[_ExtractedClaim] = []
+    for entry in raw_items[:_MAX_CLAIMS_PER_ITEM]:
+        if not isinstance(entry, dict):
+            continue
+        text_val = str(entry.get("text") or "").strip()
+        if not text_val:
+            continue
+        kind = str(entry.get("kind") or ClaimKind.OTHER).strip().lower()
+        if kind not in ClaimKind.ALL:
+            kind = ClaimKind.OTHER
+        tags_raw = entry.get("topic_tags") or []
+        if not isinstance(tags_raw, list):
+            tags_raw = []
+        tags = tuple(
+            sorted(
+                {
+                    str(tag).strip().lower()
+                    for tag in tags_raw
+                    if isinstance(tag, str) and tag.strip()
+                }
+            )
+        )
+        out.append(_ExtractedClaim(text=text_val, kind=kind, topic_tags=tags))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Persistence
+# ---------------------------------------------------------------------------
+
+
+async def _persist_claim(
+    session: AsyncSession,
+    *,
+    workspace_id: uuid.UUID,
+    item: KnowledgeSourceItem,
+    claim: _ExtractedClaim,
+    extracted_at: datetime,
+    settings: Settings,
+) -> bool:
+    """Insert a claim row, or no-op if the (ws, sha) pair already exists.
+
+    Returns True when a new row was created, False on unique-collision
+    (the row was already in the store from a prior extraction). The
+    ``source_links`` payload of the existing row is intentionally not
+    updated here; the reconciliation engine in the next phase decides
+    whether two extractions referring to the same exact text should
+    merge their provenance — that interacts with confidence
+    accumulation we don't want to settle inline.
+
+    Embedding is best-effort: a missing API key or rate-limit hiccup
+    leaves ``embedding=NULL`` and search falls back to keyword for
+    that one row, instead of poisoning the whole batch.
+    """
+    sha = _sha256(claim.text)
+    existing = (
+        await session.execute(
+            select(KnowledgeClaim).where(
+                KnowledgeClaim.workspace_id == workspace_id,
+                KnowledgeClaim.claim_md_sha == sha,
+            )
+        )
+    ).scalar_one_or_none()
+    if existing is not None:
+        # Stamp last_seen_at so decay knows the source still confirms
+        # this claim, even though we didn't insert a new row.
+        existing.last_seen_at = extracted_at
+        return False
+
+    embedding: list[float] | None
+    try:
+        embedding = await embed_text(claim.text, settings=settings)
+    except Exception as exc:  # noqa: BLE001 — best-effort
+        log.info(
+            "claim_extractor: embedding failed for sha=%s (%s) — "
+            "row stored without embedding, search will fall back to "
+            "keyword for this claim",
+            sha[:12],
+            exc,
+        )
+        embedding = None
+
+    row = KnowledgeClaim(
+        workspace_id=workspace_id,
+        claim_md=claim.text,
+        claim_md_sha=sha,
+        embedding=embedding,
+        topic_tags=list(claim.topic_tags),
+        kind=claim.kind,
+        status=ClaimStatus.ACTIVE,
+        confidence=1.0,
+        source_links=[
+            {
+                "source_item_id": str(item.id),
+                "external_url": item.external_url,
+                "title": item.title,
+                "excerpt": _excerpt(item.body_md or ""),
+                "extracted_at": extracted_at.isoformat(),
+            }
+        ],
+        first_seen_at=extracted_at,
+        last_seen_at=extracted_at,
+    )
+    session.add(row)
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Public entry points
+# ---------------------------------------------------------------------------
+
+
+async def extract_claims_for_item(
+    session: AsyncSession,
+    *,
+    item: KnowledgeSourceItem,
+    llm_client: AgentClient,
+    settings: Settings | None = None,
+) -> ExtractionReport:
+    """Run the extractor against one source item and persist its claims.
+
+    Caller owns the transaction. The function flushes between rows so
+    a partial batch failure mid-loop still leaves the successfully
+    extracted claims in the session, which the caller can commit or
+    roll back atomically.
+    """
+    settings = settings or get_settings()
+    report = ExtractionReport(source_item_id=item.id)
+
+    body = (item.body_md or "").strip()
+    if not body:
+        report.skipped_no_body = True
+        return report
+
+    body_sha = _sha256(body)
+    if (
+        item.body_md_sha == body_sha
+        and item.extracted_at is not None
+    ):
+        report.skipped_unchanged = True
+        return report
+
+    try:
+        claims = await _call_extractor_llm(
+            client=llm_client, title=item.title, body_md=body
+        )
+    except Exception as exc:  # noqa: BLE001
+        log.exception(
+            "claim_extractor: LLM call failed for item %s", item.id
+        )
+        report.llm_failed = True
+        report.errors.append(str(exc))
+        # Stamp body_md_sha so we don't redo the failed extraction
+        # on every tick — the operator can force a retry by editing
+        # the source row's ``extracted_at = NULL``.
+        item.body_md_sha = body_sha
+        item.extracted_at = datetime.now(timezone.utc)
+        return report
+
+    extracted_at = datetime.now(timezone.utc)
+    for claim in claims:
+        try:
+            created = await _persist_claim(
+                session,
+                workspace_id=item.workspace_id,
+                item=item,
+                claim=claim,
+                extracted_at=extracted_at,
+                settings=settings,
+            )
+        except Exception as exc:  # noqa: BLE001 — per-row best-effort
+            log.exception(
+                "claim_extractor: persist failed for item %s claim %r",
+                item.id,
+                claim.text[:80],
+            )
+            report.errors.append(str(exc))
+            continue
+        if created:
+            report.claims_created += 1
+        else:
+            report.claims_skipped_duplicate += 1
+
+    item.body_md_sha = body_sha
+    item.extracted_at = extracted_at
+    await session.flush()
+    return report
+
+
+async def extract_pending_workspace(
+    session: AsyncSession,
+    *,
+    workspace_id: uuid.UUID,
+    llm_client: AgentClient,
+    limit: int = _EXTRACTOR_BATCH_LIMIT,
+    settings: Settings | None = None,
+) -> BatchReport:
+    """Run the extractor over un-extracted items in one workspace.
+
+    "Un-extracted" = ``body_md`` is set AND
+    (``extracted_at IS NULL`` OR the body has changed since last
+    extraction, detected by ``body_md_sha`` mismatch).
+    """
+    settings = settings or get_settings()
+    report = BatchReport()
+
+    rows = (
+        await session.execute(
+            select(KnowledgeSourceItem)
+            .where(KnowledgeSourceItem.workspace_id == workspace_id)
+            .where(KnowledgeSourceItem.body_md.isnot(None))
+            .where(KnowledgeSourceItem.deleted_at.is_(None))
+            .order_by(KnowledgeSourceItem.last_seen_at.desc().nullslast())
+            .limit(limit)
+        )
+    ).scalars().all()
+    report.inspected = len(rows)
+
+    for item in rows:
+        item_report = await extract_claims_for_item(
+            session, item=item, llm_client=llm_client, settings=settings
+        )
+        if item_report.skipped_no_body:
+            report.skipped_no_body += 1
+            continue
+        if item_report.skipped_unchanged:
+            report.skipped_unchanged += 1
+            continue
+        if item_report.llm_failed:
+            report.failed += 1
+            continue
+        report.extracted += 1
+        report.claims_created += item_report.claims_created
+
+    return report
+
+
+__all__ = [
+    "BatchReport",
+    "ExtractionReport",
+    "extract_claims_for_item",
+    "extract_pending_workspace",
+]

--- a/backend/app/services/knowledge_ingestion.py
+++ b/backend/app/services/knowledge_ingestion.py
@@ -611,7 +611,18 @@ async def _upsert_source_item(
     source: KnowledgeImportSource,
     doc: SourceDocument,
 ) -> KnowledgeSourceItem:
+    """Upsert a ``KnowledgeSourceItem`` row keyed on (source, external_id).
+
+    Persists the full ``body_md`` plus ``body_md_sha`` so the claim
+    extractor (next phase) can find un-extracted items via a sha
+    mismatch and skip ones that haven't changed since the last
+    extract pass. Body diffs vs the stored sha trigger
+    ``extracted_at = NULL`` to mark the row pending again — that's
+    how a re-pulled Notion page automatically queues a re-extract.
+    """
     now = datetime.now(timezone.utc)
+    body_md = _normalise_markdown(doc.body_md)
+    body_sha = _sha256_text(body_md) if body_md else None
     existing = (
         await session.execute(
             select(KnowledgeSourceItem).where(
@@ -627,6 +638,13 @@ async def _upsert_source_item(
         existing.cursor = doc.cursor
         existing.last_seen_at = now
         existing.deleted_at = None
+        if body_md and existing.body_md_sha != body_sha:
+            existing.body_md = body_md
+            # Note: do NOT set body_md_sha here — the extractor stamps
+            # it after a successful run. Leaving the old sha alongside
+            # the new body marks the row pending without losing the
+            # "previously-extracted" timestamp until extract finishes.
+            existing.extracted_at = None
         return existing
     item = KnowledgeSourceItem(
         id=uuid.uuid4(),
@@ -639,6 +657,7 @@ async def _upsert_source_item(
         content_fingerprint=None,
         cursor=doc.cursor,
         last_seen_at=now,
+        body_md=body_md or None,
     )
     session.add(item)
     await session.flush()

--- a/backend/migrations/versions/0059_knowledge_claims.py
+++ b/backend/migrations/versions/0059_knowledge_claims.py
@@ -1,0 +1,274 @@
+"""knowledge_claim store + body_md on knowledge_source_items
+
+The knowledge pipeline switches its unit of canonical truth from the
+``BucketArticle`` (LLM-curated digest) to the **claim**: an atomic,
+verifiable assertion extracted from a source document. Claims carry
+their own embedding + provenance + supersedes chain, so reconciliation
+(this fact replaces that one, this one is duplicate) happens at the
+fact level instead of being baked into one all-or-nothing article body.
+
+Articles aren't being deleted — they become a derived view rendered
+on top of the active claim set per topic. This migration only sets
+up the new tables; the extractor + reconciliation engine + view
+renderer ride on later phases.
+
+Schema:
+
+- ``knowledge_claim`` — the canonical claim row.
+  - ``status``: ``active`` (current canon) / ``superseded`` (replaced
+    by another row via ``superseded_by_id``) / ``stale`` (no source
+    has confirmed it for N decay-cron ticks) / ``disputed`` (operator
+    review pending) / ``archived`` (operator-killed).
+  - ``topic_tags`` is multi-tag because one claim about Linear FSM is
+    legitimately both ``integrations`` and ``architecture-decisions``;
+    the existing single-bucket model was forcing a false choice.
+  - ``source_links`` JSONB carries the (source_item_id, excerpt,
+    extracted_at) triples — one claim can be reinforced by multiple
+    sources, and that's signal we want to surface in search results.
+  - ``supersedes_id`` / ``superseded_by_id`` together build the
+    history graph; a chain query gives "how this fact has changed
+    over time".
+
+- New columns on ``knowledge_source_items``:
+  - ``body_md`` — the actual document body. Until now we kept it on
+    ``Improvement.body``; that table was always meant as a queue of
+    events, not a corpus. Lifting body to source items lets the
+    extractor run idempotently keyed on ``body_md_sha``.
+  - ``body_md_sha`` — sha256 of the body, used by the extractor to
+    skip un-changed items.
+  - ``extracted_at`` — when the extractor last ran. NULL = pending.
+
+Revision ID: 0059_knowledge_claims
+Revises: 0058_drafting_intent
+Create Date: 2026-05-06
+"""
+
+from __future__ import annotations
+
+from typing import Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision: str = "0059_knowledge_claims"
+down_revision: Union[str, None] = "0058_drafting_intent"
+branch_labels: Union[str, tuple[str, ...], None] = None
+depends_on: Union[str, tuple[str, ...], None] = None
+
+
+_EMBED_DIM = 1536
+
+
+def upgrade() -> None:
+    op.execute("CREATE EXTENSION IF NOT EXISTS vector")
+
+    # ---- knowledge_claim --------------------------------------------------
+    op.create_table(
+        "knowledge_claim",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "workspace_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("workspaces.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("claim_md", sa.Text(), nullable=False),
+        sa.Column(
+            "claim_md_sha",
+            sa.String(length=64),
+            nullable=False,
+        ),
+        # ARRAY first; ALTER below promotes to pgvector(1536). Same
+        # pattern methodology_chunks uses — keeps the create_table call
+        # within sqlalchemy's portable surface.
+        sa.Column(
+            "embedding",
+            postgresql.ARRAY(sa.Float),
+            nullable=True,
+        ),
+        sa.Column(
+            "topic_tags",
+            postgresql.ARRAY(sa.Text),
+            nullable=False,
+            server_default=sa.text("ARRAY[]::text[]"),
+        ),
+        sa.Column(
+            "kind",
+            sa.String(length=24),
+            nullable=False,
+            server_default=sa.text("'fact'"),
+        ),
+        sa.Column(
+            "status",
+            sa.String(length=16),
+            nullable=False,
+            server_default=sa.text("'active'"),
+        ),
+        sa.Column(
+            "supersedes_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("knowledge_claim.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column(
+            "superseded_by_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("knowledge_claim.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column(
+            "confidence",
+            sa.Float(),
+            nullable=False,
+            server_default=sa.text("1.0"),
+        ),
+        sa.Column(
+            "source_links",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        sa.Column(
+            "first_seen_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "last_seen_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.CheckConstraint(
+            "status IN ('active', 'superseded', 'stale', 'disputed', 'archived')",
+            name="ck_knowledge_claim_status",
+        ),
+        sa.CheckConstraint(
+            "kind IN ('fact', 'rule', 'decision', 'example', 'glossary', 'other')",
+            name="ck_knowledge_claim_kind",
+        ),
+        sa.CheckConstraint(
+            "confidence >= 0.0 AND confidence <= 1.0",
+            name="ck_knowledge_claim_confidence_range",
+        ),
+    )
+
+    # Promote embedding to pgvector(1536) — round-trips Python lists
+    # through the same Vector mapping the rest of the schema uses.
+    op.execute(
+        "ALTER TABLE knowledge_claim DROP COLUMN embedding, "
+        f"ADD COLUMN embedding vector({_EMBED_DIM})"
+    )
+
+    op.create_index(
+        "ix_knowledge_claim_workspace_id",
+        "knowledge_claim",
+        ["workspace_id"],
+    )
+    op.create_index(
+        "ix_knowledge_claim_status",
+        "knowledge_claim",
+        ["status"],
+    )
+    op.create_index(
+        "ix_knowledge_claim_supersedes_id",
+        "knowledge_claim",
+        ["supersedes_id"],
+    )
+    op.create_index(
+        "ix_knowledge_claim_superseded_by_id",
+        "knowledge_claim",
+        ["superseded_by_id"],
+    )
+    # Idempotent re-extract: same workspace + same exact claim text
+    # (sha) collapses to one row. The reconciliation engine uses
+    # embedding-cosine to merge near-duplicates with different wording;
+    # this is just the cheap exact-string guard.
+    op.create_index(
+        "uq_knowledge_claim_workspace_sha",
+        "knowledge_claim",
+        ["workspace_id", "claim_md_sha"],
+        unique=True,
+    )
+    # GIN on the multi-tag array so topic-views can filter quickly.
+    op.execute(
+        "CREATE INDEX ix_knowledge_claim_topic_tags "
+        "ON knowledge_claim USING gin (topic_tags)"
+    )
+    # HNSW on embedding — same params as kb_chunks / methodology_chunks
+    # so cosine retrieval cost is consistent across the search surfaces.
+    op.execute(
+        "CREATE INDEX ix_knowledge_claim_embedding "
+        "ON knowledge_claim USING hnsw (embedding vector_cosine_ops) "
+        "WITH (m = 16, ef_construction = 64)"
+    )
+
+    # ---- knowledge_source_items: body_md + extraction bookkeeping --------
+    op.add_column(
+        "knowledge_source_items",
+        sa.Column("body_md", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "knowledge_source_items",
+        sa.Column("body_md_sha", sa.String(length=64), nullable=True),
+    )
+    op.add_column(
+        "knowledge_source_items",
+        sa.Column(
+            "extracted_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+    )
+    op.create_index(
+        "ix_knowledge_source_items_body_sha",
+        "knowledge_source_items",
+        ["body_md_sha"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_knowledge_source_items_body_sha",
+        table_name="knowledge_source_items",
+    )
+    op.drop_column("knowledge_source_items", "extracted_at")
+    op.drop_column("knowledge_source_items", "body_md_sha")
+    op.drop_column("knowledge_source_items", "body_md")
+
+    op.execute("DROP INDEX IF EXISTS ix_knowledge_claim_embedding")
+    op.execute("DROP INDEX IF EXISTS ix_knowledge_claim_topic_tags")
+    op.drop_index(
+        "uq_knowledge_claim_workspace_sha", table_name="knowledge_claim"
+    )
+    op.drop_index(
+        "ix_knowledge_claim_superseded_by_id", table_name="knowledge_claim"
+    )
+    op.drop_index(
+        "ix_knowledge_claim_supersedes_id", table_name="knowledge_claim"
+    )
+    op.drop_index("ix_knowledge_claim_status", table_name="knowledge_claim")
+    op.drop_index(
+        "ix_knowledge_claim_workspace_id", table_name="knowledge_claim"
+    )
+    op.drop_table("knowledge_claim")

--- a/backend/tests/test_services_knowledge_claim_extractor.py
+++ b/backend/tests/test_services_knowledge_claim_extractor.py
@@ -1,0 +1,290 @@
+"""Unit tests for the source-document claim extractor.
+
+These tests stay pure-unit by stubbing the LLM client and the
+embedding helper so they don't depend on a live Postgres or any
+network. The stages we want to lock down:
+
+- the LLM JSON envelope (and the two common wrapping mistakes —
+  markdown fences, top-level array) is parsed defensively;
+- each accepted claim is persisted with the right status, kind,
+  topic_tags + a source_link entry pointing back at the item;
+- an exact-text duplicate doesn't insert a second row (the
+  ``(workspace_id, claim_md_sha)`` uniqueness contract);
+- bodies that haven't changed since the last extract are skipped
+  (idempotency of the cron tick);
+- LLM-call exceptions are absorbed: row is stamped extracted, no
+  claims persisted, batch keeps going.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+
+import pytest
+
+from backend.app.services import knowledge_claim_extractor as ext
+from backend.app.db.models.agent_memory import (
+    ClaimKind,
+    ClaimStatus,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeItem:
+    id: uuid.UUID = field(default_factory=uuid.uuid4)
+    workspace_id: uuid.UUID = field(default_factory=uuid.uuid4)
+    title: str = "Doc"
+    external_url: str | None = "https://example/doc"
+    body_md: str | None = "# Doc\n\nContent."
+    body_md_sha: str | None = None
+    extracted_at: datetime | None = None
+    deleted_at: datetime | None = None
+
+
+class _FakeSession:
+    """Records added rows + simulates the (ws, sha) uniqueness check.
+
+    The extractor only uses ``select`` to look up an existing claim
+    by sha, ``add`` to persist new ones, and ``flush`` (no-op here).
+    """
+
+    def __init__(self):
+        self.added: list = []
+        self._by_sha: dict[tuple[uuid.UUID, str], object] = {}
+
+    async def execute(self, stmt):
+        # The extractor's only query is "select existing claim by
+        # (workspace_id, claim_md_sha)". We extract the literal values
+        # from the compiled where clause to look up our in-memory dict.
+        # Production sessions don't need this contortion — this is just
+        # for unit tests.
+        try:
+            compiled = stmt.compile(compile_kwargs={"literal_binds": False})
+            params = compiled.params
+            ws = params.get("workspace_id_1")
+            sha = params.get("claim_md_sha_1")
+        except Exception:
+            ws = None
+            sha = None
+        existing = self._by_sha.get((ws, sha)) if (ws and sha) else None
+        return _FakeResult(existing)
+
+    def add(self, row) -> None:
+        self.added.append(row)
+        self._by_sha[(row.workspace_id, row.claim_md_sha)] = row
+
+    async def flush(self) -> None:
+        return None
+
+
+class _FakeResult:
+    def __init__(self, val):
+        self._val = val
+
+    def scalar_one_or_none(self):
+        return self._val
+
+
+@dataclass
+class _FakeLLM:
+    response: str
+    raises: bool = False
+    calls: list[tuple[str, ...]] = field(default_factory=list)
+    vendor: str = "fake"
+
+    async def acomplete(self, messages, **kwargs) -> str:
+        if self.raises:
+            raise RuntimeError("simulated llm failure")
+        self.calls.append(tuple(m.content for m in messages))
+        return self.response
+
+    async def astream(self, *args, **kwargs):  # pragma: no cover
+        yield None
+
+
+@pytest.fixture(autouse=True)
+def _stub_embed(monkeypatch):
+    """Stub embed_text so tests don't try to reach OpenAI / Anthropic."""
+
+    async def _fake(text, settings=None):
+        return [0.0] * 16
+
+    monkeypatch.setattr(ext, "embed_text", _fake)
+
+
+# ---------------------------------------------------------------------------
+# Parser
+# ---------------------------------------------------------------------------
+
+
+def test_parser_accepts_canonical_envelope():
+    out = ext._parse_extractor_json(
+        '{"claims":[{"text":"X","kind":"fact","topic_tags":["a","b"]}]}'
+    )
+    assert len(out) == 1
+    assert out[0].text == "X"
+    assert out[0].kind == "fact"
+    assert out[0].topic_tags == ("a", "b")
+
+
+def test_parser_strips_markdown_fences():
+    out = ext._parse_extractor_json(
+        '```json\n{"claims":[{"text":"X","kind":"rule","topic_tags":[]}]}\n```'
+    )
+    assert len(out) == 1
+    assert out[0].kind == "rule"
+
+
+def test_parser_accepts_bare_array():
+    out = ext._parse_extractor_json(
+        '[{"text":"X","kind":"fact","topic_tags":["a"]}]'
+    )
+    assert len(out) == 1
+
+
+def test_parser_drops_invalid_kind_to_other():
+    out = ext._parse_extractor_json(
+        '{"claims":[{"text":"X","kind":"made-up","topic_tags":[]}]}'
+    )
+    assert out[0].kind == ClaimKind.OTHER
+
+
+def test_parser_returns_empty_on_garbage():
+    assert ext._parse_extractor_json("not json at all") == []
+    assert ext._parse_extractor_json("") == []
+    assert (
+        ext._parse_extractor_json('{"unrelated": "shape"}') == []
+    )
+
+
+def test_parser_caps_claim_count():
+    items = [
+        {"text": f"c{i}", "kind": "fact", "topic_tags": []}
+        for i in range(100)
+    ]
+    out = ext._parse_extractor_json('{"claims":' + str(items).replace("'", '"') + "}")
+    assert len(out) == ext._MAX_CLAIMS_PER_ITEM
+
+
+# ---------------------------------------------------------------------------
+# extract_claims_for_item
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_extract_persists_one_claim_per_llm_item():
+    item = _FakeItem(body_md="# Doc\n\nLinear FSM has 7 states.")
+    session = _FakeSession()
+    llm = _FakeLLM(
+        response='{"claims":['
+        '{"text":"Linear FSM has 7 states.","kind":"fact",'
+        '"topic_tags":["linear","fsm"]}'
+        "]}"
+    )
+
+    report = await ext.extract_claims_for_item(
+        session, item=item, llm_client=llm
+    )
+
+    assert report.claims_created == 1
+    assert len(session.added) == 1
+    row = session.added[0]
+    assert row.workspace_id == item.workspace_id
+    assert row.claim_md == "Linear FSM has 7 states."
+    assert row.kind == "fact"
+    assert row.topic_tags == ["fsm", "linear"]
+    assert row.status == ClaimStatus.ACTIVE
+    assert row.confidence == 1.0
+    # source link points back at item
+    assert row.source_links[0]["source_item_id"] == str(item.id)
+    assert row.source_links[0]["external_url"] == item.external_url
+    # item bookkeeping was stamped
+    assert item.body_md_sha is not None
+    assert item.extracted_at is not None
+
+
+@pytest.mark.asyncio
+async def test_extract_dedup_collapses_to_existing_row():
+    """A second extraction returning the same exact text doesn't
+    insert a second row — the unique-key short-circuit fires and we
+    only stamp last_seen_at on the existing row."""
+    item = _FakeItem()
+    session = _FakeSession()
+    llm = _FakeLLM(
+        response='{"claims":[{"text":"Same","kind":"fact","topic_tags":[]}]}'
+    )
+    await ext.extract_claims_for_item(session, item=item, llm_client=llm)
+    assert len(session.added) == 1
+    first_seen_before = session.added[0].last_seen_at
+
+    # Re-run on a fresh item with the same workspace_id so the
+    # uniqueness check sees the prior row.
+    item2 = _FakeItem(workspace_id=item.workspace_id)
+    report2 = await ext.extract_claims_for_item(
+        session, item=item2, llm_client=llm
+    )
+    assert report2.claims_created == 0
+    assert report2.claims_skipped_duplicate == 1
+    assert len(session.added) == 1  # no new row
+    # last_seen_at on the existing row was bumped forward
+    assert session.added[0].last_seen_at >= first_seen_before
+
+
+@pytest.mark.asyncio
+async def test_extract_skips_unchanged_body():
+    """Re-extracting an item whose body_md_sha already matches the
+    current body skips the LLM call — that's the idempotency
+    invariant the cron tick relies on."""
+    item = _FakeItem(body_md="# Doc\n\nstable text")
+    sha = ext._sha256("# Doc\n\nstable text")
+    item.body_md_sha = sha
+    item.extracted_at = datetime.now(timezone.utc)
+    session = _FakeSession()
+    llm = _FakeLLM(response="{}")  # would explode if called
+
+    report = await ext.extract_claims_for_item(
+        session, item=item, llm_client=llm
+    )
+    assert report.skipped_unchanged is True
+    assert report.claims_created == 0
+    assert llm.calls == []
+
+
+@pytest.mark.asyncio
+async def test_extract_skips_when_body_empty():
+    item = _FakeItem(body_md=None)
+    session = _FakeSession()
+    llm = _FakeLLM(response="{}")
+    report = await ext.extract_claims_for_item(
+        session, item=item, llm_client=llm
+    )
+    assert report.skipped_no_body is True
+    assert llm.calls == []
+
+
+@pytest.mark.asyncio
+async def test_extract_absorbs_llm_failure():
+    """LLM raising must not surface to the caller — the cron has
+    higher-level retry, and a single broken doc shouldn't poison the
+    batch. The item's body_md_sha is still stamped so a stuck call
+    doesn't repeat every 15 minutes for the same broken body."""
+    item = _FakeItem(body_md="some content")
+    session = _FakeSession()
+    llm = _FakeLLM(response="", raises=True)
+
+    report = await ext.extract_claims_for_item(
+        session, item=item, llm_client=llm
+    )
+    assert report.llm_failed is True
+    assert report.claims_created == 0
+    assert session.added == []
+    # extracted_at + body_md_sha stamped to suppress retry storm
+    assert item.extracted_at is not None
+    assert item.body_md_sha is not None


### PR DESCRIPTION
**Draft.** First two phases of the claim-graph knowledge model. Open as draft because the reconciliation engine (P2) and the view-renderer (P3) ride in follow-up PRs — this PR alone establishes schema + persistence and doesn't yet flip the read surface.

## Why

Today the only retrieval surface is `BucketArticle`, which is the output of one LLM call per (workspace, bucket, tick) that batch-collapses up to 20 raw notes into a single article. From the Ship workspace's own data: **50 docs → 74 notes routed → 4 published auto-articles, with 43/74 notes ignored by the LLM as `skip`**. That's by design (synth is lossy on purpose to avoid noise) but it means lots of legitimately useful per-document content is unreachable to operators and agents.

The fix is to split signal extraction from article-level aggregation. A claim is an atomic, verifiable assertion with its own embedding, provenance, and (next phase) a supersedes chain. Reconciliation operates at the fact level so a 2-year-old architecture decision can be marked `superseded` without rewriting an entire article body. Articles become a rendered view on top of the active claim set per topic — they don't disappear, they just stop being ground truth.

## What's in this PR

**P0 — schema (migration `0059_knowledge_claims`):**
- New `knowledge_claim` table.
  - `claim_md`, `claim_md_sha` — exact-text dedup via unique `(workspace_id, claim_md_sha)`.
  - `embedding vector(1536)` with HNSW (cosine, m=16, ef=64) — same params as `kb_chunks` / `methodology_chunks`.
  - `topic_tags TEXT[]` with GIN index — multi-tag is intentional; a Linear-FSM claim is legitimately both `integrations` and `architecture-decisions`.
  - `status` (`active|superseded|stale|disputed|archived`), `kind` (`fact|rule|decision|example|glossary|other`), `supersedes_id` / `superseded_by_id`, `confidence`, `source_links JSONB` carrying `(source_item_id, excerpt, extracted_at)` triples.
- New columns on `knowledge_source_items`: `body_md`, `body_md_sha`, `extracted_at`. Body lifts off `Improvement.body` (which was always meant as an event queue, not a corpus).

**P1 — extractor (`knowledge_claim_extractor.py`):**
- `extract_claims_for_item(session, item, llm_client)` — asks an LLM for atomic claims with `topic_tags` + `kind`, persists each as `status='active'`, `confidence=1.0`. Defensive parser handles markdown-fenced JSON, bare arrays, malformed shapes.
- `extract_pending_workspace(session, workspace_id, llm_client)` — batch worker, ready to wire into a cron tick in a follow-up.
- Body diffs against stored sha trigger `extracted_at=NULL` so a re-pulled Notion page auto-queues a re-extract on the next tick.
- Per-row best-effort: a bad LLM response stamps `body_md_sha` and `extracted_at` to suppress retry storms — operator can force a redo by clearing `extracted_at`.

## What's NOT in this PR

- Reconciliation engine (P2 — embedding-cosine dedup + LLM contradiction judge).
- Topic view renderer (P3 — claims → article md per topic).
- Read API surfaces (P4 — `/v1/knowledge/search` and `shipctl knowledge fetch` returning claim-level hits).
- Decay (P5 — stale claims auto-archived on signal absence).
- Cron registration for the extractor — added in P2 once the persistence path is exercised end-to-end.
- Old pipeline (`knowledge_extractor.py` for clarification Q&A, `knowledge_router`, `knowledge_synth`) is **untouched**. Once the claim store is hot it becomes a feature flag and gets retired.

## Test plan

- [x] `pytest backend/tests/test_services_knowledge_claim_extractor.py` — 11/11 (parser canonical/fenced/bare-array/malformed/cap, persistence single-claim, exact-text dedup → existing row + bumped `last_seen_at`, idempotent on unchanged sha, empty body skipped without LLM call, LLM exception absorbed)
- [x] Alembic graph: `heads=['0059_knowledge_claims']`, linear chain back to 0058
- [ ] CI: full backend suite + migration apply on clean DB
- [ ] Manual: backfill the Ship workspace via a one-shot `extract_pending_workspace` call, eyeball the `knowledge_claim` rows for sane coverage of `documentation/**`