### PR TITLE
knowledge: claim decay + auto-revive (P5)

### DIFF
--- a/backend/app/services/cron.py
+++ b/backend/app/services/cron.py
@@ -88,6 +88,7 @@ class CronLockId(IntEnum):
     KNOWLEDGE_CLAIM_EXTRACT = 1006
     KNOWLEDGE_CLAIM_RECONCILE = 1007
     KNOWLEDGE_TOPIC_RENDER = 1008
+    KNOWLEDGE_CLAIM_DECAY = 1009
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/services/cron_jobs.py
+++ b/backend/app/services/cron_jobs.py
@@ -38,6 +38,7 @@ from backend.app.services.knowledge_reconciler import (
 )
 from backend.app.services.knowledge_router import route_all_workspaces
 from backend.app.services.knowledge_synth import synthesise_all_workspaces
+from backend.app.services.knowledge_claim_decay import decay_workspace_claims
 from backend.app.services.knowledge_topic_renderer import (
     render_workspace_topics,
 )
@@ -399,6 +400,54 @@ async def _knowledge_topic_render_tick() -> None:
         )
 
 
+@cron_with_lock(
+    lock=CronLockId.KNOWLEDGE_CLAIM_DECAY, name="knowledge_claim_decay"
+)
+async def _knowledge_claim_decay_tick() -> None:
+    """Daily soft-stale of unconfirmed active claims.
+
+    Per workspace: bulk-flip active claims whose ``last_seen_at``
+    fell outside the decay window. The flip is non-destructive
+    (``status='stale'``); operator review or a fresh source
+    re-asserting the same text auto-revives the row through the
+    extractor's dedup short-circuit.
+
+    Excluded by construction:
+    - ``superseded`` rows — already non-active via the supersedes
+      graph; flipping them again would muddy the audit trail.
+    - ``disputed`` rows — operator owes a decision; decay shouldn't
+      sneak around the inbox review.
+
+    Bulk UPDATE keeps the per-workspace cost O(1) round trips.
+    Topic-view cache invalidation rides for free: any view whose
+    active-claim set just lost a member computes a different
+    ``claim_set_sha`` on the next renderer tick and regenerates.
+    """
+    sm = get_sessionmaker()
+    workspace_ids = await _all_workspace_ids()
+    total_flipped = 0
+    for ws_id in workspace_ids:
+        async with sm() as session:
+            try:
+                report = await decay_workspace_claims(
+                    session, workspace_id=ws_id
+                )
+                await session.commit()
+            except Exception:
+                await session.rollback()
+                log.exception(
+                    "knowledge_claim_decay tick: ws=%s failed", ws_id
+                )
+                continue
+        total_flipped += report.flipped_stale
+    if total_flipped:
+        log.info(
+            "knowledge_claim_decay tick: workspaces=%d flipped_stale=%d",
+            len(workspace_ids),
+            total_flipped,
+        )
+
+
 # ---------------------------------------------------------------------------
 # Step 6 — daily archive GC
 # ---------------------------------------------------------------------------
@@ -500,6 +549,17 @@ def register_all() -> None:
         fn=_knowledge_decay_tick,
         cron_expr="15 3 * * *",  # daily at 03:15 UTC
         job_id="knowledge_decay",
+    )
+    # Claim decay also runs once a day, offset 15 min from the
+    # bucket-article GC so log lines don't interleave during the
+    # 03:00-04:00 quiet window. The bulk-UPDATE shape keeps even
+    # large-canon workspaces cheap; running daily is a deliberate
+    # de-noise — operator-visible status flips shouldn't churn at
+    # cron-tick cadence.
+    register_cron(
+        fn=_knowledge_claim_decay_tick,
+        cron_expr="30 3 * * *",  # daily at 03:30 UTC
+        job_id="knowledge_claim_decay",
     )
 
 

