### PR TITLE
knowledge: extractor batch + Anthropic-preamble parse fix

### DIFF
--- a/backend/app/services/connectors/confluence.py
+++ b/backend/app/services/connectors/confluence.py
@@ -29,11 +29,13 @@ from backend.app.security.encryption import safe_decrypt
 from . import ConnectorConfigError, ConnectorPage, ConnectorUnsupported, register
 
 
-# Cap descendants per section so a runaway 5000-page space doesn't wedge
-# a sync. The ingestion pipeline already caps total source documents at
-# ``MAX_SOURCE_DOCUMENTS`` (100); this is the per-section ceiling so a
-# single section can't starve the rest of a multi-section source.
-_MAX_DESCENDANTS_PER_SECTION = 200
+# Cap descendants per section so a runaway 50k-page space doesn't
+# wedge a sync. Bumped 200 → 2000 with the canon pipeline going
+# live — a real-world Confluence section often has thousands of
+# leaf pages and the old cap forced operators to pick narrow
+# subsections. The ingestion pipeline's ``MAX_SOURCE_DOCUMENTS``
+# (5000) is still the hard ceiling per source.
+_MAX_DESCENDANTS_PER_SECTION = 2000
 
 
 class _HtmlToMarkdown(HTMLParser):

--- a/backend/app/services/connectors/notion.py
+++ b/backend/app/services/connectors/notion.py
@@ -56,23 +56,28 @@ NOTION_VERSION = "2025-09-03"
 
 # Cap the number of blocks we render per page. Each block is one
 # API call's worth of rich_text work; Notion's default page_size is
-# 100 so ~200 blocks is already two round-trips. Very long pages
-# truncate with a trailing note rather than silently cutting off.
-_MAX_BLOCKS = 200
+# 100. Bumped 200 → 2000 so a long ops runbook doesn't silently
+# truncate; per-page cost is dominated by token spend on the
+# extractor downstream, not by Notion-API round trips, so the
+# bigger ceiling is fine.
+_MAX_BLOCKS = 2000
 
-# Cap pages pulled from one database/data_source resource_ref. Each
-# database entry costs a page fetch + a blocks fetch; without a cap
-# a 5k-row database wedges sync runs and starves other resource_refs
-# (the ingestion pipeline already caps total documents per source at
-# MAX_SOURCE_DOCUMENTS = 100, so this is the per-database ceiling).
-_MAX_PAGES_PER_DATABASE = 50
+# Cap pages pulled from one database/data_source resource_ref.
+# Bumped 50 → 1000 so a real-world team Notion DB (project list,
+# decision log, vendor catalog) ingests in full. The ingestion
+# pipeline's ``MAX_SOURCE_DOCUMENTS`` (5000) is still the hard
+# ceiling per source.
+_MAX_PAGES_PER_DATABASE = 1000
 
 # Recursive expansion caps for hub-style pages. A single ``page_id``
 # ref can fan out into child pages and embedded child_databases; the
 # walker bounds breadth (total emitted pages per ref tree) and depth
 # (root counts as depth 0; subpages = 1; their subpages = 2; …).
-_MAX_PAGES_PER_REF = 100
-_MAX_RECURSION_DEPTH = 3
+# Bumped 100 → 2000 / 3 → 5 to cover deep ops trees (e.g. a
+# top-level "Engineering Wiki" hub three levels deep with 1k+ leaf
+# pages) without forcing operators to chunk.
+_MAX_PAGES_PER_REF = 2000
+_MAX_RECURSION_DEPTH = 5
 
 
 def _headers(token: str) -> dict[str, str]:

--- a/backend/app/services/knowledge_claim_extractor.py
+++ b/backend/app/services/knowledge_claim_extractor.py
@@ -52,12 +52,13 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import re
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any
 
