### PR TITLE
navigator: 3 read-only tools — get_ticket, get_dashboard, workspace_audit_search (ELS-78 PR-C1)

### DIFF
--- a/backend/app/resources/agent_roles/navigator.md
+++ b/backend/app/resources/agent_roles/navigator.md
@@ -66,13 +66,14 @@ Workflow:
 3. If new initiative → propose a project body in chat, get OK, then ``create_project``. Body should hold scope, motivation, constraints, key decisions.
 4. Add new PO ideas to an existing epic via ``append_project_description`` — accumulates across sessions.
 5. ``create_ticket`` for child work — pass ``project_id`` so the ticket attaches. Keep ticket body short: goal + AC. Don't duplicate the epic body.
-6. Before listing existing tickets, ``list_tickets`` (supports ``state``, ``query``, ``assignee_me`` for Linear / ``assignee`` login for GitHub).
+6. Before listing existing tickets, ``list_tickets`` (supports ``state``, ``query``, ``assignee_me`` for Linear / ``assignee`` login for GitHub). When the user names a specific id (``ELS-99``) → ``get_ticket`` directly; don't list 50 to find one.
 
 ## Scenario 2 — System management (Inbox + Automations)
 
 Ship's surface: **Inbox** (items that need disposition), **Plays** (catalog of operational procedures), **Automations** (Plays scoped + scheduled), **Runs** (execution history).
 
-- 'What's on my plate?' → ``inbox_list owner=me``.
+- 'What's on my plate?' / 'state of the workspace?' → ``get_dashboard`` for the denormalised snapshot (priorities by bucket, inbox totals, open PRs, 24h shipped, recent activity). One call beats five.
+- 'What's specifically in my inbox?' → ``inbox_list owner=me``.
 - 'How many open?' → already in **Session context** (Inbox snapshot line). Don't dial a tool for what's in the frame.
 - Item detail → ``inbox_get``.
 - Resolve → ``inbox_dispose`` (use ``dry_run=true`` to preview side-effects). Prefer ``inbox_dispose`` over ``create_ticket`` when the item already exists; tickets are for **new** external work, not for closing queue items.
@@ -81,7 +82,7 @@ Ship's surface: **Inbox** (items that need disposition), **Plays** (catalog of o
 - Plays catalog → ``plays_list`` then ``plays_get``.
 - 'Run play X now' → ``play_run_now``. 'Automate weekly' → ``play_automate``. 'Disable' → ``automation_toggle enabled=false``. Confirm fleet-scope or long-standing changes.
 - 'What's connected?' / 'why did the tracker call fail?' → **Session context** carries the bound tracker + status + last health error. Read from the frame, not a tool.
-- 'Who changed setting X?' / security review → out of Navigator's surface today; deeplink to the Audit page.
+- 'Who changed setting X?' / 'when did X happen?' / security review → ``workspace_audit_search`` (filter by ``action`` / ``target_kind`` / ``target_id`` / ``since``).
 
 ## Scenario 3 — Brainstorming (PO ideation)
 

