### PR TITLE
navigator: consult_specialist subagent tool (PR3 of 3)

### DIFF
--- a/backend/app/services/agent/tools.py
+++ b/backend/app/services/agent/tools.py
@@ -300,6 +300,12 @@ class ToolBox:
         # ``_tool_create_project`` reads it.
         self._thread_id = thread_id
         self._thread_intent = thread_intent
+        # Navigator overhaul PR3: re-entry guard for ``consult_specialist``.
+        # A subagent calling ``consult_specialist`` is filtered out at
+        # the tool-spec layer so the LLM literally can't emit the name,
+        # but we belt-and-suspender it here for hallucinations: the
+        # handler refuses when this flag is True.
+        self._subagent_active = False
 
     # ------------------------------------------------------------------
     # Tool specs — the "what the LLM sees" side of the surface
@@ -2020,6 +2026,71 @@ class ToolBox:
                     "additionalProperties": False,
                 },
             ),
+            ToolSpec(
+                name="consult_specialist",
+                description=(
+                    "Hand a focused task off to a specialist subagent. "
+                    "The specialist runs as an isolated agent loop with "
+                    "its own role prompt and the same workspace tool "
+                    "surface (minus this tool, to prevent recursion) "
+                    "and returns a single final report. Use when the "
+                    "problem fits a role's expertise: UX / information "
+                    "architecture → ``designer``; system shape, "
+                    "contracts, tradeoffs → ``tech-architect``; test "
+                    "strategy + coverage → ``qa-architect``; ticket "
+                    "shape / acceptance criteria → ``ba``; prod-fault "
+                    "triage → ``bug-triage``; codebase exploration "
+                    "(read-only) → ``developer``. The subagent has no "
+                    "memory of this conversation — your ``task`` + "
+                    "``context_hint`` is everything it sees, so brief "
+                    "it like a smart colleague who just walked in."
+                ),
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "specialist": {
+                            "type": "string",
+                            "enum": [
+                                "designer",
+                                "tech-architect",
+                                "qa-architect",
+                                "ba",
+                                "bug-triage",
+                                "developer",
+                            ],
+                            "description": (
+                                "Which role to delegate to. The slug "
+                                "matches a file in ``agent_roles/`` "
+                                "whose prompt becomes the subagent's "
+                                "system message."
+                            ),
+                        },
+                        "task": {
+                            "type": "string",
+                            "description": (
+                                "Concrete task / question for the "
+                                "specialist. State scope, constraints, "
+                                "and what 'done' looks like — the "
+                                "subagent won't have your conversation "
+                                "history."
+                            ),
+                            "minLength": 8,
+                            "maxLength": 8000,
+                        },
+                        "context_hint": {
+                            "type": "string",
+                            "description": (
+                                "Optional extra context (file paths, "
+                                "ticket ids, decisions already made) "
+                                "to forward verbatim to the subagent."
+                            ),
+                            "maxLength": 12000,
+                        },
+                    },
+                    "required": ["specialist", "task"],
+                    "additionalProperties": False,
+                },
+            ),
         ]
 
     # ------------------------------------------------------------------
@@ -2099,6 +2170,7 @@ class ToolBox:
             "automation_toggle": self._tool_automation_toggle,
             "archive_bucket_article": self._tool_archive_bucket_article,
             "inbox_routing_upsert": self._tool_inbox_routing_upsert,
+            "consult_specialist": self._tool_consult_specialist,
         }
 
     # ------------------------------------------------------------------
@@ -7027,6 +7099,304 @@ class ToolBox:
                 "enabled": enabled,
             }
         )
