### PR TITLE
navigator: enrich session context + auto-resolve tracker (PR1 of 3)

### DIFF
--- a/backend/app/resources/agent_roles/navigator.md
+++ b/backend/app/resources/agent_roles/navigator.md
@@ -18,10 +18,10 @@ The standing rules for honesty, tool-call discipline, mutation gating, and admin
 
 Render these as fenced code blocks. Both must be valid JSON (escape quotes; no trailing commas).
 
-``ship-choice`` — clickable multi-choice card. Use whenever a yes/no or A-vs-B-vs-C question would otherwise need typing. 2-5 options.
+``ship-choice`` — clickable multi-choice card. Use whenever a yes/no or A-vs-B-vs-C question would otherwise need typing. 2-5 options. **Never** ask "which tracker?" / "which workspace?" / "which user?" — that's already in **Session context** above; if you don't see it there, the workspace is unbound and the right answer is to say so, not to ask.
 
   ```ship-choice
-  {"prompt": "Which tracker should I open this in?", "options": ["Linear", "GitHub Issues", "skip"]}
+  {"prompt": "Park this ticket as 'won't fix' or split into a follow-up?", "options": ["Won't fix", "Split + follow-up", "Keep open"]}
   ```
 
 ``ship-todo`` — task-list card for plans or multi-step work. Status is one of ``done`` / ``in_progress`` / ``pending`` (defaults to ``pending``). Re-emit later as statuses change.

