### PR TITLE
knowledge: topic-view renderer (P3)

### DIFF
--- a/backend/app/db/models/agent_memory.py
+++ b/backend/app/db/models/agent_memory.py
@@ -1030,6 +1030,65 @@ class KnowledgeClaim(Base):
     updated_at: Mapped[datetime] = _ts_updated()
 
 
+class KnowledgeTopicView(Base):
+    """Cached canonical markdown rendered from active claims of one topic.
+
+    Topic views are the read-side replacement for ``BucketArticle``:
+    one row per ``(workspace, topic_tag)``, regenerated when the
+    underlying active claim set changes. Claims are multi-tag, so a
+    single claim about Linear FSM appears in both the
+    ``integrations`` and the ``architecture-decisions`` views — that
+    duplication is intentional, not a bug.
+
+    Cache invalidation is via ``claim_set_sha``: the renderer hashes
+    the sorted active claim ids feeding the view, compares to the
+    stored sha, and skips the LLM call when they match. That keeps
+    the per-tick cost bounded by "topics whose claim set actually
+    drifted" rather than "every topic in the workspace".
+
+    History lives upstream in the ``knowledge_claim.supersedes_id``
+    chain, so we don't keep old views around. ``BucketArticle`` is
+    untouched; once P4 swaps the read surface to topic views, the
+    legacy article table becomes a feature flag and eventually
+    retires.
+    """
+
+    __tablename__ = "knowledge_topic_view"
+    __table_args__ = (
+        UniqueConstraint(
+            "workspace_id",
+            "topic_tag",
+            name="uq_knowledge_topic_view_ws_tag",
+        ),
+        Index("ix_knowledge_topic_view_workspace_id", "workspace_id"),
+    )
+
+    id: Mapped[uuid.UUID] = _pk()
+    workspace_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("workspaces.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    topic_tag: Mapped[str] = mapped_column(Text, nullable=False)
+    title: Mapped[str] = mapped_column(String(512), nullable=False)
+    body_md: Mapped[str] = mapped_column(Text, nullable=False)
+    claim_set_sha: Mapped[str] = mapped_column(String(64), nullable=False)
+    claim_count: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default=text("0")
+    )
+    rendered_by_model: Mapped[str | None] = mapped_column(
+        String(64), nullable=True
+    )
+    embedding: Mapped[list[float] | None] = mapped_column(
+        Vector(EMBED_DIM), nullable=True
+    )
+    last_rendered_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=text("now()")
+    )
+    created_at: Mapped[datetime] = _ts_created()
+    updated_at: Mapped[datetime] = _ts_updated()
+
+
 __all__ = [
     "ArtifactFeedback",
     "BucketArticle",
@@ -1053,4 +1112,5 @@ __all__ = [
     "KnowledgeIngestionStatus",
     "KnowledgeSource",
     "KnowledgeSourceItem",
+    "KnowledgeTopicView",
 ]

--- a/backend/app/services/cron.py
+++ b/backend/app/services/cron.py
@@ -87,6 +87,7 @@ class CronLockId(IntEnum):
     KNOWLEDGE_SOURCES_SYNC = 1005
     KNOWLEDGE_CLAIM_EXTRACT = 1006
     KNOWLEDGE_CLAIM_RECONCILE = 1007
+    KNOWLEDGE_TOPIC_RENDER = 1008
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/services/cron_jobs.py
+++ b/backend/app/services/cron_jobs.py
@@ -38,6 +38,9 @@ from backend.app.services.knowledge_reconciler import (
 )
 from backend.app.services.knowledge_router import route_all_workspaces
 from backend.app.services.knowledge_synth import synthesise_all_workspaces
+from backend.app.services.knowledge_topic_renderer import (
+    render_workspace_topics,
+)
 from sqlalchemy import select
 
 
@@ -343,6 +346,59 @@ async def _knowledge_claim_reconcile_tick() -> None:
         )
 
 
+@cron_with_lock(
+    lock=CronLockId.KNOWLEDGE_TOPIC_RENDER, name="knowledge_topic_render"
+)
+async def _knowledge_topic_render_tick() -> None:
+    """Every 30 min: render derived topic-views from active claims.
+
+    Per workspace, find topics with ≥3 active claims and render any
+    whose claim_set_sha has drifted since the last render. Cache hits
+    skip the LLM call entirely, so steady-state cost is dominated by
+    the sha computation, not by tokens.
+
+    Without an LLM client the renderer falls back to a deterministic
+    bullet-list body; the next tick that does have a client refreshes
+    the same row in place. We don't skip the tick on missing LLM —
+    operators still get a structured fallback view they can search.
+    """
+    try:
+        llm_client = pick_default_client(get_settings())
+    except Exception:
+        log.info(
+            "knowledge_topic_render tick: no LLM client; "
+            "deterministic-only render this tick"
+        )
+        llm_client = None
+
+    sm = get_sessionmaker()
+    workspace_ids = await _all_workspace_ids()
+    total_rendered = total_failed = 0
+    for ws_id in workspace_ids:
+        async with sm() as session:
+            try:
+                report = await render_workspace_topics(
+                    session, workspace_id=ws_id, llm_client=llm_client
+                )
+                await session.commit()
+            except Exception:
+                await session.rollback()
+                log.exception(
+                    "knowledge_topic_render tick: ws=%s failed", ws_id
+                )
+                total_failed += 1
+                continue
+        total_rendered += report.rendered
+        total_failed += report.failed
+    if total_rendered or total_failed:
+        log.info(
+            "knowledge_topic_render tick: workspaces=%d rendered=%d failed=%d",
+            len(workspace_ids),
+            total_rendered,
+            total_failed,
+        )
+
+
 # ---------------------------------------------------------------------------
 # Step 6 — daily archive GC
 # ---------------------------------------------------------------------------
