### PR TITLE
navigator: 3 mutating tools — update_ticket, set_priority_state, start_decomposition (ELS-78 PR-C2)

### DIFF
--- a/backend/app/integrations/linear/tracker_adapter.py
+++ b/backend/app/integrations/linear/tracker_adapter.py
@@ -528,6 +528,52 @@ class LinearTracker:
             {"id": ticket.id, "body": body},
         )
 
+    async def update_ticket(
+        self,
+        ticket: TicketRef,
+        *,
+        title: str | None = None,
+        body: str | None = None,
+        labels: list[str] | None = None,
+    ) -> None:
+        """Update title / body / labels in one ``issueUpdate`` call.
+
+        ``None`` arguments leave the field as-is — pass ``""`` to clear
+        a string field, an empty list to clear all labels.
+
+        ``labels`` is a **full replacement set** — Linear's
+        ``issueUpdate`` with ``labelIds`` replaces the entire label
+        list, so partial add/remove must happen at the caller layer.
+        Unknown labels are silently dropped (same strict policy as
+        ``create_ticket`` — we don't want the LLM polluting a
+        customer's Linear with freshly invented label names).
+
+        Used by Navigator's ``update_ticket`` tool. State transitions
+        are NOT in scope here — call :meth:`transition` separately.
+        """
+        if ticket.kind != "linear":
+            raise ValueError(
+                f"LinearTracker can't update_ticket for kind={ticket.kind}"
+            )
+        input_payload: dict[str, Any] = {}
+        if title is not None:
+            input_payload["title"] = title
+        if body is not None:
+            input_payload["description"] = body
+        if labels is not None:
+            team_id = await self._resolve_team_id(None)
+            input_payload["labelIds"] = await self._resolve_label_ids(
+                team_id, labels
+            )
+        if not input_payload:
+            return
+        await self._gql(
+            """mutation ShipUpdateIssue($id: String!, $input: IssueUpdateInput!) {
+              issueUpdate(id: $id, input: $input) { success }
+            }""",
+            {"id": ticket.id, "input": input_payload},
+        )
+
     async def comment(self, ticket: TicketRef, *, body: str) -> None:
         if ticket.kind != "linear":
             raise ValueError(f"LinearTracker can't comment on kind={ticket.kind}")

--- a/backend/app/resources/agent_roles/navigator.md
+++ b/backend/app/resources/agent_roles/navigator.md
@@ -67,6 +67,9 @@ Workflow:
 4. Add new PO ideas to an existing epic via ``append_project_description`` — accumulates across sessions.
 5. ``create_ticket`` for child work — pass ``project_id`` so the ticket attaches. Keep ticket body short: goal + AC. Don't duplicate the epic body.
 6. Before listing existing tickets, ``list_tickets`` (supports ``state``, ``query``, ``assignee_me`` for Linear / ``assignee`` login for GitHub). When the user names a specific id (``ELS-99``) → ``get_ticket`` directly; don't list 50 to find one.
+7. To edit an existing ticket — title, body, labels, state — ``update_ticket``. Verify-before-mutate: describe the change unless the user gave a direct command. ``labels`` is a FULL replacement set, not add/remove.
+8. Move a project between dashboard buckets (Active / Drafts / Parked) → ``set_priority_state``. "Park this for now" / "promote it" are direct commands; ambiguous "what should we do with this?" requires a confirm.
+9. Hand a Drafts-bucket project off to decomposition → ``start_decomposition``. Strict verify-before-mutate — the chain (BA → Architect → QA-Architect → Developer) runs autonomously after the call.
 
 ## Scenario 2 — System management (Inbox + Automations)
 

