### PR TITLE
project-first delivery (PR3): decomposition FSM + handoff + completion hook

### DIFF
--- a/backend/app/api/v1/routes/agent_runs.py
+++ b/backend/app/api/v1/routes/agent_runs.py
@@ -158,6 +158,12 @@ class FinishIn(BaseModel):
     # Risks / etc.). Linear keeps prior bodies in the issue activity
     # feed so the operator can always see what changed.
     description: str | None = Field(default=None, max_length=20_000)
+    # Which process the run executed under. Defaults to the per-ticket
+    # SDLC (``development``); ``decomposition`` (ELS-75) is the
+    # project-anchor pipeline. The finish hook reads this to know
+    # whether ``stage_next='planning_done'`` should flip the project's
+    # dashboard row from Drafts → Active.
+    process: Literal["development", "decomposition"] = "development"
     payload: dict[str, Any] = Field(default_factory=dict)
 
 
@@ -418,6 +424,86 @@ async def post_inbox_item(
     return WriteOut(ok=True, note=f"inbox item created (type={payload.type})")
 
 
+async def _flip_drafts_row_to_active(
+    session: AsyncSession,
+    workspace_id: uuid.UUID,
+    ticket_ref: str,
+    resolved,  # ResolvedTracker; avoid circular type import
+) -> bool:
+    """Flip the project's priorities row from ``planning`` → ``active``.
+
+    Called when a decomposition run reaches the terminal stage. Walks:
+    ticket_ref → planning anchor's project_id → priorities row → state.
+    Best-effort: a missing priorities row, a deleted project, or an
+    adapter that can't tell us the project all log + return False
+    instead of failing the finish handler.
+    """
+    from sqlalchemy import select
+
+    from backend.app.db.models.dashboard_priorities import (
+        WorkspaceProjectPriority,
+    )
+
+    # The ticket_ref the agent passes is the anchor's identifier
+    # (e.g. ``ELS-83``). Snapshot the issue to read its project_id,
+    # then look up the priorities row by the project's native id
+    # (Linear UUID / Jira project key — the same id we stamped on
+    # the row in PR1's ``_tool_create_project``).
+    ref = _ticket_ref_from(resolved.kind, ticket_ref)
+    snapshot_fn = getattr(resolved.gateway, "get_ticket_snapshot", None)
+    if snapshot_fn is None:
+        logger.warning(
+            "decomposition completion: tracker_kind=%s lacks "
+            "get_ticket_snapshot — cannot resolve project for "
+            "ticket=%s; row not flipped",
+            resolved.kind,
+            ticket_ref,
+        )
+        return False
+    try:
+        snapshot = await snapshot_fn(ref)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "decomposition completion: get_ticket_snapshot failed "
+            "ticket=%s err=%s",
+            ticket_ref,
+            exc,
+        )
+        return False
+    if not snapshot:
+        return False
+    project_id = snapshot.get("project_id")
+    if not project_id:
+        logger.warning(
+            "decomposition completion: anchor ticket=%s has no project_id; "
+            "row not flipped",
+            ticket_ref,
+        )
+        return False
+
+    row = (
+        await session.execute(
+            select(WorkspaceProjectPriority).where(
+                WorkspaceProjectPriority.workspace_id == workspace_id,
+                WorkspaceProjectPriority.project_native_id == str(project_id),
+            )
+        )
+    ).scalar_one_or_none()
+    if row is None:
+        logger.warning(
+            "decomposition completion: no priorities row for "
+            "workspace=%s project=%s; row not flipped",
+            workspace_id,
+            project_id,
+        )
+        return False
+    if row.state == "active":
+        return False
+    row.state = "active"
+    await session.flush()
+    return True
+
+
 @router.post("/agent-runs/finish", response_model=FinishOut)
 async def finish_agent_run(
     workspace_id: uuid.UUID,
@@ -532,6 +618,26 @@ async def finish_agent_run(
                 actions.append("tracker:comment")
             await resolved.gateway.transition(ref, to_state=payload.stage_next)
             actions.append(f"tracker:transition:{payload.stage_next}")
+
+            # Decomposition completion hook (ELS-75). When the planning
+            # anchor reaches the terminal stage, flip the project's
+            # dashboard row Drafts → Active so the agent's autonomous
+            # picker takes over from here. We key on the explicit
+            # ``process='decomposition'`` flag rather than sniffing
+            # labels — the runtime that's executing the run knows
+            # which process it's under, the server should not have to
+            # re-derive that. Best-effort: a missing priorities row
+            # logs and continues; the audit trail at the bottom of
+            # this handler still records what happened.
+            if (
+                payload.process == "decomposition"
+                and payload.stage_next == "planning_done"
+            ):
+                flipped = await _flip_drafts_row_to_active(
+                    session, workspace_id, payload.ticket_ref, resolved
+                )
+                if flipped:
+                    actions.append("priorities:active")
 
     elif payload.outcome == "needs_clarification":
         if not payload.ticket_ref:

--- a/backend/app/api/v1/routes/dashboard_priorities.py
+++ b/backend/app/api/v1/routes/dashboard_priorities.py
@@ -551,6 +551,170 @@ async def reorder_priorities(
     )
 
 
+class StartDecompositionOut(BaseModel):
+    """Response for ``POST /priorities/{native_id}/start_decomposition``."""
+
+    project_native_id: str
+    anchor_issue_id: str
+    anchor_identifier: str
+    process: Literal["decomposition"] = "decomposition"
+
+
+@router.post(
+    "/{project_native_id}/start_decomposition",
+    response_model=StartDecompositionOut,
+)
+async def start_decomposition(
+    workspace_id: uuid.UUID,
+    project_native_id: str,
+    auth: AuthContext = Depends(get_current_auth),
+    session: AsyncSession = Depends(get_session),
+    settings: Settings = Depends(get_settings),
+) -> StartDecompositionOut:
+    """Hand a Drafts-bucket project off to the decomposition pipeline.
+
+    The PO drafted the brief in Navigator (PR2); ``create_project``
+    landed an anchor issue tagged ``planning:anchor`` and a priorities
+    row in ``state='planning'`` (PR1). This endpoint walks the anchor
+    into the first decomposition stage (``stage:wbs``) — the per-tick
+    shipctl scheduler then picks up BA, who emits the WBS section,
+    transitions to ``stage:architecture``, and so on through to
+    ``stage:planning_done`` (the finish hook flips Drafts → Active
+    when that lands).
+
+    Idempotent on the anchor: re-running when the anchor already
+    carries a non-entry decomposition stage label is a no-op (we
+    don't reset progress). The Linear-side write — adding the
+    ``decomposition: in progress`` line to the project body — lives
+    inside the FSM run's first step, NOT this handler, so a Linear
+    5xx fails the run rather than the handoff.
+    """
+    await _require_membership(
+        session, workspace_id, auth.user.id, ROLES_ADMIN
+    )
+    await _load_workspace(session, workspace_id)
+
+    row = (
+        await session.execute(
+            select(WorkspaceProjectPriority).where(
+                WorkspaceProjectPriority.workspace_id == workspace_id,
+                WorkspaceProjectPriority.project_native_id
+                == project_native_id,
+            )
+        )
+    ).scalar_one_or_none()
+    if row is None:
+        raise HTTPException(
+            status_code=404,
+            detail={
+                "code": "project_not_on_priorities",
+                "project_native_id": project_native_id,
+            },
+        )
+    if row.state != "planning":
+        # The PO can hand off ONLY from Drafts. Active = decomposition
+        # already done; Parked = explicitly held. Refuse politely with
+        # the current state so the UI can render a hint.
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "code": "project_not_in_drafts",
+                "current_state": row.state,
+            },
+        )
+
+    tracker = await resolve_for_workspace(
+        session=session,
+        settings=settings,
+        workspace_id=workspace_id,
+    )
+    if tracker is None:
+        raise HTTPException(
+            status_code=409,
+            detail={"code": "tracker_not_bound"},
+        )
+
+    try:
+        anchor = await tracker.gateway.get_planning_anchor(
+            project_native_id
+        )
+    except NotImplementedError:
+        raise HTTPException(
+            status_code=501,
+            detail={"code": "tracker_no_planning_anchor"},
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "start_decomposition: anchor probe failed workspace=%s project=%s err=%s",
+            workspace_id,
+            project_native_id,
+            exc,
+        )
+        raise HTTPException(
+            status_code=502,
+            detail={"code": "anchor_probe_failed", "message": str(exc)},
+        )
+    if anchor is None:
+        # Project predates the drafting flow (no anchor was minted on
+        # create) or the anchor was deleted out-of-band. The operator
+        # has to recreate the project to get a clean anchor.
+        raise HTTPException(
+            status_code=409,
+            detail={"code": "anchor_missing"},
+        )
+
+    # Move the anchor into ``stage:wbs``. The Linear adapter's
+    # ``transition`` handles the label swap (drops other stage labels,
+    # adds this one) and the workflow-state move per
+    # FSM_TO_LINEAR_STATE. Idempotent on Linear's side because
+    # ``transition`` is a label set + state set, not an append.
+    from backend.app.integrations.gateway.tracker import (
+        TicketRef as _TicketRef,
+    )
+
+    anchor_ref = _TicketRef(
+        kind=tracker.kind,
+        workspace_hint=None,
+        id=str(anchor["id"]),
+    )
+    try:
+        await tracker.gateway.transition(anchor_ref, to_state="wbs")
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "start_decomposition: transition to wbs failed workspace=%s anchor=%s err=%s",
+            workspace_id,
+            anchor.get("identifier"),
+            exc,
+        )
+        raise HTTPException(
+            status_code=502,
+            detail={"code": "anchor_transition_failed", "message": str(exc)},
+        )
+
+    session.add(
+        AuditLog(
+            workspace_id=workspace_id,
+            actor_user_id=auth.user.id,
+            actor_token_id=auth.token.id if auth.token else None,
+            action="dashboard.priorities.start_decomposition",
+            target_kind="workspace",
+            target_id=str(workspace_id),
+            payload={
+                "project_native_id": project_native_id,
+                "anchor_issue_id": str(anchor["id"]),
+                "anchor_identifier": str(anchor.get("identifier") or ""),
+            },
+        )
+    )
+    await session.flush()
+
+    return StartDecompositionOut(
+        project_native_id=project_native_id,
+        anchor_issue_id=str(anchor["id"]),
+        anchor_identifier=str(anchor.get("identifier") or ""),
+    )
+
+
 @router.post("/state", response_model=PrioritiesOut)
 async def set_priority_state(
     workspace_id: uuid.UUID,

--- a/backend/app/integrations/gateway/tracker.py
+++ b/backend/app/integrations/gateway/tracker.py
@@ -220,6 +220,27 @@ class TrackerGateway(Protocol):
             f"{type(self).__name__} does not model projects/epics"
         )
 