--- a/backend/app/services/agent/tools.py
+++ b/backend/app/services/agent/tools.py
@@ -1833,6 +1833,109 @@ class ToolBox:
                 },
             ),
             ToolSpec(
+                name="get_ticket",
+                description=(
+                    "Fetch one ticket's current state from the workspace's "
+                    "bound tracker. Use when the user names an id (``ELS-99``) "
+                    "or you've resolved one from ``list_tickets`` and need "
+                    "the body / labels / state to act. Read-only; cheaper "
+                    "than ``list_tickets`` when you already know which "
+                    "ticket. Returns ``{ticket_ref, title, description, "
+                    "url, state, labels, project_id?}``."
+                ),
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "ticket_ref": {
+                            "type": "string",
+                            "description": (
+                                "Tracker-native identifier — Linear's "
+                                "``ELS-99`` form or the issue's UUID. "
+                                "Other adapters use their native "
+                                "identifier (Jira ``ENG-42``, GitHub "
+                                "Issues ``owner/repo#42``)."
+                            ),
+                        },
+                    },
+                    "required": ["ticket_ref"],
+                    "additionalProperties": False,
+                },
+            ),
+            ToolSpec(
+                name="get_dashboard",
+                description=(
+                    "One-call denormalised snapshot of the workspace's "
+                    "current state — priorities (active / drafts / parked "
+                    "buckets), inbox totals + by-type, recent activity "
+                    "(top 5 mixed: pipeline runs, PRs, workflow runs), "
+                    "open PR count, and 24h shipped count. Use to answer "
+                    "'what's on my plate?' / 'what's the state of the "
+                    "workspace?' without dialing five separate tools. "
+                    "Read-only."
+                ),
+                parameters={
+                    "type": "object",
+                    "properties": {},
+                    "additionalProperties": False,
+                },
+            ),
+            ToolSpec(
+                name="workspace_audit_search",
+                description=(
+                    "Search the workspace audit log. Use to answer 'who "
+                    "changed setting X?' / 'when did the priorities row "
+                    "for project Y land?' / 'has anyone run the daily "
+                    "play this week?'. Returns rows ``{action, "
+                    "target_kind, target_id, actor_user_id, payload, "
+                    "created_at}`` newest first. Read-only."
+                ),
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "action": {
+                            "type": "string",
+                            "description": (
+                                "Optional exact-match filter on the "
+                                "audit ``action`` (e.g. "
+                                "``dashboard.priorities.reorder``, "
+                                "``navigator.consult_specialist``). "
+                                "Omit for any action."
+                            ),
+                        },
+                        "target_kind": {
+                            "type": "string",
+                            "description": (
+                                "Optional filter on ``target_kind`` "
+                                "(e.g. ``workspace``, ``inbox_item``, "
+                                "``agent_run``)."
+                            ),
+                        },
+                        "target_id": {
+                            "type": "string",
+                            "description": (
+                                "Optional filter on ``target_id`` — "
+                                "the audited entity's id as a string."
+                            ),
+                        },
+                        "since": {
+                            "type": "string",
+                            "description": (
+                                "ISO-8601 timestamp lower bound "
+                                "(``2026-05-01T00:00:00Z``). Omit to "
+                                "scan the last 30 days by default."
+                            ),
+                        },
+                        "limit": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 100,
+                            "default": 25,
+                        },
+                    },
+                    "additionalProperties": False,
+                },
+            ),
+            ToolSpec(
                 name="consult_specialist",
                 description=(
                     "Hand a focused task off to a specialist subagent. "
@@ -1984,6 +2087,9 @@ class ToolBox:
             "automation_toggle": self._tool_automation_toggle,
             "archive_bucket_article": self._tool_archive_bucket_article,
             "inbox_routing_upsert": self._tool_inbox_routing_upsert,
+            "get_ticket": self._tool_get_ticket,
+            "get_dashboard": self._tool_get_dashboard,
+            "workspace_audit_search": self._tool_workspace_audit_search,
             "consult_specialist": self._tool_consult_specialist,
         }
 
@@ -6664,6 +6770,287 @@ class ToolBox:
                 "enabled": enabled,
             }
         )
