### PR TITLE
fix: reconciler handles real pgvector embeddings (numpy + binary codec)

### DIFF
--- a/backend/app/services/knowledge_reconciler.py
+++ b/backend/app/services/knowledge_reconciler.py
@@ -59,7 +59,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any
 
-from sqlalchemy import select, text
+from sqlalchemy import and_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.app.core.config import Settings, get_settings
@@ -188,34 +188,40 @@ async def _nearest_active_claims(
     distance``. We compute it inline so the caller compares against
     intuitive thresholds without re-deriving the algebra.
     """
-    rows = (
-        await session.execute(
-            text(
-                """
-                SELECT id, claim_md, 1 - (embedding <=> :q) AS similarity
-                FROM knowledge_claim
-                WHERE workspace_id = :ws
-                  AND status = :active
-                  AND embedding IS NOT NULL
-                  AND id <> :self_id
-                ORDER BY embedding <=> :q
-                LIMIT :k
-                """
-            ),
-            {
-                "q": str(embedding),
-                "ws": str(workspace_id),
-                "self_id": str(self_claim_id),
-                "active": ClaimStatus.ACTIVE,
-                "k": k,
-            },
+    # Going through SQLAlchemy ORM so the pgvector dialect serialises
+    # the query embedding properly. The previous raw-SQL form
+    # interpolated ``str(embedding)`` into ``:q`` — pgvector returns
+    # the column as ``numpy.ndarray``, whose ``__str__`` produces
+    # space-separated values (``[-0.0045 0.0942 …]``), which pgvector's
+    # text input parser rejects (``invalid input syntax for type
+    # vector``). The ORM path uses the proper binary ``Vector`` codec.
+    query_vec = (
+        embedding.tolist() if hasattr(embedding, "tolist") else list(embedding)
+    )
+    distance = KnowledgeClaim.embedding.cosine_distance(query_vec).label("dist")
+    stmt = (
+        select(
+            KnowledgeClaim.id,
+            KnowledgeClaim.claim_md,
+            distance,
         )
-    ).all()
+        .where(
+            and_(
+                KnowledgeClaim.workspace_id == workspace_id,
+                KnowledgeClaim.status == ClaimStatus.ACTIVE,
+                KnowledgeClaim.embedding.is_not(None),
+                KnowledgeClaim.id != self_claim_id,
+            )
+        )
+        .order_by("dist")
+        .limit(k)
+    )
+    rows = (await session.execute(stmt)).all()
     return [
         _NearestRow(
             claim_id=row[0],
             claim_md=row[1],
-            similarity=float(row[2]),
+            similarity=1.0 - float(row[2]),
         )
         for row in rows
     ]
@@ -385,12 +391,21 @@ async def reconcile_claim(
     report = ReconcileReport(claim_id=claim.id)
     now = datetime.now(timezone.utc)
 
-    if not claim.embedding:
+    if claim.embedding is None:
         # Embedding step in P1 was best-effort. A claim without one
         # can't participate in nearest-neighbour search, so we mark
         # it reconciled (no near-match) and move on. The next
         # extractor pass on a re-pulled doc will get another shot
         # at the embedding service.
+        #
+        # Note: must be ``is None``, not ``not claim.embedding`` —
+        # pgvector returns the column as a numpy ``ndarray`` and
+        # ``bool(ndarray)`` raises ``ValueError`` on multi-element
+        # arrays. The unit-test fakes used Python lists, which is why
+        # this slipped through review for half a day in prod (every
+        # reconciler tick crashed on the first claim and rolled back
+        # the whole batch — silent, because the per-workspace ``try``
+        # in the cron tick swallowed it).
         claim.reconciled_at = now
         report.decision = "no_match"
         return report
@@ -505,7 +520,7 @@ async def reconcile_pending_workspace(
     report.inspected = len(rows)
 
     for claim in rows:
-        if not claim.embedding:
+        if claim.embedding is None:
             claim.reconciled_at = datetime.now(timezone.utc)
             report.skipped_no_embedding += 1
             continue

--- a/backend/tests/test_services_knowledge_reconciler.py
+++ b/backend/tests/test_services_knowledge_reconciler.py
@@ -270,6 +270,46 @@ async def test_no_embedding_marks_no_match_without_query(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_numpy_array_embedding_does_not_short_circuit(monkeypatch):
+    """pgvector returns the column as a ``numpy.ndarray``; ``not arr``
+    raises ``ValueError: ambiguous truth value`` on multi-element
+    arrays. The reconciler must use ``is None`` instead of truthiness
+    so prod claims (real ndarray) reach the nearest-neighbour path
+    instead of crashing the whole batch.
+
+    Prod incident 2026-05-06: every reconciler tick after the first
+    extractor flush silently rolled back on the first claim because
+    the truthiness check tripped this; 488 claims sat unreconciled
+    for an hour. Test guards against the regression.
+    """
+    import numpy as np
+
+    new = _FakeClaim(embedding=np.array([0.1] * 8))
+    ws = new.workspace_id
+    existing = _seed_claim(workspace_id=ws)
+    _patch_nearest(
+        monkeypatch,
+        [
+            recon._NearestRow(
+                claim_id=existing.id,
+                similarity=0.97,
+                claim_md=existing.claim_md,
+            )
+        ],
+    )
+    session = _FakeSession(claim_by_id={existing.id: existing})
+
+    # If the truthiness check still fires, this raises ValueError
+    # before we get to the assertion.
+    report = await recon.reconcile_claim(
+        session, claim=new, llm_client=None
+    )
+
+    assert report.decision == "duplicate"
+    assert new.reconciled_at is not None
+
+
+@pytest.mark.asyncio
 async def test_below_judge_threshold_is_no_match(monkeypatch):
     """sim < 0.85 means no near-match — leave the claim alone."""
     ws = uuid.uuid4()


### PR DESCRIPTION
## Summary

Two bugs that only surfaced once 488 real claims with real pgvector embeddings hit the reconciler tick. Both crashed before the first row could be reconciled, so every tick rolled back silently via the per-workspace ``try/except`` in ``_knowledge_claim_reconcile_tick``. Net effect: 488 claims sat with ``reconciled_at IS NULL`` for hours while the cron fired uselessly every 20 minutes.

### Bug 1 — ``not claim.embedding`` on a numpy ndarray

pgvector-sqlalchemy returns ``Vector`` columns as ``numpy.ndarray``. ``not arr`` raises ``ValueError: The truth value of an array with more than one element is ambiguous``. Unit tests passed because the fakes used Python lists, where ``not list`` works as intended.

Fix: ``if claim.embedding is None``.

### Bug 2 — raw SQL with ``str(numpy.ndarray)`` interpolation

``_nearest_active_claims`` passed ``str(embedding)`` into the ``:q`` text parameter. ndarray's ``__str__`` produces ``[-0.0045  0.0942  0.0244 …]`` — space-separated, no commas, with internal newlines. pgvector's input parser rejects that shape with ``invalid input syntax for type vector``.

Fix: replace the raw ``text()`` query with a SQLAlchemy ORM select that uses ``KnowledgeClaim.embedding.cosine_distance(query_vec)``, matching the pattern already in ``knowledge_search._vector_search``. The ORM path goes through pgvector's binary codec, so the embedding serialises correctly regardless of whether the input is a list or ndarray.

## Test plan

- [x] ``pytest backend/tests/test_services_knowledge_reconciler.py`` — 10/10 (9 prior + 1 new regression: feed ``np.ndarray`` to ``reconcile_claim`` and assert the duplicate fast-path fires, which only happens if the truthiness check + the nearest-neighbour query both succeed)
- [x] Verified against prod state: ``reconcile_pending_workspace`` runs end-to-end on 5 real Ship-workspace claims without raising
- [ ] CI: full backend suite
- [ ] Post-deploy: ``knowledge_claim.reconciled_at`` count should grow on each ``5,25,45 * * * *`` tick. Expect first ``superseded`` rows to appear once dedup spots near-text matches in the Ship workspace