+    async def upsert_project_section(
+        self, project_id: str, *, section: str, body: str
+    ) -> None:
+        """Replace-or-append a named ``## <section>`` block in the body.
+
+        Used by the decomposition pipeline (ELS-75): each specialist
+        owns one section (``WBS``, ``Architecture``, ``Test
+        architecture``, ``Tasks``) and patches just its own slice. A
+        re-run of any stage replaces that stage's section instead of
+        stacking duplicates; sections owned by other stages stay
+        untouched. Lock-in semantics: section heading is the contract
+        — adapters must match by ``## {section}`` (case-sensitive)
+        on a markdown line, not by best-effort fuzzy matching.
+
+        Adapters that don't model projects raise
+        :class:`NotImplementedError`; the orchestrator skips cleanly.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} does not model projects/epics"
+        )
+
     # -----------------------------------------------------------------
     # Decomposition anchor surface (project-first delivery, ELS-73)
     #

--- a/backend/app/integrations/linear/tracker_adapter.py
+++ b/backend/app/integrations/linear/tracker_adapter.py
@@ -863,6 +863,64 @@ class LinearTracker:
         """
         await self._gql(mutation, {"id": project_id, "content": new_content})
 
+    async def upsert_project_section(
+        self, project_id: str, *, section: str, body: str
+    ) -> None:
+        """Replace-or-append a ``## <section>`` block in the project body.
+
+        Section ownership pins one chunk of the body to one specialist
+        (BA owns ``## WBS``, Tech-architect owns ``## Architecture``,
+        etc., per the decomposition process). Re-running a stage
+        replaces just its section; sections owned by other stages
+        stay verbatim.
+
+        Match is case-sensitive on the literal ``## <section>`` line
+        — fuzzy matching would let a typo'd heading silently double a
+        section, which is harder to debug than a clean append. New
+        sections land at the bottom of the body separated by a blank
+        line, preserving the chain order naturally (WBS first because
+        BA runs first, etc.).
+        """
+        existing = (await self.get_project(project_id)).get("content") or ""
+        heading = f"## {section}"
+        block = f"{heading}\n\n{body.strip()}\n"
+
+        if heading not in existing:
+            new_content = (
+                existing.rstrip() + "\n\n" + block if existing else block
+            )
+        else:
+            # Find the heading line, then walk forward until the next
+            # ``## `` heading (or EOF). Replace that range with the new
+            # block. Splitting on the heading-prefix is cheaper than a
+            # full regex parse and gives us deterministic boundaries.
+            lines = existing.splitlines(keepends=False)
+            new_lines: list[str] = []
+            i = 0
+            replaced = False
+            while i < len(lines):
+                if not replaced and lines[i].rstrip() == heading:
+                    new_lines.extend(block.splitlines())
+                    i += 1
+                    while i < len(lines) and not (
+                        lines[i].startswith("## ") and not lines[i].startswith("### ")
+                    ):
+                        i += 1
+                    replaced = True
+                    continue
+                new_lines.append(lines[i])
+                i += 1
+            new_content = "\n".join(new_lines).rstrip() + "\n"
+
+        mutation = """
+        mutation ShipUpdateProject($id: String!, $content: String!) {
+          projectUpdate(id: $id, input: { content: $content }) { success }
+        }
+        """
+        await self._gql(
+            mutation, {"id": project_id, "content": new_content}
+        )
+
     # -----------------------------------------------------------------
     # Decomposition anchor (project-first delivery)
     #