@@ -427,6 +483,15 @@ def register_all() -> None:
         fn=_knowledge_claim_reconcile_tick,
         cron_expr="5,25,45 * * * *",
         job_id="knowledge_claim_reconcile",
+    )
+    # Topic-view render runs every 30 min, offset by 10 from the
+    # reconciler so a freshly-superseded claim flips out of any
+    # affected view's claim_set_sha before the next render. Cache
+    # hits make this cheap on workspaces with stable canon.
+    register_cron(
+        fn=_knowledge_topic_render_tick,
+        cron_expr="15,45 * * * *",
+        job_id="knowledge_topic_render",
     )
     # GC runs once daily. Cheap query (filtered DELETE by archived_at)
     # so an off-peak slot is fine; pick 03:15 UTC to avoid the on-the-

--- a/backend/app/services/knowledge_topic_renderer.py
+++ b/backend/app/services/knowledge_topic_renderer.py
@@ -1,0 +1,423 @@
+"""Render a topic's active claims into a canonical markdown view.
+
+Topic views are the post-claim-store retrieval surface: one row per
+``(workspace, topic_tag)`` containing a coherent markdown article
+rendered from the **currently active** claims that share that tag.
+
+Why a derived view instead of letting agents query claims directly:
+
+- Agents and operators want narratives. Search returning 30 atomic
+  claims is correct but unergonomic — the reader still has to do
+  the synthesis. A pre-rendered view gives them the article-shape
+  output, while the underlying claim store remains the canonical
+  fact graph for diff / supersedes / decay reasoning.
+- Topics are multi-tag, so a single Linear-FSM claim shows up in
+  both the ``integrations`` and ``architecture-decisions`` views.
+  That redundancy is the point: each view is a perspective on the
+  canon, not a partition of it.
+- Cache invalidation is cheap. ``claim_set_sha`` hashes the sorted
+  active claim ids feeding the view; if the cron tick computes the
+  same sha next time, we skip the LLM call. So the per-tick cost
+  is "topics whose claim set actually drifted", not "every topic
+  in the workspace".
+
+Threshold + caps:
+
+- ``_MIN_CLAIMS_PER_TOPIC`` skips singleton tags. With identity
+  thresholds at the extractor (one claim per Notion bullet line)
+  it's easy to end up with 5000 single-claim topics; we render
+  only ones that have enough density to merit a view.
+- ``_MAX_CLAIMS_PER_VIEW`` clamps the prompt — past ~50 claims the
+  LLM tends to lose coherence and quality drops faster than
+  coverage rises. The reader can still drill into the underlying
+  claim list via the read API.
+- ``_MAX_TOPICS_PER_TICK`` keeps one cron tick bounded so a 200-
+  topic workspace doesn't single-thread a sweep.
+
+Graceful degradation:
+
+- With an LLM client: full prose article via Haiku (cheap, 2k
+  output tokens enough for a tight article on most topics).
+- Without one: deterministic bullet-list fallback. Same
+  ``claim_set_sha`` so the cache still works; when an LLM finally
+  becomes available the next tick re-renders the same set with the
+  upgraded body. No retry storm because the fallback render still
+  stamps ``last_rendered_at`` and ``rendered_by_model='deterministic'``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy import func, select, text
+from sqlalchemy.dialects.postgresql import array
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.app.core.config import Settings, get_settings
+from backend.app.db.models.agent_memory import (
+    ClaimStatus,
+    KnowledgeClaim,
+    KnowledgeTopicView,
+)
+from backend.app.services.agent.client import AgentClient, ChatMessage
+
+
+log = logging.getLogger(__name__)
+
+
+# Topics with fewer claims than this aren't worth rendering — the
+# article would be three bullets and the LLM would either pad or
+# return half a sentence.
+_MIN_CLAIMS_PER_TOPIC = 3
+
+# Cap claims fed to the LLM. Past ~50 the article quality drops
+# faster than coverage rises; the read API can still drill into the
+# raw claim list when an operator wants the long tail.
+_MAX_CLAIMS_PER_VIEW = 50
+
+# Per-tick fan-out cap.
+_MAX_TOPICS_PER_TICK = 50
+
+# Identifies the "no LLM client" code path in the rendered_by_model
+# column so dashboards can spot tenants that synth degraded.
+_DETERMINISTIC_MODEL = "deterministic"
+
+
+_RENDER_SYSTEM_PROMPT = """\
+You produce a single canonical markdown article on the given topic
+from a list of atomic claims.
+
+Rules:
+
+- The article must be coherent prose (or short bulleted lists where
+  appropriate), not a regurgitation of the raw input.
+- DO NOT invent. Every assertion must come from one of the listed
+  claims. If you can't fit a claim into the article, drop it; never
+  paraphrase beyond what the claim says.
+- Order claims logically: facts and definitions first, rules /
+  decisions next, examples last. Group related claims into sections.
+- Start with ``# <Title>`` where Title is a short noun phrase
+  capturing the topic.
+- Don't reference "claims" or "the document" — write as if this is
+  the original canonical reference.
+
+Output ONLY the markdown article. No commentary, no JSON wrapper.
+"""
+
+
+@dataclass(slots=True)
+class TopicRenderReport:
+    """Outcome of one render call for a single topic."""
+
+    topic_tag: str
+    rendered: bool = False
+    skipped_unchanged: bool = False
+    skipped_low_density: bool = False
+    used_llm: bool = False
+    claim_count: int = 0
+    errors: list[str] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class WorkspaceRenderReport:
+    """Outcome of one cron tick over a workspace's eligible topics."""
+
+    inspected: int = 0
+    rendered: int = 0
+    skipped_unchanged: int = 0
+    skipped_low_density: int = 0
+    failed: int = 0
+
+
+def _claim_set_sha(active_claim_ids: list[uuid.UUID]) -> str:
+    """Stable hash of the sorted active claim id set.
+
+    UUID comparison is lexicographic on the canonical string form;
+    sorting there gives us reproducible bytes-into-sha256 input
+    regardless of the order Postgres returned the rows.
+    """
+    joined = ",".join(sorted(str(cid) for cid in active_claim_ids))
+    return hashlib.sha256(joined.encode("utf-8")).hexdigest()
+
+
+def _humanise_topic(topic_tag: str) -> str:
+    """``linear-fsm`` → ``Linear FSM`` for the article title."""
+    parts = [p for p in topic_tag.replace("_", "-").split("-") if p]
+    return " ".join(p.capitalize() for p in parts) or topic_tag
+
+
+def _deterministic_body(
+    topic_tag: str, claims: list[KnowledgeClaim]
+) -> tuple[str, str]:
+    """Fallback render when no LLM is available — title + bullet body.
+
+    Sorted by ``kind`` first (decisions / rules / facts cluster),
+    then by claim text to keep the output stable for the same input.
+    Same ``claim_set_sha`` as the LLM path so the cache invalidation
+    invariant still holds; the next tick that *does* have a client
+    will overwrite this body in place without growing the table.
+    """
+    title = _humanise_topic(topic_tag)
+    kind_order = {"decision": 0, "rule": 1, "fact": 2, "example": 3, "glossary": 4, "other": 5}
+    sorted_claims = sorted(
+        claims, key=lambda c: (kind_order.get(c.kind, 99), c.claim_md)
+    )
+    lines = [f"# {title}", ""]
+    for claim in sorted_claims:
+        kind_badge = f"_{claim.kind}_" if claim.kind != "fact" else ""
+        prefix = f"- {kind_badge}: " if kind_badge else "- "
+        lines.append(f"{prefix}{claim.claim_md}")
+    return title, "\n".join(lines).rstrip() + "\n"
+
+
+async def _llm_render(
+    *,
+    client: AgentClient,
+    topic_tag: str,
+    claims: list[KnowledgeClaim],
+) -> tuple[str, str] | None:
+    """Ask the LLM to render the claims as one canonical article.
+
+    Returns ``(title, body_md)`` or ``None`` on any failure (the
+    caller falls back to the deterministic body so the cache stays
+    consistent; the next tick will retry the LLM path).
+    """
+    title_hint = _humanise_topic(topic_tag)
+    claim_lines = "\n".join(
+        f"{i + 1}. ({claim.kind}) {claim.claim_md}"
+        for i, claim in enumerate(claims)
+    )
+    user_msg = (
+        f"Topic: {title_hint} (tag `{topic_tag}`)\n\n"
+        f"Claims:\n{claim_lines}\n\n"
+        f"Render the article."
+    )
+    try:
+        raw = await client.acomplete(
+            messages=[
+                ChatMessage(role="system", content=_RENDER_SYSTEM_PROMPT),
+                ChatMessage(role="user", content=user_msg),
+            ],
+            max_tokens=2000,
+            temperature=0.0,
+        )
+    except Exception as exc:  # noqa: BLE001 — best-effort
+        log.info(
+            "topic_renderer: LLM render failed for topic=%s (%s)", topic_tag, exc
+        )
+        return None
+
+    body = (raw or "").strip()
+    if not body:
+        return None
+    # Strip a markdown code fence if the model wrapped its answer in
+    # one — we want the article body raw, not embedded in a triple-
+    # backtick block.
+    if body.startswith("```"):
+        body = body.strip("`")
+        if body.lower().startswith("markdown\n"):
+            body = body[len("markdown\n"):]
+        body = body.strip("`").strip()
+    # Title = first heading line if present, else humanised tag.
+    title = title_hint
+    for line in body.splitlines():
+        line = line.strip()
+        if line.startswith("# "):
+            title = line[2:].strip() or title_hint
+            break
+    return title[:512], body + ("\n" if not body.endswith("\n") else "")
+
+
+# ---------------------------------------------------------------------------
+# Per-topic + per-workspace entry points
+# ---------------------------------------------------------------------------
+
+
+async def render_topic(
+    session: AsyncSession,
+    *,
+    workspace_id: uuid.UUID,
+    topic_tag: str,
+    llm_client: AgentClient | None,
+    settings: Settings | None = None,
+) -> TopicRenderReport:
+    """Render or refresh the ``(workspace, topic_tag)`` view.
+
+    Caller owns the transaction; this function only flushes when it
+    has work to commit. Cache hit (``claim_set_sha`` matches the
+    existing row) is a no-op — no DB writes, no LLM call.
+    """
+    settings = settings or get_settings()
+    report = TopicRenderReport(topic_tag=topic_tag)
+
+    claims = (
+        await session.execute(
+            select(KnowledgeClaim)
+            .where(KnowledgeClaim.workspace_id == workspace_id)
+            .where(KnowledgeClaim.status == ClaimStatus.ACTIVE)
+            .where(KnowledgeClaim.topic_tags.any(topic_tag))
+            .order_by(KnowledgeClaim.created_at.asc())
+            .limit(_MAX_CLAIMS_PER_VIEW)
+        )
+    ).scalars().all()
+    report.claim_count = len(claims)
+
+    if len(claims) < _MIN_CLAIMS_PER_TOPIC:
+        report.skipped_low_density = True
+        return report
+
+    sha = _claim_set_sha([c.id for c in claims])
+
+    existing = (
+        await session.execute(
+            select(KnowledgeTopicView).where(
+                KnowledgeTopicView.workspace_id == workspace_id,
+                KnowledgeTopicView.topic_tag == topic_tag,
+            )
+        )
+    ).scalar_one_or_none()
+
+    if existing is not None and existing.claim_set_sha == sha:
+        report.skipped_unchanged = True
+        return report
+
+    title: str
+    body: str
+    rendered_by: str
+    if llm_client is None:
+        title, body = _deterministic_body(topic_tag, claims)
+        rendered_by = _DETERMINISTIC_MODEL
+    else:
+        rendered = await _llm_render(
+            client=llm_client, topic_tag=topic_tag, claims=claims
+        )
+        if rendered is None:
+            title, body = _deterministic_body(topic_tag, claims)
+            rendered_by = _DETERMINISTIC_MODEL
+        else:
+            title, body = rendered
+            rendered_by = getattr(llm_client, "vendor", "llm")
+            report.used_llm = True
+
+    now = datetime.now(timezone.utc)
+    if existing is None:
+        view = KnowledgeTopicView(
+            workspace_id=workspace_id,
+            topic_tag=topic_tag,
+            title=title,
+            body_md=body,
+            claim_set_sha=sha,
+            claim_count=len(claims),
+            rendered_by_model=rendered_by,
+            last_rendered_at=now,
+        )
+        session.add(view)
+    else:
+        existing.title = title
+        existing.body_md = body
+        existing.claim_set_sha = sha
+        existing.claim_count = len(claims)
+        existing.rendered_by_model = rendered_by
+        existing.last_rendered_at = now
+
+    await session.flush()
+    report.rendered = True
+    return report
+
+
+async def _eligible_topics(
+    session: AsyncSession, *, workspace_id: uuid.UUID, limit: int
+) -> list[str]:
+    """Return topic_tags with at least ``_MIN_CLAIMS_PER_TOPIC`` active claims.
+
+    Uses ``unnest(topic_tags)`` to flatten the multi-tag arrays then
+    GROUP BY — Postgres can serve this from the GIN index on
+    ``knowledge_claim.topic_tags`` without a sequential scan.
+    """
+    rows = (
+        await session.execute(
+            text(
+                """
+                SELECT tag, count(*) AS c
+                FROM (
+                  SELECT unnest(topic_tags) AS tag
+                  FROM knowledge_claim
+                  WHERE workspace_id = :ws AND status = :active
+                ) sub
+                WHERE tag IS NOT NULL AND tag <> ''
+                GROUP BY tag
+                HAVING count(*) >= :min_count
+                ORDER BY c DESC, tag ASC
+                LIMIT :lim
+                """
+            ),
+            {
+                "ws": str(workspace_id),
+                "active": ClaimStatus.ACTIVE,
+                "min_count": _MIN_CLAIMS_PER_TOPIC,
+                "lim": limit,
+            },
+        )
+    ).all()
+    return [str(row[0]) for row in rows]
+
+
+async def render_workspace_topics(
+    session: AsyncSession,
+    *,
+    workspace_id: uuid.UUID,
+    llm_client: AgentClient | None,
+    limit: int = _MAX_TOPICS_PER_TICK,
+    settings: Settings | None = None,
+) -> WorkspaceRenderReport:
+    """Walk eligible topics for one workspace and render any that drifted.
+
+    Eligible = topic has ≥ ``_MIN_CLAIMS_PER_TOPIC`` active claims.
+    Each topic costs at most one LLM call per tick (cache-hit
+    short-circuit covers the no-change case).
+    """
+    settings = settings or get_settings()
+    report = WorkspaceRenderReport()
+
+    topics = await _eligible_topics(
+        session, workspace_id=workspace_id, limit=limit
+    )
+    report.inspected = len(topics)
+
+    for tag in topics:
+        try:
+            outcome = await render_topic(
+                session,
+                workspace_id=workspace_id,
+                topic_tag=tag,
+                llm_client=llm_client,
+                settings=settings,
+            )
+        except Exception as exc:  # noqa: BLE001 — never poison the tick
+            log.exception(
+                "topic_renderer: workspace=%s tag=%s failed", workspace_id, tag
+            )
+            report.failed += 1
+            continue
+
+        if outcome.rendered:
+            report.rendered += 1
+        elif outcome.skipped_unchanged:
+            report.skipped_unchanged += 1
+        elif outcome.skipped_low_density:
+            report.skipped_low_density += 1
+
+    return report
+
+
+__all__ = [
+    "TopicRenderReport",
+    "WorkspaceRenderReport",
+    "render_topic",
+    "render_workspace_topics",
+]