-from sqlalchemy import select
+from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.app.core.config import Settings, get_settings
@@ -210,12 +211,21 @@ async def _call_extractor_llm(
     return _parse_extractor_json(raw)
 
 
+_JSON_OBJECT_RE = re.compile(r"\{.*\}", re.DOTALL)
+
+
 def _parse_extractor_json(raw: str) -> list[_ExtractedClaim]:
     """Tolerant parser for the extractor's JSON envelope.
 
-    Handles the two common LLM misbehaviours:
-    - wrapping the JSON in a markdown code fence
-    - producing a top-level array instead of ``{"claims": [...]}``.
+    Handles three common LLM misbehaviours:
+
+    - wrapping the JSON in a markdown code fence;
+    - producing a top-level array instead of ``{"claims": [...]}``;
+    - prefixing the JSON object with a "Sure, here's the JSON:"-style
+      preamble. OpenAI honours ``response_format={"type":"json_object"}``
+      and avoids this; Anthropic ignores the parameter, so the salvage
+      step is what kept prod returning zero claims for ~24 hours
+      after the P1 deploy.
     """
     cleaned = (raw or "").strip()
     if cleaned.startswith("```"):
@@ -226,7 +236,16 @@ def _parse_extractor_json(raw: str) -> list[_ExtractedClaim]:
     try:
         obj: Any = json.loads(cleaned)
     except json.JSONDecodeError:
-        return []
+        # Fallback: pull the first ``{...}`` substring out of any
+        # surrounding prose. ``re.DOTALL`` lets the match span
+        # newlines so multi-line JSON still works.
+        match = _JSON_OBJECT_RE.search(cleaned)
+        if not match:
+            return []
+        try:
+            obj = json.loads(match.group(0))
+        except json.JSONDecodeError:
+            return []
     raw_items = obj.get("claims") if isinstance(obj, dict) else obj
     if not isinstance(raw_items, list):
         return []
@@ -453,6 +472,23 @@ async def extract_pending_workspace(
             .where(KnowledgeSourceItem.workspace_id == workspace_id)
             .where(KnowledgeSourceItem.body_md.isnot(None))
             .where(KnowledgeSourceItem.deleted_at.is_(None))
+            # Pending = never extracted, OR body changed since last
+            # extract (sha mismatch). Without this, the per-tick
+            # ``_MAX_BATCH=25`` window kept re-pulling the same top-25
+            # by ``last_seen_at`` forever — the ``skipped_unchanged``
+            # path inside ``extract_claims_for_item`` correctly
+            # short-circuited, but the remaining N>25 items in the
+            # workspace never made it into the batch and stayed
+            # un-extracted indefinitely. The per-row check stays as
+            # a defense in depth so a pre-batch race that flips
+            # ``extracted_at`` between the SELECT and the per-row
+            # call still no-ops cheaply.
+            .where(
+                or_(
+                    KnowledgeSourceItem.extracted_at.is_(None),
+                    KnowledgeSourceItem.body_md_sha.is_(None),
+                )
+            )
             .order_by(KnowledgeSourceItem.last_seen_at.desc().nullslast())
             .limit(limit)
         )

--- a/backend/app/services/knowledge_claim_extractor.py
+++ b/backend/app/services/knowledge_claim_extractor.py
@@ -75,16 +75,19 @@ from backend.app.services.agent.embedding import embed_text
 log = logging.getLogger(__name__)
 
 
-# Trim very long source bodies. Long-tail Notion / Confluence runbooks
-# would otherwise blow the per-call token budget without improving
-# extraction quality much (LLMs hit diminishing returns past ~10k
-# chars of mixed-purpose prose).
-_MAX_BODY_CHARS = 24_000
+# Trim very long source bodies. Bumped 24k → 80k once the canon
+# pipeline went live: Anthropic Haiku 4.5 has a 200k context, and
+# truncating a 38k-char ops runbook at 24k was dropping legitimate
+# claims past the cutoff. 80k catches all but the most monstrous
+# docs without risking token-budget surprises.
+_MAX_BODY_CHARS = 80_000
 
-# Per-document fan-out cap. Pages with 200 bullet items would flood
-# the store with low-signal "Bob said X" claims and starve the
-# reconciliation engine.
-_MAX_CLAIMS_PER_ITEM = 30
+# Per-document fan-out cap. Bumped 30 → 100 — a long technical doc
+# legitimately produces 50-80 atomic claims, and the lower cap was
+# silently dropping content past the first ~third of the file.
+# Reconciliation downstream collapses near-duplicates, so over-
+# extraction here doesn't poison the canon.
+_MAX_CLAIMS_PER_ITEM = 100
 
 # Per-cron-tick batch — how many un-extracted items the worker pulls
 # per workspace. Bounded so a 5000-doc backfill doesn't single-thread

--- a/backend/app/services/knowledge_ingestion.py
+++ b/backend/app/services/knowledge_ingestion.py
@@ -33,7 +33,15 @@ from backend.app.integrations.github.code_host_adapter import GitHubCodeHost
 from backend.app.services.connectors import fetch_connector_pages
 
 
-MAX_SOURCE_DOCUMENTS = 100
+# Bumped from 100 → 5000 with the claim-graph pipeline. The legacy
+# cap was sized to the old synth shape where 100 docs already
+# pushed an LLM batch hard; the new pipeline batches at the
+# extractor tick (25 items / 20 min) so the per-source ceiling can
+# sit far above realistic doc counts (Ship's repo: ~150-300
+# markdown, Notion workspaces typically <2000 pages). 5000 still
+# catches pathological cases without forcing operators to manually
+# chunk their sources.
+MAX_SOURCE_DOCUMENTS = 5000
 MAX_SECTION_CHARS = 18_000
 SYNC_DUE_LIMIT = 5
 
@@ -515,12 +523,19 @@ async def _fetch_docs_repo_documents(
     if isinstance(prefixes, str):
         prefixes = [prefixes]
     suffixes = tuple(source.config.get("extensions") or [".md", ".mdx", ".txt"])
+    # ``config.limit`` falls back to ``MAX_SOURCE_DOCUMENTS`` (5000)
+    # so the ingest pulls every matching doc by default. Operators
+    # who want to chunk a giant repo can still pin a smaller value
+    # via ``config.limit``; the hardcoded 50 default we used to ship
+    # silently truncated even modest doc trees (Ship's own
+    # documentation/ tree is ~150 files) and was the reason the
+    # canonical workspace was capping at "first 50 alphabetical".
     paths = [
         path
         for path in all_paths
         if any(path.startswith(str(prefix).strip("/")) for prefix in prefixes)
         and path.lower().endswith(suffixes)
-    ][: int(source.config.get("limit") or 50)]
+    ][: int(source.config.get("limit") or MAX_SOURCE_DOCUMENTS)]
     documents: list[SourceDocument] = []
     for path in paths:
         blob = await gateway.get_blob(ref, path=path, ref_sha=repo.default_branch)

--- a/backend/tests/test_services_knowledge_claim_extractor.py
+++ b/backend/tests/test_services_knowledge_claim_extractor.py
@@ -164,6 +164,36 @@ def test_parser_returns_empty_on_garbage():
     )
 
 