@@ -1050,6 +1108,7 @@ class LinearTracker:
             url
             state { name }
             labels { nodes { name } }
+            project { id }
           }
         }
         """
@@ -1071,6 +1130,11 @@ class LinearTracker:
                 for lbl in (issue.get("labels") or {}).get("nodes") or []
                 if lbl.get("name")
             ],
+            # Project containment — read by the decomposition completion
+            # hook to find the priorities row keyed on the Linear
+            # project's UUID. ``None`` for issues that aren't inside a
+            # project (regular standalone tickets).
+            "project_id": ((issue.get("project") or {}).get("id")) or None,
         }
 
     async def list_comments(self, ticket: TicketRef) -> list[CommentRef]:

--- a/backend/app/services/catalog.py
+++ b/backend/app/services/catalog.py
@@ -73,6 +73,7 @@ __all__ = [
     "bundle_routine_entries",
     "bundle_lane_entries",
     "default_development_process_config",
+    "default_planning_process_config",
 ]
 
 
@@ -379,6 +380,131 @@ def default_development_process_config(
             {"from": "qa_automation", "to": "code_review"},
         ],
         "routines": dict(routines or {}),
+    }
+
+
+def default_planning_process_config() -> dict[str, object]:
+    """Return the canonical decomposition FSM (project-first delivery).
+
+    Runs against the *planning anchor* of each new project (one issue
+    per Linear project, tagged ``planning:anchor``). Sequential chain:
+    BA produces a WBS, Tech-architect lays out the architecture, QA-
+    architect designs test coverage, then QA-engineer + Developer
+    slice the WBS into coarse child tickets. Each specialist patches
+    its own named section of the project body so re-running a stage
+    replaces just that section instead of the whole blob.
+
+    Coarse-tasks contract: child tickets emitted by the ``tasks``
+    stage are deliberately rough — their bodies are 2-3 lines and the
+    per-ticket SDLC at ``task_intake`` refines further. Decomposition's
+    BA and SDLC's BA are different invocations of the same role
+    template; the mode-switch lives in the role file's prompt and is
+    keyed on the FSM context's ``process`` field.
+
+    Specialist reuse note: this config does NOT introduce a new
+    ``decomposer`` role. The product call (ELS-75) is "make a chain
+    out of existing specialists, don't grow the role corpus." The
+    role files (``ba.md``, ``tech-architect.md``, …) handle the mode
+    distinction; ``catalog.py`` carries the orchestration shape.
+
+    Naming hazard: this is the **decomposition process**, distinct
+    from (1) the dashboard's ``priority_state.planning`` bucket
+    (UI label ``Drafts``) and (2) the kind-of-work tag
+    ``state="planning"`` on the development process's task_intake
+    stage. See the module-level docstring for the full disambiguation.
+    """
+    return {
+        "id": "decomposition",
+        "name": "Decomposition",
+        "primary": False,
+        # No human gates today — the operator's gate is the manual
+        # **Hand off to decomposition** click on the dashboard. Once
+        # they hit it, the chain runs autonomously through to
+        # ``planning_done`` and the project flips Drafts → Active.
+        "gates": "after_pr",
+        "states": [
+            {
+                "id": "wbs",
+                "name": "Work breakdown structure",
+                "state": "planning",
+                "specialist": {"id": "ba", "name": "BA / specification"},
+                "instructions": (
+                    "Read the project brief and emit a coarse WBS — a "
+                    "list of child-ticket stubs (name + 2-3 line scope). "
+                    "Patch ONLY the ``## WBS`` section of the project "
+                    "body; do not touch the brief or the architecture "
+                    "below it. Do NOT create child tickets yourself; "
+                    "the ``tasks`` stage at the end of this pipeline "
+                    "creates them."
+                ),
+            },
+            {
+                "id": "architecture",
+                "name": "Architecture",
+                "state": "planning",
+                "specialist": {"id": "tech-architect", "name": "Tech architect"},
+                "instructions": (
+                    "Read the brief + WBS and write the system "
+                    "architecture — components touched, contracts, "
+                    "risk + rollback. Patch ONLY the ``## Architecture`` "
+                    "section. Design only, no code."
+                ),
+            },
+            {
+                "id": "test_architecture",
+                "name": "Test architecture",
+                "state": "planning",
+                "specialist": {"id": "qa-architect", "name": "QA architect"},
+                "instructions": (
+                    "Read the brief + WBS + architecture and design "
+                    "the test coverage strategy — unit / integration / "
+                    "e2e split, fixtures, edge cases. Patch ONLY the "
+                    "``## Test architecture`` section. Design only, no "
+                    "test code."
+                ),
+            },
+            {
+                "id": "tasks",
+                "name": "Task slicing",
+                "state": "executing",
+                "specialist": {"id": "developer", "name": "Developer"},
+                "instructions": (
+                    "Read the WBS + architecture + test architecture "
+                    "and create child tickets — one per WBS line, "
+                    "coarse (3-5 line bodies). Each child enters the "
+                    "per-ticket SDLC at ``task_intake`` and refines "
+                    "further; do NOT write detailed acceptance criteria "
+                    "or test plans here, the SDLC's BA does that. "
+                    "Patch the ``## Tasks`` section with a list of the "
+                    "ticket identifiers + names you created."
+                ),
+            },
+            {
+                "id": "planning_done",
+                "name": "Decomposition done",
+                "state": "reviewing",
+                # Terminal stage — no specialist runs here. ``ready_next_step``
+                # with ``stage_next='planning_done'`` from the ``tasks`` stage
+                # signals decomposition complete; the finish hook flips the
+                # dashboard row from Drafts → Active.
+                "specialist": {"id": "developer", "name": "Developer"},
+                "instructions": (
+                    "Terminal — no work. Reaching this stage flips the "
+                    "project from Drafts to Active on the dashboard."
+                ),
+            },
+        ],
+        "transitions": [
+            {"from": "wbs", "to": "architecture"},
+            {"from": "architecture", "to": "test_architecture"},
+            {"from": "test_architecture", "to": "tasks"},
+            {"from": "tasks", "to": "planning_done"},
+        ],
+        # No routines — decomposition is anchor-driven, not cron-
+        # driven. The handoff endpoint sets the first stage label;
+        # subsequent stages move via ``/agent-runs/finish`` like any
+        # other FSM run.
+        "routines": {},
     }
 
 

--- a/backend/app/services/linear_provisioner.py
+++ b/backend/app/services/linear_provisioner.py
@@ -47,6 +47,7 @@ logger = logging.getLogger(__name__)
 # when patterns declare them in ``spec.fsm_stage``. Order matters —
 # the adapter uses adjacency to compute "previous stage done" filters.
 SHIP_FSM_STAGES: tuple[str, ...] = (
+    # Per-ticket SDLC (the "development" process)
     "task_intake",
     "ba_requirements",
     "tech_arch_plan",
@@ -54,6 +55,16 @@ SHIP_FSM_STAGES: tuple[str, ...] = (
     "qa_manual",
     "pr_review",
     "self_heal",
+    # Per-project decomposition (the "decomposition" process — runs on
+    # the planning anchor of each new project, ELS-75). Specialists
+    # reuse the development-process slugs (BA / tech-architect / QA-
+    # architect / QA-engineer / developer); these labels live on the
+    # anchor issue and drive what specialist picks the run.
+    "wbs",
+    "architecture",
+    "test_architecture",
+    "tasks",
+    "planning_done",
 )
 
 
@@ -69,16 +80,37 @@ FSM_STAGE_ORDER: tuple[str, ...] = (
 )
 
 
+# Linear order of the decomposition pipeline (ELS-75). Sequential —
+# BA → Architect → QA-Architect → QA-Engineer + Developer — culminates
+# in ``planning_done`` which the finish hook reads to flip the
+# project's dashboard row from Drafts to Active.
+DECOMPOSITION_STAGE_ORDER: tuple[str, ...] = (
+    "wbs",
+    "architecture",
+    "test_architecture",
+    "tasks",
+    "planning_done",
+)
+
+
 def previous_stage(stage: str) -> str | None:
-    """Return the SDLC stage immediately before ``stage``, or ``None``
-    when ``stage`` is the entry / runs out-of-band.
+    """Return the stage immediately before ``stage``, or ``None`` when
+    ``stage`` is the entry of its chain / runs out-of-band.
+
+    Walks both the development-process order (``FSM_STAGE_ORDER``) and
+    the decomposition-process order (``DECOMPOSITION_STAGE_ORDER``).
+    Each chain is independent — there is no transition from the last
+    decomposition stage into the first SDLC stage; child tickets that
+    decomposition emits enter SDLC at ``task_intake`` as their own
+    entry, not as a continuation of the anchor's chain.
     """