--- a/backend/app/services/agent/tools.py
+++ b/backend/app/services/agent/tools.py
@@ -1936,6 +1936,142 @@ class ToolBox:
                 },
             ),
             ToolSpec(
+                name="update_ticket",
+                description=(
+                    "Edit an existing ticket in the workspace's bound "
+                    "tracker — title, body, labels, and/or workflow "
+                    "state in one call. **Mutating; admin-only**. "
+                    "Verify-before-mutate: describe the change and "
+                    "wait for explicit OK unless the user gave a "
+                    "direct command (\"rename to X\", \"close it\", "
+                    "etc.). ``labels`` is a FULL replacement set — "
+                    "the existing label list is overwritten. State "
+                    "accepts a Ship FSM stage (``ba_requirements``, "
+                    "``dev_implementation``, …) or a Linear workflow "
+                    "state name (``Done``, ``In Progress``)."
+                ),
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "ticket_ref": {
+                            "type": "string",
+                            "description": (
+                                "Tracker-native identifier "
+                                "(``ELS-99`` for Linear)."
+                            ),
+                        },
+                        "title": {
+                            "type": "string",
+                            "description": "New title. Omit to leave as-is.",
+                        },
+                        "body": {
+                            "type": "string",
+                            "description": (
+                                "New markdown description. Replaces "
+                                "the previous body verbatim — Linear "
+                                "keeps history server-side, so the "
+                                "activity feed shows what changed."
+                            ),
+                        },
+                        "labels": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": (
+                                "FULL replacement set of label names. "
+                                "The existing label list is "
+                                "overwritten. Unknown labels are "
+                                "silently dropped."
+                            ),
+                        },
+                        "state": {
+                            "type": "string",
+                            "description": (
+                                "Optional state transition. Accepts "
+                                "a Ship FSM stage or a Linear "
+                                "workflow state name. Triggers a "
+                                "label swap + state move."
+                            ),
+                        },
+                    },
+                    "required": ["ticket_ref"],
+                    "additionalProperties": False,
+                },
+            ),
+            ToolSpec(
+                name="set_priority_state",
+                description=(
+                    "Move a project on the dashboard between buckets: "
+                    "``active`` (agent's autonomous picker may "
+                    "consume), ``planning`` (UI label: **Drafts** — "
+                    "operator is shaping; agent-invisible), "
+                    "``parked`` (explicit hold). **Mutating; "
+                    "admin-only**. Verify-before-mutate: describe "
+                    "the move and wait for explicit OK unless the "
+                    "user gave a direct command (\"park this\", "
+                    "\"promote it\"). Creates a priorities row at "
+                    "MAX+1 ordinal if none exists yet."
+                ),
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "project_native_id": {
+                            "type": "string",
+                            "description": (
+                                "Tracker-native project id (Linear "
+                                "project UUID, Jira project key)."
+                            ),
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": ["active", "planning", "parked"],
+                            "description": (
+                                "Target bucket. ``planning`` is the "
+                                "internal name for the **Drafts** UI "
+                                "label."
+                            ),
+                        },
+                    },
+                    "required": ["project_native_id", "state"],
+                    "additionalProperties": False,
+                },
+            ),
+            ToolSpec(
+                name="start_decomposition",
+                description=(
+                    "Hand a Drafts-bucket project off to the "
+                    "decomposition pipeline. **Mutating; admin-"
+                    "only; strict verify-before-mutate** — the chain "
+                    "(BA → Architect → QA-Architect → Developer) "
+                    "runs autonomously after this and you can't "
+                    "easily undo. Always confirm with the user "
+                    "before calling. Walks the planning anchor into "
+                    "``stage:wbs``; the per-tick scheduler picks up "
+                    "BA, who emits the WBS section, transitions to "
+                    "``stage:architecture``, and so on through "
+                    "``stage:planning_done`` — at which point the "
+                    "project flips Drafts → Active and the agent's "
+                    "autonomous picker takes over."
+                ),
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "project_native_id": {
+                            "type": "string",
+                            "description": (
+                                "Tracker-native project id. Must "
+                                "already be on the dashboard in the "
+                                "Drafts bucket "
+                                "(``priority_state='planning'``); "
+                                "the tool refuses for ``active`` / "
+                                "``parked`` states."
+                            ),
+                        },
+                    },
+                    "required": ["project_native_id"],
+                    "additionalProperties": False,
+                },
+            ),
+            ToolSpec(
                 name="consult_specialist",
                 description=(
                     "Hand a focused task off to a specialist subagent. "
@@ -2090,6 +2226,9 @@ class ToolBox:
             "get_ticket": self._tool_get_ticket,
             "get_dashboard": self._tool_get_dashboard,
             "workspace_audit_search": self._tool_workspace_audit_search,
+            "update_ticket": self._tool_update_ticket,
+            "set_priority_state": self._tool_set_priority_state,
+            "start_decomposition": self._tool_start_decomposition,
             "consult_specialist": self._tool_consult_specialist,
         }
 
@@ -7051,6 +7190,273 @@ class ToolBox:
             for r in rows
         ]
         return _json_result({"audit_log": items, "count": len(items)})