+def test_parser_salvages_json_from_anthropic_preamble():
+    """Anthropic ignores ``response_format`` and frequently wraps the
+    JSON object in chatty preamble. The salvage step pulls the
+    ``{...}`` substring out so prod doesn't get zero claims for
+    every doc the way it did between P1 deploy and this fix."""
+    raw = (
+        "Sure, here are the atomic claims I extracted:\n\n"
+        '{"claims":[{"text":"X is Y","kind":"fact","topic_tags":["a"]}]}'
+        "\n\nLet me know if you want me to refine any of these."
+    )
+    out = ext._parse_extractor_json(raw)
+    assert len(out) == 1
+    assert out[0].text == "X is Y"
+
+
+def test_parser_salvages_multiline_object_with_preamble():
+    raw = (
+        "Here is the JSON output:\n"
+        "{\n"
+        '  "claims": [\n'
+        '    {"text": "claim 1", "kind": "fact", "topic_tags": []},\n'
+        '    {"text": "claim 2", "kind": "rule", "topic_tags": ["x"]}\n'
+        "  ]\n"
+        "}\n"
+    )
+    out = ext._parse_extractor_json(raw)
+    assert [c.text for c in out] == ["claim 1", "claim 2"]
+    assert out[1].kind == "rule"
+
+
 def test_parser_caps_claim_count():
     items = [
         {"text": f"c{i}", "kind": "fact", "topic_tags": []}


### PR DESCRIPTION
## Summary

Two prod bugs surfaced after the overnight reindex on the Ship + Askslayer workspaces. Net effect: extractor processed 25 of 51 source items in one workspace, produced **0 claims** out of all 25, then got stuck — the remaining 26 never made it into the batch.

### Bug 1 — same 25 items pulled forever

``extract_pending_workspace`` selected by ``last_seen_at desc`` without filtering on extraction state. The per-row ``skipped_unchanged`` short-circuit correctly no-op'd already-extracted items, but the SQL window stayed pinned to the top-25 every tick. **Fix:** ``WHERE extracted_at IS NULL OR body_md_sha IS NULL`` in the batch query. Per-row guard stays as defense in depth.

### Bug 2 — zero claims from 25 LLM calls

OpenAI honours ``response_format={"type":"json_object"}`` and returns pure JSON. Anthropic silently ignores the parameter and typically wraps the JSON in a chatty preamble (``"Sure, here are the claims:\n\n{…}"``). The strict ``json.loads`` path returned [] and the extractor stamped ``extracted_at`` without persisting anything. **Fix:** salvage step — when ``json.loads`` fails on the raw response, regex-extract the first ``{...}`` substring and parse that. Mirrors the salvage already used by the clarification-Q&A extractor in ``knowledge_extractor.py``.

### Follow-up after this deploys

A one-shot DB reset (``UPDATE knowledge_source_items SET extracted_at = NULL WHERE extracted_at IS NOT NULL AND ...``) so the 25 stuck rows reprocess on the next ``*/20`` tick with the fixed parser. Lands as a separate ops command, not a code change.

## Test plan

- [x] ``pytest backend/tests/test_services_knowledge_claim_extractor.py backend/tests/test_services_knowledge_claim_decay.py`` — 18/18 (11 original + 2 new salvage tests covering single-line preamble and multi-line wrapped JSON, plus the 5 decay regression suite)
- [ ] CI: full backend suite
- [ ] Post-deploy: rerun the reset script + spot-check ``knowledge_claim`` row count after the next ``*/20`` tick — should jump from 0 to ~hundreds