+
+    # ------------------------------------------------------------------
+    # Read-only tools (Navigator tool review PR-C1, ELS-78):
+    # ``get_ticket``, ``get_dashboard``, ``workspace_audit_search``.
+    # ------------------------------------------------------------------
+
+    async def _tool_get_ticket(self, args: dict[str, Any]) -> str:
+        ticket_ref = _require_str(args, "ticket_ref").strip()
+        tracker = await self._resolve_tracker(None, None)
+        ref = _ticket_ref_from(_tracker_kind_of(tracker), ticket_ref)
+        snapshot_fn = getattr(tracker, "get_ticket_snapshot", None)
+        if snapshot_fn is None:
+            raise ToolInvocationError(
+                "this tracker does not implement single-ticket lookup"
+            )
+        snapshot = await snapshot_fn(ref)
+        if snapshot is None:
+            return _json_result(
+                {
+                    "error": "ticket_not_found",
+                    "ticket_ref": ticket_ref,
+                    "message": (
+                        f"the bound tracker has no ticket matching "
+                        f"{ticket_ref!r}"
+                    ),
+                }
+            )
+        return _json_result(snapshot)
+
+    async def _tool_get_dashboard(self, args: dict[str, Any]) -> str:
+        """Stitch the workspace's headline state into one payload.
+
+        Composes cheap queries against ``WorkspaceProjectPriority``,
+        ``InboxItem``, ``PullRequest``, ``PipelineRun``, and
+        ``WorkflowRun``. The shape is deliberately slim — the agent
+        gets enough to answer "what's on my plate?" without a five-
+        tool fan-out, but not the full ``/dashboard/ops`` payload
+        (which is route-only, requires HTTP auth context, and carries
+        per-repo enrichment the agent rarely needs in chat).
+        """
+        del args  # no parameters
+
+        from datetime import datetime as _dt, timedelta, timezone
+
+        from backend.app.db.models.dashboard_priorities import (
+            WorkspaceProjectPriority,
+        )
+
+        now = _dt.now(timezone.utc)
+        cutoff_24h = now - timedelta(days=1)
+        cutoff_recent = now - timedelta(days=7)
+
+        # Priorities — group by state, ordered.
+        priority_rows = (
+            await self._session.execute(
+                select(WorkspaceProjectPriority)
+                .where(
+                    WorkspaceProjectPriority.workspace_id
+                    == self._workspace_id
+                )
+                .order_by(
+                    WorkspaceProjectPriority.state,
+                    WorkspaceProjectPriority.ordinal.asc(),
+                )
+            )
+        ).scalars().all()
+        by_state: dict[str, list[dict[str, Any]]] = {
+            "active": [],
+            "planning": [],
+            "parked": [],
+        }
+        for row in priority_rows:
+            bucket = by_state.setdefault(row.state, [])
+            bucket.append(
+                {
+                    "project_native_id": row.project_native_id,
+                    "ordinal": row.ordinal,
+                    "originating_thread_id": (
+                        str(row.originating_thread_id)
+                        if row.originating_thread_id
+                        else None
+                    ),
+                }
+            )
+
+        # Inbox snapshot. We intentionally include this even though
+        # the session-context frame already has it — when the user
+        # asks "what's on my plate?" they want a structured
+        # response that doesn't depend on the agent regurgitating
+        # the frame back. The detail here also exposes a 24-hour
+        # arrival count the frame doesn't carry.
+        inbox_total = (
+            await self._session.execute(
+                select(func.count(InboxItem.id)).where(
+                    InboxItem.workspace_id == self._workspace_id,
+                    InboxItem.status.in_(("new", "snoozed")),
+                )
+            )
+        ).scalar_one() or 0
+        inbox_by_type_rows = (
+            await self._session.execute(
+                select(InboxItem.type, func.count(InboxItem.id))
+                .where(
+                    InboxItem.workspace_id == self._workspace_id,
+                    InboxItem.status.in_(("new", "snoozed")),
+                )
+                .group_by(InboxItem.type)
+            )
+        ).all()
+        inbox_by_type = {
+            str(row[0]): int(row[1])
+            for row in inbox_by_type_rows
+            if row[0]
+        }
+        inbox_arrived_24h = (
+            await self._session.execute(
+                select(func.count(InboxItem.id)).where(
+                    InboxItem.workspace_id == self._workspace_id,
+                    InboxItem.created_at >= cutoff_24h,
+                )
+            )
+        ).scalar_one() or 0
+
+        # Open PRs + recent merged.
+        open_pr_count = (
+            await self._session.execute(
+                select(func.count(PullRequest.id)).where(
+                    PullRequest.workspace_id == self._workspace_id,
+                    PullRequest.state == "open",
+                )
+            )
+        ).scalar_one() or 0
+        shipped_24h = (
+            await self._session.execute(
+                select(func.count(PullRequest.id)).where(
+                    PullRequest.workspace_id == self._workspace_id,
+                    PullRequest.merged.is_(True),
+                    PullRequest.merged_at >= cutoff_24h,
+                )
+            )
+        ).scalar_one() or 0
+
+        # Recent activity — top 5 mixed across pipeline runs + PRs +
+        # workflow runs in the last week. Cheap unioned listing; the
+        # agent calls ``runs_query`` / ``list_pull_requests`` if it
+        # needs detail beyond the headline.
+        recent: list[dict[str, Any]] = []
+        recent_runs = (
+            await self._session.execute(
+                select(PipelineRun)
+                .where(
+                    PipelineRun.workspace_id == self._workspace_id,
+                    PipelineRun.created_at >= cutoff_recent,
+                )
+                .order_by(desc(PipelineRun.created_at))
+                .limit(5)
+            )
+        ).scalars().all()
+        for r in recent_runs:
+            recent.append(
+                {
+                    "kind": "pipeline_run",
+                    "id": str(r.id),
+                    "status": r.status,
+                    "trigger": r.trigger,
+                    "created_at": r.created_at.isoformat()
+                    if r.created_at
+                    else None,
+                }
+            )
+        recent_prs = (
+            await self._session.execute(
+                select(PullRequest)
+                .where(
+                    PullRequest.workspace_id == self._workspace_id,
+                    PullRequest.updated_at_external >= cutoff_recent,
+                )
+                .order_by(desc(PullRequest.updated_at_external))
+                .limit(5)
+            )
+        ).scalars().all()
+        for pr in recent_prs:
+            recent.append(
+                {
+                    "kind": "pull_request",
+                    "repo_full_name": pr.repo_full_name,
+                    "number": pr.number,
+                    "title": pr.title,
+                    "state": pr.state,
+                    "merged": pr.merged,
+                    "url": pr.html_url,
+                    "updated_at": (
+                        pr.updated_at_external.isoformat()
+                        if pr.updated_at_external
+                        else None
+                    ),
+                }
+            )
+        # Sort merged stream by timestamp desc; trim to top 5.
+        recent.sort(
+            key=lambda x: x.get("updated_at") or x.get("created_at") or "",
+            reverse=True,
+        )
+        recent = recent[:5]
+
+        return _json_result(
+            {
+                "now": now.isoformat(),
+                "priorities": by_state,
+                "inbox": {
+                    "open_total": int(inbox_total),
+                    "by_type": inbox_by_type,
+                    "arrived_24h": int(inbox_arrived_24h),
+                },
+                "pull_requests": {
+                    "open_total": int(open_pr_count),
+                    "shipped_24h": int(shipped_24h),
+                },
+                "recent_activity": recent,
+            }
+        )
+
+    async def _tool_workspace_audit_search(
+        self, args: dict[str, Any]
+    ) -> str:
+        from datetime import datetime as _dt, timedelta, timezone
+
+        action = args.get("action")
+        if action is not None and not isinstance(action, str):
+            raise ToolInvocationError("action must be a string when provided")
+        target_kind = args.get("target_kind")
+        if target_kind is not None and not isinstance(target_kind, str):
+            raise ToolInvocationError(
+                "target_kind must be a string when provided"
+            )
+        target_id = args.get("target_id")
+        if target_id is not None and not isinstance(target_id, str):
+            raise ToolInvocationError(
+                "target_id must be a string when provided"
+            )
+        since_dt = _parse_iso_datetime(args.get("since"), "since")
+        if since_dt is None:
+            since_dt = _dt.now(timezone.utc) - timedelta(days=30)
+        limit = _clamp_int(
+            args.get("limit"), default=25, low=1, high=100
+        )
+
+        stmt = (
+            select(AuditLog)
+            .where(
+                AuditLog.workspace_id == self._workspace_id,
+                AuditLog.created_at >= since_dt,
+            )
+            .order_by(desc(AuditLog.created_at))
+            .limit(limit)
+        )
+        if action:
+            stmt = stmt.where(AuditLog.action == action)
+        if target_kind:
+            stmt = stmt.where(AuditLog.target_kind == target_kind)
+        if target_id:
+            stmt = stmt.where(AuditLog.target_id == target_id)
+
+        rows = (await self._session.execute(stmt)).scalars().all()
+        items = [
+            {
+                "id": int(r.id),
+                "action": r.action,
+                "target_kind": r.target_kind,
+                "target_id": r.target_id,
+                "actor_user_id": (
+                    str(r.actor_user_id) if r.actor_user_id else None
+                ),
+                "payload": r.payload or {},
+                "created_at": r.created_at.isoformat()
+                if r.created_at
+                else None,
+            }
+            for r in rows
+        ]
+        return _json_result({"audit_log": items, "count": len(items)})
 
     # ------------------------------------------------------------------
     # consult_specialist — subagent loop (Navigator overhaul PR3, ELS-74).