+
+    # ------------------------------------------------------------------
+    # Mutating tools (Navigator tool review PR-C2, ELS-78):
+    # ``update_ticket``, ``set_priority_state``, ``start_decomposition``.
+    # All admin-gated and audited. The agentic prompt's
+    # ``Verify before mutate`` rule (PR2 of the overhaul, navigator.md)
+    # tells the agent to confirm before calling these unless the user
+    # gave a direct command — the tools execute when called; the
+    # gating lives in the prompt.
+    # ------------------------------------------------------------------
+
+    async def _tool_update_ticket(self, args: dict[str, Any]) -> str:
+        from backend.app.api.v1.routes.workspaces import ROLES_ADMIN
+
+        await self._require_workspace_role(ROLES_ADMIN)
+
+        ticket_ref = _require_str(args, "ticket_ref").strip()
+        title = args.get("title")
+        body = args.get("body")
+        labels = args.get("labels")
+        state = args.get("state")
+        if title is not None and not isinstance(title, str):
+            raise ToolInvocationError("title must be a string")
+        if body is not None and not isinstance(body, str):
+            raise ToolInvocationError("body must be a string")
+        if labels is not None:
+            if not isinstance(labels, list) or not all(
+                isinstance(x, str) for x in labels
+            ):
+                raise ToolInvocationError(
+                    "labels must be a list of strings"
+                )
+        if state is not None and not isinstance(state, str):
+            raise ToolInvocationError("state must be a string")
+        if title is None and body is None and labels is None and state is None:
+            raise ToolInvocationError(
+                "update_ticket needs at least one of title, body, labels, "
+                "or state to update"
+            )
+
+        tracker = await self._resolve_tracker(None, None)
+        ref = _ticket_ref_from(_tracker_kind_of(tracker), ticket_ref)
+        actions: list[str] = []
+
+        # Single ``issueUpdate`` call covers title/body/labels.
+        if title is not None or body is not None or labels is not None:
+            update_fn = getattr(tracker, "update_ticket", None)
+            if update_fn is None:
+                raise ToolInvocationError(
+                    "this tracker does not implement ticket updates"
+                )
+            try:
+                await update_fn(
+                    ref, title=title, body=body, labels=labels
+                )
+            except Exception as exc:  # noqa: BLE001 — surface vendor errors
+                raise ToolInvocationError(
+                    f"tracker rejected update: {exc}"
+                ) from exc
+            if title is not None:
+                actions.append("title")
+            if body is not None:
+                actions.append("body")
+            if labels is not None:
+                actions.append(f"labels:{len(labels)}")
+
+        # State transitions go through ``transition`` (label swap +
+        # workflow state move per FSM_TO_LINEAR_STATE).
+        if state is not None:
+            try:
+                await tracker.transition(ref, to_state=state)
+            except Exception as exc:  # noqa: BLE001
+                raise ToolInvocationError(
+                    f"tracker rejected transition to {state!r}: {exc}"
+                ) from exc
+            actions.append(f"state:{state}")
+
+        self._session.add(
+            AuditLog(
+                workspace_id=self._workspace_id,
+                actor_user_id=self._user_id,
+                actor_token_id=None,
+                action="navigator.update_ticket",
+                target_kind="ticket",
+                target_id=ticket_ref,
+                payload={
+                    "ticket_ref": ticket_ref,
+                    "actions": actions,
+                    "had_title": title is not None,
+                    "had_body": body is not None,
+                    "labels_count": (
+                        len(labels) if isinstance(labels, list) else None
+                    ),
+                    "state_target": state,
+                },
+            )
+        )
+        await self._session.flush()
+
+        return _json_result(
+            {"ticket_ref": ticket_ref, "actions": actions}
+        )
+
+    async def _tool_set_priority_state(self, args: dict[str, Any]) -> str:
+        from backend.app.api.v1.routes.workspaces import ROLES_ADMIN
+
+        from backend.app.db.models.dashboard_priorities import (
+            WorkspaceProjectPriority,
+        )
+
+        await self._require_workspace_role(ROLES_ADMIN)
+
+        project_native_id = _require_str(args, "project_native_id").strip()
+        state = _require_str(args, "state").strip()
+        if state not in ("active", "planning", "parked"):
+            raise ToolInvocationError(
+                f"state must be one of active|planning|parked (got {state!r})"
+            )
+
+        existing = (
+            await self._session.execute(
+                select(WorkspaceProjectPriority).where(
+                    WorkspaceProjectPriority.workspace_id == self._workspace_id,
+                    WorkspaceProjectPriority.project_native_id
+                    == project_native_id,
+                )
+            )
+        ).scalar_one_or_none()
+        prior_state: str | None = None
+        if existing is None:
+            # Create new row at MAX+1 ordinal so the project shows up
+            # without disturbing existing ordering.
+            max_ord = await self._session.scalar(
+                select(WorkspaceProjectPriority.ordinal)
+                .where(
+                    WorkspaceProjectPriority.workspace_id == self._workspace_id
+                )
+                .order_by(WorkspaceProjectPriority.ordinal.desc())
+                .limit(1)
+            )
+            next_ord = 0 if max_ord is None else int(max_ord) + 1
+            self._session.add(
+                WorkspaceProjectPriority(
+                    workspace_id=self._workspace_id,
+                    project_native_id=project_native_id,
+                    ordinal=next_ord,
+                    state=state,
+                )
+            )
+        else:
+            prior_state = existing.state
+            existing.state = state
+
+        self._session.add(
+            AuditLog(
+                workspace_id=self._workspace_id,
+                actor_user_id=self._user_id,
+                actor_token_id=None,
+                action="navigator.set_priority_state",
+                target_kind="workspace_project_priority",
+                target_id=project_native_id,
+                payload={
+                    "project_native_id": project_native_id,
+                    "state": state,
+                    "prior_state": prior_state,
+                    "created_row": existing is None,
+                },
+            )
+        )
+        await self._session.flush()
+
+        return _json_result(
+            {
+                "project_native_id": project_native_id,
+                "state": state,
+                "prior_state": prior_state,
+            }
+        )
+
+    async def _tool_start_decomposition(self, args: dict[str, Any]) -> str:
+        from backend.app.api.v1.routes.workspaces import ROLES_ADMIN
+
+        from backend.app.db.models.dashboard_priorities import (
+            WorkspaceProjectPriority,
+        )
+
+        await self._require_workspace_role(ROLES_ADMIN)
+
+        project_native_id = _require_str(args, "project_native_id").strip()
+
+        row = (
+            await self._session.execute(
+                select(WorkspaceProjectPriority).where(
+                    WorkspaceProjectPriority.workspace_id == self._workspace_id,
+                    WorkspaceProjectPriority.project_native_id
+                    == project_native_id,
+                )
+            )
+        ).scalar_one_or_none()
+        if row is None:
+            raise ToolInvocationError(
+                f"project {project_native_id!r} is not on the dashboard "
+                f"priorities; create_project (or drag-in via the UI) "
+                f"first"
+            )
+        if row.state != "planning":
+            raise ToolInvocationError(
+                f"project is in state={row.state!r} — only Drafts "
+                f"(state='planning') projects can hand off to "
+                f"decomposition"
+            )
+
+        tracker = await self._resolve_tracker(None, None)
+        get_anchor_fn = getattr(tracker, "get_planning_anchor", None)
+        if get_anchor_fn is None:
+            raise ToolInvocationError(
+                "this tracker does not model planning anchors"
+            )
+        anchor = await get_anchor_fn(project_native_id)
+        if anchor is None:
+            raise ToolInvocationError(
+                f"project has no planning anchor — was it created via the "
+                f"drafting flow (`create_project` from Navigator)?"
+            )
+
+        anchor_id = str(anchor.get("id") or "")
+        anchor_identifier = str(
+            anchor.get("identifier") or anchor.get("id") or ""
+        )
+        if not anchor_id:
+            raise ToolInvocationError(
+                "planning anchor has no id; tracker returned malformed shape"
+            )
+
+        ref = _ticket_ref_from(_tracker_kind_of(tracker), anchor_id)
+        try:
+            await tracker.transition(ref, to_state="wbs")
+        except Exception as exc:  # noqa: BLE001
+            raise ToolInvocationError(
+                f"tracker rejected transition to stage:wbs: {exc}"
+            ) from exc
+
+        self._session.add(
+            AuditLog(
+                workspace_id=self._workspace_id,
+                actor_user_id=self._user_id,
+                actor_token_id=None,
+                action="navigator.start_decomposition",
+                target_kind="workspace_project_priority",
+                target_id=project_native_id,
+                payload={
+                    "project_native_id": project_native_id,
+                    "anchor_issue_id": anchor_id,
+                    "anchor_identifier": anchor_identifier,
+                },
+            )
+        )
+        await self._session.flush()
+
+        return _json_result(
+            {
+                "project_native_id": project_native_id,
+                "anchor_issue_id": anchor_id,
+                "anchor_identifier": anchor_identifier,
+                "process": "decomposition",
+            }
+        )
 
     # ------------------------------------------------------------------
     # consult_specialist — subagent loop (Navigator overhaul PR3, ELS-74).

