### PR TITLE
project-first delivery: decomposition-mode role prompts (ELS-29)

### DIFF
--- a/backend/app/resources/agent_roles/ba.md
+++ b/backend/app/resources/agent_roles/ba.md
@@ -30,3 +30,15 @@ If you have enough to specify, finish with `outcome=ready_next_step`, `stage_nex
 The standing rules — write to `description` not `comment`, respect the intake sections, escalate as `needs_clarification` when scope is too large — come from your workspace's policies.
 
 The `comment` field on this stage is a one-paragraph audit narration of what you added/changed and why. End it with: `[Ship SDLC:role-ba]`
+
+## Decomposition mode
+
+When the run context flags `process=decomposition` (project-first delivery, ELS-75) you're not refining a single ticket — you're producing the **WBS section** of a *project body* on the project's planning anchor. Different rules apply:
+
+- The "ticket" the runtime hands you is the **planning anchor** (`planning:anchor` label). Do NOT rewrite the anchor's description; the project body — not the anchor — carries decomposition artefacts.
+- Read the project's `## Brief` (the PO drafted it in Navigator). Emit a coarse **work breakdown structure** — a list of child-ticket stubs.
+- Each WBS line is **name + 2-3 lines of scope**. NOT detailed acceptance criteria. SDLC's BA writes those when each child enters `task_intake`; pre-writing them here is wasted work.
+- Patch ONLY the `## WBS` section via `upsert_project_section(project_id=<from anchor's project>, section="WBS", body=<your WBS>)`. NEVER touch `## Brief`, `## Architecture`, `## Test architecture`, or `## Tasks` — those are owned by other stages.
+- Do NOT create child tickets yourself. The `tasks` stage at the end of the decomposition chain creates them from the WBS you produce.
+- Finish with `outcome=ready_next_step`, `stage_next=architecture`, `process=decomposition`.
+- End your audit `comment` with: `[Ship decomposition:role-ba]`

--- a/backend/app/resources/agent_roles/developer.md
+++ b/backend/app/resources/agent_roles/developer.md
@@ -18,3 +18,16 @@ Linear status is already **In Progress** (set by GitHub). The API has provided t
 The standing rules — branch contract, tests, lint/typecheck/test/build/e2e gates, commit message format, the "exactly one PR with `Closes {{ISSUE}}` and move to In Review" shape — come from your workspace's policies.
 
 End your single ticket comment (with the PR link) with: `[GitHub SDLC:developer]`
+
+## Decomposition mode
+
+When the run context flags `process=decomposition` (project-first delivery, ELS-75) you are the **task-slicing** stage, not the implementation stage. **No code, no PR, no branch.** Different rules apply:
+
+- The "ticket" handed to you is the **planning anchor** (`planning:anchor` label). Read the project's `## Brief`, `## WBS`, `## Architecture`, and `## Test architecture` — these are the inputs the chain has produced for you.
+- For each line in `## WBS`, create exactly **one child ticket** via the `create_ticket` tool, with `project_id` set to the anchor's project. Each child:
+  - **Title**: the WBS line's name, verbatim.
+  - **Body**: 3-5 lines pulling Goal + Scope from the WBS line + 1-2 architecture pointers from `## Architecture`. Do NOT write detailed acceptance criteria, test plans, or implementation notes — SDLC's BA, tech architect, and QA architect refine those when the child enters `task_intake`.
+- After all child tickets exist, patch `## Tasks` via `upsert_project_section(project_id=<from anchor's project>, section="Tasks", body=<list of identifiers + names>)` — one bullet per child ticket created.
+- NEVER touch `## Brief`, `## WBS`, `## Architecture`, or `## Test architecture`. Those are owned by upstream stages.
+- Finish with `outcome=ready_next_step`, `stage_next=planning_done`, `process=decomposition`. The server's completion hook then flips the project's dashboard row from Drafts → Active and the agent's autonomous picker takes over from there.
+- End your audit `comment` with: `[Ship decomposition:role-developer]`