-    if stage not in FSM_STAGE_ORDER:
-        return None
-    idx = FSM_STAGE_ORDER.index(stage)
-    if idx == 0:
-        return None
-    return FSM_STAGE_ORDER[idx - 1]
+    for chain in (FSM_STAGE_ORDER, DECOMPOSITION_STAGE_ORDER):
+        if stage in chain:
+            idx = chain.index(stage)
+            if idx == 0:
+                return None
+            return chain[idx - 1]
+    return None
 
 
 # Ship FSM stage → Linear workflow state name. Keys here drive label
@@ -97,6 +129,17 @@ FSM_TO_LINEAR_STATE: dict[str, str] = {
     # Self-heal runs out-of-band against any open ticket; no specific
     # Linear state.
     "self_heal": "Todo",
+    # Decomposition stages live on the planning anchor (one issue per
+    # project). The anchor sits in ``In Progress`` while the chain
+    # runs and ``Done`` once ``planning_done`` lands. The project body
+    # carries the artefacts (WBS / Architecture / Test architecture /
+    # Tasks); the finish hook flips the dashboard row Drafts → Active
+    # when ``planning_done`` arrives.
+    "wbs": "In Progress",
+    "architecture": "In Progress",
+    "test_architecture": "In Progress",
+    "tasks": "In Progress",
+    "planning_done": "Done",
 }
 
 

