### PR TITLE
fix: bump default Anthropic Haiku model to the post-preview stable id

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -79,8 +79,16 @@ _LIBPQ_ONLY_KEYS = frozenset({"sslmode", "channel_binding", "sslrootcert", "sslc
 # When ``AGENT_VENDOR=anthropic`` but operators only flip the vendor switch
 # and leave ``AGENT_MODEL_*`` at the OpenAI defaults, Anthropic returns 404
 # ("model: gpt-4o"). These ids match ``documentation/internal/agent-setup.md``.
+#
+# 2026-05-06: bumped fast model from ``-20250929`` → ``-20251001``. The
+# ``-20250929`` snapshot was the Haiku 4.5 preview id; Anthropic retired it
+# when the stable release shipped under ``-20251001``. Prod was returning
+# 404 on every Haiku call — the router + claim extractor caught the
+# exception and stamped ``no_fit`` / empty-claims accordingly, which is
+# why the overnight reindex on Ship + Askslayer produced zero claims
+# despite ``extracted_at`` being set on 50 source items.
 _DEFAULT_ANTHROPIC_MODEL_MAIN = "claude-sonnet-4-5-20250929"
-_DEFAULT_ANTHROPIC_MODEL_FAST = "claude-haiku-4-5-20250929"
+_DEFAULT_ANTHROPIC_MODEL_FAST = "claude-haiku-4-5-20251001"
 
 
 def _looks_like_openai_chat_model_id(model: str) -> bool:


### PR DESCRIPTION
## Summary

Prod has been silently failing every Haiku-driven LLM call since the ``-20250929`` snapshot was retired. Anthropic returns 404 on the preview id once the stable release ships under a different date stamp. Both the legacy router (LLM tiebreaker) and the new claim extractor catch the exception via their best-effort ``try/except`` and stamp ``no_fit`` / empty-claims accordingly — neither raised loudly, so the break only surfaced after the overnight reindex produced zero ``knowledge_claim`` rows despite ``extracted_at`` being stamped on 50 source items.

### Audit log evidence (2026-05-06 07:30 UTC)

```
knowledge.note.routed | source=no_fit
                      | no_fit_reason="llm_call_failed"
                      | candidate_buckets=6
                      | populated_buckets=0
```

### Fix

One-character diff in the date stamp:

```diff
- _DEFAULT_ANTHROPIC_MODEL_FAST = "claude-haiku-4-5-20250929"
+ _DEFAULT_ANTHROPIC_MODEL_FAST = "claude-haiku-4-5-20251001"
```

Stable Haiku 4.5 ships under ``claude-haiku-4-5-20251001`` (per the Anthropic model card; matches what's documented for the 4.X family).

Sonnet is left at ``claude-sonnet-4-5-20250929`` for now — that one hasn't surfaced as failing in prod yet. If the next synth tick after this deploy still ``llm_call_failed``s on Sonnet, we bump it the same way.

## Test plan

- [ ] CI: full backend suite — change is config-only, regression risk minimal
- [ ] Post-deploy: watch ``knowledge_claim`` row count + ``audit_log`` action=``knowledge.note.routed``. Within one ``*/20`` extractor tick + the next ``5,25,45`` reconciler tick we should see (a) claims appear, (b) ``no_fit_reason`` stop being ``llm_call_failed``.