### PR TITLE
hotfix: hoist prioritizer handoff hooks above empty-state returns

### DIFF
--- a/console/src/components/dashboard/prioritizer.tsx
+++ b/console/src/components/dashboard/prioritizer.tsx
@@ -315,6 +315,40 @@ export function DashboardPrioritizer({ workspaceId, initial }: Props) {
     [draftOrder, serverRows],
   );
 
+  // Hand off to decomposition. Records pending state per-project so
+  // double-clicks don't spawn two start runs (the endpoint is also
+  // server-side idempotent, but optimistic UI keeps the row from
+  // flashing twice). On success we mark the row "decomposing" locally
+  // so the chip swaps before the next /priorities round-trip.
+  //
+  // These hooks live ABOVE the empty-state early returns below — moving
+  // them under the returns broke ``react-hooks/rules-of-hooks`` because
+  // hooks must run in a stable order on every render and the empty
+  // branches return before reaching them. ``next build`` (lint enabled)
+  // catches it; bare ``tsc`` doesn't, which is how the regression slipped
+  // past local checks in the original PR3.
+  const [handoffPending, setHandoffPending] = useState<string | null>(null);
+  const [decomposingIds, setDecomposingIds] = useState<Set<string>>(new Set());
+  const handleHandoff = useCallback(
+    async (nativeId: string) => {
+      if (handoffPending) return;
+      setHandoffPending(nativeId);
+      setErrorMessage(null);
+      const result = await startDecompositionAction(workspaceId, nativeId);
+      setHandoffPending(null);
+      if (!result.ok) {
+        setErrorMessage(result.message);
+        return;
+      }
+      setDecomposingIds((prev) => {
+        const next = new Set(prev);
+        next.add(nativeId);
+        return next;
+      });
+    },
+    [handoffPending, workspaceId],
+  );
+
   // ----- empty states -----------------------------------------------
 
   if (tracker.status === "disconnected") {
@@ -413,33 +447,6 @@ export function DashboardPrioritizer({ workspaceId, initial }: Props) {
   }
 
   // ----- main list (state-grouped) ----------------------------------
-
-  // Hand off to decomposition. Records pending state per-project so
-  // double-clicks don't spawn two start runs (the endpoint is also
-  // server-side idempotent, but optimistic UI keeps the row from
-  // flashing twice). On success we mark the row "decomposing" locally
-  // so the chip swaps before the next /priorities round-trip.
-  const [handoffPending, setHandoffPending] = useState<string | null>(null);
-  const [decomposingIds, setDecomposingIds] = useState<Set<string>>(new Set());
-  const handleHandoff = useCallback(
-    async (nativeId: string) => {
-      if (handoffPending) return;
-      setHandoffPending(nativeId);
-      setErrorMessage(null);
-      const result = await startDecompositionAction(workspaceId, nativeId);
-      setHandoffPending(null);
-      if (!result.ok) {
-        setErrorMessage(result.message);
-        return;
-      }
-      setDecomposingIds((prev) => {
-        const next = new Set(prev);
-        next.add(nativeId);
-        return next;
-      });
-    },
-    [handoffPending, workspaceId],
-  );
 
   const renderRow = (project: ApiPriorityProject, state: ApiPriorityState) => (
     <PrioritizerRow


### PR DESCRIPTION
## What broke

The `console` build on `main` is failing with three `react-hooks/rules-of-hooks` errors after PR #145 (project-first delivery PR3) merged:

```
./src/components/dashboard/prioritizer.tsx
422:47  Error: React Hook "useState" is called conditionally
423:47  Error: React Hook "useState" is called conditionally
424:25  Error: React Hook "useCallback" is called conditionally
```

PR3 introduced `useState(handoffPending)`, `useState(decomposingIds)`, and `useCallback(handleHandoff)` for the new **Hand off →** affordance — but placed them immediately above the main list render, **below** the disconnected / error / empty-projects early-return branches. Hooks must fire in a stable order on every render; the early branches return before reaching them, so on those code paths the hook count differs from the main path. React's rules-of-hooks linter blocks the build.

## Fix

Move the three hook declarations into the top-of-component cluster where `moveBy` / `reorderTo` / `moveToSection` already live. No behaviour change — same hooks, same dependencies, same ordering relative to one another.

## Why this slipped past PR3 local checks

`npx tsc --noEmit` doesn't run lint (this rule is enforced by ESLint, not the type checker). Local `npm run build` would have caught it. **Follow-up:** add `next lint` to the pre-push script so rules-of-hooks regressions block the push, not just the post-merge CI.

## Test plan

- [x] `npx next lint --dir src` — no rules-of-hooks errors on `prioritizer.tsx`.
- [x] `npx tsc --noEmit` clean.
- [x] `npm run build` exits 0 locally (the exact `next build` step that fails in the CI Dockerfile at line 25).