--- a/backend/tests/test_navigator_readonly_tools.py
+++ b/backend/tests/test_navigator_readonly_tools.py
@@ -1,0 +1,411 @@
+"""Read-only Navigator tools added in PR-C1 of the tool review (ELS-78).
+
+Three tools, all read-only and DB-backed:
+
+- ``get_ticket(ticket_ref)`` — single-ticket lookup; routes through the
+  bound tracker's ``get_ticket_snapshot``. Tested with a stub tracker
+  so we don't need a live Linear connection.
+- ``get_dashboard()`` — denormalised "what's on my plate?" payload
+  composed from priorities + inbox + PRs + recent runs. Tested
+  end-to-end with a seeded workspace + fixtures.
+- ``workspace_audit_search`` — straight DB query against ``audit_log``
+  with optional ``action`` / ``target_kind`` / ``target_id`` / ``since``
+  filters. Tested with seeded rows.
+
+The shape assertions are deliberately broad — these are denormalised
+payloads whose copy may evolve. We pin only the load-bearing keys
+that the agent will read.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def toolbox(db_session, seed_workspace):
+    from backend.app.core.config import get_settings
+    from backend.app.services.agent.tools import ToolBox
+
+    user, _, workspace = seed_workspace
+    return ToolBox(
+        db_session,
+        settings=get_settings(),
+        workspace_id=workspace.id,
+        user_id=user.id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# get_ticket
+# ---------------------------------------------------------------------------
+
+
+class _StubTrackerWithSnapshot:
+    """Minimal stub for the tracker resolution path in ``_tool_get_ticket``.
+
+    The handler calls ``self._resolve_tracker(None, None)`` to get a
+    tracker object, then ``tracker.get_ticket_snapshot(ref)``. Since
+    ``_resolve_tracker`` queries DB integrations, we monkey-patch
+    ``_resolve_tracker`` directly and skip the DB dance.
+    """
+
+    kind = "linear"
+
+    def __init__(self, snapshot=None) -> None:
+        self.snapshot = snapshot
+        self.calls = []
+
+    async def get_ticket_snapshot(self, ref):
+        self.calls.append(ref)
+        return self.snapshot
+
+
+@pytest.mark.asyncio
+async def test_get_ticket_returns_snapshot(toolbox, monkeypatch) -> None:
+    stub = _StubTrackerWithSnapshot(
+        snapshot={
+            "ticket_ref": "ELS-99",
+            "title": "Test ticket",
+            "description": "body",
+            "url": "https://linear.app/elship/issue/ELS-99",
+            "state": "In Progress",
+            "labels": ["bug"],
+            "project_id": "proj-uuid",
+        }
+    )
+
+    async def _stub_resolve(_self, _kind, _hint):
+        return stub
+
+    monkeypatch.setattr(
+        type(toolbox), "_resolve_tracker", _stub_resolve, raising=True
+    )
+
+    raw = await toolbox._tool_get_ticket({"ticket_ref": "ELS-99"})
+    payload = json.loads(raw)
+    assert payload["ticket_ref"] == "ELS-99"
+    assert payload["title"] == "Test ticket"
+    assert payload["state"] == "In Progress"
+    assert payload["project_id"] == "proj-uuid"
+    assert len(stub.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_get_ticket_returns_not_found_when_missing(
+    toolbox, monkeypatch
+) -> None:
+    stub = _StubTrackerWithSnapshot(snapshot=None)
+
+    async def _stub_resolve(_self, _kind, _hint):
+        return stub
+
+    monkeypatch.setattr(
+        type(toolbox), "_resolve_tracker", _stub_resolve, raising=True
+    )
+
+    raw = await toolbox._tool_get_ticket({"ticket_ref": "ELS-9999"})
+    payload = json.loads(raw)
+    assert payload["error"] == "ticket_not_found"
+    assert payload["ticket_ref"] == "ELS-9999"
+
+
+@pytest.mark.asyncio
+async def test_get_ticket_requires_ticket_ref(toolbox) -> None:
+    from backend.app.services.agent.tools import ToolInvocationError
+
+    with pytest.raises(ToolInvocationError):
+        await toolbox._tool_get_ticket({})
+
+
+# ---------------------------------------------------------------------------
+# get_dashboard
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_dashboard_returns_load_bearing_keys(
+    toolbox, db_session, seed_workspace
+) -> None:
+    """Empty workspace returns the canonical shape with zero counts —
+    the agent should be able to phrase a useful answer even without
+    seeded data."""
+    raw = await toolbox._tool_get_dashboard({})
+    payload = json.loads(raw)
+
+    # Top-level keys that the agent will read
+    for key in ("now", "priorities", "inbox", "pull_requests", "recent_activity"):
+        assert key in payload, f"missing top-level key {key!r}"
+
+    # Priorities buckets (always present, even if empty)
+    for bucket in ("active", "planning", "parked"):
+        assert bucket in payload["priorities"]
+        assert isinstance(payload["priorities"][bucket], list)
+
+    # Inbox shape
+    assert "open_total" in payload["inbox"]
+    assert "by_type" in payload["inbox"]
+    assert "arrived_24h" in payload["inbox"]
+
+    # PRs shape
+    assert "open_total" in payload["pull_requests"]
+    assert "shipped_24h" in payload["pull_requests"]
+
+
+@pytest.mark.asyncio
+async def test_get_dashboard_groups_priorities_by_state(
+    toolbox, db_session, seed_workspace
+) -> None:
+    from backend.app.db.models.dashboard_priorities import (
+        WorkspaceProjectPriority,
+    )
+
+    user, _, workspace = seed_workspace
+    db_session.add(
+        WorkspaceProjectPriority(
+            workspace_id=workspace.id,
+            project_native_id="proj-active-1",
+            ordinal=0,
+            state="active",
+        )
+    )
+    db_session.add(
+        WorkspaceProjectPriority(
+            workspace_id=workspace.id,
+            project_native_id="proj-active-2",
+            ordinal=1,
+            state="active",
+        )
+    )
+    db_session.add(
+        WorkspaceProjectPriority(
+            workspace_id=workspace.id,
+            project_native_id="proj-draft",
+            ordinal=2,
+            state="planning",
+        )
+    )
+    db_session.add(
+        WorkspaceProjectPriority(
+            workspace_id=workspace.id,
+            project_native_id="proj-parked",
+            ordinal=3,
+            state="parked",
+        )
+    )
+    await db_session.flush()
+
+    raw = await toolbox._tool_get_dashboard({})
+    payload = json.loads(raw)
+    active_ids = [
+        p["project_native_id"] for p in payload["priorities"]["active"]
+    ]
+    assert active_ids == ["proj-active-1", "proj-active-2"]
+    assert [p["project_native_id"] for p in payload["priorities"]["planning"]] == [
+        "proj-draft"
+    ]
+    assert [p["project_native_id"] for p in payload["priorities"]["parked"]] == [
+        "proj-parked"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_get_dashboard_inbox_counts(
+    toolbox, db_session, seed_workspace
+) -> None:
+    from backend.app.db.models.inbox import InboxItem
+
+    _, _, workspace = seed_workspace
+    db_session.add(
+        InboxItem(
+            workspace_id=workspace.id,
+            repo_id=None,
+            type="clarification",
+            title="x1",
+            status="new",
+            intake_handle=None,
+        )
+    )
+    db_session.add(
+        InboxItem(
+            workspace_id=workspace.id,
+            repo_id=None,
+            type="clarification",
+            title="x2",
+            status="snoozed",
+            intake_handle=None,
+        )
+    )
+    db_session.add(
+        InboxItem(
+            workspace_id=workspace.id,
+            repo_id=None,
+            type="approval",
+            title="x3",
+            status="new",
+            intake_handle=None,
+        )
+    )
+    db_session.add(
+        InboxItem(
+            workspace_id=workspace.id,
+            repo_id=None,
+            type="failure",
+            title="x4",
+            status="dismissed",  # NOT counted (closed)
+            intake_handle=None,
+        )
+    )
+    await db_session.flush()
+
+    raw = await toolbox._tool_get_dashboard({})
+    payload = json.loads(raw)
+    assert payload["inbox"]["open_total"] == 3
+    assert payload["inbox"]["by_type"]["clarification"] == 2
+    assert payload["inbox"]["by_type"]["approval"] == 1
+    assert "failure" not in payload["inbox"]["by_type"]
+
+
+# ---------------------------------------------------------------------------
+# workspace_audit_search
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_audit_search_returns_recent_rows(
+    toolbox, db_session, seed_workspace
+) -> None:
+    from backend.app.db.models.tenancy import AuditLog
+
+    user, _, workspace = seed_workspace
+    now = datetime.now(timezone.utc)
+
+    db_session.add(
+        AuditLog(
+            workspace_id=workspace.id,
+            actor_user_id=user.id,
+            actor_token_id=None,
+            action="dashboard.priorities.reorder",
+            target_kind="workspace",
+            target_id=str(workspace.id),
+            payload={"order_count": 3},
+        )
+    )
+    db_session.add(
+        AuditLog(
+            workspace_id=workspace.id,
+            actor_user_id=user.id,
+            actor_token_id=None,
+            action="navigator.consult_specialist",
+            target_kind="agent_role",
+            target_id="designer",
+            payload={"task_preview": "review the dashboard"},
+        )
+    )
+    await db_session.flush()
+
+    raw = await toolbox._tool_workspace_audit_search({})
+    payload = json.loads(raw)
+    actions = [r["action"] for r in payload["audit_log"]]
+    assert "dashboard.priorities.reorder" in actions
+    assert "navigator.consult_specialist" in actions
+    assert payload["count"] == len(payload["audit_log"])
+
+
+@pytest.mark.asyncio
+async def test_audit_search_filters_by_action(
+    toolbox, db_session, seed_workspace
+) -> None:
+    from backend.app.db.models.tenancy import AuditLog
+
+    user, _, workspace = seed_workspace
+    db_session.add(
+        AuditLog(
+            workspace_id=workspace.id,
+            actor_user_id=user.id,
+            action="dashboard.priorities.reorder",
+            target_kind="workspace",
+            target_id=str(workspace.id),
+            payload={},
+        )
+    )
+    db_session.add(
+        AuditLog(
+            workspace_id=workspace.id,
+            actor_user_id=user.id,
+            action="navigator.consult_specialist",
+            target_kind="agent_role",
+            target_id="ba",
+            payload={},
+        )
+    )
+    await db_session.flush()
+
+    raw = await toolbox._tool_workspace_audit_search(
+        {"action": "navigator.consult_specialist"}
+    )
+    payload = json.loads(raw)
+    assert all(
+        r["action"] == "navigator.consult_specialist"
+        for r in payload["audit_log"]
+    )
+    assert len(payload["audit_log"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_audit_search_respects_since(
+    toolbox, db_session, seed_workspace
+) -> None:
+    """Rows older than ``since`` must NOT come back. The default
+    30-day window is enforced when ``since`` isn't provided."""
+    from backend.app.db.models.tenancy import AuditLog
+
+    user, _, workspace = seed_workspace
+    old_row = AuditLog(
+        workspace_id=workspace.id,
+        actor_user_id=user.id,
+        action="ancient.event",
+        target_kind="workspace",
+        target_id=str(workspace.id),
+        payload={},
+    )
+    db_session.add(old_row)
+    await db_session.flush()
+    # Force the row's timestamp to 60 days ago — past the default
+    # 30-day window.
+    old_row.created_at = datetime.now(timezone.utc) - timedelta(days=60)
+    await db_session.flush()
+
+    raw = await toolbox._tool_workspace_audit_search({})
+    payload = json.loads(raw)
+    actions = [r["action"] for r in payload["audit_log"]]
+    assert "ancient.event" not in actions
+
+    # Explicit since=90 days back — old row comes back.
+    raw = await toolbox._tool_workspace_audit_search(
+        {"since": (datetime.now(timezone.utc) - timedelta(days=90)).isoformat()}
+    )
+    payload = json.loads(raw)
+    actions = [r["action"] for r in payload["audit_log"]]
+    assert "ancient.event" in actions
+
+
+@pytest.mark.asyncio
+async def test_audit_search_validates_filter_types(toolbox) -> None:
+    from backend.app.services.agent.tools import ToolInvocationError
+
+    with pytest.raises(ToolInvocationError, match="action must be a string"):
+        await toolbox._tool_workspace_audit_search({"action": 42})
+    with pytest.raises(
+        ToolInvocationError, match="target_kind must be a string"
+    ):
+        await toolbox._tool_workspace_audit_search({"target_kind": 42})

