### PR TITLE
knowledge: claim reconciliation engine + extractor cron (P2)

### DIFF
--- a/backend/app/db/models/agent_memory.py
+++ b/backend/app/db/models/agent_memory.py
@@ -1020,6 +1020,12 @@ class KnowledgeClaim(Base):
     last_seen_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=text("now()")
     )
+    # NULL = pending reconciliation. Stamped by the reconciler tick
+    # after the claim has been compared against its nearest neighbours
+    # and any duplicate / refines / contradicts decisions applied.
+    reconciled_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
     created_at: Mapped[datetime] = _ts_created()
     updated_at: Mapped[datetime] = _ts_updated()
 

--- a/backend/app/services/cron.py
+++ b/backend/app/services/cron.py
@@ -85,6 +85,8 @@ class CronLockId(IntEnum):
     KNOWLEDGE_SYNTH = 1003
     KNOWLEDGE_DECAY = 1004
     KNOWLEDGE_SOURCES_SYNC = 1005
+    KNOWLEDGE_CLAIM_EXTRACT = 1006
+    KNOWLEDGE_CLAIM_RECONCILE = 1007
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/services/cron_jobs.py
+++ b/backend/app/services/cron_jobs.py
@@ -26,11 +26,19 @@ from backend.app.services.cron import (
     cron_with_lock,
     register_cron,
 )
+from backend.app.db.models.tenancy import Workspace
+from backend.app.services.knowledge_claim_extractor import (
+    extract_pending_workspace,
+)
 from backend.app.services.knowledge_decay import gc_all_workspaces
 from backend.app.services.knowledge_harvest import harvest_all_workspaces
 from backend.app.services.knowledge_ingestion import sync_due_import_sources
+from backend.app.services.knowledge_reconciler import (
+    reconcile_pending_workspace,
+)
 from backend.app.services.knowledge_router import route_all_workspaces
 from backend.app.services.knowledge_synth import synthesise_all_workspaces
+from sqlalchemy import select
 
 
 log = logging.getLogger(__name__)
@@ -210,6 +218,132 @@ async def _knowledge_sources_sync_tick() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Claim store — extractor + reconciler (post-0059)
+# ---------------------------------------------------------------------------
+
+
+async def _all_workspace_ids() -> list[Any]:
+    """Fetch every workspace id once per tick — both claim ticks fan
+    out per-workspace because ``extract_pending_workspace`` and
+    ``reconcile_pending_workspace`` cap their batches to a workspace's
+    own pending queue."""
+    sm = get_sessionmaker()
+    async with sm() as session:
+        rows = (
+            await session.execute(select(Workspace.id))
+        ).scalars().all()
+    return list(rows)
+
+
+@cron_with_lock(
+    lock=CronLockId.KNOWLEDGE_CLAIM_EXTRACT, name="knowledge_claim_extract"
+)
+async def _knowledge_claim_extract_tick() -> None:
+    """Every 20 min: turn un-extracted source items into claims.
+
+    Per-workspace fan-out so one big workspace's body doesn't starve
+    the rest. The extractor itself is best-effort — a malformed LLM
+    response stamps the item and moves on, and the next body change
+    queues a re-extract automatically.
+
+    Without an LLM client the tick logs once and skips: the extractor
+    can't run identity-style on document bodies (it'd dump full doc
+    text into the claim store and defeat the whole point).
+    """
+    try:
+        llm_client = pick_default_client(get_settings())
+    except Exception:
+        log.info(
+            "knowledge_claim_extract tick: no LLM client configured; "
+            "extractor skipped this tick"
+        )
+        return
+
+    sm = get_sessionmaker()
+    workspace_ids = await _all_workspace_ids()
+    total_claims = 0
+    total_failed = 0
+    for ws_id in workspace_ids:
+        async with sm() as session:
+            try:
+                report = await extract_pending_workspace(
+                    session, workspace_id=ws_id, llm_client=llm_client
+                )
+                await session.commit()
+            except Exception:
+                await session.rollback()
+                log.exception(
+                    "knowledge_claim_extract tick: ws=%s failed", ws_id
+                )
+                total_failed += 1
+                continue
+        total_claims += report.claims_created
+        total_failed += report.failed
+    if total_claims or total_failed:
+        log.info(
+            "knowledge_claim_extract tick: workspaces=%d claims=%d failed=%d",
+            len(workspace_ids),
+            total_claims,
+            total_failed,
+        )
+
+
+@cron_with_lock(
+    lock=CronLockId.KNOWLEDGE_CLAIM_RECONCILE,
+    name="knowledge_claim_reconcile",
+)
+async def _knowledge_claim_reconcile_tick() -> None:
+    """Every 25 min: collapse near-duplicates and resolve supersedes.
+
+    Runs offset 5 min after the extractor so freshly-inserted claims
+    have time to land before the reconciler looks for neighbours.
+    The reconciler tolerates a missing LLM client — the cosine
+    fast-path (sim ≥ 0.95) still folds obvious duplicates, the
+    LLM-judge band is just left alone.
+    """
+    try:
+        llm_client = pick_default_client(get_settings())
+    except Exception:
+        log.info(
+            "knowledge_claim_reconcile tick: no LLM client configured; "
+            "running cosine-only reconciliation"
+        )
+        llm_client = None
+
+    sm = get_sessionmaker()
+    workspace_ids = await _all_workspace_ids()
+    total_dup = total_refines = total_contradict = total_failed = 0
+    for ws_id in workspace_ids:
+        async with sm() as session:
+            try:
+                report = await reconcile_pending_workspace(
+                    session, workspace_id=ws_id, llm_client=llm_client
+                )
+                await session.commit()
+            except Exception:
+                await session.rollback()
+                log.exception(
+                    "knowledge_claim_reconcile tick: ws=%s failed", ws_id
+                )
+                total_failed += 1
+                continue
+        total_dup += report.auto_duplicates + report.llm_duplicates
+        total_refines += report.refines
+        total_contradict += report.contradicts
+        total_failed += report.failed
+    if total_dup or total_refines or total_contradict or total_failed:
+        log.info(
+            "knowledge_claim_reconcile tick: workspaces=%d duplicates=%d "
+            "refines=%d contradicts=%d failed=%d",
+            len(workspace_ids),
+            total_dup,
+            total_refines,
+            total_contradict,
+            total_failed,
+        )
+
+
+# ---------------------------------------------------------------------------
 # Step 6 — daily archive GC
 # ---------------------------------------------------------------------------
 