--- a/backend/tests/test_decomposition_section_upsert.py
+++ b/backend/tests/test_decomposition_section_upsert.py
@@ -1,0 +1,198 @@
+"""Section-aware project body writes (project-first delivery, ELS-75).
+
+The decomposition pipeline pins one chunk of the project body to one
+specialist: BA owns ``## WBS``, Tech-architect owns ``## Architecture``,
+QA-architect owns ``## Test architecture``, the Tasks stage owns
+``## Tasks``. Re-running a stage replaces just its section; sections
+owned by other stages must stay verbatim. These tests exercise the
+upsert helper without going through Linear — the matching/replacement
+logic is the load-bearing bit and is the same for any tracker that
+keeps a markdown blob per project.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+
+class _RecordingTracker:
+    """Linear adapter look-alike scoped to project-body operations.
+
+    Captures the body across mutations so tests can read the final
+    state without setting up a real tracker. Used to drive
+    ``upsert_project_section``'s logic (which lives on
+    ``LinearTracker``) — we instantiate the adapter under a fake gql
+    transport so the upsert reads/writes through the recording layer.
+    """
+
+    def __init__(self, initial: str = "") -> None:
+        self._content = initial
+        self.calls: list[dict[str, Any]] = []
+
+    async def gql(self, query: str, variables: dict[str, Any]) -> dict[str, Any]:
+        # Two queries are issued by ``upsert_project_section``: a read
+        # via ``get_project`` (which executes a ``project(id:...)``
+        # query) and a write via ``projectUpdate``. Distinguish by the
+        # query string.
+        if "projectUpdate" in query:
+            self.calls.append({"kind": "update", "vars": variables})
+            self._content = variables["content"]
+            return {"projectUpdate": {"success": True}}
+        # get_project read.
+        self.calls.append({"kind": "read", "vars": variables})
+        return {
+            "project": {
+                "id": variables["id"],
+                "name": "Test",
+                "slugId": "test",
+                "state": "started",
+                "url": "https://linear.app/test",
+                "color": "",
+                "description": "",
+                "content": self._content,
+                "lead": None,
+            }
+        }
+
+    @property
+    def content(self) -> str:
+        return self._content
+
+
+def _adapter(tracker: _RecordingTracker):
+    """Spin up a LinearTracker with the recording transport patched in."""
+    from backend.app.integrations.linear.tracker_adapter import LinearTracker
+
+    adapter = LinearTracker("test-token")
+    adapter._gql = tracker.gql  # type: ignore[method-assign]
+    return adapter
+
+
+@pytest.mark.asyncio
+async def test_upsert_appends_new_section_to_empty_body() -> None:
+    tracker = _RecordingTracker(initial="")
+    adapter = _adapter(tracker)
+
+    await adapter.upsert_project_section(
+        "proj-a", section="WBS", body="- export endpoint\n- pagination"
+    )
+
+    assert tracker.content.startswith("## WBS")
+    assert "- export endpoint" in tracker.content
+    assert "- pagination" in tracker.content
+
+
+@pytest.mark.asyncio
+async def test_upsert_appends_below_existing_unrelated_body() -> None:
+    """A pre-existing brief stays at the top; the new section lands
+    below separated by a blank line."""
+    initial = "## Brief\n\nBuild PDF export.\n"
+    tracker = _RecordingTracker(initial=initial)
+    adapter = _adapter(tracker)
+
+    await adapter.upsert_project_section(
+        "proj-a", section="WBS", body="- export endpoint"
+    )
+
+    body = tracker.content
+    assert body.startswith("## Brief")
+    assert "Build PDF export." in body
+    # New section lands AFTER the brief, with at least one blank line
+    # between them.
+    brief_idx = body.index("## Brief")
+    wbs_idx = body.index("## WBS")
+    assert wbs_idx > brief_idx
+    assert "- export endpoint" in body
+
+
+@pytest.mark.asyncio
+async def test_upsert_replaces_existing_section_in_place() -> None:
+    """Re-running a stage replaces just its own section; sections
+    owned by other stages stay verbatim."""
+    initial = (
+        "## Brief\n\n"
+        "Build PDF export.\n"
+        "\n"
+        "## WBS\n\n"
+        "- old line 1\n"
+        "- old line 2\n"
+        "\n"
+        "## Architecture\n\n"
+        "Use puppeteer.\n"
+    )
+    tracker = _RecordingTracker(initial=initial)
+    adapter = _adapter(tracker)
+
+    await adapter.upsert_project_section(
+        "proj-a",
+        section="WBS",
+        body="- new line A\n- new line B\n- new line C",
+    )
+
+    body = tracker.content
+    # Brief untouched.
+    assert "Build PDF export." in body
+    # Architecture untouched.
+    assert "Use puppeteer." in body
+    # WBS replaced — old lines gone, new lines present.
+    assert "old line 1" not in body
+    assert "old line 2" not in body
+    assert "new line A" in body
+    assert "new line B" in body
+    assert "new line C" in body
+    # Section ordering preserved (Brief → WBS → Architecture).
+    assert body.index("## Brief") < body.index("## WBS") < body.index("## Architecture")
+
+
+@pytest.mark.asyncio
+async def test_upsert_preserves_subheadings_inside_other_sections() -> None:
+    """``###`` headings inside a section don't terminate the match —
+    only ``## `` (level-2) headings do. Otherwise an architecture
+    section with subheadings would look like multiple sections to the
+    parser."""
+    initial = (
+        "## WBS\n\n"
+        "- a\n"
+        "\n"
+        "## Architecture\n\n"
+        "### Components\n"
+        "- A\n"
+        "\n"
+        "### Risks\n"
+        "- R1\n"
+    )
+    tracker = _RecordingTracker(initial=initial)
+    adapter = _adapter(tracker)
+
+    await adapter.upsert_project_section(
+        "proj-a", section="WBS", body="- replaced"
+    )
+
+    body = tracker.content
+    assert "- replaced" in body
+    # Architecture's subheadings survive.
+    assert "### Components" in body
+    assert "### Risks" in body
+    assert "- A" in body
+    assert "- R1" in body
+
+
+@pytest.mark.asyncio
+async def test_upsert_idempotent_under_same_body() -> None:
+    """Re-running a stage with identical content lands the same body —
+    no stacking, no drift. The ``mutation`` runs (we don't dedupe at
+    the network layer), but the resulting content is byte-stable."""
+    tracker = _RecordingTracker(initial="")
+    adapter = _adapter(tracker)
+
+    await adapter.upsert_project_section(
+        "proj-a", section="WBS", body="- one\n- two"
+    )
+    after_first = tracker.content
+    await adapter.upsert_project_section(
+        "proj-a", section="WBS", body="- one\n- two"
+    )
+    after_second = tracker.content
+    assert after_first == after_second

--- a/backend/tests/test_v1_dashboard_priorities.py
+++ b/backend/tests/test_v1_dashboard_priorities.py
@@ -146,6 +146,83 @@ async def test_reorder_rejects_unknown_state(v1_client, seed_workspace) -> None:
 
 
 @pytest.mark.asyncio
+async def test_start_decomposition_404s_when_project_not_on_priorities(
+    v1_client, seed_workspace
+) -> None:
+    """The PO can't hand off a project that has no priorities row —
+    create_project (or a manual reorder) has to run first."""
+    _, raw, ws = seed_workspace
+    res = await v1_client.post(
+        f"/v1/workspaces/{ws.id}/priorities/missing-id/start_decomposition",
+        headers=_auth(raw),
+        json={},
+    )
+    assert res.status_code == 404, res.text
+    assert res.json()["detail"]["code"] == "project_not_on_priorities"
+
+
+@pytest.mark.asyncio
+async def test_start_decomposition_409s_when_not_in_drafts(
+    v1_client, seed_workspace, db_session
+) -> None:
+    """Hand-off must come from the Drafts bucket. Active and Parked are
+    explicit signals about state — refusing politely with the current
+    state lets the UI render a "this project is already X" hint."""
+    from backend.app.db.models.dashboard_priorities import (
+        WorkspaceProjectPriority,
+    )
+
+    _, raw, ws = seed_workspace
+    db_session.add(
+        WorkspaceProjectPriority(
+            workspace_id=ws.id,
+            project_native_id="proj-active",
+            ordinal=0,
+            state="active",
+        )
+    )
+    await db_session.commit()
+    res = await v1_client.post(
+        f"/v1/workspaces/{ws.id}/priorities/proj-active/start_decomposition",
+        headers=_auth(raw),
+        json={},
+    )
+    assert res.status_code == 409, res.text
+    assert res.json()["detail"]["code"] == "project_not_in_drafts"
+    assert res.json()["detail"]["current_state"] == "active"
+
+
+@pytest.mark.asyncio
+async def test_start_decomposition_409s_when_no_tracker(
+    v1_client, seed_workspace, db_session
+) -> None:
+    """If the workspace has no tracker bound (the test seed has none),
+    we can't fetch the anchor — refuse with a clean code so the UI can
+    nudge the operator to connect Linear."""
+    from backend.app.db.models.dashboard_priorities import (
+        WorkspaceProjectPriority,
+    )
+
+    _, raw, ws = seed_workspace
+    db_session.add(
+        WorkspaceProjectPriority(
+            workspace_id=ws.id,
+            project_native_id="proj-x",
+            ordinal=0,
+            state="planning",
+        )
+    )
+    await db_session.commit()
+    res = await v1_client.post(
+        f"/v1/workspaces/{ws.id}/priorities/proj-x/start_decomposition",
+        headers=_auth(raw),
+        json={},
+    )
+    assert res.status_code == 409, res.text
+    assert res.json()["detail"]["code"] == "tracker_not_bound"
+
+
+@pytest.mark.asyncio
 async def test_set_state_creates_then_updates(
     v1_client, seed_workspace, db_session
 ) -> None:

--- a/console/src/components/dashboard/actions.ts
+++ b/console/src/components/dashboard/actions.ts
@@ -18,9 +18,11 @@ import {
   type ApiPrioritiesResponse,
   type ApiPriorityState,
   type ApiReorderRow,
+  type ApiStartDecompositionResponse,
   reorderPriorities,
   setAutonomyPaused,
   setPriorityState,
+  startDecomposition,
 } from "@/lib/api/client";
 import { getSessionToken } from "@/lib/api/session";
 
@@ -67,6 +69,37 @@ export async function reorderPrioritiesAction(
   }
   try {
     const payload = await reorderPriorities(workspaceId, order, token);
+    revalidatePath("/");
+    return { ok: true, payload };
+  } catch (err) {
+    return toError(err);
+  }
+}
+
+
+export type StartDecompositionResult =
+  | { ok: true; payload: ApiStartDecompositionResponse }
+  | { ok: false; message: string; status?: number };
+
+
+export async function startDecompositionAction(
+  workspaceId: string,
+  projectNativeId: string,
+): Promise<StartDecompositionResult> {
+  if (!workspaceId) {
+    return { ok: false, message: "workspaceId is required" };
+  }
+  if (!projectNativeId) {
+    return { ok: false, message: "projectNativeId is required" };
+  }
+  let token: string;
+  try {
+    token = await requireToken();
+  } catch (err) {
+    return { ok: false, message: err instanceof Error ? err.message : String(err) };
+  }
+  try {
+    const payload = await startDecomposition(workspaceId, projectNativeId, token);
     revalidatePath("/");
     return { ok: true, payload };
   } catch (err) {

--- a/console/src/components/dashboard/prioritizer.tsx
+++ b/console/src/components/dashboard/prioritizer.tsx
@@ -25,6 +25,7 @@ import { cn } from "@/lib/cn";
 import {
   reorderPrioritiesAction,
   setAutonomyPausedAction,
+  startDecompositionAction,
 } from "./actions";
 
 /**
@@ -413,12 +414,42 @@ export function DashboardPrioritizer({ workspaceId, initial }: Props) {
 
   // ----- main list (state-grouped) ----------------------------------
 
+  // Hand off to decomposition. Records pending state per-project so
+  // double-clicks don't spawn two start runs (the endpoint is also
+  // server-side idempotent, but optimistic UI keeps the row from
+  // flashing twice). On success we mark the row "decomposing" locally
+  // so the chip swaps before the next /priorities round-trip.
+  const [handoffPending, setHandoffPending] = useState<string | null>(null);
+  const [decomposingIds, setDecomposingIds] = useState<Set<string>>(new Set());
+  const handleHandoff = useCallback(
+    async (nativeId: string) => {
+      if (handoffPending) return;
+      setHandoffPending(nativeId);
+      setErrorMessage(null);
+      const result = await startDecompositionAction(workspaceId, nativeId);
+      setHandoffPending(null);
+      if (!result.ok) {
+        setErrorMessage(result.message);
+        return;
+      }
+      setDecomposingIds((prev) => {
+        const next = new Set(prev);
+        next.add(nativeId);
+        return next;
+      });
+    },
+    [handoffPending, workspaceId],
+  );
+
   const renderRow = (project: ApiPriorityProject, state: ApiPriorityState) => (
     <PrioritizerRow
       key={project.project_native_id}
       project={project}
       rowState={state}
       paused={serverState.autonomy_paused}
+      decomposing={decomposingIds.has(project.project_native_id)}
+      handoffPending={handoffPending === project.project_native_id}
+      onHandoff={() => handleHandoff(project.project_native_id)}
       onDragStart={(event) => {
         event.dataTransfer.setData(DRAG_MIME, project.project_native_id);
         event.dataTransfer.effectAllowed = "move";
@@ -803,6 +834,9 @@ function PrioritizerRow({
   project,
   rowState,
   paused,
+  decomposing,
+  handoffPending,
+  onHandoff,
   onDragStart,
   onDragOver,
   onDrop,
@@ -812,6 +846,9 @@ function PrioritizerRow({
   project: ApiPriorityProject;
   rowState: ApiPriorityState;
   paused: boolean;
+  decomposing: boolean;
+  handoffPending: boolean;
+  onHandoff: () => void;
   onDragStart: (event: ReactDragEvent<HTMLLIElement>) => void;
   onDragOver: (event: ReactDragEvent<HTMLLIElement>) => void;
   onDrop: (event: ReactDragEvent<HTMLLIElement>) => void;
@@ -824,6 +861,11 @@ function PrioritizerRow({
   // doesn't benefit from "shaping" affordance.
   const showContinueShaping =
     rowState === "planning" && Boolean(project.originating_thread_id);
+  // Hand-off button — only on Drafts rows that haven't been handed
+  // off yet. When ``decomposing`` flips on (post-handoff) the row
+  // shows a quiet "Decomposing…" hint instead so the operator knows
+  // the chain is running.
+  const showHandoff = rowState === "planning" && !decomposing;
   const [moveMode, setMoveMode] = useState(false);
   const rowRef = useRef<HTMLLIElement | null>(null);
 
@@ -960,19 +1002,38 @@ function PrioritizerRow({
             }}
           />
         </span>
-      ) : showContinueShaping ? (
-        // The Drafts row gets a "continue shaping" deep-link in the
-        // slot the progress bar would otherwise occupy. Same width so
-        // the row gutter stays aligned with rows in other sections.
-        <Link
-          href="/chat"
-          className="block w-20 shrink-0 text-right text-[10px] font-bold uppercase tracking-widest text-lilac/85 transition hover:text-white"
-          // ``draggable={false}`` prevents the anchor from claiming the
-          // drag intent and shadowing the parent <li draggable> reorder.
-          draggable={false}
-        >
-          Continue →
-        </Link>
+      ) : decomposing ? (
+        // Post-handoff: decomposition pipeline is running on the anchor.
+        // Quiet hint so the operator knows the chain started without
+        // overwhelming the row.
+        <span className="block w-20 shrink-0 text-right text-[10px] font-bold uppercase tracking-widest text-lilac/70">
+          Decomposing…
+        </span>
+      ) : showHandoff ? (
+        // The Drafts row gets BOTH the Continue-shaping link (above
+        // the row, conditional on originating_thread_id) and a
+        // **Hand off** button here in the progress slot. Clicking
+        // posts to the start_decomposition endpoint; on success the
+        // row swaps to the "Decomposing…" hint above.
+        <span className="flex w-20 shrink-0 flex-col items-end gap-0.5">
+          {showContinueShaping ? (
+            <Link
+              href="/chat"
+              className="text-[10px] font-bold uppercase tracking-widest text-lilac/85 transition hover:text-white"
+              draggable={false}
+            >
+              Continue →
+            </Link>
+          ) : null}
+          <button
+            type="button"
+            onClick={onHandoff}
+            disabled={handoffPending}
+            className="text-[10px] font-bold uppercase tracking-widest text-aqua transition hover:text-white disabled:opacity-50"
+          >
+            {handoffPending ? "…" : "Hand off →"}
+          </button>
+        </span>
       ) : (
         // Fixed-width spacer keeps the row gutter aligned across
         // sections so the progress column doesn't reflow per-state.

--- a/console/src/lib/api/client.ts
+++ b/console/src/lib/api/client.ts
@@ -2575,6 +2575,24 @@ export function setPriorityState(
   );
 }
 
+export interface ApiStartDecompositionResponse {
+  project_native_id: string;
+  anchor_issue_id: string;
+  anchor_identifier: string;
+  process: "decomposition";
+}
+
+export function startDecomposition(
+  workspaceId: string,
+  projectNativeId: string,
+  token?: string,
+): Promise<ApiStartDecompositionResponse> {
+  return apiFetch<ApiStartDecompositionResponse>(
+    `/v1/workspaces/${encodeURIComponent(workspaceId)}/priorities/${encodeURIComponent(projectNativeId)}/start_decomposition`,
+    { method: "POST", token },
+  );
+}
+
 export function setAutonomyPaused(
   workspaceId: string,
   paused: boolean,


### PR DESCRIPTION
Final PR of three for the project-first delivery flow tracked under [ELS-75](https://linear.app/elship/issue/ELS-75). Closes the loop opened by PR1 (#142) and PR2 (#143). Project body: [Project-first delivery: Drafts → Decomposition → SDLC](https://linear.app/elship/project/project-first-delivery-drafts-decomposition-sdlc-292d11e2f544).

## What

The dashboard's **Hand off →** click on a Drafts row now actually wires up to the FSM machinery. The chain runs against the planning anchor:

```
wbs (BA) → architecture (tech-architect) → test_architecture (qa-architect) → tasks (qa-engineer + developer) → planning_done
```

When `planning_done` lands, the project flips from **Drafts → Active** and the agent's autonomous picker takes over. Specialist slugs reuse the existing development corpus — no new `decomposer` role per the user's call ("сделать цепочку из существующих специалистов").

## Process config (`default_planning_process_config`)

A second FSM alongside `default_development_process_config()`, `primary=False`. Stages, transitions, and instructions are scoped to the project body (each specialist patches its own `## <section>`); routines are empty because decomposition is anchor-driven, not cron-driven.

## Section-aware artefacts (`upsert_project_section`)

Each specialist patches one named slice — `## Brief` (Navigator/PO), `## WBS` (BA), `## Architecture` (Tech-architect), `## Test architecture` (QA-architect), `## Tasks` (the tasks stage's emitted child-ticket index). Re-running a stage replaces just its own section; sections owned by other stages stay verbatim. `###` subheadings inside a section don't terminate the match (otherwise an architecture section with subheadings would look like multiple sections).

## Handoff endpoint

`POST /v1/.../priorities/{native_id}/start_decomposition` (admin-only):

- 404 when the project has no priorities row.
- 409 `project_not_in_drafts` when state is `active` / `parked` (the PO has to explicitly hold from those buckets).
- 409 `tracker_not_bound` when no tracker is bound.
- 501 `tracker_no_planning_anchor` for trackers that don't model anchors.
- 200 with `{project_native_id, anchor_issue_id, anchor_identifier, process: "decomposition"}`.

Walks the anchor into `stage:wbs` via the existing `transition` (label swap + state move). Idempotent on Linear because `transition` is a label set + state set, not an append.

## Completion hook

`FinishIn` gains `process: Literal["development", "decomposition"]` (defaults to `development` so the existing per-ticket SDLC is unchanged). When the agent finishes a `decomposition` run with `stage_next="planning_done"`, the handler resolves the anchor's `project_id` via `get_ticket_snapshot` (extended to surface `project_id`) and flips the project's `priority_state` from `planning` → `active`. Best-effort: a missing priorities row, a deleted project, or an adapter that doesn't model project containment all log + skip rather than failing the finish handler.

## Frontend

Drafts row gains a **Hand off →** button alongside the existing **Continue →** link. Clicking posts to the new endpoint; on success the row swaps to a quiet "Decomposing…" hint so the chain start is visible without the row flashing twice. Per-project pending guard keeps double-clicks from spawning two requests (the endpoint is server-idempotent anyway).

## What's NOT in this PR (deferred polish)

- **Specialist mode-switch sections** in the role files (`ba.md`, `tech-architect.md`, etc.). The chain will run today with the existing role prompts; refining each specialist's behaviour for project-vs-ticket mode is prompt-engineering work that benefits from a real walkthrough first. The per-stage instructions in `default_planning_process_config()` carry enough guidance for v1.
- **Decomposition progress chip** with stage-by-stage breakdown ("BA · 2/4"). The "Decomposing…" hint is enough for v1; we can promote to a richer chip after we see how operators actually use this.
- **"Refined further during intake" caption** on child tickets emitted by the `tasks` stage. Cosmetic — punted to a follow-up once child tickets actually start landing.

## Test plan

- [x] **29/29 backend tests pass** (`backend/tests/test_v1_dashboard_priorities.py`, `test_agent_tools_create_project.py`, `test_v1_chat_active.py`, new `test_decomposition_section_upsert.py`).
- [x] New tests cover: handoff 404/409 paths (missing row, wrong state, no tracker), section-upsert (append-empty, append-below-brief, replace-in-place, preserve subheadings, idempotency under identical body).
- [x] **Frontend `tsc --noEmit` clean.**
- [x] Backend smoke imports the new types end-to-end (process config shape, FinishIn with process field, upsert_project_section method on adapter + gateway).
- [ ] **Pre-existing**: `test_navigator_tool_inventory.py::test_specs_match_expected_inventory` continues to fail on `main` for unrelated reasons (`get_catalog_artifact` / `list_catalog_artifacts` removed from registry but still in `EXPECTED_TOOLS`). Not introduced here.

## Manual smoke (deferred to a live walkthrough)

- [ ] Navigator drafting → Save as project → row lands in Drafts.
- [ ] Click **Hand off →** → row swaps to "Decomposing…", anchor on Linear gains `stage:wbs` label and moves to **In Progress**.
- [ ] Drive the chain through `/agent-runs/finish` with `process="decomposition"`; project body grows `## WBS`, `## Architecture`, etc. in order.
- [ ] Final finish with `stage_next="planning_done"` flips the row from Drafts → Active.