--- a/backend/tests/test_navigator_tool_inventory.py
+++ b/backend/tests/test_navigator_tool_inventory.py
@@ -39,11 +39,13 @@ EXPECTED_TOOLS: frozenset[str] = frozenset(
         "consult_specialist",
         "create_project",
         "create_ticket",
+        "get_dashboard",
         "get_knowledge_bucket",
         "get_pipeline_run",
         "get_project",
         "get_pull_request",
         "get_repo_file",
+        "get_ticket",
         "inbox_dispose",
         "inbox_get",
         "inbox_list",
@@ -72,6 +74,7 @@ EXPECTED_TOOLS: frozenset[str] = frozenset(
         "run_detail",
         "runs_query",
         "search_code",
+        "workspace_audit_search",
     }
 )
 


### PR DESCRIPTION
PR-C1 of two halves of [ELS-78](https://linear.app/elship/issue/ELS-78). PR-A (#157, merged) dropped 4 redundant tools; PR-B (#158, merged) consolidated 6 → 3 (search + pipelines). This one fills three concrete gaps in the agent's **read** surface where the API was already there but Navigator couldn't reach it. The mutating half (PR-C2) follows separately so verify-before-mutate gating gets its own review.

## What's added

| Tool | Why |
|---|---|
| ``get_ticket(ticket_ref)`` | Today's ``list_tickets`` is a sweep. When the user names ``ELS-99`` the agent lists 50 to find one. Routes through the bound tracker's ``get_ticket_snapshot``. |
| ``get_dashboard()`` | Today the agent fans out to ``inbox_list`` + ``runs_query`` + priorities lookup + ``automations_list`` + ``list_pull_requests`` to answer "what's on my plate?". This composes them. |
| ``workspace_audit_search(action?, target_kind?, target_id?, since?, limit?)`` | Today's prompt says "out of Navigator's surface today; deeplink to the Audit page" for "who changed setting X?". The audit_log table is right there. |

## ``get_dashboard`` payload (slim by design)

```json
{
  "now": "2026-05-05T...",
  "priorities": {
    "active": [{"project_native_id", "ordinal", "originating_thread_id"}, ...],
    "planning": [...],
    "parked": [...]
  },
  "inbox": {"open_total", "by_type", "arrived_24h"},
  "pull_requests": {"open_total", "shipped_24h"},
  "recent_activity": [{kind, ...}, ...]   // top 5 mixed
}
```

The agent gets enough to answer "what's on my plate?" without a fan-out. Detail beyond the headline still routes through ``runs_query`` / ``list_pull_requests``.

## ``workspace_audit_search`` defaults

- ``since`` defaults to **30 days back** if not provided. Older rows need an explicit override — keeps the default response bounded.
- ``limit`` capped at 100, defaults to 25.
- Filters: ``action``, ``target_kind``, ``target_id`` are exact-match.

## Prompt updates

- Scenario 1 (Planning): "When the user names a specific id (``ELS-99``) → ``get_ticket`` directly; don't list 50 to find one."
- Scenario 2 (System mgmt) leads with ``get_dashboard`` for "what's on my plate?" / "state of the workspace?".
- The ``Who changed setting X?`` line flips from "out of Navigator's surface today" to ``workspace_audit_search`` with the available filters.

## Test plan

- [x] Inventory test (``test_navigator_tool_inventory``) — all 4 tests green; 43 tools (was 40).
- [x] AST + smoke check on ``ToolBox.specs()`` + ``_handlers()`` — new entries present, dispatch covered.
- [x] New test file ``test_navigator_readonly_tools.py`` — 9 tests covering: get_ticket happy path, not-found path, missing arg; get_dashboard structural shape, priorities grouping by state, inbox totals + by-type including dismissed-not-counted; audit_search recent rows, action filter, default 30-day cutoff with 90-day override, arg type validation. **DB-backed; will run in CI** (local postgres-on-5433 still down).

## Surface

```
48 (pre-PR-A) → 44 → 40 → 43 (this PR)
```

## What's NOT in this PR

PR-C2: 3 mutating tools — ``update_ticket``, ``set_priority_state``, ``start_decomposition``. Split out so the verify-before-mutate gating gets a focused review pass.