+
+    # ------------------------------------------------------------------
+    # consult_specialist — subagent loop (Navigator overhaul PR3, ELS-74).
+    # Hands a focused task off to a role-prompted subagent that runs
+    # against the same workspace tool surface (minus this tool, to
+    # prevent recursion) and returns a single final report.
+    # ------------------------------------------------------------------
+
+    _SUBAGENT_ALLOWED_SPECIALISTS: tuple[str, ...] = (
+        "designer",
+        "tech-architect",
+        "qa-architect",
+        "ba",
+        "bug-triage",
+        "developer",
+    )
+    _SUBAGENT_MAX_TOOL_CALLS: int = 25
+    _SUBAGENT_MAX_SECONDS: float = 300.0
+
+    async def _tool_consult_specialist(self, args: dict[str, Any]) -> str:
+        if self._subagent_active:
+            # Defensive: tool spec is filtered out of the subagent's
+            # tool list so the LLM literally can't emit this name, but
+            # belt-and-suspender for hallucinations.
+            raise ToolInvocationError(
+                "nested consult_specialist is not allowed (already running "
+                "inside a subagent)"
+            )
+        specialist = _require_str(args, "specialist").strip()
+        task = _require_str(args, "task").strip()
+        context_hint_raw = args.get("context_hint")
+        context_hint = (
+            context_hint_raw.strip()
+            if isinstance(context_hint_raw, str) and context_hint_raw.strip()
+            else None
+        )
+        if specialist not in self._SUBAGENT_ALLOWED_SPECIALISTS:
+            raise ToolInvocationError(
+                f"unknown specialist {specialist!r}; allowed: "
+                + ", ".join(self._SUBAGENT_ALLOWED_SPECIALISTS)
+            )
+
+        # Load the role file's prompt body. ``agent_roles_svc.get_default``
+        # reads the seeded markdown corpus we ship under
+        # ``backend/app/resources/agent_roles/``.
+        from backend.app.services import agent_roles as agent_roles_svc
+
+        role = agent_roles_svc.get_default(specialist)
+        if role is None or not role.prompt.strip():
+            raise ToolInvocationError(
+                f"specialist {specialist!r} is not registered as a default "
+                f"agent role"
+            )
+
+        # Subagent system prompt = role prompt + a short framing block.
+        # We don't try to render ``{{ISSUE}}`` / ``{{BASE}}`` substitutions
+        # here — the role files use those for SDLC ticket invocation
+        # context that doesn't apply to a Navigator-spawned consultation.
+        # Leaving the placeholders raw is fine; the LLM treats them as
+        # template fragments and the framing tells it to ignore.
+        framing = (
+            "## You are running as a subagent\n\n"
+            "A parent Navigator agent invoked you for one focused task. "
+            "Rules:\n\n"
+            "- You will NOT be re-invoked. Produce one final report at "
+            "the end of this run; the parent receives only your last "
+            "message.\n"
+            "- Tool surface: same as the parent (workspace context, KB, "
+            "tracker, repos) MINUS ``consult_specialist`` itself. Use "
+            "tools to gather evidence — don't guess.\n"
+            "- Template placeholders in the role prompt below "
+            "(``{{ISSUE}}``, ``{{BASE}}``, ``{{TITLE}}``, "
+            "``{{DESCRIPTION}}``) are SDLC fixtures from the role's "
+            "ticket-mode invocation; they don't apply to this "
+            "consultation. Read past them.\n"
+            "- Stop when you've answered the parent's task. End your "
+            "final message with: ``[Ship subagent:" + specialist + "]``.\n\n"
+            "## Role prompt\n\n"
+        )
+        system_prompt = framing + role.prompt.strip()
+
+        user_message_parts = [
+            "## Task from the parent agent",
+            "",
+            task,
+        ]
+        if context_hint:
+            user_message_parts.extend(
+                ["", "## Context the parent passed", "", context_hint]
+            )
+        user_message = "\n".join(user_message_parts)
+
+        # Filter out ``consult_specialist`` from the tool spec list the
+        # subagent sees. Recursion guard #1 (the LLM can't emit a name
+        # it doesn't know about); the ``_subagent_active`` flag is
+        # guard #2.
+        all_specs = self.specs()
+        sub_specs = [s for s in all_specs if s.name != "consult_specialist"]
+
+        self._subagent_active = True
+        try:
+            outcome = await self._run_subagent_loop(
+                system_prompt=system_prompt,
+                user_message=user_message,
+                tool_specs=sub_specs,
+            )
+        finally:
+            self._subagent_active = False
+
+        # Audit row: subagent runs are operator-visible work and must
+        # be debuggable from the audit log without grepping LLM logs.
+        try:
+            self._session.add(
+                AuditLog(
+                    workspace_id=self._workspace_id,
+                    actor_user_id=self._user_id,
+                    actor_token_id=None,
+                    action="navigator.consult_specialist",
+                    target_kind="agent_role",
+                    target_id=specialist,
+                    payload={
+                        "specialist": specialist,
+                        "task_preview": task[:300],
+                        "tool_calls_used": outcome["tool_calls_used"],
+                        "finish_reason": outcome["finish_reason"],
+                        "had_error": bool(outcome.get("error")),
+                    },
+                )
+            )
+            await self._session.flush()
+        except Exception as exc:  # noqa: BLE001 — audit failure must not sink the result
+            logger.warning(
+                "consult_specialist: audit insert failed specialist=%s err=%s",
+                specialist,
+                exc,
+            )
+
+        return _json_result(
+            {
+                "specialist": specialist,
+                "report": outcome["text"],
+                "tool_calls_used": outcome["tool_calls_used"],
+                "finish_reason": outcome["finish_reason"],
+                **({"error": outcome["error"]} if outcome.get("error") else {}),
+            }
+        )
+
+    async def _run_subagent_loop(
+        self,
+        *,
+        system_prompt: str,
+        user_message: str,
+        tool_specs: list[ToolSpec],
+    ) -> dict[str, Any]:
+        """Drive the subagent's astream→tool→astream cycle to completion.
+
+        Mirrors the chat-stream tool loop in
+        ``backend/app/api/v1/routes/chat.py`` but synchronously: no SSE
+        streaming, no per-event yield, just collect text + run tools
+        until the model stops or the budget runs out. Returns a dict
+        with ``text``, ``tool_calls_used``, ``finish_reason``, and an
+        optional ``error`` key when the loop bailed for non-success
+        reasons.
+
+        Budgets:
+
+        - ``_SUBAGENT_MAX_TOOL_CALLS`` (25) — caps the chain so a
+          runaway specialist can't burn the whole context window.
+        - ``_SUBAGENT_MAX_SECONDS`` (300s) — wall-clock cap so a
+          Navigator request waiting on a stuck subagent surfaces the
+          timeout instead of hanging indefinitely.
+        """
+        import time as _time
+
+        from backend.app.services.agent.client import (
+            ChatMessage as _CM,
+            End,
+            TextDelta,
+            ToolCall,
+            pick_default_client,
+        )
+
+        try:
+            client = pick_default_client(self._settings)
+        except RuntimeError as exc:
+            return {
+                "text": "",
+                "tool_calls_used": 0,
+                "finish_reason": "agent_unavailable",
+                "error": f"agent client unavailable: {exc}",
+            }
+
+        messages: list[_CM] = [
+            _CM(role="system", content=system_prompt),
+            _CM(role="user", content=user_message),
+        ]
+
+        text_chunks: list[str] = []
+        tool_calls_used = 0
+        deadline = _time.monotonic() + self._SUBAGENT_MAX_SECONDS
+
+        while True:
+            if _time.monotonic() > deadline:
+                return {
+                    "text": ("".join(text_chunks)).strip(),
+                    "tool_calls_used": tool_calls_used,
+                    "finish_reason": "deadline_exceeded",
+                    "error": (
+                        f"subagent ran past {int(self._SUBAGENT_MAX_SECONDS)}s"
+                    ),
+                }
+            if tool_calls_used >= self._SUBAGENT_MAX_TOOL_CALLS:
+                return {
+                    "text": ("".join(text_chunks)).strip(),
+                    "tool_calls_used": tool_calls_used,
+                    "finish_reason": "tool_loop_exceeded",
+                    "error": (
+                        f"subagent hit the {self._SUBAGENT_MAX_TOOL_CALLS}-"
+                        "tool-call cap"
+                    ),
+                }
+
+            turn_text: list[str] = []
+            turn_tool_calls: list[ToolCall] = []
+            try:
+                stream = await client.astream(messages, tools=tool_specs)
+                async for ev in stream:
+                    if isinstance(ev, TextDelta):
+                        turn_text.append(ev.text)
+                    elif isinstance(ev, ToolCall):
+                        turn_tool_calls.append(ev)
+                    elif isinstance(ev, End):
+                        # We don't surface ``finish_reason`` from End
+                        # directly — the loop's own counters give the
+                        # parent a stable contract regardless of which
+                        # vendor's SDK we're behind.
+                        pass
+            except Exception as exc:  # noqa: BLE001 — vendor + transport errors
+                logger.warning("subagent astream failed: %s", exc)
+                return {
+                    "text": ("".join(text_chunks + turn_text)).strip(),
+                    "tool_calls_used": tool_calls_used,
+                    "finish_reason": "llm_error",
+                    "error": str(exc),
+                }
+
+            text_chunks.extend(turn_text)
+
+            if not turn_tool_calls:
+                # Model produced text and no tool calls → final answer.
+                return {
+                    "text": ("".join(text_chunks)).strip(),
+                    "tool_calls_used": tool_calls_used,
+                    "finish_reason": "stop",
+                }
+
+            # Append the assistant turn (with the tool_calls in
+            # OpenAI-style envelope) and run each tool, then loop.
+            openai_style = [
+                {
+                    "id": tc.id,
+                    "type": "function",
+                    "function": {
+                        "name": tc.name,
+                        "arguments": json.dumps(tc.arguments, ensure_ascii=False),
+                    },
+                }
+                for tc in turn_tool_calls
+            ]
+            messages.append(
+                _CM(
+                    role="assistant",
+                    content="".join(turn_text),
+                    tool_calls=openai_style,
+                )
+            )
+            for tc in turn_tool_calls:
+                tool_calls_used += 1
+                try:
+                    result = await self.invoke(tc.name, tc.arguments)
+                except ToolInvocationError as exc:
+                    result = json.dumps({"error": str(exc)}, ensure_ascii=False)
+                except Exception as exc:  # noqa: BLE001 — defensive
+                    logger.exception(
+                        "subagent tool %s failed", tc.name
+                    )
+                    result = json.dumps(
+                        {"error": f"{tc.name} failed: {exc}"},
+                        ensure_ascii=False,
+                    )
+                messages.append(
+                    _CM(
+                        role="tool",
+                        name=tc.name,
+                        tool_call_id=tc.id,
+                        content=result,
+                    )
+                )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_consult_specialist.py
+++ b/backend/tests/test_consult_specialist.py
@@ -1,0 +1,332 @@
+"""``consult_specialist`` subagent tool — Navigator overhaul PR3.
+
+The Navigator can now hand a focused task off to a specialist
+subagent (designer / tech-architect / qa-architect / ba / bug-triage
+/ developer-as-researcher). The subagent runs as an isolated
+``astream → tool calls → astream`` loop with the role's prompt as
+its system message and the same workspace tool surface MINUS the
+``consult_specialist`` tool itself (no recursion). It returns one
+final report which the parent Navigator then consumes.
+
+These tests cover the load-bearing invariants without requiring a
+live LLM: a stub ``AgentClient`` scripts pre-recorded events, the
+``pick_default_client`` factory is monkey-patched to hand back the
+stub, and the handler's behaviour is asserted against deterministic
+event sequences. The actual LLM integration is verified separately
+via the live-deploy smoke checklist.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from typing import Any
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Stub agent client — the only "moving part" the tests script
+# ---------------------------------------------------------------------------
+
+
+class _StubAgentClient:
+    """Hand-rolled ``AgentClient`` that yields pre-scripted events.
+
+    Each entry in ``scripts`` is a list of events produced on one
+    ``astream`` round-trip. The stub records every call so tests can
+    assert on what the subagent loop sent (system prompt, tools list,
+    message stack growth across turns).
+    """
+
+    vendor = "stub"
+
+    def __init__(self, scripts: list[list[Any]]) -> None:
+        self._remaining = list(scripts)
+        self.calls: list[dict[str, Any]] = []
+
+    async def astream(self, messages, tools=(), **_kwargs):  # noqa: ANN001
+        self.calls.append(
+            {
+                "messages": [
+                    {"role": m.role, "content": m.content, "name": m.name}
+                    for m in messages
+                ],
+                "tool_names": [t.name for t in tools],
+            }
+        )
+        events = self._remaining.pop(0) if self._remaining else []
+
+        async def _gen():
+            for e in events:
+                yield e
+
+        return _gen()
+
+    async def acomplete(self, *_args, **_kwargs):  # pragma: no cover
+        return ""
+
+
+def _patch_client(monkeypatch, stub: _StubAgentClient) -> None:
+    """Wire the stub in front of ``pick_default_client`` so the
+    subagent loop talks to it instead of a live vendor."""
+    monkeypatch.setattr(
+        "backend.app.services.agent.client.pick_default_client",
+        lambda settings: stub,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def toolbox(db_session, seed_workspace):
+    from backend.app.core.config import get_settings
+    from backend.app.services.agent.tools import ToolBox
+
+    user, _, workspace = seed_workspace
+    return ToolBox(
+        db_session,
+        settings=get_settings(),
+        workspace_id=workspace.id,
+        user_id=user.id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Spec / argument validation
+# ---------------------------------------------------------------------------
+
+
+def test_spec_is_present_and_advertises_allowed_specialists(
+    db_session, seed_workspace
+) -> None:
+    """The Navigator's tool list MUST include ``consult_specialist``
+    and the spec's ``specialist`` enum MUST match the handler's
+    allowlist verbatim — drift would let the LLM emit a slug the
+    handler rejects, which surfaces as a useless ``unknown
+    specialist`` error to the model."""
+    from backend.app.core.config import get_settings
+    from backend.app.services.agent.tools import ToolBox
+
+    user, _, workspace = seed_workspace
+    tb = ToolBox(
+        db_session,
+        settings=get_settings(),
+        workspace_id=workspace.id,
+        user_id=user.id,
+    )
+    specs = tb.specs()
+    by_name = {s.name: s for s in specs}
+    assert "consult_specialist" in by_name
+    enum = by_name["consult_specialist"].parameters["properties"]["specialist"][
+        "enum"
+    ]
+    assert sorted(enum) == sorted(tb._SUBAGENT_ALLOWED_SPECIALISTS)
+
+
+@pytest.mark.asyncio
+async def test_handler_rejects_unknown_specialist(toolbox) -> None:
+    from backend.app.services.agent.tools import ToolInvocationError
+
+    with pytest.raises(ToolInvocationError, match="unknown specialist"):
+        await toolbox._tool_consult_specialist(
+            {"specialist": "fortune-teller", "task": "tell me the future"}
+        )
+
+
+@pytest.mark.asyncio
+async def test_handler_rejects_when_subagent_active(toolbox) -> None:
+    """Recursion guard: if a stray ``consult_specialist`` invocation
+    fires while ``_subagent_active`` is True (defensive — the spec is
+    filtered out of the subagent's tool list, so this only fires on
+    LLM hallucination), the handler must refuse loudly."""
+    from backend.app.services.agent.tools import ToolInvocationError
+
+    toolbox._subagent_active = True
+    with pytest.raises(ToolInvocationError, match="nested consult_specialist"):
+        await toolbox._tool_consult_specialist(
+            {"specialist": "ba", "task": "anything"}
+        )
+
+
+# ---------------------------------------------------------------------------
+# Subagent loop — happy path + tool loop + caps
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_subagent_returns_text_when_model_stops_immediately(
+    toolbox, monkeypatch
+) -> None:
+    """First (and only) astream turn produces text + no tool calls.
+    The handler returns the report text wrapped in JSON for the
+    parent. Audit row records the call."""
+    from backend.app.services.agent.client import End, TextDelta
+
+    stub = _StubAgentClient(
+        scripts=[
+            [TextDelta(text="One-shot answer."), End(finish_reason="stop")],
+        ]
+    )
+    _patch_client(monkeypatch, stub)
+
+    out = await toolbox._tool_consult_specialist(
+        {
+            "specialist": "designer",
+            "task": "Quick UX check on the dashboard handoff button.",
+        }
+    )
+    payload = json.loads(out)
+    assert payload["specialist"] == "designer"
+    assert payload["report"] == "One-shot answer."
+    assert payload["tool_calls_used"] == 0
+    assert payload["finish_reason"] == "stop"
+    assert "error" not in payload
+
+    # Recursion guard: tool list passed to the stub MUST NOT include
+    # ``consult_specialist`` — otherwise the subagent could self-call.
+    assert "consult_specialist" not in stub.calls[0]["tool_names"]
+    # Subagent's system prompt carries the role file's name + the
+    # subagent framing block. We don't assert on copy, only structure.
+    sys_msg = stub.calls[0]["messages"][0]
+    assert sys_msg["role"] == "system"
+    assert "subagent" in sys_msg["content"].lower()
+    user_msg = stub.calls[0]["messages"][1]
+    assert user_msg["role"] == "user"
+    assert "Quick UX check" in user_msg["content"]
+
+
+@pytest.mark.asyncio
+async def test_subagent_runs_one_tool_then_finalises(
+    toolbox, monkeypatch
+) -> None:
+    """Turn 1: model emits a tool call. Loop runs the tool, appends
+    the result, calls astream again. Turn 2: model produces text + no
+    tool calls. Handler returns the text and ``tool_calls_used=1``."""
+    from backend.app.services.agent.client import End, TextDelta, ToolCall
+
+    stub = _StubAgentClient(
+        scripts=[
+            # Turn 1: ask for activated repos.
+            [
+                ToolCall(
+                    id="call-1", name="list_activated_repos", arguments={}
+                ),
+                End(finish_reason="tool_use"),
+            ],
+            # Turn 2: model has the tool result, produces final text.
+            [
+                TextDelta(text="Found one repo. Done."),
+                End(finish_reason="stop"),
+            ],
+        ]
+    )
+    _patch_client(monkeypatch, stub)
+
+    out = await toolbox._tool_consult_specialist(
+        {"specialist": "tech-architect", "task": "List the repos."}
+    )
+    payload = json.loads(out)
+    assert payload["report"] == "Found one repo. Done."
+    assert payload["tool_calls_used"] == 1
+    assert payload["finish_reason"] == "stop"
+
+    # Stub got called exactly twice and the second call has the tool
+    # result in its message stack.
+    assert len(stub.calls) == 2
+    second_messages = stub.calls[1]["messages"]
+    roles = [m["role"] for m in second_messages]
+    assert "tool" in roles  # the tool result re-injected for turn 2
+
+
+@pytest.mark.asyncio
+async def test_subagent_bails_at_tool_call_cap(
+    toolbox, monkeypatch
+) -> None:
+    """A runaway specialist that keeps emitting tool calls hits the
+    25-call cap and the handler returns ``finish_reason=tool_loop_exceeded``
+    rather than spinning forever."""
+    from backend.app.services.agent.client import End, ToolCall
+
+    # Script: every turn the model emits one tool call (forever).
+    looping_turn = [
+        ToolCall(id="call-x", name="list_activated_repos", arguments={}),
+        End(finish_reason="tool_use"),
+    ]
+    stub = _StubAgentClient(scripts=[looping_turn] * 50)  # plenty
+    _patch_client(monkeypatch, stub)
+    # Tighten the cap so the test runs fast — same code path.
+    monkeypatch.setattr(toolbox, "_SUBAGENT_MAX_TOOL_CALLS", 3)
+
+    out = await toolbox._tool_consult_specialist(
+        {"specialist": "ba", "task": "Stress the loop cap."}
+    )
+    payload = json.loads(out)
+    assert payload["finish_reason"] == "tool_loop_exceeded"
+    assert payload["tool_calls_used"] == 3
+    assert "error" in payload
+    assert "tool-call cap" in payload["error"]
+
+
+@pytest.mark.asyncio
+async def test_subagent_surfaces_agent_unavailable(
+    toolbox, monkeypatch
+) -> None:
+    """When ``pick_default_client`` raises (no LLM key), the handler
+    must NOT raise to the parent — instead it returns a structured
+    ``finish_reason=agent_unavailable`` so the LLM can phrase a useful
+    response to the user."""
+    def _broken(*_args, **_kwargs):
+        raise RuntimeError("no LLM key configured")
+
+    monkeypatch.setattr(
+        "backend.app.services.agent.client.pick_default_client", _broken
+    )
+
+    out = await toolbox._tool_consult_specialist(
+        {"specialist": "designer", "task": "Anything."}
+    )
+    payload = json.loads(out)
+    assert payload["finish_reason"] == "agent_unavailable"
+    assert payload["report"] == ""
+    assert "no LLM key" in payload["error"]
+
+
+@pytest.mark.asyncio
+async def test_audit_log_row_inserted_on_success(
+    toolbox, monkeypatch, db_session, seed_workspace
+) -> None:
+    """A subagent run must drop an audit row so an operator can
+    answer 'when did the navigator delegate to a designer?' from the
+    audit page without scraping LLM logs."""
+    from sqlalchemy import select
+
+    from backend.app.db.models.tenancy import AuditLog
+    from backend.app.services.agent.client import End, TextDelta
+
+    _, _, workspace = seed_workspace
+
+    stub = _StubAgentClient(
+        scripts=[[TextDelta(text="Ok."), End(finish_reason="stop")]]
+    )
+    _patch_client(monkeypatch, stub)
+
+    await toolbox._tool_consult_specialist(
+        {"specialist": "qa-architect", "task": "Any test gaps in the dashboard?"}
+    )
+
+    rows = (
+        await db_session.execute(
+            select(AuditLog).where(
+                AuditLog.workspace_id == workspace.id,
+                AuditLog.action == "navigator.consult_specialist",
+            )
+        )
+    ).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].target_id == "qa-architect"
+    assert rows[0].payload["specialist"] == "qa-architect"
+    assert rows[0].payload["had_error"] is False


### PR DESCRIPTION
Final PR of the Navigator overhaul. PR1 (#153) wired identity + tracker into the session frame; PR2 (#154) shifted the prompt to plan-first / evidence-first / verify-before-mutate. Rule #6 of the operating block told the agent to **delegate to specialists** — until this PR there was no actual mechanism. Now there is.

## What

A new tool: ``consult_specialist(specialist, task, context_hint?)``. Hands a focused task off to a role-prompted subagent that runs as an isolated ``astream → tool calls → astream`` loop. Same workspace tool surface as Navigator, MINUS the tool itself (no recursion). Returns one final report.

Allowed specialists (curated):

| Slug | When to delegate |
|---|---|
| ``designer`` | UX / IA review |
| ``tech-architect`` | System shape, contracts, tradeoffs |
| ``qa-architect`` | Test strategy + coverage |
| ``ba`` | Ticket scoping / acceptance criteria |
| ``bug-triage`` | Prod-fault triage |
| ``developer`` | Codebase exploration (read-only) |

## Architecture

- ``ToolBox._run_subagent_loop`` mirrors the chat-stream tool loop synchronously: no SSE, no per-event yield, just collect text + run tools until stop / budget.
- **Recursion guard #1**: ``consult_specialist`` is filtered out of the spec list passed to the subagent's ``astream`` — the LLM can't emit a name it doesn't see.
- **Recursion guard #2** (defensive): ``_subagent_active`` flag on the ToolBox instance during a run; stray re-entry raises ``ToolInvocationError``.
- **Budgets** (hardcoded class-level constants): 25 tool calls, 300s wall-clock. Either trip → ``finish_reason`` reflects it (``tool_loop_exceeded`` / ``deadline_exceeded``) and the parent gets a structured payload, not a hang.
- **Errors are returned, not raised**. The parent LLM can phrase a user-facing answer instead of seeing a tool exception. Vendor failures, missing LLM keys, and timeouts all degrade through the same JSON shape.
- **Audit row dropped per run** — specialist slug, task preview (300 chars), tool calls used, finish reason, error flag. Operators can answer "when did Navigator delegate?" from the audit page.

## Subagent context contract

The subagent has NO memory of the parent's chat history. Its system message is the role file's prompt + a framing block ("you are a subagent, return one final message, role-prompt placeholders like ``{{ISSUE}}`` are SDLC fixtures from ticket-mode and don't apply here"). The user message is the parent's ``task`` + optional ``context_hint`` block. Parent must brief it like a smart colleague who just walked into the room.

## Test plan

- [x] **8/8 new tests** (``test_consult_specialist.py``):
  - Spec advertised on the toolbox + enum matches the handler's allowlist verbatim (drift would surface as "unknown specialist" errors at runtime).
  - Unknown-specialist rejection.
  - Recursion guard fires when ``_subagent_active=True``.
  - Single-turn happy path: stub model returns text + no tool calls; handler returns the report.
  - Multi-turn: stub emits a tool call on turn 1, text on turn 2; handler invokes the tool, appends the result, calls astream again, returns the final text. **Critically asserts the subagent's tool list EXCLUDES ``consult_specialist``.**
  - Tool-call cap: stub loops forever; handler bails at the cap with ``finish_reason=tool_loop_exceeded`` + structured error.
  - Missing LLM key: ``pick_default_client`` raises; handler surfaces ``finish_reason=agent_unavailable`` without raising.
  - Audit row insertion verifies the operator-visibility commitment.
- [x] **47/47 adjacent regression tests pass** (``test_navigator_session_context``, ``test_navigator_prompt_agentic``, ``test_v1_agent_roles``, ``test_decomposition_role_modes``, ``test_agent_tools_create_project``).
- [x] Tests use a stub ``AgentClient`` that scripts pre-recorded events; no live LLM required.

## What's NOT in this PR

- A streaming surface for subagent events (the parent gets one final text). If a subagent run takes 30s+ today, the user sees Navigator "thinking" with no progress signal. Worth promoting later if delegation becomes common.
- A ``plan(steps: list)`` tool. PR2's prompt rule says "plan first" but the agent renders the plan as inline markdown today. A structured tool would let the chat UI render it as a checklist; punted unless we observe the inline approach failing.
- A per-specialist tool subset (today the subagent gets the full Navigator toolset minus this tool). Role prompts already gate behaviour ("no commits from this role" etc.); curated subsets can come later if we see specific specialists abusing tools.

## Sample expected behaviour after merge

User to Navigator: *"How should we restructure the agent_roles model now that we have decomposition + development processes?"*

After merge:
1. Navigator reads Session context, sees the workspace + bound tracker + repos.
2. Renders ``## Plan``: gather current state of agent_roles → consult tech-architect on the shape question → return synthesized recommendation.
3. Calls ``search_workspace_kb`` / ``get_repo_file`` to gather the current model.
4. Calls ``consult_specialist(specialist="tech-architect", task="...", context_hint="...")`` — the subagent runs its own loop with the tech-architect role prompt and returns a focused architectural recommendation.
5. Navigator synthesises and returns to the user.