--- a/backend/app/services/agent/tools.py
+++ b/backend/app/services/agent/tools.py
@@ -423,15 +423,6 @@ class ToolBox:
                 parameters={
                     "type": "object",
                     "properties": {
-                        "tracker": {
-                            "type": "string",
-                            "enum": ["linear", "notion", "jira", "github_issues"],
-                            "description": (
-                                "Which tracker to post to. If the workspace "
-                                "has only one configured tracker, omit and "
-                                "the server picks."
-                            ),
-                        },
                         "title": {"type": "string"},
                         "body": {
                             "type": "string",
@@ -740,14 +731,6 @@ class ToolBox:
                 parameters={
                     "type": "object",
                     "properties": {
-                        "tracker": {
-                            "type": "string",
-                            "enum": ["linear", "notion", "jira", "github_issues"],
-                            "description": (
-                                "Which tracker to query. Omit when the "
-                                "workspace only has one configured."
-                            ),
-                        },
                         "project_hint": {
                             "type": "string",
                             "description": (

--- a/backend/app/services/agent/topic.py
+++ b/backend/app/services/agent/topic.py
@@ -45,7 +45,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Final, Sequence
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.app.core.config import Settings
@@ -907,11 +907,32 @@ class TopicService:
            so a long-running thread doesn't chew the context window).
         6. The new user message as the final turn.
         """
+        # Collect dynamic identity / surface facts BEFORE rendering the
+        # session-context frame so the agent reads workspace name +
+        # bound tracker + activated repos + inbox snapshot at the top
+        # of every turn. Best-effort: if collection itself raises, fall
+        # back to the bare frame so a transient DB hiccup doesn't sink
+        # the chat — this is observability, not correctness.
+        try:
+            facts = await _collect_session_facts(
+                self._session,
+                workspace_id=self._workspace_id,
+                user_id=self._user_id,
+                settings=self._settings,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "session-facts: collection failed workspace=%s err=%s",
+                self._workspace_id,
+                exc,
+            )
+            facts = None
         out: list[ChatMessage] = [
             ChatMessage(role="system", content=_load_navigator_prompt()),
             ChatMessage(role="system", content=_render_session_context(
                 workspace_id=self._workspace_id,
                 now=datetime.now(timezone.utc),
+                facts=facts,
             )),
         ]
         # Policies preamble lives between the static system prompt and
@@ -993,27 +1014,222 @@ class TopicService:
 _MAX_HISTORY_TURNS = 40
 
 
+@dataclass(frozen=True)
+class _SessionFacts:
+    """Pre-fetched context the renderer formats into the system frame.
+
+    Decoupled from the async fetch so ``_render_session_context`` stays
+    a pure function — the test surface is then "given these facts,
+    does the markdown look right?", not "given these mocks, do these
+    DB calls fire in this order?".
+    """
+
+    workspace_name: str | None
+    workspace_slug: str | None
+    user_name: str | None
+    user_email: str | None
+    tracker_kind: str | None  # "linear" / "jira" / "github_issues" / etc; None if unbound
+    tracker_scope_hint: str | None  # Linear team key, Jira project key, etc.
+    tracker_status: str  # "connected" / "error" / "disconnected"
+    tracker_health_error: str | None
+    activated_repos: list[str]  # full_names; cap'd to keep the frame compact
+    inbox_open_total: int
+    inbox_by_type: dict[str, int]
+
+
+_INBOX_OPEN_STATES: tuple[str, ...] = ("new", "snoozed")
+_REPOS_PREVIEW_CAP = 6  # ``+N more`` past this — frame stays under ~250 tokens
+
+
+async def _collect_session_facts(
+    session: AsyncSession,
+    *,
+    workspace_id: uuid.UUID,
+    user_id: uuid.UUID,
+    settings: Settings,
+) -> _SessionFacts:
+    """Fetch the dynamic facts the agent should see at the top of every turn.
+
+    Two-three lightweight DB hits + one tracker resolve. We trade a
+    handful of milliseconds per turn for the agent NOT having to dial
+    ``list_integrations`` / ``list_activated_repos`` / ``inbox_counts``
+    just to know where it lives. Anything that fails (tracker probe
+    raised, inbox query timed out) degrades to a polite null in the
+    rendered frame — never blocks the LLM call.
+    """
+    from sqlalchemy import select as _select  # local: avoid topping the file
+
+    from backend.app.db.models.tenancy import User, Workspace
+    from backend.app.db.models.integrations import WorkspaceRepo
+    from backend.app.db.models.inbox import InboxItem
+    from backend.app.services.tracker_resolver import resolve_for_workspace
+
+    workspace = await session.get(Workspace, workspace_id)
+    user = await session.get(User, user_id)
+
+    repos = (
+        await session.execute(
+            _select(WorkspaceRepo.full_name)
+            .where(WorkspaceRepo.workspace_id == workspace_id)
+            .order_by(WorkspaceRepo.full_name)
+        )
+    ).scalars().all()
+
+    inbox_total = (
+        await session.execute(
+            _select(func.count(InboxItem.id)).where(
+                InboxItem.workspace_id == workspace_id,
+                InboxItem.status.in_(_INBOX_OPEN_STATES),
+            )
+        )
+    ).scalar_one() or 0
+
+    inbox_by_type_rows = (
+        await session.execute(
+            _select(InboxItem.type, func.count(InboxItem.id))
+            .where(
+                InboxItem.workspace_id == workspace_id,
+                InboxItem.status.in_(_INBOX_OPEN_STATES),
+            )
+            .group_by(InboxItem.type)
+        )
+    ).all()
+    inbox_by_type: dict[str, int] = {
+        str(row[0]): int(row[1]) for row in inbox_by_type_rows if row[0]
+    }
+
+    tracker_kind: str | None = None
+    tracker_scope_hint: str | None = None
+    tracker_status = "disconnected"
+    tracker_health_error: str | None = None
+    try:
+        resolved = await resolve_for_workspace(
+            session=session,
+            settings=settings,
+            workspace_id=workspace_id,
+        )
+    except Exception as exc:  # noqa: BLE001 — defensive, don't block the turn
+        logger.warning(
+            "session-facts: tracker resolve failed workspace=%s err=%s",
+            workspace_id,
+            exc,
+        )
+        resolved = None
+        tracker_status = "error"
+        tracker_health_error = str(exc)
+    if resolved is not None:
+        tracker_kind = resolved.kind
+        tracker_scope_hint = resolved.scope_hint
+        tracker_status = "error" if resolved.last_health_error else "connected"
+        tracker_health_error = resolved.last_health_error
+
+    return _SessionFacts(
+        workspace_name=workspace.name if workspace else None,
+        workspace_slug=workspace.slug if workspace else None,
+        user_name=user.display_name if user else None,
+        user_email=user.email if user else None,
+        tracker_kind=tracker_kind,
+        tracker_scope_hint=tracker_scope_hint,
+        tracker_status=tracker_status,
+        tracker_health_error=tracker_health_error,
+        activated_repos=[str(r) for r in repos],
+        inbox_open_total=int(inbox_total),
+        inbox_by_type=inbox_by_type,
+    )
+
+
 def _render_session_context(
-    *, workspace_id: uuid.UUID, now: datetime
+    *, workspace_id: uuid.UUID, now: datetime, facts: _SessionFacts | None = None
 ) -> str:
     """Dynamic frame the agent reads right after the static prompt.
 
-    Pins today's date and the active workspace id so the model can't
-    fall back on training-data assumptions ("it must be 2024 / 2025"
-    when the operator is actually in 2026). The static system prompt
-    references this frame by name in its "Today's date" hard rule —
-    if you rename the heading, update the prompt too.
+    Pins today's date, the active workspace + user identity, the
+    bound tracker, the activated repo set, and the open inbox counts
+    so the model can't fall back on training-data assumptions ("it
+    must be 2024 / 2025") and doesn't have to dial three discovery
+    tools every turn just to learn where it lives.
+
+    Keep the frame under ~250 tokens — every turn's prefix counts.
+    Repo list is capped at ``_REPOS_PREVIEW_CAP`` with a "+N more"
+    tail; the agent calls ``list_activated_repos`` if it needs the
+    rest. Tracker line is single-line per-state so a degraded
+    workspace still surfaces the failure mode (``status=error`` +
+    last health error) rather than vanishing into a polite default.
+
+    The static system prompt references the **Session context**
+    heading by name in its "Today's date" rule and in the
+    don't-re-ask-context rule — if you rename the heading, update
+    the prompt too.
     """
     iso_date = now.strftime("%Y-%m-%d")
     weekday = now.strftime("%A")
-    return (
-        "## Session context\n\n"
-        f"- Today: **{iso_date} ({weekday}) UTC**.\n"
-        f"- Active workspace id: `{workspace_id}`.\n"
-        "- Use these for any \"today\" / \"yesterday\" / \"this week\" "
-        "/ \"last N days\" wording. Never assume the year or month "
-        "from your training data — when in doubt about a date, ask."
+    lines: list[str] = [
+        "## Session context",
+        "",
+        f"- Today: **{iso_date} ({weekday}) UTC**.",
+    ]
+    if facts is None:
+        lines.append(f"- Active workspace id: `{workspace_id}`.")
+    else:
+        if facts.workspace_name and facts.workspace_slug:
+            lines.append(
+                f"- Workspace: **{facts.workspace_name}** "
+                f"(`{facts.workspace_slug}`, id `{workspace_id}`)."
+            )
+        else:
+            lines.append(f"- Active workspace id: `{workspace_id}`.")
+        if facts.user_name and facts.user_email:
+            lines.append(
+                f"- You're talking to: **{facts.user_name}** <{facts.user_email}>."
+            )
+        elif facts.user_email:
+            lines.append(f"- You're talking to: <{facts.user_email}>.")
+        if facts.tracker_kind:
+            scope = (
+                f" scope `{facts.tracker_scope_hint}`"
+                if facts.tracker_scope_hint
+                else ""
+            )
+            tracker_line = (
+                f"- Bound tracker: **{facts.tracker_kind}**"
+                f"{scope} · status={facts.tracker_status}"
+            )
+            if facts.tracker_status == "error" and facts.tracker_health_error:
+                tracker_line += f" ({facts.tracker_health_error[:120]})"
+            lines.append(tracker_line + ".")
+        else:
+            lines.append("- Bound tracker: **none** — `create_ticket` / `list_tickets` will refuse until one is bound.")
+        if facts.activated_repos:
+            preview = facts.activated_repos[:_REPOS_PREVIEW_CAP]
+            tail = (
+                f" + {len(facts.activated_repos) - _REPOS_PREVIEW_CAP} more"
+                if len(facts.activated_repos) > _REPOS_PREVIEW_CAP
+                else ""
+            )
+            joined = ", ".join(f"`{r}`" for r in preview)
+            lines.append(
+                f"- Activated repos ({len(facts.activated_repos)}): {joined}{tail}."
+            )
+        else:
+            lines.append("- Activated repos: **none** — point the operator at `/onboarding` if they want to ship code.")
+        if facts.inbox_open_total > 0:
+            by_type = ", ".join(
+                f"{k}={v}" for k, v in sorted(facts.inbox_by_type.items())
+            )
+            lines.append(
+                f"- Inbox: **{facts.inbox_open_total} open**"
+                + (f" ({by_type})" if by_type else "")
+                + "."
+            )
+        else:
+            lines.append("- Inbox: **0 open**.")
+    lines.append(
+        "- Use these for \"today\" / \"yesterday\" / \"this week\" "
+        "wording AND for routing decisions. Never re-ask the user for "
+        "anything already on this list; never assume year/month from "
+        "your training data."
     )
+    return "\n".join(lines)
 
 
 def _trim_history(

--- a/backend/tests/test_navigator_session_context.py
+++ b/backend/tests/test_navigator_session_context.py
@@ -1,0 +1,224 @@
+"""Navigator session-context frame (the system message the agent reads
+each turn before any tool call).
+
+Two surfaces are covered here:
+
+- ``_render_session_context`` — pure rendering. Given a ``_SessionFacts``
+  dataclass it must spit out a markdown block with workspace + user +
+  tracker + repos + inbox lines. We assert structurally so editorial
+  changes to the copy don't trip the test, but the load-bearing tokens
+  (workspace name, tracker kind, status, repo full names, inbox count)
+  must show up.
+
+- ``_collect_session_facts`` — integration. Given a real workspace +
+  seeded ``WorkspaceRepo`` rows + a couple of inbox items, the helper
+  reports the right counts. The tracker resolver runs against the
+  seeded workspace (which has none) so we assert the unbound-tracker
+  branch surfaces in the rendered frame.
+
+Why this matters: PR1 of the Navigator overhaul wires the agent's
+identity into the prompt so it stops asking the user "which tracker?"
+or "what's my workspace?" every turn. If a future change drops one of
+the load-bearing fields these tests catch it.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+
+def _facts(**overrides):
+    from backend.app.services.agent.topic import _SessionFacts
+
+    base = dict(
+        workspace_name="Acme",
+        workspace_slug="acme",
+        user_name="Alice",
+        user_email="alice@acme.test",
+        tracker_kind="linear",
+        tracker_scope_hint="ENG",
+        tracker_status="connected",
+        tracker_health_error=None,
+        activated_repos=["acme/api", "acme/web"],
+        inbox_open_total=3,
+        inbox_by_type={"clarification": 2, "approval": 1},
+    )
+    base.update(overrides)
+    return _SessionFacts(**base)
+
+
+def test_render_includes_load_bearing_fields() -> None:
+    from backend.app.services.agent.topic import _render_session_context
+
+    out = _render_session_context(
+        workspace_id=uuid.UUID("00000000-0000-0000-0000-000000000042"),
+        now=datetime(2026, 5, 5, tzinfo=timezone.utc),
+        facts=_facts(),
+    )
+    # Workspace identity
+    assert "Acme" in out
+    assert "acme" in out  # slug
+    # User identity
+    assert "Alice" in out
+    assert "alice@acme.test" in out
+    # Tracker
+    assert "linear" in out
+    assert "ENG" in out
+    assert "connected" in out
+    # Repos
+    assert "acme/api" in out
+    assert "acme/web" in out
+    # Inbox snapshot
+    assert "3 open" in out
+    assert "clarification=2" in out
+    # Date pin
+    assert "2026-05-05" in out
+    assert "Tuesday" in out
+
+
+def test_render_falls_back_when_facts_unavailable() -> None:
+    """A failed fact-collection must not block the turn — the bare
+    frame still pins date + workspace id."""
+    from backend.app.services.agent.topic import _render_session_context
+
+    workspace_id = uuid.UUID("00000000-0000-0000-0000-000000000043")
+    out = _render_session_context(
+        workspace_id=workspace_id,
+        now=datetime(2026, 5, 5, tzinfo=timezone.utc),
+        facts=None,
+    )
+    assert "2026-05-05" in out
+    assert str(workspace_id) in out
+    # No identity fields when facts are missing
+    assert "Bound tracker" not in out
+    assert "Activated repos" not in out
+
+
+def test_render_unbound_tracker_says_so() -> None:
+    """An unbound tracker must surface explicitly so the agent knows
+    not to call ``create_ticket`` (and not to ask the user which one
+    to use). Refusal-grade copy beats a polite null."""
+    from backend.app.services.agent.topic import _render_session_context
+
+    out = _render_session_context(
+        workspace_id=uuid.uuid4(),
+        now=datetime(2026, 5, 5, tzinfo=timezone.utc),
+        facts=_facts(tracker_kind=None, tracker_scope_hint=None, tracker_status="disconnected"),
+    )
+    assert "Bound tracker:" in out
+    assert "none" in out.lower()
+    assert "create_ticket" in out  # explicit about what's broken
+
+
+def test_render_tracker_error_surfaces_health_message() -> None:
+    """When the resolved tracker is in error state, the rendered frame
+    must show ``status=error`` AND the underlying message so the agent
+    can phrase a useful response without dialling /_debug-tracker."""
+    from backend.app.services.agent.topic import _render_session_context
+
+    out = _render_session_context(
+        workspace_id=uuid.uuid4(),
+        now=datetime(2026, 5, 5, tzinfo=timezone.utc),
+        facts=_facts(
+            tracker_status="error",
+            tracker_health_error="401 Unauthorized — token expired",
+        ),
+    )
+    assert "status=error" in out
+    assert "401 Unauthorized" in out
+
+
+def test_render_caps_repo_list_with_tail() -> None:
+    """Long repo lists get a ``+N more`` tail so the prefix stays
+    bounded. The agent calls ``list_activated_repos`` for the rest."""
+    from backend.app.services.agent.topic import _render_session_context
+
+    repos = [f"acme/{i}" for i in range(20)]
+    out = _render_session_context(
+        workspace_id=uuid.uuid4(),
+        now=datetime(2026, 5, 5, tzinfo=timezone.utc),
+        facts=_facts(activated_repos=repos),
+    )
+    assert "Activated repos (20)" in out
+    assert "+ 14 more" in out  # 20 - 6-cap
+
+
+def test_render_zero_inbox_says_zero() -> None:
+    """Empty inbox surfaces as `0 open` so the agent knows there's no
+    queue to mention; absence of the line would invite hallucination."""
+    from backend.app.services.agent.topic import _render_session_context
+
+    out = _render_session_context(
+        workspace_id=uuid.uuid4(),
+        now=datetime(2026, 5, 5, tzinfo=timezone.utc),
+        facts=_facts(inbox_open_total=0, inbox_by_type={}),
+    )
+    assert "0 open" in out
+
+
+@pytest.mark.asyncio
+async def test_collect_session_facts_reports_seeded_state(
+    db_session, seed_workspace
+) -> None:
+    """End-to-end fact collection: the helper queries workspace, user,
+    tracker resolver, repos, and inbox counts. Test seeds a workspace
+    with no tracker + no repos + a couple of inbox items and asserts
+    the helper surfaces the expected shape."""
+    from backend.app.core.config import get_settings
+    from backend.app.db.models.inbox import InboxItem
+    from backend.app.services.agent.topic import _collect_session_facts
+
+    user, _, workspace = seed_workspace
+    db_session.add(
+        InboxItem(
+            workspace_id=workspace.id,
+            repo_id=None,
+            type="clarification",
+            title="t1",
+            status="new",
+            intake_handle=None,
+        )
+    )
+    db_session.add(
+        InboxItem(
+            workspace_id=workspace.id,
+            repo_id=None,
+            type="approval",
+            title="t2",
+            status="new",
+            intake_handle=None,
+        )
+    )
+    db_session.add(
+        InboxItem(
+            workspace_id=workspace.id,
+            repo_id=None,
+            type="failure",
+            title="t3",
+            status="dismissed",  # NOT counted — closed.
+            intake_handle=None,
+        )
+    )
+    await db_session.flush()
+
+    facts = await _collect_session_facts(
+        db_session,
+        workspace_id=workspace.id,
+        user_id=user.id,
+        settings=get_settings(),
+    )
+
+    # Identity
+    assert facts.workspace_name == workspace.name
+    assert facts.workspace_slug == workspace.slug
+    assert facts.user_email == user.email
+    # Tracker — none seeded; resolver returns None and helper reports unbound
+    assert facts.tracker_kind is None
+    # Repos — none seeded
+    assert facts.activated_repos == []
+    # Inbox — 2 open (the dismissed row is excluded)
+    assert facts.inbox_open_total == 2
+    assert facts.inbox_by_type == {"clarification": 1, "approval": 1}


### PR DESCRIPTION
First of three PRs in the Navigator overhaul. PR2 = agentic system-prompt rewrite. PR3 = ``consult_specialist`` subagent tool.

## Why

Two bugs that compound:

1. **Navigator can't tell which tracker is bound to the workspace.** Today's static frame surfaces only the date and the workspace UUID. Workspace name, user identity, tracker kind, activated repos, inbox state — all have to be dialed via tools every turn.

2. **The tool surface offers a ``tracker`` enum** on ``create_ticket`` / ``list_tickets``, AND ``navigator.md`` literally ships a ``ship-choice`` example asking "Which tracker should I open this in?". Three reinforcing surfaces, one bug — the agent ends up re-asking the user what we already know.

## Fix

- **`_render_session_context`** grows a structured `_SessionFacts` + sibling `_collect_session_facts` that fetches workspace name, user identity, resolved tracker (kind + scope hint + status + health error), activated repos, and inbox snapshot in one pass. The renderer formats them into a markdown frame at the top of every turn — capped at ~250 tokens; repo lists trim with a `+N more` tail.
- **Tracker error states** surface explicitly (`status=error (401 Unauthorized — token expired)`) so the agent can phrase a useful response instead of "the tracker is broken, can you check?".
- **Unbound tracker** spells out that `create_ticket` will refuse until one is bound — refusal-grade copy beats a polite null.
- **Best-effort collection**: if the resolver raises or the DB hiccups, we log and fall back to the bare frame so a transient blip doesn't sink the chat.
- The `tracker` enum drops out of `create_ticket` + `list_tickets` tool specs. `_resolve_tracker(None, None)` already auto-picks server-side; exposing the choice was the LLM's licence to ask.
- `navigator.md` strips the `"Which tracker should I open this in?"` `ship-choice` example, replaces it with a "never ask which tracker / workspace / user — read Session context" rule.

## Sample frame after this PR

```
## Session context

- Today: **2026-05-05 (Tuesday) UTC**.
- Workspace: **Denys's workspace** (`denys-99938640`, id `d591af28-...`).
- You're talking to: **Denys Kuzin** <denys@bodyman.io>.
- Bound tracker: **linear** scope `ELS` · status=connected.
- Activated repos (3): `ElMundiUA/ship`, `ElMundiUA/elmundi`, `ElMundiUA/oneoff-tools`.
- Inbox: **4 open** (approval=1, clarification=2, failure=1).
- Use these for "today" / "yesterday" / "this week" wording AND for routing decisions. Never re-ask the user for anything already on this list; never assume year/month from your training data.
```

## Test plan

- [x] **7 new tests** (`test_navigator_session_context.py`) — load-bearing fields, fallback path, unbound-tracker copy, error-state health surface, repo-list trim, zero-inbox baseline, and an end-to-end fact collection against a seeded workspace.
- [x] **14/14 adjacent tests pass** (`test_v1_chat_active.py`, `test_agent_tools_create_project.py`, `test_agent_tools_native_linear.py`).
- [x] **Smoke import** confirms `_collect_session_facts`, `_render_session_context`, and `_SessionFacts` all wire through and the frame renders correctly across connected / errored / unbound / 0-inbox / 20-repos cases.

## What's NOT in this PR

- The agentic prompt rewrite (plan-first, gather-context-with-tools, cite-evidence, verify-before-mutate). PR2.
- The `consult_specialist` subagent tool (designer / architect / qa-architect / bug-triage / researcher). PR3.