--- a/backend/app/resources/agent_roles/qa-architect.md
+++ b/backend/app/resources/agent_roles/qa-architect.md
@@ -29,3 +29,13 @@ If you have enough to design tests, finish with `outcome=ready_next_step`, `stag
 The standing rules — write to `description` not `comment`, no test commits from this role, escalate as `needs_clarification` when AC are too thin to test against — come from your workspace's policies.
 
 The `comment` field is a one-paragraph audit narration of *what you covered and why this split*. End it with: `[Ship SDLC:role-qa-architect]`
+
+## Decomposition mode
+
+When the run context flags `process=decomposition` (project-first delivery, ELS-75) you're producing the **Test architecture section** of a *project body*, not designing tests for one ticket. Different rules apply:
+
+- The "ticket" handed to you is the **planning anchor** (`planning:anchor` label). Read the project's `## Brief`, `## WBS`, and `## Architecture` — the PO drafted the brief, BA emitted the WBS, the tech architect designed the system.
+- Test architecture is at **project scale**: unit / integration / e2e split for the feature as a whole, fixtures the team needs to stand up once, risk-based focus across the WBS. Per-child-ticket test cases come later (SDLC's QA architect handles those when each child reaches `qa_arch_plan`).
+- Patch ONLY the `## Test architecture` section via `upsert_project_section(project_id=<from anchor's project>, section="Test architecture", body=<your strategy>)`. Never touch `## Brief`, `## WBS`, `## Architecture`, or `## Tasks`.
+- Finish with `outcome=ready_next_step`, `stage_next=tasks`, `process=decomposition`.
+- End your audit `comment` with: `[Ship decomposition:role-qa-architect]`

--- a/backend/app/resources/agent_roles/qa-engineer.md
+++ b/backend/app/resources/agent_roles/qa-engineer.md
@@ -29,3 +29,9 @@ If you found defects, do **not** fix them. Finish with `outcome=blocked` and a s
 The standing rules — read-only on the codebase (no commits from this role), one defect-list comment per pass, escalate as `needs_clarification` when AC are ambiguous — come from your workspace's policies.
 
 End your single ticket comment with: `[Ship SDLC:role-qa-engineer]`
+
+## Decomposition mode
+
+When the run context flags `process=decomposition` (project-first delivery, ELS-75): the current `tasks` stage is **developer-only** — see `developer.md`'s decomposition section. QA-engineer is not invoked in today's decomposition chain.
+
+If a future stage routes you here under `process=decomposition`, your owned section in the project body is `## QA scenarios`. Output 1-2 happy-path scenarios per WBS line — coarse, project-level. Per-ticket QA work is the SDLC `qa_manual` stage's job; do NOT pre-walk every edge case here. Patch ONLY `## QA scenarios` via `upsert_project_section`. Never edit other sections.

--- a/backend/app/resources/agent_roles/tech-architect.md
+++ b/backend/app/resources/agent_roles/tech-architect.md
@@ -29,3 +29,14 @@ If you have enough to plan, finish with `outcome=ready_next_step`, `stage_next=q
 The standing rules — write to `description` not `comment`, no code commits from this role, escalate as `needs_clarification` when the ticket is too vague to design — come from your workspace's policies.
 
 The `comment` field is a one-paragraph audit narration of *what you decided and why*. End it with: `[Ship SDLC:role-tech-architect]`
+
+## Decomposition mode
+
+When the run context flags `process=decomposition` (project-first delivery, ELS-75) you're producing the **Architecture section** of a *project body*, not refining a single ticket. Different rules apply:
+
+- The "ticket" handed to you is the **planning anchor** (`planning:anchor` label). Read the project's `## Brief` and `## WBS` — the PO drafted the brief in Navigator and BA emitted the WBS upstream.
+- Architecture is at **project scale**: components touched, contracts, risk + rollback for the feature as a whole — not per-ticket. Each WBS line will spawn its own child ticket whose own architect-stage refines into a per-ticket plan; pre-writing per-ticket designs here is wasted work.
+- Patch ONLY the `## Architecture` section via `upsert_project_section(project_id=<from anchor's project>, section="Architecture", body=<your design>)`. Never touch `## Brief`, `## WBS`, `## Test architecture`, or `## Tasks`.
+- Open questions belong in your section under an explicit `### Open questions` subheading; do NOT escalate via `needs_clarification` from decomposition unless the gap is fatal — the WBS already carries the human's brief, and child tickets surface their own clarifications when they hit SDLC.
+- Finish with `outcome=ready_next_step`, `stage_next=test_architecture`, `process=decomposition`.
+- End your audit `comment` with: `[Ship decomposition:role-tech-architect]`

--- a/backend/tests/test_decomposition_role_modes.py
+++ b/backend/tests/test_decomposition_role_modes.py
@@ -1,0 +1,68 @@
+"""Decomposition-mode prompt sections on the SDLC role files (ELS-29).
+
+Each role that participates in the decomposition chain — BA,
+Tech-architect, QA-architect, QA-engineer (placeholder), Developer —
+gets a ``## Decomposition mode`` block in its prompt. The block
+documents the project-anchor-vs-ticket distinction and pins which
+``## <section>`` of the project body the role owns.
+
+These tests are deliberately structural rather than semantic: the
+role corpus is markdown driven by humans, and asserting on the
+prompt text would lock in editorial choices that should be free to
+evolve. We assert the load-bearing invariants only:
+
+- The block exists.
+- It explicitly mentions ``process=decomposition`` so a runtime that
+  passes that flag triggers the right branch in the agent's reading.
+- It pins the role's owned project-body section by name so a human
+  editor can't silently rename it without the test catching the drift.
+
+The development-process flow — which lives above the new block in
+each role file — keeps its own coverage in the role-loader tests.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+# (slug, owned_section_in_project_body) — the section names ride the
+# ``upsert_project_section`` contract; keep these in sync with
+# ``default_planning_process_config()`` in ``catalog.py``.
+_ROLE_SECTION = [
+    ("ba", "WBS"),
+    ("tech-architect", "Architecture"),
+    ("qa-architect", "Test architecture"),
+    # qa-engineer is a placeholder — not invoked in the current chain
+    # but documented so a future stage can route to it without the
+    # prompt going stale.
+    ("qa-engineer", None),
+    ("developer", "Tasks"),
+]
+
+
+@pytest.mark.parametrize("slug,section", _ROLE_SECTION)
+def test_role_carries_decomposition_block(slug: str, section: str | None) -> None:
+    from backend.app.services import agent_roles as svc
+
+    role = svc.get_default(slug)
+    assert role is not None, f"missing default agent role: {slug}"
+    prompt = role.prompt
+
+    assert "## Decomposition mode" in prompt, (
+        f"{slug}: role file is missing the Decomposition mode block"
+    )
+    assert "process=decomposition" in prompt, (
+        f"{slug}: Decomposition block must reference ``process=decomposition`` "
+        f"so a runtime passing that flag triggers the right branch"
+    )
+
+    if section is not None:
+        # Pin the owned ``## <name>`` section by literal text so a
+        # rename slips into a test failure instead of a silent
+        # drift that breaks ``upsert_project_section`` matching.
+        assert f'section="{section}"' in prompt, (
+            f"{slug}: Decomposition block should pin its owned section to "
+            f'``section="{section}"`` so the prompt and the tracker '
+            f"helper agree on the heading"
+        )


### PR DESCRIPTION
Polish on top of the project-first delivery PRs (#142/#143/#145). Closes [ELS-29](https://linear.app/elship/issue/ELS-29) — the last open implementation ticket on the [project-first delivery project](https://linear.app/elship/project/project-first-delivery-drafts-decomposition-sdlc-292d11e2f544).

## Why

PR3 shipped the FSM machinery, the section-aware writer, the handoff endpoint, and the completion hook — but the specialists themselves were still running per-ticket prompts. A BA invoked under `process=decomposition` would happily rewrite the anchor's `description` with acceptance criteria instead of patching the project body's `## WBS` section. This PR closes that gap with `## Decomposition mode` blocks on the five participating role files.

## Approach

Path A from the architect's review: single prompt per role, mode header keyed on FSM context. No parallel `*_decomposition.md` files that would drift.

Each block:

- Reframes the "ticket" — the runtime hands the role the **planning anchor**, but artefacts live on the project body.
- Pins the owned `## <section>`: BA → WBS, Tech-architect → Architecture, QA-architect → Test architecture, Developer → Tasks. Patches go through `upsert_project_section` so re-running a stage replaces just its slice and leaves siblings verbatim.
- Spells out the coarse-output contract: WBS lines 2-3 lines, child tickets 3-5 lines. SDLC's per-ticket FSM refines further; pre-writing detailed AC at decomposition is waste.
- Sets the next-stage transition explicitly: BA→architecture, Tech-architect→test_architecture, QA-architect→tasks, Developer→planning_done.

The **developer** block carries the heaviest divergence — NO branch, NO PR, NO code commits. The role's job in decomposition is to call `create_ticket` once per WBS line, then patch `## Tasks` with an index of the created children. The completion hook fires from there.

The **qa-engineer** block is a placeholder — today's chain runs developer-only at the `tasks` stage. The block documents what the role would do if a future stage routed to it (own `## QA scenarios`, emit 1-2 happy-path scenarios per WBS line). Adding a `qa_tasks` stage later is a process-config change, not a fresh prompt-engineering pass.

## Test plan

- [x] **5/5 new tests pass** — `backend/tests/test_decomposition_role_modes.py`. Structural only (the role corpus is markdown driven by humans; asserting on prompt text would lock in editorial choices). The tests assert: block exists, references `process=decomposition` so runtime branching works, and pins the owned section literal so a rename trips the test rather than silently breaking `upsert_project_section` matching.
- [x] **19/19 role-loader tests pass** (`test_v1_agent_roles.py`, `test_default_bundle.py`) — frontmatter still parses, role registry still serves all five.
- [x] Manual smoke: `agent_roles.get_default(slug).prompt` for each of the five carries `## Decomposition mode`.

## What's NOT in this PR

- A `qa_tasks` stage in `default_planning_process_config()` (would invoke qa-engineer in the chain). Today the `tasks` stage is developer-only; the qa-engineer prompt is forward-compatible. Promoting it to a real stage is a follow-up if we see decomposition outputs that need a QA pass before child tickets land.
- Stage-by-stage progress chip on Drafts rows. Still in the "deferred polish" bucket from PR3.
- "Refined further during intake" caption on child tickets. Same bucket.