--- a/backend/migrations/versions/0061_knowledge_topic_views.py
+++ b/backend/migrations/versions/0061_knowledge_topic_views.py
@@ -1,0 +1,143 @@
+"""knowledge_topic_view: cached canonical markdown per topic_tag
+
+The topic view is a derived surface — a coherent markdown article
+rendered from the active claims that share a topic_tag. It replaces
+the role of ``BucketArticle`` as the retrieval target for agent /
+operator search: instead of synth deciding "new vs update vs skip"
+and producing one blob per bucket per tick, the renderer takes the
+**current** active claims for a topic and produces one canonical
+view, regenerating only when the claim set actually changes.
+
+Schema notes:
+
+- ``topic_tag`` is the same free-form kebab-case label the extractor
+  attaches to claims via ``KnowledgeClaim.topic_tags``. Multi-tag
+  claims appear in multiple topic views — that's the point.
+- ``claim_set_sha`` is a deterministic hash of the sorted active
+  claim ids feeding the view. Cache invalidation: if the cron tick
+  computes a different sha for the topic, the view gets regenerated;
+  otherwise the LLM call is skipped.
+- ``claim_count`` is denormalised so the read API can rank topics
+  by canon depth without joining to ``knowledge_claim``.
+- ``embedding`` is a pgvector(1536) so the topic view participates
+  in the same cosine-search surface as ``bucket_articles`` /
+  ``knowledge_claim``. Optional (NULL until embedded).
+
+Uniqueness: ``(workspace_id, topic_tag)`` — at most one current view
+per topic. Re-rendering an existing topic UPDATEs in place; we don't
+keep historical views in this table (the supersedes graph already
+records the underlying claim history).
+
+Revision ID: 0061_knowledge_topic_views
+Revises: 0060_claim_reconciled_at
+Create Date: 2026-05-06
+"""
+
+from __future__ import annotations
+
+from typing import Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision: str = "0061_knowledge_topic_views"
+down_revision: Union[str, None] = "0060_claim_reconciled_at"
+branch_labels: Union[str, tuple[str, ...], None] = None
+depends_on: Union[str, tuple[str, ...], None] = None
+
+
+_EMBED_DIM = 1536
+
+
+def upgrade() -> None:
+    op.execute("CREATE EXTENSION IF NOT EXISTS vector")
+
+    op.create_table(
+        "knowledge_topic_view",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "workspace_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("workspaces.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("topic_tag", sa.Text(), nullable=False),
+        sa.Column("title", sa.String(length=512), nullable=False),
+        sa.Column("body_md", sa.Text(), nullable=False),
+        sa.Column("claim_set_sha", sa.String(length=64), nullable=False),
+        sa.Column(
+            "claim_count",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column(
+            "rendered_by_model",
+            sa.String(length=64),
+            nullable=True,
+        ),
+        # ARRAY first, ALTER below to pgvector — same idiom we already
+        # use for knowledge_claim.embedding so the migration stays
+        # within sqlalchemy's portable surface for the create_table
+        # call.
+        sa.Column(
+            "embedding",
+            postgresql.ARRAY(sa.Float),
+            nullable=True,
+        ),
+        sa.Column(
+            "last_rendered_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.UniqueConstraint(
+            "workspace_id",
+            "topic_tag",
+            name="uq_knowledge_topic_view_ws_tag",
+        ),
+    )
+
+    op.execute(
+        "ALTER TABLE knowledge_topic_view DROP COLUMN embedding, "
+        f"ADD COLUMN embedding vector({_EMBED_DIM})"
+    )
+
+    op.create_index(
+        "ix_knowledge_topic_view_workspace_id",
+        "knowledge_topic_view",
+        ["workspace_id"],
+    )
+    op.execute(
+        "CREATE INDEX ix_knowledge_topic_view_embedding "
+        "ON knowledge_topic_view USING hnsw (embedding vector_cosine_ops) "
+        "WITH (m = 16, ef_construction = 64)"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS ix_knowledge_topic_view_embedding")
+    op.drop_index(
+        "ix_knowledge_topic_view_workspace_id",
+        table_name="knowledge_topic_view",
+    )
+    op.drop_table("knowledge_topic_view")

--- a/backend/tests/test_services_knowledge_topic_renderer.py
+++ b/backend/tests/test_services_knowledge_topic_renderer.py
@@ -1,0 +1,301 @@
+"""Unit tests for the topic-view renderer.
+
+Stays pure-unit by stubbing the LLM client, the active-claims query,
+and the existing-view lookup so the tests don't need a live
+Postgres. The behaviours we want to lock down:
+
+- Below the density threshold the renderer skips without touching
+  the LLM or writing rows.
+- A cache hit (same ``claim_set_sha`` as the existing row) is a
+  no-op.
+- A cache miss with no LLM client falls back to the deterministic
+  bullet body and stamps ``rendered_by_model='deterministic'``.
+- A cache miss with an LLM client uses the LLM body and stamps the
+  vendor.
+- An LLM failure inside the call falls back to the deterministic
+  body — no retry storm, the operator sees structured fallback.
+- ``claim_set_sha`` is order-invariant on the underlying claim ids
+  (so claims fetched in different orders by Postgres still hit the
+  cache).
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+import pytest
+
+from backend.app.services import knowledge_topic_renderer as ktr
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeClaim:
+    id: uuid.UUID = field(default_factory=uuid.uuid4)
+    workspace_id: uuid.UUID = field(default_factory=uuid.uuid4)
+    claim_md: str = "claim text"
+    kind: str = "fact"
+
+
+@dataclass
+class _FakeView:
+    workspace_id: uuid.UUID
+    topic_tag: str
+    title: str = ""
+    body_md: str = ""
+    claim_set_sha: str = ""
+    claim_count: int = 0
+    rendered_by_model: str | None = None
+    last_rendered_at: datetime | None = None
+
+
+class _FakeSession:
+    """Minimal session that returns canned (claims, view) for the two
+    queries the renderer issues — claims-by-tag and existing-view-
+    by-(ws, tag)."""
+
+    def __init__(self, *, claims=None, existing=None):
+        self.claims_by_tag = list(claims or [])
+        self.existing = existing
+        self.added: list = []
+        self.flush_count = 0
+
+    async def execute(self, stmt):
+        body = str(stmt)
+        if "knowledge_topic_view" in body:
+            return _FakeResult(self.existing)
+        return _FakeResult(self.claims_by_tag, scalars=True)
+
+    def add(self, row) -> None:
+        self.added.append(row)
+
+    async def flush(self):
+        self.flush_count += 1
+
+
+class _FakeResult:
+    def __init__(self, val, *, scalars: bool = False):
+        self._val = val
+        self._scalars = scalars
+
+    def scalar_one_or_none(self):
+        return self._val
+
+    def scalars(self):
+        return self
+
+    def all(self):
+        return list(self._val) if isinstance(self._val, list) else []
+
+
+@dataclass
+class _FakeLLM:
+    response: str
+    raises: bool = False
+    calls: int = 0
+    vendor: str = "fakevendor"
+
+    async def acomplete(self, messages, **kwargs) -> str:
+        self.calls += 1
+        if self.raises:
+            raise RuntimeError("simulated render failure")
+        return self.response
+
+    async def astream(self, *args, **kwargs):  # pragma: no cover
+        yield None
+
+
+# ---------------------------------------------------------------------------
+# Hashing
+# ---------------------------------------------------------------------------
+
+
+def test_claim_set_sha_is_order_invariant():
+    a = uuid.uuid4()
+    b = uuid.uuid4()
+    c = uuid.uuid4()
+    assert ktr._claim_set_sha([a, b, c]) == ktr._claim_set_sha([c, a, b])
+
+
+def test_claim_set_sha_distinguishes_membership():
+    a = uuid.uuid4()
+    b = uuid.uuid4()
+    assert ktr._claim_set_sha([a, b]) != ktr._claim_set_sha([a])
+
+
+# ---------------------------------------------------------------------------
+# Density threshold
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_render_topic_skips_when_under_threshold():
+    """A single-claim topic isn't worth rendering — the LLM would
+    produce a half-sentence article. The renderer skips and the
+    cache stays untouched."""
+    ws = uuid.uuid4()
+    session = _FakeSession(
+        claims=[_FakeClaim(workspace_id=ws)],  # only 1, threshold=3
+        existing=None,
+    )
+    llm = _FakeLLM(response="should not be called")
+
+    report = await ktr.render_topic(
+        session, workspace_id=ws, topic_tag="tiny", llm_client=llm
+    )
+
+    assert report.skipped_low_density is True
+    assert report.rendered is False
+    assert llm.calls == 0
+    assert session.added == []
+
+
+# ---------------------------------------------------------------------------
+# Cache hit / miss
+# ---------------------------------------------------------------------------
+
+
+def _three_claims(ws: uuid.UUID) -> list[_FakeClaim]:
+    return [
+        _FakeClaim(workspace_id=ws, claim_md="alpha"),
+        _FakeClaim(workspace_id=ws, claim_md="beta", kind="rule"),
+        _FakeClaim(workspace_id=ws, claim_md="gamma", kind="decision"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_cache_hit_skips_llm_and_persistence():
+    """Same claim set as last render → no LLM call, no DB writes."""
+    ws = uuid.uuid4()
+    claims = _three_claims(ws)
+    sha = ktr._claim_set_sha([c.id for c in claims])
+    existing = _FakeView(
+        workspace_id=ws,
+        topic_tag="t",
+        body_md="cached body",
+        claim_set_sha=sha,
+        claim_count=3,
+        rendered_by_model="vendorA",
+    )
+    session = _FakeSession(claims=claims, existing=existing)
+    llm = _FakeLLM(response="should not be called")
+
+    report = await ktr.render_topic(
+        session, workspace_id=ws, topic_tag="t", llm_client=llm
+    )
+
+    assert report.skipped_unchanged is True
+    assert report.rendered is False
+    assert llm.calls == 0
+    assert session.added == []
+    # No mutation of the existing view.
+    assert existing.body_md == "cached body"
+    assert existing.rendered_by_model == "vendorA"
+
+
+@pytest.mark.asyncio
+async def test_cache_miss_with_llm_renders_and_inserts():
+    """First render of a topic creates a row, stamps the LLM vendor."""
+    ws = uuid.uuid4()
+    claims = _three_claims(ws)
+    session = _FakeSession(claims=claims, existing=None)
+    llm = _FakeLLM(response="# Linear FSM\n\nLinear FSM uses 7 states. …")
+
+    report = await ktr.render_topic(
+        session, workspace_id=ws, topic_tag="linear-fsm", llm_client=llm
+    )
+
+    assert report.rendered is True
+    assert report.used_llm is True
+    assert llm.calls == 1
+    assert len(session.added) == 1
+    row = session.added[0]
+    assert row.workspace_id == ws
+    assert row.topic_tag == "linear-fsm"
+    assert "Linear FSM uses 7 states." in row.body_md
+    assert row.title == "Linear FSM"
+    assert row.claim_count == 3
+    assert row.rendered_by_model == "fakevendor"
+    assert row.claim_set_sha == ktr._claim_set_sha([c.id for c in claims])
+
+
+@pytest.mark.asyncio
+async def test_cache_miss_without_llm_falls_back_to_deterministic():
+    """No LLM client → bullet-list body, model stamp = 'deterministic'.
+    Cache invariant still holds so the next tick with an LLM upgrades
+    the same row in place."""
+    ws = uuid.uuid4()
+    claims = _three_claims(ws)
+    session = _FakeSession(claims=claims, existing=None)
+
+    report = await ktr.render_topic(
+        session, workspace_id=ws, topic_tag="example-tag", llm_client=None
+    )
+
+    assert report.rendered is True
+    assert report.used_llm is False
+    row = session.added[0]
+    assert row.rendered_by_model == "deterministic"
+    assert "# Example Tag" in row.body_md
+    # Bullet-list output starts with the title then a blank line, then
+    # the kind-sorted claims.
+    assert "- alpha" in row.body_md
+    assert "_decision_: gamma" in row.body_md
+    assert "_rule_: beta" in row.body_md
+
+
+@pytest.mark.asyncio
+async def test_llm_exception_falls_back_to_deterministic():
+    """An LLM call that raises mid-render must not surface — we still
+    get a structured fallback body and a row written, so search has
+    something to index."""
+    ws = uuid.uuid4()
+    claims = _three_claims(ws)
+    session = _FakeSession(claims=claims, existing=None)
+    llm = _FakeLLM(response="", raises=True)
+
+    report = await ktr.render_topic(
+        session, workspace_id=ws, topic_tag="boom", llm_client=llm
+    )
+
+    assert report.rendered is True
+    assert report.used_llm is False
+    row = session.added[0]
+    assert row.rendered_by_model == "deterministic"
+
+
+@pytest.mark.asyncio
+async def test_cache_miss_updates_existing_row_in_place():
+    """A drifted claim set updates the existing row, not inserts a new
+    one — uniqueness on (workspace, topic_tag) means we mutate."""
+    ws = uuid.uuid4()
+    claims = _three_claims(ws)
+    existing = _FakeView(
+        workspace_id=ws,
+        topic_tag="evolving",
+        body_md="old body",
+        claim_set_sha="STALE_SHA",
+        claim_count=2,
+        rendered_by_model="oldvendor",
+    )
+    session = _FakeSession(claims=claims, existing=existing)
+    llm = _FakeLLM(response="# Evolving\n\nFresh body.")
+
+    report = await ktr.render_topic(
+        session, workspace_id=ws, topic_tag="evolving", llm_client=llm
+    )
+
+    assert report.rendered is True
+    # No new row added — we mutated the existing one.
+    assert session.added == []
+    assert "Fresh body." in existing.body_md
+    assert existing.claim_set_sha != "STALE_SHA"
+    assert existing.claim_count == 3
+    assert existing.rendered_by_model == "fakevendor"


### PR DESCRIPTION
## Summary

P3 of the claim-graph knowledge model. Renders the active claim set of each ``topic_tag`` into a coherent markdown view that the read API will surface in P4 — replaces the role of the legacy synth-driven ``BucketArticle`` as the retrieval target.

### Schema (migration 0061)

New ``knowledge_topic_view`` table keyed ``(workspace_id, topic_tag)`` carrying the rendered markdown, ``claim_set_sha`` for cache invalidation, ``claim_count`` for ranking, ``rendered_by_model`` for telemetry, plus a pgvector(1536) column with HNSW for the eventual cosine-search join. One row per ``(workspace, topic_tag)``; multi-tag claims naturally appear in multiple views — the perspective is the point.

### Renderer

- ``render_topic`` for one ``(ws, tag)``: gathers up to ``_MAX_CLAIMS_PER_VIEW=50`` active claims, computes ``claim_set_sha`` from the sorted claim id set, no-ops on cache hit, regenerates on drift.
- **LLM path:** Haiku with a "render N atomic claims as one canonical article, never invent" prompt. Title pulled from the model's H1.
- **Deterministic fallback** when no LLM client is configured (or the call raises): kind-sorted bullet list with the same ``claim_set_sha`` so the cache invariant still holds. The next tick with a healthy client upgrades the same row in place — no retry storm because the fallback render still stamps ``last_rendered_at`` and ``rendered_by_model='deterministic'``.
- ``_MIN_CLAIMS_PER_TOPIC=3`` skips singleton tags. ``_MAX_TOPICS_PER_TICK=50`` keeps one cron tick bounded; eligible topics discovered via ``unnest(topic_tags)`` GROUP BY served from the GIN index.

### Cron wiring

- New ``CronLockId.KNOWLEDGE_TOPIC_RENDER = 1008``.
- Ticks at ``15,45 * * * *`` — offset 10 from the reconciler so freshly-superseded claims flip out of any affected view's ``claim_set_sha`` before the next render.
- Per-workspace fan-out mirrors the extractor / reconciler ticks.

### What's NOT in this PR

- Read API surfaces (P4 — ``/v1/knowledge/search`` and ``shipctl knowledge fetch`` returning topic-view hits with provenance).
- Decay (P5 — stale claims auto-archived).
- Old ``knowledge_router`` / ``knowledge_synth`` / ``BucketArticle`` are still untouched. They retire after P4 once the new read surface is hot.

## Test plan

- [x] ``pytest backend/tests/test_services_knowledge_topic_renderer.py`` — 8/8 (sha order-invariance, below-threshold skip, cache hit no-op, cache miss with/without LLM, LLM-failure fallback, drift updates in place not insert)
- [x] Alembic graph: ``heads=['0061_knowledge_topic_views']``, linear chain back to 0058
- [ ] CI: full backend suite + migration apply on clean DB
- [ ] Post-deploy: spot-check the Ship workspace once topics start populating — eyeball that ``architecture-decisions`` view stops surfacing the 2-year-old ADRs and ``runbooks-deploy`` reads as a coherent ops doc