--- a/backend/app/services/policies_seed.py
+++ b/backend/app/services/policies_seed.py
@@ -569,10 +569,11 @@ _NAVIGATOR_POLICIES: tuple[SeedPolicy, ...] = (
             "Mutating tools (``inbox_dispose``, ``inbox_snooze``, "
             "``inbox_reassign``, ``play_run_now``, "
             "``play_automate``, ``automation_toggle``, "
-            "``inbox_routing_upsert``, ``archive_bucket_article``) "
-            "require workspace admin. If a call returns "
-            "``{\"error\": \"forbidden\"}``, explain that admin is "
-            "required; don't retry."
+            "``inbox_routing_upsert``, ``archive_bucket_article``, "
+            "``update_ticket``, ``set_priority_state``, "
+            "``start_decomposition``) require workspace admin. If a "
+            "call returns ``{\"error\": \"forbidden\"}``, explain "
+            "that admin is required; don't retry."
         ),
         applies_to_roles=("navigator",),
         sort_order=40,

--- a/backend/tests/test_navigator_mutating_tools.py
+++ b/backend/tests/test_navigator_mutating_tools.py
@@ -1,0 +1,421 @@
+"""Mutating Navigator tools added in PR-C2 of the tool review (ELS-78).
+
+Three admin-gated, audited tools:
+
+- ``update_ticket(ticket_ref, title?, body?, labels?, state?)`` —
+  edit an existing ticket on the bound tracker. Composes
+  ``tracker.update_ticket`` (one ``issueUpdate`` covering title /
+  body / labels) and ``tracker.transition`` for state changes.
+- ``set_priority_state(project_native_id, state)`` — move a project
+  between Active / Drafts (``planning`` enum) / Parked. Creates a
+  priorities row at MAX+1 ordinal if none exists yet.
+- ``start_decomposition(project_native_id)`` — walk a Drafts-bucket
+  project's planning anchor into ``stage:wbs`` to kick off the
+  decomposition pipeline. Refuses if project is not in Drafts or
+  has no anchor.
+
+The tests use a stub tracker for adapter operations and seeded DB
+rows for the priorities-side tools. Audit log insertion is verified.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+
+import pytest
+
+
+@pytest.fixture
+def toolbox(db_session, seed_workspace):
+    from backend.app.core.config import get_settings
+    from backend.app.services.agent.tools import ToolBox
+
+    user, _, workspace = seed_workspace
+    return ToolBox(
+        db_session,
+        settings=get_settings(),
+        workspace_id=workspace.id,
+        user_id=user.id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Stub tracker — covers update_ticket, transition, get_planning_anchor
+# ---------------------------------------------------------------------------
+
+
+class _StubTracker:
+    """Captures every adapter call so tests can assert on them."""
+
+    kind = "linear"
+
+    def __init__(self, anchor=None) -> None:
+        self.anchor = anchor
+        self.update_calls: list[dict] = []
+        self.transition_calls: list[dict] = []
+        self.anchor_calls: list[str] = []
+
+    async def update_ticket(self, ref, *, title=None, body=None, labels=None):
+        self.update_calls.append(
+            {
+                "ref_id": ref.id,
+                "title": title,
+                "body": body,
+                "labels": labels,
+            }
+        )
+
+    async def transition(self, ref, *, to_state):
+        self.transition_calls.append(
+            {"ref_id": ref.id, "to_state": to_state}
+        )
+
+    async def get_planning_anchor(self, project_id):
+        self.anchor_calls.append(project_id)
+        return self.anchor
+
+
+def _patch_tracker(toolbox, monkeypatch, stub: _StubTracker) -> None:
+    async def _stub_resolve(_self, _kind, _hint):
+        return stub
+
+    monkeypatch.setattr(
+        type(toolbox), "_resolve_tracker", _stub_resolve, raising=True
+    )
+
+
+# ---------------------------------------------------------------------------
+# update_ticket
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_update_ticket_combines_metadata_and_state(
+    toolbox, monkeypatch, db_session, seed_workspace
+) -> None:
+    from sqlalchemy import select
+
+    from backend.app.db.models.tenancy import AuditLog
+
+    _, _, workspace = seed_workspace
+    stub = _StubTracker()
+    _patch_tracker(toolbox, monkeypatch, stub)
+
+    raw = await toolbox._tool_update_ticket(
+        {
+            "ticket_ref": "ELS-99",
+            "title": "Fixed title",
+            "body": "Updated body",
+            "labels": ["bug", "p2"],
+            "state": "Done",
+        }
+    )
+    payload = json.loads(raw)
+    assert payload["ticket_ref"] == "ELS-99"
+    assert "title" in payload["actions"]
+    assert "body" in payload["actions"]
+    assert "state:Done" in payload["actions"]
+
+    # One update call covers title/body/labels; one transition call for state.
+    assert len(stub.update_calls) == 1
+    call = stub.update_calls[0]
+    assert call["title"] == "Fixed title"
+    assert call["body"] == "Updated body"
+    assert call["labels"] == ["bug", "p2"]
+    assert len(stub.transition_calls) == 1
+    assert stub.transition_calls[0]["to_state"] == "Done"
+
+    # Audit row landed.
+    rows = (
+        await db_session.execute(
+            select(AuditLog).where(
+                AuditLog.workspace_id == workspace.id,
+                AuditLog.action == "navigator.update_ticket",
+            )
+        )
+    ).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].target_id == "ELS-99"
+
+
+@pytest.mark.asyncio
+async def test_update_ticket_state_only_skips_metadata_call(
+    toolbox, monkeypatch
+) -> None:
+    """A call with only ``state`` triggers the transition but NOT the
+    metadata-update call — saves a round-trip when the agent just
+    wants to close a ticket."""
+    stub = _StubTracker()
+    _patch_tracker(toolbox, monkeypatch, stub)
+
+    raw = await toolbox._tool_update_ticket(
+        {"ticket_ref": "ELS-1", "state": "Canceled"}
+    )
+    payload = json.loads(raw)
+    assert payload["actions"] == ["state:Canceled"]
+    assert stub.update_calls == []
+    assert len(stub.transition_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_update_ticket_rejects_empty_call(toolbox) -> None:
+    from backend.app.services.agent.tools import ToolInvocationError
+
+    with pytest.raises(
+        ToolInvocationError, match="at least one of title"
+    ):
+        await toolbox._tool_update_ticket({"ticket_ref": "ELS-1"})
+
+
+@pytest.mark.asyncio
+async def test_update_ticket_rejects_bad_label_type(
+    toolbox, monkeypatch
+) -> None:
+    from backend.app.services.agent.tools import ToolInvocationError
+
+    _patch_tracker(toolbox, monkeypatch, _StubTracker())
+
+    with pytest.raises(
+        ToolInvocationError, match="labels must be a list of strings"
+    ):
+        await toolbox._tool_update_ticket(
+            {"ticket_ref": "ELS-1", "labels": [1, 2, 3]}
+        )
+
+
+# ---------------------------------------------------------------------------
+# set_priority_state
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_set_priority_state_creates_row_when_missing(
+    toolbox, db_session, seed_workspace
+) -> None:
+    from sqlalchemy import select
+
+    from backend.app.db.models.dashboard_priorities import (
+        WorkspaceProjectPriority,
+    )
+    from backend.app.db.models.tenancy import AuditLog
+
+    _, _, workspace = seed_workspace
+
+    raw = await toolbox._tool_set_priority_state(
+        {"project_native_id": "proj-new", "state": "planning"}
+    )
+    payload = json.loads(raw)
+    assert payload["project_native_id"] == "proj-new"
+    assert payload["state"] == "planning"
+    assert payload["prior_state"] is None
+
+    rows = (
+        await db_session.execute(
+            select(WorkspaceProjectPriority).where(
+                WorkspaceProjectPriority.workspace_id == workspace.id
+            )
+        )
+    ).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].project_native_id == "proj-new"
+    assert rows[0].state == "planning"
+    assert rows[0].ordinal == 0  # MAX+1 of an empty workspace = 0
+
+    audit = (
+        await db_session.execute(
+            select(AuditLog).where(
+                AuditLog.workspace_id == workspace.id,
+                AuditLog.action == "navigator.set_priority_state",
+            )
+        )
+    ).scalars().all()
+    assert len(audit) == 1
+    assert audit[0].payload["created_row"] is True
+
+
+@pytest.mark.asyncio
+async def test_set_priority_state_updates_existing_in_place(
+    toolbox, db_session, seed_workspace
+) -> None:
+    from sqlalchemy import select
+
+    from backend.app.db.models.dashboard_priorities import (
+        WorkspaceProjectPriority,
+    )
+
+    _, _, workspace = seed_workspace
+    db_session.add(
+        WorkspaceProjectPriority(
+            workspace_id=workspace.id,
+            project_native_id="proj-x",
+            ordinal=5,
+            state="active",
+        )
+    )
+    await db_session.flush()
+
+    raw = await toolbox._tool_set_priority_state(
+        {"project_native_id": "proj-x", "state": "parked"}
+    )
+    payload = json.loads(raw)
+    assert payload["state"] == "parked"
+    assert payload["prior_state"] == "active"
+
+    rows = (
+        await db_session.execute(
+            select(WorkspaceProjectPriority).where(
+                WorkspaceProjectPriority.workspace_id == workspace.id
+            )
+        )
+    ).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].ordinal == 5  # ordinal unchanged
+    assert rows[0].state == "parked"
+
+
+@pytest.mark.asyncio
+async def test_set_priority_state_validates_enum(toolbox) -> None:
+    from backend.app.services.agent.tools import ToolInvocationError
+
+    with pytest.raises(
+        ToolInvocationError, match="state must be one of"
+    ):
+        await toolbox._tool_set_priority_state(
+            {"project_native_id": "p", "state": "shipped"}
+        )
+
+
+# ---------------------------------------------------------------------------
+# start_decomposition
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_start_decomposition_transitions_anchor_to_wbs(
+    toolbox, monkeypatch, db_session, seed_workspace
+) -> None:
+    from sqlalchemy import select
+
+    from backend.app.db.models.dashboard_priorities import (
+        WorkspaceProjectPriority,
+    )
+    from backend.app.db.models.tenancy import AuditLog
+
+    _, _, workspace = seed_workspace
+    db_session.add(
+        WorkspaceProjectPriority(
+            workspace_id=workspace.id,
+            project_native_id="proj-drafted",
+            ordinal=0,
+            state="planning",
+        )
+    )
+    await db_session.flush()
+
+    stub = _StubTracker(
+        anchor={
+            "id": "anchor-uuid",
+            "identifier": "ELS-101",
+            "url": "https://linear.app/elship/issue/ELS-101",
+            "state": "Backlog",
+        }
+    )
+    _patch_tracker(toolbox, monkeypatch, stub)
+
+    raw = await toolbox._tool_start_decomposition(
+        {"project_native_id": "proj-drafted"}
+    )
+    payload = json.loads(raw)
+    assert payload["anchor_issue_id"] == "anchor-uuid"
+    assert payload["anchor_identifier"] == "ELS-101"
+    assert payload["process"] == "decomposition"
+
+    # Anchor probed; transition fired with stage:wbs.
+    assert stub.anchor_calls == ["proj-drafted"]
+    assert len(stub.transition_calls) == 1
+    assert stub.transition_calls[0]["to_state"] == "wbs"
+    assert stub.transition_calls[0]["ref_id"] == "anchor-uuid"
+
+    audit = (
+        await db_session.execute(
+            select(AuditLog).where(
+                AuditLog.workspace_id == workspace.id,
+                AuditLog.action == "navigator.start_decomposition",
+            )
+        )
+    ).scalars().all()
+    assert len(audit) == 1
+
+
+@pytest.mark.asyncio
+async def test_start_decomposition_rejects_non_drafts(
+    toolbox, monkeypatch, db_session, seed_workspace
+) -> None:
+    """A project in Active or Parked must NOT hand off — only Drafts.
+    The tool refuses with a clear message so the agent can phrase a
+    useful response instead of silently leaving the project in a
+    half-state."""
+    from backend.app.db.models.dashboard_priorities import (
+        WorkspaceProjectPriority,
+    )
+    from backend.app.services.agent.tools import ToolInvocationError
+
+    _, _, workspace = seed_workspace
+    db_session.add(
+        WorkspaceProjectPriority(
+            workspace_id=workspace.id,
+            project_native_id="proj-active",
+            ordinal=0,
+            state="active",
+        )
+    )
+    await db_session.flush()
+    _patch_tracker(toolbox, monkeypatch, _StubTracker())
+
+    with pytest.raises(ToolInvocationError, match="only Drafts"):
+        await toolbox._tool_start_decomposition(
+            {"project_native_id": "proj-active"}
+        )
+
+
+@pytest.mark.asyncio
+async def test_start_decomposition_404s_when_not_on_priorities(
+    toolbox, monkeypatch
+) -> None:
+    from backend.app.services.agent.tools import ToolInvocationError
+
+    _patch_tracker(toolbox, monkeypatch, _StubTracker())
+    with pytest.raises(ToolInvocationError, match="not on the dashboard"):
+        await toolbox._tool_start_decomposition(
+            {"project_native_id": "proj-missing"}
+        )
+
+
+@pytest.mark.asyncio
+async def test_start_decomposition_404s_when_anchor_missing(
+    toolbox, monkeypatch, db_session, seed_workspace
+) -> None:
+    """Project predates the drafting flow (no anchor minted on
+    create) — refuse and tell the agent why."""
+    from backend.app.db.models.dashboard_priorities import (
+        WorkspaceProjectPriority,
+    )
+    from backend.app.services.agent.tools import ToolInvocationError
+
+    _, _, workspace = seed_workspace
+    db_session.add(
+        WorkspaceProjectPriority(
+            workspace_id=workspace.id,
+            project_native_id="proj-no-anchor",
+            ordinal=0,
+            state="planning",
+        )
+    )
+    await db_session.flush()
+    _patch_tracker(toolbox, monkeypatch, _StubTracker(anchor=None))
+
+    with pytest.raises(ToolInvocationError, match="no planning anchor"):
+        await toolbox._tool_start_decomposition(
+            {"project_native_id": "proj-no-anchor"}
+        )

--- a/backend/tests/test_navigator_tool_inventory.py
+++ b/backend/tests/test_navigator_tool_inventory.py
@@ -74,6 +74,9 @@ EXPECTED_TOOLS: frozenset[str] = frozenset(
         "run_detail",
         "runs_query",
         "search_code",
+        "set_priority_state",
+        "start_decomposition",
+        "update_ticket",
         "workspace_audit_search",
     }
 )


### PR DESCRIPTION
Final half of [ELS-78](https://linear.app/elship/issue/ELS-78) and the Navigator tool review trilogy. PR-A (#157) dropped 4 redundant tools. PR-B (#158) consolidated 6 → 3. PR-C1 (#160) added 3 read-only tools. This adds the 3 mutating tools and closes the review.

## What's added

| Tool | Why |
|---|---|
| ``update_ticket(ticket_ref, title?, body?, labels?, state?)`` | Today the agent can ``create_ticket`` but not modify. User has to leave Navigator to fix a typo or close a ticket. |
| ``set_priority_state(project_native_id, state)`` | Move a project between Active / Drafts / Parked buckets. Endpoint exists from project-first delivery PR3 (#145); Navigator just couldn't reach it. |
| ``start_decomposition(project_native_id)`` | Kick off the decomposition pipeline. Endpoint exists from #145; Navigator just couldn't reach it. |

## Adapter additions

New ``LinearTracker.update_ticket(ref, title?, body?, labels?)`` method — single ``issueUpdate`` GraphQL covers all three fields in one round-trip. ``labels`` is a **FULL replacement set** (not add/remove) — Linear's ``issueUpdate`` with ``labelIds`` overwrites the entire list. The tool's spec documents the semantic explicitly.

## Admin gating

All three tools are admin-gated via ``_require_workspace_role(ROLES_ADMIN)`` — same gate as the corresponding HTTP endpoints. The seeded ``navigator-admin-only-mutators`` policy (read by every Navigator turn) gains the three new tool names so the **Verify before mutate** rule (PR2 of the agentic prompt overhaul) keeps gating them on ``ship-choice`` confirmation. ``test_admin_mutating_tools_in_prompt_match_registry`` enforces no drift between policy text and registry.

## Audit log

Every call drops a row:
- ``navigator.update_ticket`` with target_id = ticket ref, payload includes which fields changed.
- ``navigator.set_priority_state`` with target_id = project_native_id, payload includes prior state and whether a row was created.
- ``navigator.start_decomposition`` with target_id = project_native_id, payload includes anchor id + identifier.

Operators can answer "what did Navigator change?" from the audit page without scraping LLM logs.

## ``navigator.md`` updates

Scenario 1 (Planning) gains three rules at steps 7-9:
- ``update_ticket`` — verify-before-mutate, ``labels`` is FULL replacement set.
- ``set_priority_state`` — direct commands ("park this", "promote it") OK; ambiguous needs confirm.
- ``start_decomposition`` — strict verify-before-mutate, the chain runs autonomously.

## ``start_decomposition`` refusal contract

The tool refuses (raises ``ToolInvocationError`` with structured message) when:
1. Project not on dashboard priorities → "create_project or drag-in first"
2. Project not in Drafts (state=active|parked) → "only Drafts can hand off"
3. Tracker doesn't model anchors → "this tracker does not model planning anchors"
4. Project has no anchor → "was it created via the drafting flow?"

The agent gets a clear failure mode, not a half-state. State 2 is intentional — Active or Parked projects require an explicit ``set_priority_state`` move to Drafts first; the agent can't accidentally restart a project that was deliberately held.

## Test plan

- [x] **17/17 non-DB tests green** (``test_navigator_tool_inventory``, ``test_navigator_prompt_agentic``).
- [x] AST + smoke check on the toolbox.
- [x] New test file ``test_navigator_mutating_tools.py`` — 11 tests covering: update_ticket combined metadata+state, state-only path skips metadata, empty-call rejection, label type validation; set_priority_state creates row at MAX+1, updates in place preserving ordinal, enum validation; start_decomposition happy path with audit row, refuses non-Drafts state, refuses missing priorities row, refuses missing anchor. **DB-backed; will run in CI.**

## Final accounting

```
48 (pre-PR-A)
→ 44 (PR-A: drop 4 redundant)
→ 40 (PR-B: consolidate 3 search → 1, drop 2 pipelines)
→ 43 (PR-C1: add 3 read-only)
→ 46 (PR-C2: add 3 mutating)
```

Closes ELS-78 and the Navigator overhaul project.