### PR TITLE
notion: walker soft-skips child_database with no accessible data sources

### DIFF
--- a/backend/app/services/connectors/notion.py
+++ b/backend/app/services/connectors/notion.py
@@ -455,6 +455,22 @@ async def _walk_page_tree(
                     )
                     continue
                 raise
+            except ConnectorConfigError as exc:
+                # ``_resolve_data_source_id`` raises this when a database
+                # we discovered via a ``child_database`` block has no
+                # accessible data sources (legacy un-migrated DB, or the
+                # workspace bot lost share access since the parent page
+                # was indexed). For an *explicit* ``database_id`` ref the
+                # operator wants this loud — they pointed at it on
+                # purpose — but during a recursive walk one missing
+                # child_database shouldn't take down the whole sync. Log
+                # + skip mirrors the 401/403/404 handling above.
+                logger.warning(
+                    "notion walker: skipping embedded database %s — %s",
+                    dbid,
+                    exc,
+                )
+                continue
             for eid in entry_ids:
                 if eid not in visited:
                     queue.append((eid, depth + 1))

--- a/backend/tests/test_connectors_notion.py
+++ b/backend/tests/test_connectors_notion.py
@@ -692,3 +692,68 @@ async def test_notion_walker_skips_locked_subpages_but_fails_locked_seeds(
             await fetch_connector_pages(
                 integration, {"page_id": hub_id}, http_client=client
             )
+
+
+@pytest.mark.asyncio
+async def test_notion_walker_skips_child_db_with_empty_datasources(integration) -> None:
+    """A ``child_database`` block whose database resolves to
+    ``data_sources=[]`` (legacy un-migrated DB or revoked share since
+    the parent was indexed) used to raise ``ConnectorConfigError``,
+    bringing the whole walk down. Hub pages with one such block were
+    silently failing every cron sync. The walker now logs + skips
+    that database and keeps walking the rest of the tree, mirroring
+    the 401/403/404 soft-skip path."""
+
+    hub_id = "hub-cdb-empty"
+    db_id = "db-empty"
+    sub_visible = "sub-vis"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if path == f"/v1/pages/{hub_id}":
+            return httpx.Response(200, json=_page_payload(hub_id, title="Hub"))
+        if path == f"/v1/pages/{sub_visible}":
+            return httpx.Response(
+                200, json=_page_payload(sub_visible, title="Visible Sub")
+            )
+        if path == f"/v1/blocks/{hub_id}/children":
+            return httpx.Response(
+                200,
+                json=_blocks_payload(
+                    [
+                        _block(
+                            "child_database",
+                            {"title": "Empty DB"},
+                            block_id=db_id,
+                        ),
+                        _block(
+                            "child_page",
+                            {"title": "Visible Sub"},
+                            block_id=sub_visible,
+                        ),
+                    ]
+                ),
+            )
+        if path.startswith("/v1/blocks/") and path.endswith("/children"):
+            return httpx.Response(200, json=_blocks_payload([]))
+        # /data_sources/{db_id} → 404 forces the fallback through
+        # /databases/{db_id}, which returns an empty data_sources
+        # list — exactly the shape that used to crash the walker.
+        if path == f"/v1/data_sources/{db_id}":
+            return httpx.Response(404, json={"object": "error"})
+        if path == f"/v1/databases/{db_id}":
+            return httpx.Response(
+                200,
+                json={"object": "database", "id": db_id, "data_sources": []},
+            )
+        return httpx.Response(404)
+
+    async with _make_client(handler) as client:
+        pages = await fetch_connector_pages(
+            integration, {"page_id": hub_id}, http_client=client
+        )
+
+    titles = [p.title for p in pages]
+    # Empty-DB block was skipped; the rest of the tree (hub + visible
+    # sibling subpage) still made it into the result.
+    assert titles == ["Hub", "Visible Sub"]


### PR DESCRIPTION
## Summary

Askslayer's hub page contains a ``child_database`` block (``1566798a-d368-8107-9552-c816a0415ad3``) whose database resolves to ``data_sources=[]`` — either a legacy un-migrated DB or one the workspace bot lost share access to since the parent page was indexed.

``_resolve_data_source_id`` raised ``ConnectorConfigError`` on that shape, the walker had no handler for it, the whole sync tore down. Net effect on prod: every ``*/15`` ``sync_due`` tick since the P0+P1 deploy attempted Askslayer's source, raised, rolled back via the per-source ``try/except`` in ``sync_due_import_sources``, and left zero trace (``last_synced_at`` stayed NULL, ``last_error`` stayed NULL, ``knowledge_ingestion_runs`` got nothing). The bug was invisible from the DB alone — only surfaced once I ran the sync against prod state from a local repro.

### Fix

For an *explicit* ``database_id`` ref (``_seed_database``) the loud ``ConnectorConfigError`` is correct — the operator pointed at that database on purpose and needs the wizard hint to re-share. For a database we *discovered* during a recursive walk, one missing entry mustn't take down the rest of the tree.

New behaviour mirrors the existing ``401 / 403 / 404`` soft-skip in the same loop: log warning, drop the unreachable database, keep walking.

```diff
  except httpx.HTTPStatusError as exc:
      ...
      if status_code in (401, 403, 404):
          logger.warning(...)
          continue
      raise
+ except ConnectorConfigError as exc:
+     logger.warning(
+         "notion walker: skipping embedded database %s — %s",
+         dbid, exc,
+     )
+     continue
```

## Test plan

- [x] ``pytest backend/tests/test_connectors_notion.py`` — 14/14 (13 prior + 1 new: hub with one empty-data_sources child_database + visible sibling subpage now yields ``[Hub, Visible Sub]`` rather than crashing)
- [ ] CI: full backend suite
- [ ] Post-deploy: watch ``last_synced_at`` flip on Askslayer's notion source within one ``*/15`` tick. Expect ``ConnectorConfigError`` to log as a warning rather than raise.