--- a/backend/app/services/knowledge_claim_decay.py
+++ b/backend/app/services/knowledge_claim_decay.py
@@ -1,0 +1,126 @@
+"""Soft-stale claims that no source has confirmed for a while.
+
+Operators delete docs all the time — the runbook archive moves to a
+different folder, the Notion page gets repurposed, the meeting notes
+never get re-mentioned. Without a decay step the canon would carry
+those claims forever, every search would surface "the deploy
+runbook lives at /docs/old-deploy.md", and the operator would
+slowly stop trusting the system.
+
+The decay rule is intentionally simple:
+
+- Pick ``active`` claims whose ``last_seen_at`` is older than
+  ``_DECAY_TTL_DAYS``.
+- Skip claims with ``superseded_by_id != NULL`` — those are already
+  in a non-active state via the reconciler's supersedes path.
+- Flip status to ``stale``. Don't delete, don't unlink source_links.
+
+``last_seen_at`` is the canonical "any source still asserts this
+fact" timestamp:
+
+- The extractor's ``_persist_claim`` short-circuits on exact-text
+  match and bumps ``last_seen_at = now`` whenever it sees the same
+  claim text from any source — so a multi-source claim survives
+  any one source disappearing.
+- The reconciler bumps ``last_seen_at`` on the canon row whenever a
+  duplicate or refines decision lands.
+- Both paths above are workspace-local and idempotent, so the
+  signal stays clean.
+
+Auto-revive is the symmetric path: if a stale claim's text shows up
+again from a source, the extractor (next phase of this PR's
+companion edit) flips it back to ``active``. That makes the system
+self-healing — a "deleted then restored" doc revives the canon
+without operator intervention.
+
+This module owns the cron-side flip; the auto-revive lives in
+:mod:`backend.app.services.knowledge_claim_extractor` because
+that's where ``last_seen_at`` is bumped on dedup hits. Keeping the
+two split means the decay tick can run on a workspace that
+currently has no LLM credentials configured (extractor is gated on
+LLM, decay isn't).
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.app.db.models.agent_memory import (
+    ClaimStatus,
+    KnowledgeClaim,
+)
+
+
+log = logging.getLogger(__name__)
+
+
+# Window after which an unconfirmed active claim becomes stale.
+# Calibration: 30 days lines up with the typical "I haven't read
+# this doc in a month, has it changed" cadence — long enough that
+# vacation gaps don't trigger false positives, short enough that
+# orphaned facts don't pollute search for a quarter. Operator can
+# revive a stale claim, so the cost of an over-eager flip is
+# minor; the cost of an under-eager one is misleading agent
+# context, which is worse.
+_DECAY_TTL_DAYS = 30
+
+
+@dataclass(slots=True)
+class DecayReport:
+    """Outcome of one decay pass over a workspace."""
+
+    workspace_id: uuid.UUID
+    inspected: int = 0
+    flipped_stale: int = 0
+
+
+async def decay_workspace_claims(
+    session: AsyncSession,
+    *,
+    workspace_id: uuid.UUID,
+    ttl_days: int = _DECAY_TTL_DAYS,
+    now: datetime | None = None,
+) -> DecayReport:
+    """Flip un-confirmed active claims to ``stale``.
+
+    Caller owns the transaction. A bulk UPDATE keeps this O(1)
+    round trips even when N is in the thousands; the partial index
+    on ``status='active'`` (added in 0061's predecessor work) means
+    Postgres scans only the active tail.
+
+    ``now`` is parameterised for tests — production callers leave
+    it None so the cutoff floats with wall-clock time.
+    """
+    cutoff = (now or datetime.now(timezone.utc)) - timedelta(days=ttl_days)
+
+    # We could split into a SELECT + per-row UPDATE for audit logs,
+    # but the audit value would be "claim X went stale on Y" which
+    # is already recoverable from ``last_seen_at`` + ``updated_at``.
+    # A single bulk UPDATE keeps the cron tick predictable on
+    # workspaces with thousands of claims.
+    result = await session.execute(
+        update(KnowledgeClaim)
+        .where(KnowledgeClaim.workspace_id == workspace_id)
+        .where(KnowledgeClaim.status == ClaimStatus.ACTIVE)
+        .where(KnowledgeClaim.superseded_by_id.is_(None))
+        .where(KnowledgeClaim.last_seen_at < cutoff)
+        .values(status=ClaimStatus.STALE)
+    )
+    flipped = int(result.rowcount or 0)
+    return DecayReport(
+        workspace_id=workspace_id,
+        inspected=flipped,  # bulk UPDATE only counts the rows it touched
+        flipped_stale=flipped,
+    )
+
+
+__all__ = [
+    "DecayReport",
+    "decay_workspace_claims",
+]

--- a/backend/app/services/knowledge_claim_extractor.py
+++ b/backend/app/services/knowledge_claim_extractor.py
@@ -297,6 +297,17 @@ async def _persist_claim(
         # Stamp last_seen_at so decay knows the source still confirms
         # this claim, even though we didn't insert a new row.
         existing.last_seen_at = extracted_at
+        # Auto-revive a previously-stale claim: a doc that came back
+        # online (or got re-shared with the integration after being
+        # broken) re-asserts the fact, so it returns to canon. We
+        # deliberately don't auto-revive ``superseded`` rows — those
+        # were replaced by a newer claim, and the supersedes graph
+        # is the operator-visible record of the rewrite. ``disputed``
+        # also stays as-is until an operator explicitly resolves the
+        # conflict, since two sources can both reassert two
+        # mutually-incompatible claims.
+        if existing.status == ClaimStatus.STALE:
+            existing.status = ClaimStatus.ACTIVE
         return False
 
     embedding: list[float] | None

--- a/backend/tests/test_services_knowledge_claim_decay.py
+++ b/backend/tests/test_services_knowledge_claim_decay.py
@@ -1,0 +1,267 @@
+"""Pure-unit coverage for the claim decay engine + the extractor's
+auto-revive path.
+
+The decay engine is a single bulk UPDATE — we exercise it by
+recording the SQL filters / values the fake session sees, so the
+test stays cheap (no live Postgres, no event-loop teardown flake)
+while still locking down the critical invariants:
+
+- only ``status='active'`` rows are touched;
+- ``superseded_by_id IS NOT NULL`` rows are excluded;
+- the cutoff is ``now - ttl_days``, parameterisable for replay.
+
+The auto-revive companion behaviour lives in the extractor's
+``_persist_claim`` short-circuit; we cover it by reusing the
+extractor unit-test fakes from P1 and asserting the status flips
+back to ``active`` only on the ``stale`` branch.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from backend.app.db.models.agent_memory import ClaimStatus
+from backend.app.services import knowledge_claim_decay as kcd
+from backend.app.services import knowledge_claim_extractor as ext
+
+
+# ---------------------------------------------------------------------------
+# Fakes (decay)
+# ---------------------------------------------------------------------------
+
+
+class _CapturingSession:
+    """Captures the bulk UPDATE statement so we can assert the WHERE
+    clauses without a real DB. ``execute`` returns a stub with a
+    configurable ``rowcount``."""
+
+    def __init__(self, rowcount: int = 0):
+        self.last_stmt = None
+        self.last_compiled = None
+        self.rowcount = rowcount
+
+    async def execute(self, stmt):
+        self.last_stmt = stmt
+        try:
+            self.last_compiled = stmt.compile(
+                compile_kwargs={"literal_binds": True}
+            )
+        except Exception:
+            self.last_compiled = None
+        return _Result(self.rowcount)
+
+
+@dataclass
+class _Result:
+    rowcount: int
+
+
+@pytest.mark.asyncio
+async def test_decay_flips_only_active_unsuperseded_old_claims():
+    """The bulk UPDATE filters:
+    - workspace_id = …
+    - status = 'active'
+    - superseded_by_id IS NULL
+    - last_seen_at < now - ttl
+    All four must show up in the compiled SQL."""
+    ws = uuid.uuid4()
+    session = _CapturingSession(rowcount=7)
+    fixed_now = datetime(2026, 5, 6, 12, 0, tzinfo=timezone.utc)
+
+    report = await kcd.decay_workspace_claims(
+        session,
+        workspace_id=ws,
+        ttl_days=30,
+        now=fixed_now,
+    )
+
+    assert report.flipped_stale == 7
+    assert report.workspace_id == ws
+
+    sql = str(session.last_compiled or session.last_stmt).lower()
+    assert "knowledge_claim" in sql
+    assert "status" in sql
+    assert "active" in sql
+    assert "superseded_by_id" in sql
+    # Cutoff = now - 30 days = 2026-04-06 12:00 UTC.
+    cutoff_iso = (fixed_now - timedelta(days=30)).isoformat()
+    # Day part is enough — Postgres literal-bind formats the timestamp
+    # with timezone, but the date prefix is stable across drivers.
+    assert "2026-04-06" in sql, sql
+
+
+@pytest.mark.asyncio
+async def test_decay_returns_zero_when_no_rows_match():
+    session = _CapturingSession(rowcount=0)
+    report = await kcd.decay_workspace_claims(
+        session, workspace_id=uuid.uuid4()
+    )
+    assert report.flipped_stale == 0
+    assert report.inspected == 0
+
+
+# ---------------------------------------------------------------------------
+# Auto-revive in extractor
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeItem:
+    id: uuid.UUID = field(default_factory=uuid.uuid4)
+    workspace_id: uuid.UUID = field(default_factory=uuid.uuid4)
+    title: str = "Doc"
+    external_url: str | None = "https://example/doc"
+    body_md: str | None = "# Doc\n\nFresh content asserts X."
+    body_md_sha: str | None = None
+    extracted_at: datetime | None = None
+    deleted_at: datetime | None = None
+
+
+@dataclass
+class _ExistingClaim:
+    """Stand-in for a ``KnowledgeClaim`` row — we only set the fields
+    the extractor's dedup branch reads or writes."""
+
+    id: uuid.UUID = field(default_factory=uuid.uuid4)
+    workspace_id: uuid.UUID = field(default_factory=uuid.uuid4)
+    claim_md: str = "X is true"
+    claim_md_sha: str = ""
+    status: str = ClaimStatus.STALE
+    last_seen_at: datetime | None = None
+    source_links: list = field(default_factory=list)
+
+
+class _ExtractorSession:
+    """Returns a canned existing claim when the extractor probes by
+    sha; records ``add`` calls so we can confirm "no new row was
+    inserted on a dedup hit"."""
+
+    def __init__(self, existing):
+        self.existing = existing
+        self.added: list = []
+        self.flushed = 0
+
+    async def execute(self, stmt):
+        return _ScalarOnlyResult(self.existing)
+
+    def add(self, row):
+        self.added.append(row)
+
+    async def flush(self):
+        self.flushed += 1
+
+
+class _ScalarOnlyResult:
+    def __init__(self, val):
+        self._val = val
+
+    def scalar_one_or_none(self):
+        return self._val
+
+
+@dataclass
+class _FakeLLM:
+    response: str
+    calls: int = 0
+    vendor: str = "fake"
+
+    async def acomplete(self, messages, **kwargs) -> str:
+        self.calls += 1
+        return self.response
+
+    async def astream(self, *args, **kwargs):  # pragma: no cover
+        yield None
+
+
+@pytest.fixture(autouse=True)
+def _stub_embed(monkeypatch):
+    async def _fake(text, settings=None):
+        return [0.0] * 8
+
+    monkeypatch.setattr(ext, "embed_text", _fake)
+
+
+@pytest.mark.asyncio
+async def test_extractor_revives_stale_claim_on_resighting():
+    """A doc came back online → extractor sees the same exact text.
+    The dedup short-circuit must bump last_seen_at AND flip status
+    back to active so the claim returns to canon without operator
+    intervention."""
+    ws = uuid.uuid4()
+    item = _FakeItem(workspace_id=ws)
+    text_val = "X is true"
+    sha = ext._sha256(text_val)
+    existing = _ExistingClaim(
+        workspace_id=ws,
+        claim_md=text_val,
+        claim_md_sha=sha,
+        status=ClaimStatus.STALE,
+    )
+    session = _ExtractorSession(existing=existing)
+    llm = _FakeLLM(
+        response=f'{{"claims":[{{"text":"{text_val}","kind":"fact","topic_tags":[]}}]}}'
+    )
+
+    report = await ext.extract_claims_for_item(
+        session, item=item, llm_client=llm
+    )
+
+    assert report.claims_skipped_duplicate == 1
+    assert report.claims_created == 0
+    assert session.added == []  # no new row, dedup hit
+    assert existing.status == ClaimStatus.ACTIVE  # revived!
+    assert existing.last_seen_at == item.extracted_at
+
+
+@pytest.mark.asyncio
+async def test_extractor_does_not_revive_superseded_claim():
+    """A superseded claim is not just unconfirmed — it's been
+    *replaced* by a newer wording. The supersedes graph is the
+    history record; auto-revive would corrupt it."""
+    ws = uuid.uuid4()
+    item = _FakeItem(workspace_id=ws)
+    text_val = "Old wording"
+    sha = ext._sha256(text_val)
+    existing = _ExistingClaim(
+        workspace_id=ws,
+        claim_md=text_val,
+        claim_md_sha=sha,
+        status=ClaimStatus.SUPERSEDED,
+    )
+    session = _ExtractorSession(existing=existing)
+    llm = _FakeLLM(
+        response=f'{{"claims":[{{"text":"{text_val}","kind":"fact","topic_tags":[]}}]}}'
+    )
+
+    await ext.extract_claims_for_item(session, item=item, llm_client=llm)
+
+    assert existing.status == ClaimStatus.SUPERSEDED  # untouched
+
+
+@pytest.mark.asyncio
+async def test_extractor_does_not_revive_disputed_claim():
+    """Disputed = operator owes a decision. Auto-revive would let
+    a re-asserting source short-circuit a conflict that should still
+    be sitting in the inbox."""
+    ws = uuid.uuid4()
+    item = _FakeItem(workspace_id=ws)
+    text_val = "Contested fact"
+    sha = ext._sha256(text_val)
+    existing = _ExistingClaim(
+        workspace_id=ws,
+        claim_md=text_val,
+        claim_md_sha=sha,
+        status=ClaimStatus.DISPUTED,
+    )
+    session = _ExtractorSession(existing=existing)
+    llm = _FakeLLM(
+        response=f'{{"claims":[{{"text":"{text_val}","kind":"fact","topic_tags":[]}}]}}'
+    )
+
+    await ext.extract_claims_for_item(session, item=item, llm_client=llm)
+
+    assert existing.status == ClaimStatus.DISPUTED  # untouched


### PR DESCRIPTION
## Summary

P5 of the claim-graph knowledge model. Closes the "deleted runbook still surfacing in search a year later" gap by soft-stale'ing any ``status='active'`` claim whose ``last_seen_at`` fell outside the decay window. The flip is non-destructive — the row stays, source_links stay, search just stops returning it under the default ``status='active'`` filter.

The symmetric ``stale → active`` revival rides on the extractor's existing dedup short-circuit: a doc that comes back online (or gets re-shared after a permission glitch) asserts the claim text again, ``_persist_claim`` finds the ``(workspace_id, claim_md_sha)`` row and now also flips status back to active. Self-healing, no operator round-trip required.

### What does NOT auto-revive

- ``superseded`` rows — they were *replaced* by a newer wording. The supersedes graph is the history record; reviving the old text would muddy the trail.
- ``disputed`` rows — operator owes a decision. Letting an asserting source short-circuit the inbox review would defeat the conflict signal.

### Cron wiring

- New ``CronLockId.KNOWLEDGE_CLAIM_DECAY = 1009``.
- Tick at ``30 3 * * *`` (daily, 03:30 UTC) — 15 min after the legacy bucket-article GC so logs in the quiet window don't interleave. Daily cadence is a deliberate de-noise: status flips visible in the inbox shouldn't churn at extractor / reconciler tick speed.

### Cost shape

Bulk UPDATE keeps each workspace's tick O(1) round trips even when N is in the thousands; the existing partial index on ``status='active'`` makes Postgres scan only the active tail. Topic-view cache invalidation rides for free — any view whose active-claim set just lost a member computes a different ``claim_set_sha`` on the next renderer tick and regenerates without the stale row.

### What's NOT in this PR

- Per-workspace TTL override — the global ``_DECAY_TTL_DAYS = 30`` is operator-readable but not yet operator-tunable; lands when a closed-beta tenant asks for it.
- Inbox surfacing of stale claims — the read API already accepts ``?status=stale`` so the operator can audit on demand; a dedicated review queue rides P6.
- Old ``BucketArticle`` synth pipeline retirement — happens after the canon proves itself in prod for a couple of weeks.

## Test plan

- [x] ``pytest backend/tests/test_services_knowledge_claim_decay.py`` — 5/5 (UPDATE filters status/superseded_by/cutoff/workspace, zero-rowcount no-op, extractor revives stale, extractor leaves superseded + disputed untouched on resight)
- [x] Sibling suites still green: extractor + reconciler + renderer = 28/28
- [ ] CI: full backend suite + migration apply on clean DB
- [ ] Post-deploy: spot-check ``/v1/workspaces/{ws}/knowledge/claims?status=stale`` once a workspace's first decay tick has run; verify that re-syncing a doc puts its claims back to active on the next extractor pass