@@ -277,6 +411,22 @@ def register_all() -> None:
         fn=_knowledge_sources_sync_tick,
         cron_expr="*/15 * * * *",
         job_id="knowledge_sources_sync",
+    )
+    # Claim extractor runs every 20 min — fast enough that an
+    # operator who pushed a doc edit sees claims appear within minutes,
+    # bounded enough that a full backfill of an existing workspace
+    # paces itself without saturating the LLM API. The reconciler
+    # offsets by +5 so freshly-inserted claims land before the
+    # cosine-nearest sweep looks for neighbours.
+    register_cron(
+        fn=_knowledge_claim_extract_tick,
+        cron_expr="*/20 * * * *",
+        job_id="knowledge_claim_extract",
+    )
+    register_cron(
+        fn=_knowledge_claim_reconcile_tick,
+        cron_expr="5,25,45 * * * *",
+        job_id="knowledge_claim_reconcile",
     )
     # GC runs once daily. Cheap query (filtered DELETE by archived_at)
     # so an off-peak slot is fine; pick 03:15 UTC to avoid the on-the-

--- a/backend/app/services/knowledge_reconciler.py
+++ b/backend/app/services/knowledge_reconciler.py
@@ -1,0 +1,547 @@
+"""Reconcile freshly-extracted claims against existing canon.
+
+The extractor (P1) is intentionally promiscuous — it inserts every
+atomic statement the LLM finds with ``status='active'`` and
+``confidence=1.0``, no awareness of what's already in the store. That
+keeps extraction cheap, parallel-safe, and idempotent on re-runs.
+
+The flip side: a workspace that re-syncs the same Notion page over a
+month accumulates near-duplicate claims with slightly different
+wording, and architecture decisions overwritten by later ones live
+side-by-side with their replacements. Search would surface both,
+the agent would have no way to tell which is current, and the
+"clean canon" promise rots quickly.
+
+This module is the catch-up pass. Per pending claim:
+
+1. **Fast-path duplicate.** Find the single nearest active claim by
+   cosine similarity; if it's > ``_DUP_AUTO_THRESHOLD`` (0.95) we
+   call them duplicates without spending an LLM call. The new claim
+   is folded into the existing row's ``source_links`` and marked
+   ``status='superseded', superseded_by_id=existing.id``.
+
+2. **LLM-judge band.** For sims ≥ ``_LLM_JUDGE_THRESHOLD`` (0.85)
+   but below the auto-threshold, run a small LLM call labelling
+   the relationship as one of:
+
+   - ``duplicate``  — same fact, different wording. Apply same
+     handling as the fast-path.
+   - ``refines``    — the new claim is more current / accurate. The
+     old claim is the one that becomes superseded; the new one
+     stays active.
+   - ``contradicts``— both claim something incompatible about the
+     same fact. We can't pick a winner without an operator;
+     **both** rows get ``status='disputed'`` and stay queryable
+     under that filter so the inbox surfaces them for review.
+   - ``unrelated``  — textual proximity but different topics. No
+     action; reconciler simply marks the new claim done.
+
+3. **No near-match.** Below the LLM-judge threshold, leave the new
+   claim alone — it's a genuinely new fact.
+
+Whatever the outcome, the reconciler stamps ``reconciled_at = now()``
+on the new claim so the next tick's filter (``WHERE reconciled_at IS
+NULL``) skips it. Failures inside an LLM call also stamp the
+timestamp so a stuck judge call doesn't loop the same row forever;
+the operator can force a redo by NULL-ing the column.
+
+This module deliberately stays out of the inbox. ``status='disputed'``
+is the queryable surface; an operator review UI ride in a follow-up
+PR rather than blocking the dedup logic on UX work.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.app.core.config import Settings, get_settings
+from backend.app.db.models.agent_memory import (
+    ClaimStatus,
+    KnowledgeClaim,
+)
+from backend.app.services.agent.client import AgentClient, ChatMessage
+
+
+log = logging.getLogger(__name__)
+
+
+# Cosine similarity above this → auto-fold without spending an LLM
+# call. The 0.95 threshold is calibrated so genuinely different claims
+# with overlapping vocabulary (e.g. two different rules about the same
+# subject) stay above the LLM-judge band rather than getting silently
+# merged.
+_DUP_AUTO_THRESHOLD = 0.95
+
+# Below this similarity we don't ask the LLM at all — a coincidental
+# vocabulary overlap isn't worth the token spend. Tunable per
+# workspace if a deployment has unusually low-vocabulary drift.
+_LLM_JUDGE_THRESHOLD = 0.85
+
+# Top-K nearest claims to consider per pending row. Most decisions
+# fire on rank 1; the small K is there to handle the case where the
+# nearest neighbour happens to be ``unrelated`` and the actual
+# duplicate sits at rank 2 (e.g. when an old claim's wording drifted
+# more than its modern restatement).
+_NEAREST_K = 5
+
+# Per-cron-tick batch — bounded so a 5000-claim backfill doesn't
+# single-thread one tick.
+_RECONCILE_BATCH_LIMIT = 25
+
+
+_JUDGE_SYSTEM_PROMPT = """\
+You compare two claims that are both currently in our knowledge base
+and decide their relationship. Output ONLY a JSON object.
+
+Pick exactly one label:
+
+- "duplicate"   — the two claims assert the same fact (wording differs,
+                  meaning is identical).
+- "refines"     — the NEW claim is a more current / accurate / specific
+                  version of the OLD claim. The OLD claim should be
+                  marked superseded.
+- "contradicts" — the two claims disagree about the same fact. Both
+                  cannot be true; needs human review.
+- "unrelated"   — they're about different things despite vocabulary
+                  overlap.
+
+Output schema (no commentary, no markdown fences):
+  {"decision": "duplicate|refines|contradicts|unrelated",
+   "reason": "≤140 chars why"}
+"""
+
+
+_DECISION_DUPLICATE = "duplicate"
+_DECISION_REFINES = "refines"
+_DECISION_CONTRADICTS = "contradicts"
+_DECISION_UNRELATED = "unrelated"
+_VALID_DECISIONS = frozenset(
+    {
+        _DECISION_DUPLICATE,
+        _DECISION_REFINES,
+        _DECISION_CONTRADICTS,
+        _DECISION_UNRELATED,
+    }
+)
+
+
+@dataclass(slots=True)
+class ReconcileReport:
+    """Outcome of one reconciliation pass over a single claim."""
+
+    claim_id: uuid.UUID
+    decision: str | None = None  # duplicate / refines / contradicts / unrelated / no_match
+    matched_claim_id: uuid.UUID | None = None
+    similarity: float | None = None
+    used_llm: bool = False
+    errors: list[str] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class BatchReport:
+    """Outcome of one reconciler tick across a workspace's pending claims."""
+
+    inspected: int = 0
+    auto_duplicates: int = 0
+    llm_duplicates: int = 0
+    refines: int = 0
+    contradicts: int = 0
+    unrelated: int = 0
+    no_match: int = 0
+    skipped_no_embedding: int = 0
+    failed: int = 0
+
+
+# ---------------------------------------------------------------------------
+# Nearest-neighbour lookup
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class _NearestRow:
+    claim_id: uuid.UUID
+    similarity: float
+    claim_md: str
+
+
+async def _nearest_active_claims(
+    session: AsyncSession,
+    *,
+    workspace_id: uuid.UUID,
+    self_claim_id: uuid.UUID,
+    embedding: list[float],
+    k: int,
+) -> list[_NearestRow]:
+    """Top-K active claims in the same workspace, ranked by cosine similarity.
+
+    Uses the HNSW index from migration 0059 (``vector_cosine_ops``).
+    Postgres pgvector exposes cosine distance via the ``<=>`` operator
+    (0 = identical, 2 = opposite); cosine *similarity* is ``1 -
+    distance``. We compute it inline so the caller compares against
+    intuitive thresholds without re-deriving the algebra.
+    """
+    rows = (
+        await session.execute(
+            text(
+                """
+                SELECT id, claim_md, 1 - (embedding <=> :q) AS similarity
+                FROM knowledge_claim
+                WHERE workspace_id = :ws
+                  AND status = :active
+                  AND embedding IS NOT NULL
+                  AND id <> :self_id
+                ORDER BY embedding <=> :q
+                LIMIT :k
+                """
+            ),
+            {
+                "q": str(embedding),
+                "ws": str(workspace_id),
+                "self_id": str(self_claim_id),
+                "active": ClaimStatus.ACTIVE,
+                "k": k,
+            },
+        )
+    ).all()
+    return [
+        _NearestRow(
+            claim_id=row[0],
+            claim_md=row[1],
+            similarity=float(row[2]),
+        )
+        for row in rows
+    ]
+
+
+# ---------------------------------------------------------------------------
+# LLM judge
+# ---------------------------------------------------------------------------
+
+
+async def _llm_judge(
+    *,
+    client: AgentClient,
+    old_text: str,
+    new_text: str,
+) -> tuple[str, str] | None:
+    """Ask the LLM to label the (old, new) relationship.
+
+    Returns ``(decision, reason)`` or ``None`` if the call failed or
+    the response was malformed. The caller treats ``None`` the same
+    as ``unrelated`` — better to leave the claim alone than to mark
+    a supersedes chain off a flaky completion.
+    """
+    user_msg = (
+        f"OLD claim (already in store):\n  {old_text}\n\n"
+        f"NEW claim (just extracted):\n  {new_text}"
+    )
+    try:
+        raw = await client.acomplete(
+            messages=[
+                ChatMessage(role="system", content=_JUDGE_SYSTEM_PROMPT),
+                ChatMessage(role="user", content=user_msg),
+            ],
+            max_tokens=200,
+            temperature=0.0,
+            response_format={"type": "json_object"},
+        )
+    except Exception as exc:  # noqa: BLE001 — best-effort
+        log.info("reconciler: LLM judge call failed (%s)", exc)
+        return None
+
+    cleaned = (raw or "").strip()
+    if cleaned.startswith("```"):
+        cleaned = cleaned.strip("`")
+        if cleaned.lower().startswith("json"):
+            cleaned = cleaned[4:].lstrip()
+        cleaned = cleaned.strip("`").strip()
+    try:
+        obj: Any = json.loads(cleaned)
+    except json.JSONDecodeError:
+        log.info("reconciler: LLM judge returned non-JSON (%r)", raw[:120])
+        return None
+    if not isinstance(obj, dict):
+        return None
+    decision = str(obj.get("decision") or "").strip().lower()
+    if decision not in _VALID_DECISIONS:
+        return None
+    reason = str(obj.get("reason") or "").strip()[:200]
+    return decision, reason
+
+
+# ---------------------------------------------------------------------------
+# Decision application
+# ---------------------------------------------------------------------------
+
+
+def _merge_source_links(
+    target: KnowledgeClaim, source: KnowledgeClaim, now: datetime
+) -> None:
+    """Append ``source.source_links`` into ``target.source_links``.
+
+    Idempotent: a (source_item_id, extracted_at) pair already present
+    is skipped. last_seen_at is bumped so decay knows the canon claim
+    is still being asserted by at least one source.
+    """
+    existing = list(target.source_links or [])
+    seen = {
+        (
+            entry.get("source_item_id"),
+            entry.get("extracted_at"),
+        )
+        for entry in existing
+        if isinstance(entry, dict)
+    }
+    for entry in source.source_links or []:
+        if not isinstance(entry, dict):
+            continue
+        key = (
+            entry.get("source_item_id"),
+            entry.get("extracted_at"),
+        )
+        if key in seen:
+            continue
+        existing.append(entry)
+        seen.add(key)
+    target.source_links = existing
+    target.last_seen_at = now
+
+
+def _apply_duplicate(
+    new: KnowledgeClaim, existing: KnowledgeClaim, now: datetime
+) -> None:
+    """``new`` is a duplicate of ``existing``: fold and supersede.
+
+    ``existing`` is the canon row that wins; ``new`` becomes a
+    superseded synonym pointing at it. We deliberately keep the new
+    row instead of deleting it so the supersedes graph still records
+    that this exact wording was once asserted (and audit log can
+    surface that later).
+    """
+    _merge_source_links(existing, new, now)
+    new.status = ClaimStatus.SUPERSEDED
+    new.superseded_by_id = existing.id
+
+
+def _apply_refines(
+    new: KnowledgeClaim, existing: KnowledgeClaim, now: datetime
+) -> None:
+    """``new`` is a more current version of ``existing``: invert direction."""
+    existing.status = ClaimStatus.SUPERSEDED
+    existing.superseded_by_id = new.id
+    # The new row absorbs the old row's provenance trail so the
+    # current canon's source_links list "this is where we know this
+    # from" stays complete instead of starting fresh on every
+    # rewording.
+    _merge_source_links(new, existing, now)
+
+
+def _apply_contradicts(
+    new: KnowledgeClaim, existing: KnowledgeClaim
+) -> None:
+    """Both claims disagree: park them for operator review.
+
+    Disputed rows still match search filters that explicitly include
+    ``status='disputed'`` (the operator-review surface), but the
+    default ``status='active'`` retrieval skips them so a confused
+    canon doesn't poison agent context.
+    """
+    existing.status = ClaimStatus.DISPUTED
+    new.status = ClaimStatus.DISPUTED
+
+
+# ---------------------------------------------------------------------------
+# Public entry points
+# ---------------------------------------------------------------------------
+
+
+async def reconcile_claim(
+    session: AsyncSession,
+    *,
+    claim: KnowledgeClaim,
+    llm_client: AgentClient | None,
+    settings: Settings | None = None,
+) -> ReconcileReport:
+    """Reconcile one freshly-extracted claim against existing canon.
+
+    Caller owns the transaction. The function flushes (not commits)
+    after applying a decision so a partial batch failure mid-loop
+    rolls back cleanly.
+
+    ``llm_client`` is optional. When it's missing or its judge call
+    fails, we still apply the auto-threshold fast-path; near-matches
+    in the LLM-judge band are left alone (treated as ``unrelated``)
+    rather than guessed at heuristically.
+    """
+    settings = settings or get_settings()
+    report = ReconcileReport(claim_id=claim.id)
+    now = datetime.now(timezone.utc)
+
+    if not claim.embedding:
+        # Embedding step in P1 was best-effort. A claim without one
+        # can't participate in nearest-neighbour search, so we mark
+        # it reconciled (no near-match) and move on. The next
+        # extractor pass on a re-pulled doc will get another shot
+        # at the embedding service.
+        claim.reconciled_at = now
+        report.decision = "no_match"
+        return report
+
+    try:
+        nearest = await _nearest_active_claims(
+            session,
+            workspace_id=claim.workspace_id,
+            self_claim_id=claim.id,
+            embedding=claim.embedding,
+            k=_NEAREST_K,
+        )
+    except Exception as exc:  # noqa: BLE001 — best-effort
+        log.exception("reconciler: nearest-neighbour query failed")
+        report.errors.append(str(exc))
+        claim.reconciled_at = now
+        return report
+
+    if not nearest or nearest[0].similarity < _LLM_JUDGE_THRESHOLD:
+        claim.reconciled_at = now
+        report.decision = "no_match"
+        return report
+
+    top = nearest[0]
+    report.matched_claim_id = top.claim_id
+    report.similarity = top.similarity
+
+    # Fast-path: well above the LLM-judge band. Skip the model call.
+    if top.similarity >= _DUP_AUTO_THRESHOLD:
+        existing = await session.get(KnowledgeClaim, top.claim_id)
+        if existing is None:  # disappeared between query + get
+            claim.reconciled_at = now
+            report.decision = "no_match"
+            return report
+        _apply_duplicate(new=claim, existing=existing, now=now)
+        claim.reconciled_at = now
+        await session.flush()
+        report.decision = _DECISION_DUPLICATE
+        return report
+
+    # LLM-judge band. If we have no client, fall back to "unrelated".
+    if llm_client is None:
+        claim.reconciled_at = now
+        report.decision = _DECISION_UNRELATED
+        return report
+
+    judged = await _llm_judge(
+        client=llm_client,
+        old_text=top.claim_md,
+        new_text=claim.claim_md,
+    )
+    report.used_llm = True
+    if judged is None:
+        # Judge failure is treated as unrelated — better than risking
+        # a wrong supersedes write off a malformed completion.
+        claim.reconciled_at = now
+        report.decision = _DECISION_UNRELATED
+        return report
+
+    decision, _reason = judged
+    report.decision = decision
+
+    if decision == _DECISION_UNRELATED:
+        claim.reconciled_at = now
+        await session.flush()
+        return report
+
+    existing = await session.get(KnowledgeClaim, top.claim_id)
+    if existing is None:
+        claim.reconciled_at = now
+        return report
+
+    if decision == _DECISION_DUPLICATE:
+        _apply_duplicate(new=claim, existing=existing, now=now)
+    elif decision == _DECISION_REFINES:
+        _apply_refines(new=claim, existing=existing, now=now)
+    elif decision == _DECISION_CONTRADICTS:
+        _apply_contradicts(new=claim, existing=existing)
+
+    claim.reconciled_at = now
+    await session.flush()
+    return report
+
+
+async def reconcile_pending_workspace(
+    session: AsyncSession,
+    *,
+    workspace_id: uuid.UUID,
+    llm_client: AgentClient | None,
+    limit: int = _RECONCILE_BATCH_LIMIT,
+    settings: Settings | None = None,
+) -> BatchReport:
+    """Walk one workspace's un-reconciled claims and apply decisions.
+
+    Pending = ``status='active' AND reconciled_at IS NULL``. The
+    partial index from migration 0060 makes this scan O(pending),
+    not O(total claims), so a large canon doesn't slow the tick.
+    """
+    settings = settings or get_settings()
+    report = BatchReport()
+
+    rows = (
+        await session.execute(
+            select(KnowledgeClaim)
+            .where(KnowledgeClaim.workspace_id == workspace_id)
+            .where(KnowledgeClaim.reconciled_at.is_(None))
+            .where(KnowledgeClaim.status == ClaimStatus.ACTIVE)
+            .order_by(KnowledgeClaim.created_at.asc())
+            .limit(limit)
+        )
+    ).scalars().all()
+    report.inspected = len(rows)
+
+    for claim in rows:
+        if not claim.embedding:
+            claim.reconciled_at = datetime.now(timezone.utc)
+            report.skipped_no_embedding += 1
+            continue
+        try:
+            outcome = await reconcile_claim(
+                session,
+                claim=claim,
+                llm_client=llm_client,
+                settings=settings,
+            )
+        except Exception as exc:  # noqa: BLE001 — never poison the tick
+            log.exception("reconciler: claim %s failed", claim.id)
+            report.failed += 1
+            claim.reconciled_at = datetime.now(timezone.utc)
+            continue
+
+        if outcome.decision == _DECISION_DUPLICATE:
+            if outcome.used_llm:
+                report.llm_duplicates += 1
+            else:
+                report.auto_duplicates += 1
+        elif outcome.decision == _DECISION_REFINES:
+            report.refines += 1
+        elif outcome.decision == _DECISION_CONTRADICTS:
+            report.contradicts += 1
+        elif outcome.decision == _DECISION_UNRELATED:
+            report.unrelated += 1
+        else:
+            report.no_match += 1
+
+    return report
+
+
+__all__ = [
+    "BatchReport",
+    "ReconcileReport",
+    "reconcile_claim",
+    "reconcile_pending_workspace",
+]

