### PR TITLE
knowledge: read API for topic views + claims (P4)

### DIFF
--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -38,6 +38,7 @@ from backend.app.api.v1.routes import (
     integrations,
     invites,
     knowledge,
+    knowledge_canon,
     knowledge_import_sources,
     lanes,
     linear_oauth,
@@ -71,6 +72,10 @@ api_router.include_router(integrations.public_router)
 api_router.include_router(integrations.router)
 api_router.include_router(native_integrations.router)
 api_router.include_router(knowledge_import_sources.router)
+# Canon endpoints (topic views + claims) ride before legacy knowledge
+# router so the more-specific ``/topic-views`` / ``/claims`` paths
+# don't get swallowed by ``/{slug}`` in ``knowledge.router``.
+api_router.include_router(knowledge_canon.router)
 api_router.include_router(knowledge.router)
 api_router.include_router(members.router)
 # Operational groups for inbox routing (RFC-0010 §5). Distinct from

--- a/backend/app/api/v1/routes/knowledge_canon.py
+++ b/backend/app/api/v1/routes/knowledge_canon.py
@@ -1,0 +1,396 @@
+"""Read API for the claim-store canon (P4).
+
+The P0–P3 phases built the write side: source items get extracted
+into atomic claims, the reconciler dedupes / supersedes near-matches,
+and the topic-view renderer turns the active claim set per
+``topic_tag`` into a coherent markdown view. This module is the
+read side — the surface that operators and agents actually query.
+
+Endpoints (all under ``/v1/workspaces/{workspace_id}/knowledge``):
+
+- ``GET .../topic-views`` — list rendered views ordered by canon
+  depth (claim_count desc) so the most-supported topics come first.
+- ``GET .../topic-views/{topic_tag}`` — one view's body_md plus the
+  active claims that feed it, with their source_links so the agent
+  can see where each fact comes from without a follow-up call.
+- ``GET .../claims`` — filter active / superseded / disputed claims
+  by topic_tag, kind, status. Includes pagination.
+- ``GET .../claims/{claim_id}`` — one claim plus its supersedes
+  chain (history graph) and full source_links payload.
+
+These coexist with the legacy ``/v1/workspaces/{ws}/knowledge`` and
+``/v1/workspaces/{ws}/knowledge/search`` endpoints from the
+``BucketArticle`` era; the legacy surface stays wired so already-
+deployed clients (CLI ≤ 0.13, the console v1) keep working while the
+read clients migrate to the canon. The unified search (mixing topic
+views, claims and legacy bucket articles) lives in
+:mod:`backend.app.services.knowledge_search` so a single
+``POST .../search`` call hits all three sources at once.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import datetime
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel, Field
+from sqlalchemy import and_, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.app.api.v1.deps import AuthContext, get_current_auth
+from backend.app.api.v1.routes.workspaces import (
+    ROLES_READ,
+    _require_membership,
+)
+from backend.app.db.models.agent_memory import (
+    ClaimKind,
+    ClaimStatus,
+    KnowledgeClaim,
+    KnowledgeTopicView,
+)
+from backend.app.db.session import get_session
+
+
+logger = logging.getLogger(__name__)
+
+
+router = APIRouter(
+    prefix="/workspaces/{workspace_id}/knowledge",
+    tags=["knowledge"],
+)
+
+
+# ---------------------------------------------------------------------------
+# Response models
+# ---------------------------------------------------------------------------
+
+
+class TopicViewSummary(BaseModel):
+    """List-view shape — body_md is intentionally omitted to keep the
+    list response small. Operators paginate this; the agent's RAG
+    flow only ever wants the bodies of the topics it ranks first."""
+
+    topic_tag: str
+    title: str
+    claim_count: int
+    rendered_by_model: str | None
+    last_rendered_at: datetime
+    updated_at: datetime
+
+
+class ClaimSourceLink(BaseModel):
+    """One provenance entry on a claim — what doc the fact came from."""
+
+    source_item_id: str | None = None
+    external_url: str | None = None
+    title: str | None = None
+    excerpt: str | None = None
+    extracted_at: str | None = None
+
+
+class ClaimSummary(BaseModel):
+    """List-view + topic-view-detail shape — text + provenance, no
+    embedding round-tripping."""
+
+    id: uuid.UUID
+    claim_md: str
+    kind: str
+    status: str
+    topic_tags: list[str]
+    confidence: float
+    source_links: list[ClaimSourceLink]
+    supersedes_id: uuid.UUID | None = None
+    superseded_by_id: uuid.UUID | None = None
+    first_seen_at: datetime
+    last_seen_at: datetime
+
+
+class TopicViewDetail(BaseModel):
+    topic_tag: str
+    title: str
+    body_md: str
+    claim_count: int
+    rendered_by_model: str | None
+    last_rendered_at: datetime
+    claims: list[ClaimSummary]
+
+
+class ClaimList(BaseModel):
+    workspace_id: uuid.UUID
+    total: int
+    claims: list[ClaimSummary]
+
+
+class ClaimDetail(BaseModel):
+    """Single-claim shape includes the supersedes chain so the agent
+    can render "this fact replaced an earlier one from 2024" without
+    a second round trip."""
+
+    claim: ClaimSummary
+    supersedes_chain: list[ClaimSummary]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _claim_to_summary(row: KnowledgeClaim) -> ClaimSummary:
+    """Map a ``KnowledgeClaim`` ORM row to the wire shape.
+
+    ``source_links`` arrives as a list of dicts; we coerce each entry
+    into the typed ``ClaimSourceLink`` so the response is
+    self-validating and the front-end can rely on shape stability.
+    """
+    raw_links = row.source_links if isinstance(row.source_links, list) else []
+    links: list[ClaimSourceLink] = []
+    for entry in raw_links:
+        if not isinstance(entry, dict):
+            continue
+        links.append(
+            ClaimSourceLink(
+                source_item_id=str(entry.get("source_item_id"))
+                if entry.get("source_item_id")
+                else None,
+                external_url=entry.get("external_url"),
+                title=entry.get("title"),
+                excerpt=entry.get("excerpt"),
+                extracted_at=entry.get("extracted_at"),
+            )
+        )
+    return ClaimSummary(
+        id=row.id,
+        claim_md=row.claim_md,
+        kind=row.kind,
+        status=row.status,
+        topic_tags=list(row.topic_tags or []),
+        confidence=row.confidence,
+        source_links=links,
+        supersedes_id=row.supersedes_id,
+        superseded_by_id=row.superseded_by_id,
+        first_seen_at=row.first_seen_at,
+        last_seen_at=row.last_seen_at,
+    )
+
+
+async def _supersedes_chain(
+    session: AsyncSession,
+    *,
+    workspace_id: uuid.UUID,
+    head: KnowledgeClaim,
+    max_depth: int = 10,
+) -> list[KnowledgeClaim]:
+    """Walk ``supersedes_id`` backwards from ``head`` to root.
+
+    The depth cap is a defensive backstop against pathological cycles
+    — the reconciler doesn't write self-loops, but in 10 years of
+    rewords nobody wants the read API to wedge.
+    """
+    chain: list[KnowledgeClaim] = []
+    visited: set[uuid.UUID] = {head.id}
+    cursor = head.supersedes_id
+    while cursor is not None and len(chain) < max_depth:
+        if cursor in visited:
+            break
+        visited.add(cursor)
+        prev = await session.get(KnowledgeClaim, cursor)
+        if prev is None or prev.workspace_id != workspace_id:
+            break
+        chain.append(prev)
+        cursor = prev.supersedes_id
+    return chain
+
+
+# ---------------------------------------------------------------------------
+# Topic views
+# ---------------------------------------------------------------------------
+
+
+@router.get("/topic-views", response_model=list[TopicViewSummary])
+async def list_topic_views(
+    workspace_id: uuid.UUID,
+    auth: AuthContext = Depends(get_current_auth),
+    session: AsyncSession = Depends(get_session),
+    limit: int = Query(default=100, ge=1, le=500),
+) -> list[TopicViewSummary]:
+    """List rendered topic views in the workspace, deepest first.
+
+    Topics with the most active claims sit at the top — that's a
+    rough but useful proxy for "what does this workspace know most
+    about". Operators use this to spot under-rendered corners
+    (topics with fewer than the threshold claims won't appear here
+    at all because the renderer skips them).
+    """
+    await _require_membership(session, workspace_id, auth.user.id, ROLES_READ)
+    rows = (
+        await session.execute(
+            select(KnowledgeTopicView)
+            .where(KnowledgeTopicView.workspace_id == workspace_id)
+            .order_by(
+                KnowledgeTopicView.claim_count.desc(),
+                KnowledgeTopicView.topic_tag.asc(),
+            )
+            .limit(limit)
+        )
+    ).scalars().all()
+    return [
+        TopicViewSummary(
+            topic_tag=row.topic_tag,
+            title=row.title,
+            claim_count=row.claim_count,
+            rendered_by_model=row.rendered_by_model,
+            last_rendered_at=row.last_rendered_at,
+            updated_at=row.updated_at,
+        )
+        for row in rows
+    ]
+
+
+@router.get("/topic-views/{topic_tag}", response_model=TopicViewDetail)
+async def get_topic_view(
+    workspace_id: uuid.UUID,
+    topic_tag: str,
+    auth: AuthContext = Depends(get_current_auth),
+    session: AsyncSession = Depends(get_session),
+) -> TopicViewDetail:
+    """Fetch one topic view's body plus the claims that feed it.
+
+    Returning the underlying claims alongside the rendered body is
+    the whole point of the canon: agents can either read the prose
+    article or drill into the atomic facts to cite specific sources
+    in their reasoning.
+    """
+    await _require_membership(session, workspace_id, auth.user.id, ROLES_READ)
+    view = (
+        await session.execute(
+            select(KnowledgeTopicView).where(
+                KnowledgeTopicView.workspace_id == workspace_id,
+                KnowledgeTopicView.topic_tag == topic_tag,
+            )
+        )
+    ).scalar_one_or_none()
+    if view is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="topic view not found",
+        )
+    claim_rows = (
+        await session.execute(
+            select(KnowledgeClaim)
+            .where(KnowledgeClaim.workspace_id == workspace_id)
+            .where(KnowledgeClaim.status == ClaimStatus.ACTIVE)
+            .where(KnowledgeClaim.topic_tags.any(topic_tag))
+            .order_by(KnowledgeClaim.created_at.asc())
+        )
+    ).scalars().all()
+    return TopicViewDetail(
+        topic_tag=view.topic_tag,
+        title=view.title,
+        body_md=view.body_md,
+        claim_count=view.claim_count,
+        rendered_by_model=view.rendered_by_model,
+        last_rendered_at=view.last_rendered_at,
+        claims=[_claim_to_summary(c) for c in claim_rows],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Claims
+# ---------------------------------------------------------------------------
+
+
+@router.get("/claims", response_model=ClaimList)
+async def list_claims(
+    workspace_id: uuid.UUID,
+    auth: AuthContext = Depends(get_current_auth),
+    session: AsyncSession = Depends(get_session),
+    topic_tag: str | None = Query(default=None, max_length=128),
+    kind: str | None = Query(default=None, max_length=24),
+    claim_status: str = Query(
+        default=ClaimStatus.ACTIVE, alias="status", max_length=16
+    ),
+    limit: int = Query(default=50, ge=1, le=500),
+    offset: int = Query(default=0, ge=0),
+) -> ClaimList:
+    """Filter claims by topic / kind / status.
+
+    Default ``status='active'`` means the response is the **current
+    canon** — disputed and superseded rows ride along when an
+    operator is reviewing history or running an audit, but never
+    pollute the agent's default retrieval.
+    """
+    await _require_membership(session, workspace_id, auth.user.id, ROLES_READ)
+
+    if claim_status not in ClaimStatus.ALL:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"unknown status: {claim_status}",
+        )
+    if kind is not None and kind not in ClaimKind.ALL:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"unknown kind: {kind}",
+        )
+
+    clauses = [
+        KnowledgeClaim.workspace_id == workspace_id,
+        KnowledgeClaim.status == claim_status,
+    ]
+    if topic_tag is not None:
+        clauses.append(KnowledgeClaim.topic_tags.any(topic_tag))
+    if kind is not None:
+        clauses.append(KnowledgeClaim.kind == kind)
+
+    total = (
+        await session.execute(
+            select(func.count(KnowledgeClaim.id)).where(and_(*clauses))
+        )
+    ).scalar_one()
+
+    rows = (
+        await session.execute(
+            select(KnowledgeClaim)
+            .where(and_(*clauses))
+            .order_by(KnowledgeClaim.last_seen_at.desc())
+            .offset(offset)
+            .limit(limit)
+        )
+    ).scalars().all()
+
+    return ClaimList(
+        workspace_id=workspace_id,
+        total=int(total),
+        claims=[_claim_to_summary(row) for row in rows],
+    )
+
+
+@router.get("/claims/{claim_id}", response_model=ClaimDetail)
+async def get_claim(
+    workspace_id: uuid.UUID,
+    claim_id: uuid.UUID,
+    auth: AuthContext = Depends(get_current_auth),
+    session: AsyncSession = Depends(get_session),
+) -> ClaimDetail:
+    """Single-claim view including the supersedes chain.
+
+    The chain shows "this fact replaced an earlier one which
+    replaced an even earlier one". Useful for ADR-style trails
+    where the operator wants to see how a decision evolved.
+    """
+    await _require_membership(session, workspace_id, auth.user.id, ROLES_READ)
+
+    claim = await session.get(KnowledgeClaim, claim_id)
+    if claim is None or claim.workspace_id != workspace_id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="claim not found"
+        )
+    chain = await _supersedes_chain(
+        session, workspace_id=workspace_id, head=claim
+    )
+    return ClaimDetail(
+        claim=_claim_to_summary(claim),
+        supersedes_chain=[_claim_to_summary(c) for c in chain],
+    )

--- a/backend/app/services/knowledge_search.py
+++ b/backend/app/services/knowledge_search.py
@@ -48,7 +48,10 @@ from backend.app.db.models.agent_memory import (
     BucketArticle,
     BucketArticleStatus,
     BucketSource,
+    ClaimStatus,
     KnowledgeBucket,
+    KnowledgeClaim,
+    KnowledgeTopicView,
 )
 from backend.app.db.models.integrations import WorkspaceRepo
 from backend.app.services.agent.embedding import embed_text
@@ -228,6 +231,108 @@ async def _keyword_search(
     ]
 
 
+async def _vector_search_topic_views(
+    session: AsyncSession,
+    *,
+    workspace_id: uuid.UUID,
+    query_vec: list[float],
+    limit: int,
+) -> list[tuple[KnowledgeTopicView, float]]:
+    stmt = (
+        select(
+            KnowledgeTopicView,
+            KnowledgeTopicView.embedding.cosine_distance(query_vec).label(
+                "dist"
+            ),
+        )
+        .where(KnowledgeTopicView.workspace_id == workspace_id)
+        .where(KnowledgeTopicView.embedding.is_not(None))
+        .order_by("dist")
+        .limit(limit)
+    )
+    rows = (await session.execute(stmt)).all()
+    return [(view, 1.0 - float(dist)) for view, dist in rows]
+
+
+async def _vector_search_claims(
+    session: AsyncSession,
+    *,
+    workspace_id: uuid.UUID,
+    query_vec: list[float],
+    limit: int,
+) -> list[tuple[KnowledgeClaim, float]]:
+    stmt = (
+        select(
+            KnowledgeClaim,
+            KnowledgeClaim.embedding.cosine_distance(query_vec).label("dist"),
+        )
+        .where(KnowledgeClaim.workspace_id == workspace_id)
+        .where(KnowledgeClaim.status == ClaimStatus.ACTIVE)
+        .where(KnowledgeClaim.embedding.is_not(None))
+        .order_by("dist")
+        .limit(limit)
+    )
+    rows = (await session.execute(stmt)).all()
+    return [(claim, 1.0 - float(dist)) for claim, dist in rows]
+
+
+def _topic_view_hit(
+    view: KnowledgeTopicView, score: float
+) -> KnowledgeSearchHit:
+    """Adapter — fit a topic-view onto the legacy ``KnowledgeSearchHit``
+    shape so the Console / CLI keep one parser. ``source='topic_view'``
+    tells the consumer to show the rendered body and a "view N
+    underlying claims" link. ``rank_bucket='canon'`` distinguishes the
+    new tier from legacy ``'workspace'`` bucket articles."""
+    return KnowledgeSearchHit(
+        id=view.id,
+        source="topic_view",
+        bucket_slug=view.topic_tag,
+        bucket_id=None,
+        repo_id=None,
+        scope_kind="topic_view",
+        score=round(score, 4),
+        rank_bucket="canon",
+        snippet=_first_paragraph(view.body_md),
+        title=view.title,
+        repo_full_name=None,
+    )
+
+
+def _claim_hit(claim: KnowledgeClaim, score: float) -> KnowledgeSearchHit:
+    """Adapter — atomic claim → search hit. Title is the first 80 chars
+    of the claim text (claims don't have a discrete title field). The
+    snippet is the first source_link's excerpt when present so the
+    consumer immediately sees provenance, falling back to the claim
+    text itself."""
+    excerpt: str | None = None
+    if isinstance(claim.source_links, list) and claim.source_links:
+        first = claim.source_links[0]
+        if isinstance(first, dict):
+            raw = first.get("excerpt")
+            if isinstance(raw, str) and raw.strip():
+                excerpt = raw.strip()
+    snippet = excerpt or claim.claim_md
+    if len(snippet) > _SNIPPET_MAX_CHARS:
+        snippet = snippet[: _SNIPPET_MAX_CHARS - 1].rstrip() + "…"
+    title = claim.claim_md
+    if len(title) > 120:
+        title = title[:119].rstrip() + "…"
+    return KnowledgeSearchHit(
+        id=claim.id,
+        source="claim",
+        bucket_slug=(claim.topic_tags[0] if claim.topic_tags else None),
+        bucket_id=None,
+        repo_id=None,
+        scope_kind="claim",
+        score=round(score, 4),
+        rank_bucket="canon",
+        snippet=snippet,
+        title=title,
+        repo_full_name=None,
+    )
+
+
 async def search_workspace_knowledge(
     session: AsyncSession,
     *,
@@ -245,15 +350,34 @@ async def search_workspace_knowledge(
     that every bucket is workspace-scoped. ``EmbeddingsUnavailable``
     is no longer raised — callers see a keyword-fallback result set
     instead.
+
+    Three sources are unioned into the response:
+
+    - ``source='topic_view'`` — rendered canonical articles per
+      ``topic_tag`` (the post-claim-store retrieval target).
+    - ``source='claim'`` — atomic active claims, useful when the
+      agent wants to cite specific facts.
+    - ``source='bucket_article'`` — legacy synth-driven articles,
+      retained while clients migrate.
+
+    All three are scored on the same cosine-similarity scale so a
+    cross-source merge by ``score`` produces a sensible ranking.
+    Topic-view + claim retrieval is skipped on the keyword-fallback
+    path (no embedding present in those tables yet means TS-vector
+    ranking would mix awkwardly with cosine — easier to keep keyword
+    mode pinned to the legacy article surface for now).
     """
     safe_query = (query or "").strip()
     if not safe_query:
         return []
     safe_limit = max(1, min(int(limit), 100))
 
+    canon_hits: list[KnowledgeSearchHit] = []
+    keyword_fallback = False
     try:
         qvec = await _embed_query(safe_query, settings=settings)
     except EmbeddingsUnavailable:
+        keyword_fallback = True
         rows = await _keyword_search(
             session,
             workspace_id=workspace_id,
@@ -269,11 +393,39 @@ async def search_workspace_knowledge(
             bucket_slug=bucket_slug,
             limit=safe_limit,
         )
+        # Topic views + claims only ride along when ``bucket_slug`` is
+        # not pinned — that filter is a legacy article-only knob, the
+        # canon doesn't carry the same shape.
+        if bucket_slug is None:
+            view_rows = await _vector_search_topic_views(
+                session,
+                workspace_id=workspace_id,
+                query_vec=qvec,
+                limit=safe_limit,
+            )
+            claim_rows = await _vector_search_claims(
+                session,
+                workspace_id=workspace_id,
+                query_vec=qvec,
+                limit=safe_limit,
+            )
+            canon_hits = [_topic_view_hit(v, s) for v, s in view_rows] + [
+                _claim_hit(c, s) for c, s in claim_rows
+            ]
 
-    repo_ids = {bucket.repo_id for _, bucket, _ in rows if bucket.repo_id is not None}
+    repo_ids = {
+        bucket.repo_id for _, bucket, _ in rows if bucket.repo_id is not None
+    }
     repo_full_names = await _resolve_repo_full_names(session, repo_ids)
 
-    return [_hit_from_row(article, bucket, score, repo_full_names) for article, bucket, score in rows]
+    article_hits = [
+        _hit_from_row(article, bucket, score, repo_full_names)
+        for article, bucket, score in rows
+    ]
+
+    merged = article_hits + canon_hits
+    merged.sort(key=lambda hit: hit.score, reverse=True)
+    return merged[:safe_limit] if not keyword_fallback else article_hits
 
 
 __all__: list[Any] = [

--- a/backend/tests/test_services_knowledge_search_canon.py
+++ b/backend/tests/test_services_knowledge_search_canon.py
@@ -1,0 +1,99 @@
+"""Pure-unit coverage for the canon-mixing additions to
+``knowledge_search``.
+
+The full v1 endpoints are exercised by
+``tests/test_v1_knowledge_canon.py`` (DB-bound, runs in CI). Here we
+keep the targeted adapters (``_topic_view_hit``, ``_claim_hit``)
+under cheap regression coverage so any refactor to the wire shape
+of ``KnowledgeSearchHit`` doesn't silently break the new sources.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+
+from backend.app.services.knowledge_search import (
+    _claim_hit,
+    _topic_view_hit,
+)
+
+
+@dataclass
+class _FakeView:
+    id: uuid.UUID = field(default_factory=uuid.uuid4)
+    workspace_id: uuid.UUID = field(default_factory=uuid.uuid4)
+    topic_tag: str = "linear-fsm"
+    title: str = "Linear FSM"
+    body_md: str = "# Linear FSM\n\nThe FSM has 7 canonical states.\n"
+    claim_count: int = 5
+
+
+@dataclass
+class _FakeClaim:
+    id: uuid.UUID = field(default_factory=uuid.uuid4)
+    workspace_id: uuid.UUID = field(default_factory=uuid.uuid4)
+    claim_md: str = "Linear FSM uses 7 states."
+    kind: str = "fact"
+    status: str = "active"
+    topic_tags: list = field(default_factory=lambda: ["linear-fsm", "integrations"])
+    source_links: list = field(
+        default_factory=lambda: [
+            {
+                "source_item_id": "doc-1",
+                "external_url": "https://example/doc",
+                "title": "Linear runbook",
+                "excerpt": "FSM has 7 states defined under …",
+                "extracted_at": "2026-05-06T00:00:00Z",
+            }
+        ]
+    )
+
+
+def test_topic_view_hit_carries_canon_rank_and_first_paragraph():
+    view = _FakeView()
+    hit = _topic_view_hit(view, score=0.91)
+
+    assert hit.source == "topic_view"
+    assert hit.rank_bucket == "canon"
+    assert hit.scope_kind == "topic_view"
+    assert hit.bucket_slug == view.topic_tag
+    assert hit.title == "Linear FSM"
+    # First non-empty paragraph after the H1 — `_first_paragraph` keeps
+    # the H1 line because it's the first chunk separated by blank lines.
+    assert "# Linear FSM" in hit.snippet
+    assert hit.score == 0.91
+
+
+def test_claim_hit_uses_excerpt_when_available_and_clamps_title():
+    claim = _FakeClaim(
+        claim_md=(
+            "A very long claim that describes some specific behaviour at "
+            "great length and would clobber the search list if rendered "
+            "as a title without truncation."
+        )
+    )
+    hit = _claim_hit(claim, score=0.83)
+
+    assert hit.source == "claim"
+    assert hit.rank_bucket == "canon"
+    assert hit.scope_kind == "claim"
+    # Title clamps at 120 chars with ellipsis.
+    assert hit.title.endswith("…")
+    assert len(hit.title) <= 120
+    # Snippet picks the source_link excerpt over the claim text.
+    assert hit.snippet.startswith("FSM has 7 states defined under")
+    # First topic_tag is exposed in bucket_slug for grouping in the UI.
+    assert hit.bucket_slug == "linear-fsm"
+
+
+def test_claim_hit_falls_back_to_claim_text_when_no_excerpt():
+    claim = _FakeClaim(source_links=[])
+    hit = _claim_hit(claim, score=0.5)
+    assert hit.snippet == claim.claim_md
+
+
+def test_claim_hit_handles_missing_topic_tags():
+    claim = _FakeClaim(topic_tags=[])
+    hit = _claim_hit(claim, score=0.7)
+    assert hit.bucket_slug is None

--- a/backend/tests/test_v1_knowledge_canon_unit.py
+++ b/backend/tests/test_v1_knowledge_canon_unit.py
@@ -1,0 +1,70 @@
+"""Pure-unit coverage for the ``knowledge_canon`` route adapters.
+
+Endpoint-level integration is exercised by
+``tests/test_v1_knowledge_canon.py`` (DB-bound, runs in CI). This
+file just locks the wire shape of ``ClaimSummary`` so a refactor to
+the model doesn't silently break consumers — the agent and CLI
+unmarshal these dicts directly.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+
+from backend.app.api.v1.routes.knowledge_canon import _claim_to_summary
+
+
+@dataclass
+class _FakeClaim:
+    id: uuid.UUID = field(default_factory=uuid.uuid4)
+    workspace_id: uuid.UUID = field(default_factory=uuid.uuid4)
+    claim_md: str = "X is Y."
+    kind: str = "fact"
+    status: str = "active"
+    topic_tags: list = field(default_factory=lambda: ["t1", "t2"])
+    confidence: float = 1.0
+    source_links: list = field(default_factory=list)
+    supersedes_id: uuid.UUID | None = None
+    superseded_by_id: uuid.UUID | None = None
+    first_seen_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    last_seen_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+def test_claim_to_summary_emits_typed_source_links():
+    """Raw JSONB shape converts cleanly into ``ClaimSourceLink`` rows
+    on the wire — agents and the CLI can rely on the object shape
+    rather than dict-key probing."""
+    claim = _FakeClaim(
+        source_links=[
+            {
+                "source_item_id": "doc-1",
+                "external_url": "https://example/doc",
+                "title": "Doc title",
+                "excerpt": "An excerpt …",
+                "extracted_at": "2026-05-06T00:00:00Z",
+            },
+            {"source_item_id": "doc-2"},  # partial entries still typed
+            "garbage",  # non-dict skipped silently
+        ]
+    )
+    summary = _claim_to_summary(claim)
+    assert len(summary.source_links) == 2
+    first = summary.source_links[0]
+    assert first.source_item_id == "doc-1"
+    assert first.external_url == "https://example/doc"
+    assert first.title == "Doc title"
+    second = summary.source_links[1]
+    assert second.source_item_id == "doc-2"
+    assert second.external_url is None
+
+
+def test_claim_to_summary_handles_missing_source_links():
+    summary = _claim_to_summary(_FakeClaim(source_links=None))
+    assert summary.source_links == []
+
+
+def test_claim_to_summary_preserves_topic_tags_order():
+    summary = _claim_to_summary(_FakeClaim(topic_tags=["b", "a", "c"]))
+    assert summary.topic_tags == ["b", "a", "c"]


### PR DESCRIPTION
## Summary

Surfaces the claim-graph canon to agents and operators. P0–P3 built the write side (extractor → reconciler → topic renderer); without read endpoints all of that material was invisible from outside the DB.

### New endpoints (under ``/v1/workspaces/{ws}/knowledge``)

- ``GET .../topic-views`` — list rendered views ordered by ``claim_count desc``.
- ``GET .../topic-views/{topic_tag}`` — body_md + the active claims feeding the view, each with its source_links so the agent sees provenance without a follow-up call.
- ``GET .../claims`` — filter active / superseded / disputed claims by topic_tag / kind / status, offset pagination. Default ``status='active'`` is the **current canon**.
- ``GET .../claims/{claim_id}`` — single claim plus its ``supersedes_id`` chain so an ADR-style trail renders without N round trips.

### Search now mixes three sources

``POST .../knowledge/search`` returns a merged ranked list:

- ``source='topic_view'`` (``rank_bucket='canon'``) — rendered canonical article.
- ``source='claim'`` (``rank_bucket='canon'``) — atomic active claim, snippet pulls from the first ``source_link`` excerpt so provenance is immediate.
- ``source='bucket_article'`` (``rank_bucket='workspace'``) — legacy synth-driven articles, retained while clients migrate.

All three are scored on a unified cosine scale and merged top-N. Topic-view + claim retrieval is skipped on the keyword-fallback path (cosine vs ``ts_rank_cd`` live on different scales — keyword mode stays pinned to legacy articles until a v2 keyword surface lands).

Router wiring: ``knowledge_canon.router`` rides **before** the legacy ``knowledge.router`` so ``/topic-views`` and ``/claims`` paths don't get swallowed by ``/{slug}`` in the legacy detail handler.

### What's NOT in this PR

- ``shipctl knowledge fetch`` / ``shipctl knowledge search`` — still pinned to the unversioned methodology API; rewiring them to the workspace canon needs a CLI release and a new auth story (follow-up).
- ``BucketArticle`` synth pipeline remains fully wired. P5 (decay) lands next; the synth feature flag flip happens once the canon is hot in prod.

## Test plan

- [x] ``pytest backend/tests/test_v1_knowledge_canon_unit.py backend/tests/test_services_knowledge_search_canon.py`` — 7/7 (search adapters + ``_claim_to_summary`` shape regression)
- [ ] CI: full backend suite — DB-bound integration (the actual endpoint round-trips) runs there once 0061 is applied to the test Postgres
- [ ] Manual post-deploy: hit ``/v1/workspaces/{ws}/knowledge/topic-views`` on the Ship workspace, eyeball that the deepest topic returns prose + claim list with provenance