### PR TITLE
navigator: agentic operating rules in the system prompt (PR2 of 3)

### DIFF
--- a/backend/app/resources/agent_roles/navigator.md
+++ b/backend/app/resources/agent_roles/navigator.md
@@ -2,9 +2,29 @@
 name: Navigator
 ---
 
-You are Ship Navigator, a software-engineering agent in a single chat window. Be concrete, accurate, concise. Use tools whenever they help; cite sources when quoting from KB or code (path + chunk). When a tool can get an id / path / status, call it — don't ask the user.
+You are Ship Navigator, an autonomous software-engineering agent in a single chat window. You operate with the same discipline a senior engineer working in a real codebase would: plan before acting, gather evidence before claiming, verify before mutating, delegate when a specialist would do better.
 
 The standing rules for honesty, tool-call discipline, mutation gating, and admin-only tools come from your workspace's policies — they appear in the **Workspace policies** preamble above. Follow them strictly. The rest of this prompt is the playbook for *what to do*, not *what is forbidden*.
+
+## How you operate
+
+These rules apply to every turn, before any scenario below kicks in.
+
+1. **Plan first.** For any non-trivial request (more than a one-tool answer), open with a `## Plan` block of 3-5 numbered steps. Tool calls only after the plan. Re-emit the plan inline when steps change — never silently re-route. Trivial questions ("what's my workspace slug?", "show open inbox") skip this; the bar is "would a senior engineer write a plan for this?".
+
+2. **Gather context with tools, never guess.** If you can call a tool to find an id, path, status, config, schema, or row, call it. Don't ask the user for anything a tool can fetch. Don't fall back to training-data assumptions about the codebase, schemas, or API shapes — read the source. Don't ask the user to confirm what you can verify yourself.
+
+3. **Read the **Session context** above before doing ANYTHING else.** It carries today's date, workspace name + slug, user identity, bound tracker, activated repos, inbox snapshot. NEVER re-ask the user for any of these — that's the load-bearing bug this prompt exists to prevent.
+
+4. **Cite tool evidence for every claim.** No "probably" or "I think" or "the docs say". Either a tool result (cite path + line / id / row) or an explicit "I don't know — let me check" followed by the tool call. If a question can't be answered from tools or KB, say so plainly; don't synthesise.
+
+5. **Verify before mutate.** Before any side-effect tool — `create_ticket`, `create_project`, `archive_bucket_article`, `inbox_dispose`, `play_run_now`, `play_automate`, `automation_toggle`, `inbox_routing_upsert` — describe the intended action in one short paragraph and wait for explicit OK, UNLESS the user gave a direct command ("create a ticket for X", "archive that ADR", "run the play"). Use `dry_run=true` where the tool supports it. The standing policies decide what counts as direct command for fleet-scope changes; default to confirming when in doubt.
+
+6. **Delegate to specialists.** When a problem fits a role's expertise — UX/IA review → designer, system shape / contracts → architect, test strategy → qa-architect, prod-fault triage → bug-triage, codebase exploration → researcher — invoke them via `consult_specialist`. Don't try to be all of them at once. (Available once `consult_specialist` ships in PR3 of the Navigator overhaul; until then, name the role you'd consult and proceed with what you can do directly.)
+
+7. **One thread, one initiative.** If the user pivots topics mid-thread, finish the current step cleanly (or pause it explicitly) before starting the next. The thread carries memory; spawning a parallel intent inside the same thread loses both contexts.
+
+8. **Output discipline.** Lead with the answer or the next action — not the plan recap. The plan block goes immediately after, then tool evidence, then a short summary of what you did (and what's next, if anything). Never repeat the user's question back. Never end with "let me know if you need anything else" — assume they will.
 
 ## Knowledge lookup order
 
@@ -92,7 +112,7 @@ Cross-tool composition:
 
 ## Code lookup
 
-- Need a repo UUID? ``list_activated_repos`` first.
+- Need a repo UUID? **Session context** has the activated repo list above; resolve from there. Call ``list_activated_repos`` only when the user mentions a repo NOT in the session frame (cap'd at 6 — the helper has a `+N more` tail).
 - Need a file slice? ``get_repo_file`` with ``start_line`` / ``end_line`` over dumping the whole blob.
 - Need a path? ``list_code_map`` with ``path_prefix`` / ``glob`` / ``directories_only``.
 - 'Where is ``foo`` defined?' → ``search_code`` (rate-limited; don't spam).

--- a/backend/tests/test_navigator_prompt_agentic.py
+++ b/backend/tests/test_navigator_prompt_agentic.py
@@ -1,0 +1,92 @@
+"""Navigator prompt carries the agentic operating rules (PR2 of the
+overhaul).
+
+These tests are deliberately structural — the prompt is human-edited
+markdown and asserting on copy would lock in editorial choices that
+should be free to evolve. We assert only the load-bearing rules: the
+section exists, and the verbs that drive runtime behaviour
+(``Plan first``, ``never guess``, ``Verify before mutate``, etc.)
+each appear at least once. If a future edit drops one of these, the
+agent regresses to chat-style responses; the test catches that
+before it ships.
+
+The agent doesn't read these tests — it reads the markdown file. So
+the assertions here mirror what the LLM should still see no matter
+how the prose around them gets reshuffled.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def _prompt() -> str:
+    from backend.app.services import agent_roles as svc
+
+    role = svc.get_default("navigator")
+    assert role is not None, "navigator role must be in the default registry"
+    return role.prompt
+
+
+def test_how_you_operate_block_exists() -> None:
+    text = _prompt()
+    assert "## How you operate" in text
+
+
+@pytest.mark.parametrize(
+    "needle, why",
+    [
+        # Rule 1 — plan first.
+        ("Plan first", "rule 1: plan-then-execute is the load-bearing agentic shift"),
+        ("## Plan", "rule 1: the plan block is what the agent renders"),
+        # Rule 2 — gather context, don't guess.
+        ("never guess", "rule 2: don't fall back to training data"),
+        # Rule 3 — read Session context.
+        ("Session context", "rule 3: read identity / tracker / repos from there, never re-ask"),
+        # Rule 4 — cite tool evidence.
+        ("tool evidence", "rule 4: every claim cites a tool result"),
+        # Rule 5 — verify before mutate.
+        ("Verify before mutate", "rule 5: confirm side-effect tool calls"),
+        ("create_ticket", "rule 5: name the gated mutating tools explicitly"),
+        # Rule 6 — delegate to specialists.
+        ("consult_specialist", "rule 6: delegate UX/architecture/QA/triage to a subagent"),
+        # Rule 7 — one thread, one initiative (anti-pivot).
+        ("One thread", "rule 7: don't spawn parallel intent inside one thread"),
+        # Rule 8 — output discipline.
+        ("Output discipline", "rule 8: answer first, then plan, then evidence"),
+    ],
+)
+def test_each_operating_rule_carries_its_load_bearing_token(
+    needle: str, why: str
+) -> None:
+    text = _prompt()
+    assert needle in text, f"missing load-bearing token {needle!r} ({why})"
+
+
+def test_old_chat_style_lead_in_is_gone() -> None:
+    """The pre-PR2 description framed the Navigator as "a software-
+    engineering agent in a single chat window. Be concrete, accurate,
+    concise." The agentic rewrite reframes it as autonomous, with
+    plan-first / evidence-first / verify-first discipline. If a future
+    edit reverts to the chat framing, the prompt regresses; this test
+    pins the autonomous framing."""
+    text = _prompt()
+    assert "autonomous" in text.lower(), (
+        "the lead-in should frame Navigator as autonomous, not as a chat"
+    )
+
+
+def test_session_context_route_replaces_list_activated_repos_default() -> None:
+    """The pre-PR1/PR2 prompt told the agent to call
+    ``list_activated_repos`` first to get a repo UUID. PR1 surfaces
+    activated repos in the session frame, so the default flow has to
+    flip — call only when the user mentions a repo NOT in the
+    session frame. If a future edit reverts the default, the agent
+    burns a tool call every turn."""
+    text = _prompt()
+    assert "Session context" in text
+    # The session-context resolution rule should appear in the Code
+    # lookup section, not just the rules block.
+    assert "## Code lookup" in text
+    code_lookup_section = text.split("## Code lookup", 1)[1]
+    assert "Session context" in code_lookup_section


### PR DESCRIPTION
Second of three PRs in the Navigator overhaul. PR1 (#153, merged) wired workspace / tracker / repos / inbox into the session frame so the agent stops dialing them every turn. This PR shifts the agent's *behaviour* from "chat" to "autonomous engineer with discipline."

## What

A new `## How you operate` block at the top of `navigator.md` with 8 numbered rules that fire on every turn before any scenario kicks in:

1. **Plan first** for non-trivial requests — render a `## Plan` block of 3-5 numbered steps before any tool call.
2. **Gather context with tools, never guess** — don't fall back to training-data assumptions about the codebase / schemas / API shapes.
3. **Read Session context** before doing anything else — workspace, tracker, repos, inbox snapshot are all there. NEVER re-ask the user for any of these.
4. **Cite tool evidence for every claim.** No "probably" / "I think" / "the docs say".
5. **Verify before mutate.** Before any side-effect tool, describe the action and wait for OK unless the user gave a direct command.
6. **Delegate to specialists** via `consult_specialist` (PR3) — UX → designer, system shape → architect, test strategy → qa-architect, prod-fault triage → bug-triage, codebase exploration → researcher.
7. **One thread, one initiative.** Mid-thread topic pivots finish or pause the current step explicitly.
8. **Output discipline.** Lead with the answer or next action, not the plan recap. Plan block goes immediately after, then tool evidence, then a short summary.

The lead-in paragraph reframes Navigator as **autonomous** — the prior "be concrete, accurate, concise" framing is replaced with the same discipline-stack a senior engineer working in a real codebase would use.

The Code-lookup section flips its default: previously it told the agent to call `list_activated_repos` first; now it says resolve from Session context (PR1's frame caps at 6 with a `+N more` tail) and only call the tool when the user mentions a repo not in the frame.

## Test plan

- [x] **13 new structural tests** (`test_navigator_prompt_agentic.py`) — assert the rules block exists, each numbered rule's load-bearing token survives editorial changes (`Plan first`, `never guess`, `Session context`, `tool evidence`, `Verify before mutate`, `consult_specialist`, `One thread`, `Output discipline`), the autonomous lead-in framing held, and the code-lookup default flipped.
- [x] **31/31 adjacent tests pass** — `test_v1_agent_roles.py`, `test_default_bundle.py`, `test_decomposition_role_modes.py`, `test_navigator_session_context.py`.
- [x] Tests are deliberately structural — the prompt is human-edited markdown and asserting on copy would lock in editorial choices that should be free to evolve.

## What's NOT in this PR

- The actual `consult_specialist` tool. Rule #6 references it, but the tool ships in PR3. Until then the agent reads the rule, names the role it would consult, and proceeds with what it can do directly.

## Sample expected behaviour after merge

User: "Write me a plan to migrate the dashboard from Linear-only to Linear + GitHub Issues."

Before this PR: agent answers immediately, asks 2-3 clarifying questions, maybe makes a checklist.

After this PR (full effect lands with PR3):
1. Reads Session context — sees `Bound tracker: linear`, `Activated repos (3): ...`.
2. Renders `## Plan` block: investigate current adapter contract → review GitHub adapter gaps → consult architect via `consult_specialist` for the contract design → propose migration scope.
3. Calls tools to fetch the current state (search KB, read adapter file).
4. Cites findings with file paths.
5. Stops at "ready to write the migration RFC?" — doesn't auto-create a project / ticket without OK.