--- a/backend/migrations/versions/0060_claim_reconciled_at.py
+++ b/backend/migrations/versions/0060_claim_reconciled_at.py
@@ -1,0 +1,57 @@
+"""knowledge_claim.reconciled_at timestamp + pending-claims partial index
+
+The claim extractor (P1) inserts every freshly extracted claim with
+``status='active', confidence=1.0`` and never looks at neighbours. The
+reconciliation engine (P2) needs a way to find claims that haven't
+been through the dedup / supersede / contradict-judge pass yet without
+re-scanning the whole table on every cron tick.
+
+``reconciled_at TIMESTAMPTZ`` defaults to NULL on insert (so the next
+reconciler tick picks the row up); the partial index targets exactly
+that NULL set so a workspace with 50k canon claims still scans a
+handful of pending rows per tick.
+
+Revision ID: 0060_claim_reconciled_at
+Revises: 0059_knowledge_claims
+Create Date: 2026-05-06
+"""
+
+from __future__ import annotations
+
+from typing import Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "0060_claim_reconciled_at"
+down_revision: Union[str, None] = "0059_knowledge_claims"
+branch_labels: Union[str, tuple[str, ...], None] = None
+depends_on: Union[str, tuple[str, ...], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "knowledge_claim",
+        sa.Column(
+            "reconciled_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+    )
+    # Partial index: every existing row from P1 is NULL, and the cron
+    # tick filters on ``reconciled_at IS NULL``. A full btree index
+    # would index ~all rows for a query that always wants the tiny
+    # tail; partial keeps the index hot and small.
+    op.execute(
+        "CREATE INDEX ix_knowledge_claim_pending_reconciliation "
+        "ON knowledge_claim (workspace_id, created_at) "
+        "WHERE reconciled_at IS NULL"
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        "DROP INDEX IF EXISTS ix_knowledge_claim_pending_reconciliation"
+    )
+    op.drop_column("knowledge_claim", "reconciled_at")

--- a/backend/tests/test_services_knowledge_reconciler.py
+++ b/backend/tests/test_services_knowledge_reconciler.py
@@ -1,0 +1,331 @@
+"""Unit tests for the claim-store reconciliation engine.
+
+Stays pure-unit by stubbing the LLM judge and the nearest-neighbour
+SQL query so the tests don't depend on a live Postgres or pgvector
+index. The behaviours we want to lock down:
+
+- the cosine fast-path (sim ≥ 0.95) folds without spending an LLM
+  call;
+- LLM-judge band returns ``duplicate`` / ``refines`` / ``contradicts``
+  / ``unrelated`` with the right state mutations on each;
+- a missing or failed LLM client in the judge band leaves the new
+  claim alone (treated as ``unrelated``);
+- a claim with no embedding gets reconciled-stamped without a
+  neighbour query;
+- ``reconciled_at`` is always stamped, including failure paths, so
+  the cron tick's ``WHERE reconciled_at IS NULL`` filter never
+  loops the same broken row.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime
+
+import pytest
+
+from backend.app.db.models.agent_memory import ClaimStatus
+from backend.app.services import knowledge_reconciler as recon
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeClaim:
+    id: uuid.UUID = field(default_factory=uuid.uuid4)
+    workspace_id: uuid.UUID = field(default_factory=uuid.uuid4)
+    claim_md: str = "claim"
+    embedding: list[float] | None = field(default_factory=lambda: [0.1] * 8)
+    status: str = ClaimStatus.ACTIVE
+    superseded_by_id: uuid.UUID | None = None
+    source_links: list[dict] = field(default_factory=list)
+    last_seen_at: datetime | None = None
+    reconciled_at: datetime | None = None
+
+
+class _FakeSession:
+    """Minimal session that:
+    - returns a canned nearest-neighbour list when the reconciler
+      executes the raw SQL,
+    - resolves ``session.get(KnowledgeClaim, claim_id)`` to entries
+      in a dict the test seeds.
+    """
+
+    def __init__(self, *, neighbours=None, claim_by_id=None):
+        self.neighbours = list(neighbours or [])
+        self.claim_by_id = dict(claim_by_id or {})
+        self.flushed = False
+
+    async def execute(self, stmt, params=None):
+        # Return canned nearest-neighbour rows. The reconciler maps
+        # them via ``row[0], row[1], row[2]`` so we mimic SQLAlchemy
+        # Row tuples.
+        return _FakeAllResult(
+            [(n.claim_id, n.claim_md, n.similarity) for n in self.neighbours]
+        )
+
+    async def get(self, model, key):
+        return self.claim_by_id.get(key)
+
+    async def flush(self):
+        self.flushed = True
+
+
+class _FakeAllResult:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def all(self):
+        return self._rows
+
+
+@dataclass
+class _FakeLLM:
+    decision: str
+    reason: str = "synthetic"
+    raises: bool = False
+    calls: int = 0
+    vendor: str = "fake"
+
+    async def acomplete(self, messages, **kwargs) -> str:
+        self.calls += 1
+        if self.raises:
+            raise RuntimeError("simulated judge failure")
+        return f'{{"decision":"{self.decision}","reason":"{self.reason}"}}'
+
+    async def astream(self, *args, **kwargs):  # pragma: no cover
+        yield None
+
+
+def _seed_claim(
+    *,
+    workspace_id: uuid.UUID,
+    text: str = "existing claim",
+    source_links: list[dict] | None = None,
+) -> _FakeClaim:
+    return _FakeClaim(
+        workspace_id=workspace_id,
+        claim_md=text,
+        source_links=source_links or [],
+    )
+
+
+def _patch_nearest(monkeypatch, neighbours: list[recon._NearestRow]):
+    async def _fake(*args, **kwargs):
+        return list(neighbours)
+
+    monkeypatch.setattr(recon, "_nearest_active_claims", _fake)
+
+
+# ---------------------------------------------------------------------------
+# Fast-path: cosine ≥ 0.95
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_auto_duplicate_fast_path_does_not_call_llm(monkeypatch):
+    """sim ≥ 0.95 short-circuits to duplicate without spending an LLM call."""
+    ws = uuid.uuid4()
+    new = _FakeClaim(workspace_id=ws, claim_md="new wording", source_links=[
+        {"source_item_id": "doc-2", "extracted_at": "t2"}
+    ])
+    existing = _seed_claim(workspace_id=ws, source_links=[
+        {"source_item_id": "doc-1", "extracted_at": "t1"}
+    ])
+    _patch_nearest(
+        monkeypatch,
+        [recon._NearestRow(claim_id=existing.id, similarity=0.97, claim_md=existing.claim_md)],
+    )
+    session = _FakeSession(claim_by_id={existing.id: existing})
+    llm = _FakeLLM(decision="duplicate")  # would tick if called
+
+    report = await recon.reconcile_claim(
+        session, claim=new, llm_client=llm
+    )
+
+    assert report.decision == "duplicate"
+    assert report.used_llm is False
+    assert llm.calls == 0
+    assert new.status == ClaimStatus.SUPERSEDED
+    assert new.superseded_by_id == existing.id
+    # source_links got merged into the canon row, not the superseded one
+    sl_keys = {(e["source_item_id"], e["extracted_at"]) for e in existing.source_links}
+    assert ("doc-1", "t1") in sl_keys
+    assert ("doc-2", "t2") in sl_keys
+    assert new.reconciled_at is not None
+
+
+# ---------------------------------------------------------------------------
+# LLM-judge band: 0.85 ≤ sim < 0.95
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_llm_judge_duplicate_supersedes_new(monkeypatch):
+    ws = uuid.uuid4()
+    existing = _seed_claim(workspace_id=ws)
+    new = _FakeClaim(workspace_id=ws)
+    _patch_nearest(
+        monkeypatch,
+        [recon._NearestRow(claim_id=existing.id, similarity=0.88, claim_md=existing.claim_md)],
+    )
+    session = _FakeSession(claim_by_id={existing.id: existing})
+    llm = _FakeLLM(decision="duplicate")
+
+    report = await recon.reconcile_claim(session, claim=new, llm_client=llm)
+
+    assert report.decision == "duplicate"
+    assert report.used_llm is True
+    assert new.status == ClaimStatus.SUPERSEDED
+    assert new.superseded_by_id == existing.id
+    assert existing.status == ClaimStatus.ACTIVE  # canon survives
+
+
+@pytest.mark.asyncio
+async def test_llm_judge_refines_supersedes_existing(monkeypatch):
+    ws = uuid.uuid4()
+    existing = _seed_claim(workspace_id=ws, text="old way")
+    new = _FakeClaim(workspace_id=ws, claim_md="new way")
+    _patch_nearest(
+        monkeypatch,
+        [recon._NearestRow(claim_id=existing.id, similarity=0.9, claim_md=existing.claim_md)],
+    )
+    session = _FakeSession(claim_by_id={existing.id: existing})
+    llm = _FakeLLM(decision="refines")
+
+    report = await recon.reconcile_claim(session, claim=new, llm_client=llm)
+
+    assert report.decision == "refines"
+    # Direction inverts vs duplicate: existing is now superseded, new is canon.
+    assert existing.status == ClaimStatus.SUPERSEDED
+    assert existing.superseded_by_id == new.id
+    assert new.status == ClaimStatus.ACTIVE
+
+
+@pytest.mark.asyncio
+async def test_llm_judge_contradicts_marks_both_disputed(monkeypatch):
+    ws = uuid.uuid4()
+    existing = _seed_claim(workspace_id=ws, text="A is true")
+    new = _FakeClaim(workspace_id=ws, claim_md="A is false")
+    _patch_nearest(
+        monkeypatch,
+        [recon._NearestRow(claim_id=existing.id, similarity=0.9, claim_md=existing.claim_md)],
+    )
+    session = _FakeSession(claim_by_id={existing.id: existing})
+    llm = _FakeLLM(decision="contradicts")
+
+    report = await recon.reconcile_claim(session, claim=new, llm_client=llm)
+
+    assert report.decision == "contradicts"
+    assert existing.status == ClaimStatus.DISPUTED
+    assert new.status == ClaimStatus.DISPUTED
+    # Neither is a "winner" — no supersedes link gets written.
+    assert existing.superseded_by_id is None
+    assert new.superseded_by_id is None
+
+
+@pytest.mark.asyncio
+async def test_llm_judge_unrelated_no_op(monkeypatch):
+    ws = uuid.uuid4()
+    existing = _seed_claim(workspace_id=ws, text="A")
+    new = _FakeClaim(workspace_id=ws, claim_md="B")
+    _patch_nearest(
+        monkeypatch,
+        [recon._NearestRow(claim_id=existing.id, similarity=0.9, claim_md="A")],
+    )
+    session = _FakeSession(claim_by_id={existing.id: existing})
+    llm = _FakeLLM(decision="unrelated")
+
+    report = await recon.reconcile_claim(session, claim=new, llm_client=llm)
+
+    assert report.decision == "unrelated"
+    assert new.status == ClaimStatus.ACTIVE
+    assert existing.status == ClaimStatus.ACTIVE
+    assert new.reconciled_at is not None
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_embedding_marks_no_match_without_query(monkeypatch):
+    new = _FakeClaim(embedding=None)
+
+    async def _should_not_query(*args, **kwargs):
+        raise AssertionError("nearest query must not run for embeddingless claim")
+
+    monkeypatch.setattr(recon, "_nearest_active_claims", _should_not_query)
+    session = _FakeSession()
+
+    report = await recon.reconcile_claim(session, claim=new, llm_client=None)
+
+    assert report.decision == "no_match"
+    assert new.reconciled_at is not None
+
+
+@pytest.mark.asyncio
+async def test_below_judge_threshold_is_no_match(monkeypatch):
+    """sim < 0.85 means no near-match — leave the claim alone."""
+    ws = uuid.uuid4()
+    new = _FakeClaim(workspace_id=ws)
+    _patch_nearest(
+        monkeypatch,
+        [recon._NearestRow(claim_id=uuid.uuid4(), similarity=0.6, claim_md="X")],
+    )
+    session = _FakeSession()
+    llm = _FakeLLM(decision="duplicate")  # would fire if used
+
+    report = await recon.reconcile_claim(session, claim=new, llm_client=llm)
+
+    assert report.decision == "no_match"
+    assert llm.calls == 0
+    assert new.status == ClaimStatus.ACTIVE
+    assert new.reconciled_at is not None
+
+
+@pytest.mark.asyncio
+async def test_judge_band_without_llm_falls_back_to_unrelated(monkeypatch):
+    """If the LLM client is unavailable in the judge band, treat as unrelated
+    rather than guessing — preserves the canon's correctness."""
+    ws = uuid.uuid4()
+    existing = _seed_claim(workspace_id=ws)
+    new = _FakeClaim(workspace_id=ws)
+    _patch_nearest(
+        monkeypatch,
+        [recon._NearestRow(claim_id=existing.id, similarity=0.88, claim_md=existing.claim_md)],
+    )
+    session = _FakeSession(claim_by_id={existing.id: existing})
+
+    report = await recon.reconcile_claim(session, claim=new, llm_client=None)
+
+    assert report.decision == "unrelated"
+    assert new.status == ClaimStatus.ACTIVE
+    assert existing.status == ClaimStatus.ACTIVE
+
+
+@pytest.mark.asyncio
+async def test_judge_failure_falls_back_to_unrelated(monkeypatch):
+    """LLM raising mid-judge: treat as unrelated, stamp reconciled_at,
+    don't mutate either row."""
+    ws = uuid.uuid4()
+    existing = _seed_claim(workspace_id=ws)
+    new = _FakeClaim(workspace_id=ws)
+    _patch_nearest(
+        monkeypatch,
+        [recon._NearestRow(claim_id=existing.id, similarity=0.88, claim_md=existing.claim_md)],
+    )
+    session = _FakeSession(claim_by_id={existing.id: existing})
+    llm = _FakeLLM(decision="duplicate", raises=True)
+
+    report = await recon.reconcile_claim(session, claim=new, llm_client=llm)
+
+    assert report.decision == "unrelated"
+    assert new.status == ClaimStatus.ACTIVE
+    assert existing.status == ClaimStatus.ACTIVE
+    assert new.reconciled_at is not None


### PR DESCRIPTION
## Summary

P2 of the claim-graph knowledge model. Closes the dedup / supersede / contradict gap after P1 by running cosine + LLM-judge over freshly-extracted claims and folding them into the canon. Also wires the extractor (P1) into the cron scheduler so the pipeline now runs end-to-end without manual triggers.

### Reconciler logic (per pending claim)

1. **Cosine fast-path** (`sim ≥ 0.95`) — fold without an LLM call. New becomes `superseded`, `source_links` merge into the canon row, `last_seen_at` bumps so decay knows the canon is still being asserted.
2. **LLM-judge band** (`0.85 ≤ sim < 0.95`) — one Haiku call per pair labels as `duplicate` / `refines` / `contradicts` / `unrelated`:
   - `duplicate` → new becomes superseded by existing (same as fast-path)
   - `refines` → existing becomes superseded by new (direction inverts)
   - `contradicts` → both → `status='disputed'` for inbox review (UX surface in a follow-up; the disputed status is queryable now)
   - `unrelated` → no-op
3. Below `0.85` — no near-match, leave alone.

Failures (judge call dies, malformed JSON, missing LLM client) fall back to `unrelated` and stamp `reconciled_at` — better than guessing a supersedes link off a flaky completion.

### Schema

Migration `0060_claim_reconciled_at`: `knowledge_claim.reconciled_at TIMESTAMPTZ` (NULL = pending) + partial index `WHERE reconciled_at IS NULL` so the cron tick scans the small pending tail, not the whole canon.

### Cron wiring

- New `CronLockId.KNOWLEDGE_CLAIM_EXTRACT = 1006` and `KNOWLEDGE_CLAIM_RECONCILE = 1007`.
- Extractor tick at `*/20 * * * *` — fans out per workspace so one big workspace's body doesn't starve the rest.
- Reconciler tick at `5,25,45 * * * *` — offset 5 min after the extractor so freshly-inserted claims have time to land before the cosine sweep runs.
- Both ticks always stamp the bookkeeping timestamps on exit, which prevents retry storms on stuck rows.

### What's NOT in this PR

- View renderer (P3 — claims → article md per topic).
- Read API surfaces (P4 — `/v1/knowledge/search` and `shipctl knowledge fetch` returning claim-level hits).
- Decay (P5 — stale claims auto-archived).
- Inbox UX for disputed claims (the status filter is queryable today; the operator review page rides P3-P5).
- Old `knowledge_router` / `knowledge_synth` are still untouched and fire on schedule. Retirement happens after P3-P4 once the claim store is the canonical retrieval surface.

## Test plan

- [x] `pytest backend/tests/test_services_knowledge_reconciler.py` — 9/9 (fast-path duplicate skips LLM, judge band routes all 4 decisions to right mutations, direction correct on duplicate vs refines, contradicts marks both disputed without writing a supersedes link, no-embedding short-circuits, sub-threshold leaves claim alone, judge failure / missing client both fall back to unrelated)
- [x] Alembic graph: `heads=['0060_claim_reconciled_at']`, linear chain back to 0058
- [ ] CI: full backend suite + migration apply on clean DB
- [ ] Post-deploy: backfill the Ship workspace via a one-shot `extract_pending_workspace` + `reconcile_pending_workspace`, sanity-check that supersedes links land on the obvious 2-year-old ADR vs current architecture pairs