### PR TITLE
console: knowledge index reads claim-graph topic views, drops legacy buckets

### DIFF
--- a/console/src/app/(authed)/knowledge/knowledge-control-center.tsx
+++ b/console/src/app/(authed)/knowledge/knowledge-control-center.tsx
@@ -40,23 +40,12 @@ import { archiveImportSourceAction } from "./actions";
 import { KnowledgeImportWizard } from "./import-wizard";
 
 
-export type KnowledgeBucketRow = {
-  id: string;
-  slug: string;
-  name: string;
-  description: string;
-  archived: boolean;
-  articleCount: number;
-};
-
-export type KnowledgeArticleRow = {
-  id: string;
-  bucketSlug: string;
-  bucketName: string;
-  slug: string;
+export type KnowledgeTopicViewRow = {
+  topicTag: string;
   title: string;
-  snippet: string;
-  updatedAt: string;
+  claimCount: number;
+  renderedByModel: string | null;
+  lastRenderedAt: string;
 };
 
 export type KnowledgeSourceRow = {
@@ -70,8 +59,7 @@ export type KnowledgeSourceRow = {
 
 type Props = {
   workspace: { id?: string; slug: string; name: string };
-  buckets: KnowledgeBucketRow[];
-  articles: KnowledgeArticleRow[];
+  topicViews: KnowledgeTopicViewRow[];
   sources: KnowledgeSourceRow[];
   repos: ApiActivatedRepo[];
   integrations: ApiIntegration[];
@@ -80,8 +68,7 @@ type Props = {
 
 export function KnowledgeControlCenter({
   workspace,
-  buckets,
-  articles,
+  topicViews,
   sources,
   repos,
   integrations,
@@ -139,10 +126,7 @@ export function KnowledgeControlCenter({
     setSearchError(null);
   }
 
-  const liveBuckets = buckets.filter((b) => !b.archived);
   const isSearching = searchHits !== null;
-  const lede = articles[0] ?? null;
-  const rest = articles.slice(1);
 
   return (
     <div className="mx-auto max-w-6xl space-y-12 2xl:max-w-screen-2xl">
@@ -173,41 +157,91 @@ export function KnowledgeControlCenter({
         <SearchResults hits={searchHits ?? []} queriedFor={searchedFor} />
       ) : (
         <div className="grid grid-cols-1 gap-x-12 gap-y-12 lg:grid-cols-12 2xl:gap-x-16">
-          <section className="space-y-8 lg:col-span-8 2xl:col-span-7">
-            <SectionKicker tone="aqua">Recent</SectionKicker>
-            {lede ? (
-              <>
-                <LedeArticle article={lede} />
-                {rest.length > 0 && (
-                  <ul className="divide-y divide-white/5">
-                    {rest.map((article) => (
-                      <li key={article.id} className="py-5 first:pt-6">
-                        <ArticleRow article={article} showBucket />
-                      </li>
-                    ))}
-                  </ul>
-                )}
-              </>
+          <section className="space-y-8 lg:col-span-8 2xl:col-span-9">
+            <SectionKicker tone="aqua">
+              Topics
+              {topicViews.length > 0 && (
+                <span className="ml-2 text-white/40">
+                  · {topicViews.length}
+                </span>
+              )}
+            </SectionKicker>
+            {topicViews.length === 0 ? (
+              <EmptyTopics hasSources={sources.length > 0} />
             ) : (
-              <p className="text-sm text-white/55">
-                No articles in this workspace yet. Connect an import source or
-                wait for the harvester to surface drafts.
-              </p>
+              <ul className="divide-y divide-white/5">
+                {topicViews.map((view) => (
+                  <li key={view.topicTag} className="py-5 first:pt-6">
+                    <TopicViewRow view={view} />
+                  </li>
+                ))}
+              </ul>
             )}
           </section>
 
-          <aside className="space-y-6 lg:col-span-4 lg:sticky lg:top-24 lg:self-start 2xl:col-span-3">
-            <SectionKicker tone="lilac">Browse by area</SectionKicker>
-            <BucketDirectory buckets={liveBuckets} />
-          </aside>
-
           {sources.length > 0 && (
-            <section className="space-y-3 lg:col-span-12 2xl:col-span-2 2xl:sticky 2xl:top-24 2xl:self-start">
+            <aside className="space-y-3 lg:col-span-4 lg:sticky lg:top-24 lg:self-start 2xl:col-span-3">
               <SectionKicker tone="muted">Sources</SectionKicker>
               <ConnectedSources sources={sources} />
-            </section>
+            </aside>
           )}
         </div>
+      )}
+    </div>
+  );
+}
+
+
+function TopicViewRow({ view }: { view: KnowledgeTopicViewRow }) {
+  const isAuto = view.renderedByModel && view.renderedByModel !== "deterministic";
+  return (
+    <Link
+      href={`/knowledge/topics/${encodeURIComponent(view.topicTag)}`}
+      className="group block"
+    >
+      <h3 className="text-base font-medium text-white transition-colors group-hover:text-aqua">
+        {view.title}
+      </h3>
+      <p className="mt-1 text-xs text-white/45">
+        <span className="font-mono">{view.topicTag}</span>
+        <span className="mx-2">·</span>
+        <span>
+          {view.claimCount} claim{view.claimCount === 1 ? "" : "s"}
+        </span>
+        <span className="mx-2">·</span>
+        <span>{relativeDate(view.lastRenderedAt)}</span>
+        {!isAuto && (
+          <>
+            <span className="mx-2">·</span>
+            <span className="text-coral/70">deterministic fallback</span>
+          </>
+        )}
+      </p>
+    </Link>
+  );
+}
+
+
+function EmptyTopics({ hasSources }: { hasSources: boolean }) {
+  return (
+    <div className="space-y-3 text-sm text-white/55">
+      <p>
+        No topics rendered yet. The claim-graph pipeline groups extracted
+        atomic facts by ``topic_tag`` once at least three claims land per
+        topic.
+      </p>
+      {!hasSources ? (
+        <p>
+          Connect an import source (top right) so the extractor has
+          something to read.
+        </p>
+      ) : (
+        <p>
+          Sources are connected — wait for the next ``*/20`` extractor tick
+          and the ``15,45`` topic-render tick. If nothing appears within
+          an hour, the pipeline is broken upstream and you should ping
+          ops.
+        </p>
       )}
     </div>
   );
@@ -283,105 +317,6 @@ function SearchHeader({
         )}
       </div>
     </div>
-  );
-}
-
-
-// ---------------------------------------------------------------------------
-// Recent — lede + rows
-// ---------------------------------------------------------------------------
-
-
-function LedeArticle({ article }: { article: KnowledgeArticleRow }) {
-  return (
-    <Link
-      href={`/knowledge/${encodeURIComponent(article.bucketSlug)}?article=${encodeURIComponent(article.id)}`}
-      className="group block space-y-3 border-b border-aqua/30 pb-8"
-    >
-      <h3 className="font-display text-2xl font-bold leading-tight text-white group-hover:text-aqua md:text-3xl">
-        {article.title}
-      </h3>
-      {article.snippet && (
-        <p className="line-clamp-3 text-base leading-relaxed text-white/65">
-          {article.snippet}
-        </p>
-      )}
-      <p className="flex items-center gap-2 text-[11px] uppercase tracking-widest text-white/40">
-        <span>{article.bucketName}</span>
-        <span className="text-white/20">·</span>
-        <span>{relativeDate(article.updatedAt)}</span>
-      </p>
-    </Link>
-  );
-}
-
-
-function ArticleRow({
-  article,
-  showBucket,
-}: {
-  article: KnowledgeArticleRow;
-  showBucket?: boolean;
-}) {
-  return (
-    <Link
-      href={`/knowledge/${encodeURIComponent(article.bucketSlug)}?article=${encodeURIComponent(article.id)}`}
-      className="group block space-y-1.5"
-    >
-      <div className="text-base font-semibold text-white group-hover:text-aqua">
-        {article.title}
-      </div>
-      {article.snippet && (
-        <p className="line-clamp-2 text-sm leading-relaxed text-white/55">
-          {article.snippet}
-        </p>
-      )}
-      <div className="text-[11px] text-white/40">
-        {showBucket && (
-          <>
-            <span>{article.bucketName}</span>
-            <span className="mx-2 text-white/20">·</span>
-          </>
-        )}
-        <span>{relativeDate(article.updatedAt)}</span>
-      </div>
-    </Link>
-  );
-}
-
-
-// ---------------------------------------------------------------------------
-// Browse by area — bucket directory
-// ---------------------------------------------------------------------------
-
-
-function BucketDirectory({ buckets }: { buckets: KnowledgeBucketRow[] }) {
-  if (buckets.length === 0) return null;
-  return (
-    <ul className="divide-y divide-white/5">
-      {buckets.map((bucket) => (
-        <li key={bucket.slug}>
-          <Link
-            href={`/knowledge/${encodeURIComponent(bucket.slug)}`}
-            className="group flex items-baseline justify-between gap-3 py-3"
-          >
-            <div className="min-w-0 flex-1">
-              <div className="font-display text-sm font-bold uppercase tracking-wider text-white/85 group-hover:text-lilac">
-                {bucket.name}
-              </div>
-              {bucket.description && (
-                <p className="mt-1 line-clamp-1 text-xs text-white/45">
-                  {bucket.description}
-                </p>
-              )}
-            </div>
-            <span className="shrink-0 font-mono text-xs text-white/35">
-              {bucket.articleCount}
-            </span>
-          </Link>
-        </li>
-      ))}
-    </ul>
   );
 }
 

--- a/console/src/app/(authed)/knowledge/page.tsx
+++ b/console/src/app/(authed)/knowledge/page.tsx
@@ -5,13 +5,11 @@ import { PageBody, PageHeader } from "@/components/app-shell";
 import { ScopePill } from "@/components/scope-pill";
 import {
   type ApiActivatedRepo,
-  type ApiBucket,
   ApiHttpError,
   listActivatedRepos,
-  listBucketArticles,
   listIntegrations,
   listKnowledgeImportSources,
-  listBuckets,
+  listTopicViews,
 } from "@/lib/api/client";
 import {
   getCachedMe,
@@ -21,24 +19,21 @@ import {
 import { getResolvedWorkspaceId } from "@/lib/workspace-resolve.server";
 import { pickWorkspace } from "@/lib/workspace-scope";
 import type {
-  ApiBucketArticle,
   ApiIntegration,
   ApiKnowledgeImportSource,
 } from "@/lib/api/types";
 
 import {
   KnowledgeControlCenter,
-  type KnowledgeArticleRow,
-  type KnowledgeBucketRow,
   type KnowledgeSourceRow,
+  type KnowledgeTopicViewRow,
 } from "./knowledge-control-center";
 
 export const dynamic = "force-dynamic";
 
 type LiveData = {
   workspace: { id: string; slug: string; name: string };
-  buckets: KnowledgeBucketRow[];
-  articles: KnowledgeArticleRow[];
+  topicViews: KnowledgeTopicViewRow[];
   sources: KnowledgeSourceRow[];
   repos: ApiActivatedRepo[];
   integrations: ApiIntegration[];
@@ -65,47 +60,26 @@ async function load(
   const workspace = pickWorkspace(workspaceRows, resolved);
 
   try {
-    const [repos, integrations, me, rawBuckets, importSources] =
+    // Knowledge index reads the claim-graph canon directly. Legacy
+    // ``bucket_articles`` are intentionally NOT fetched here: keeping
+    // them on the page masks pipeline failures (operator sees stale
+    // articles from days ago and assumes the system is fine while
+    // the new extractor / reconciler / renderer chain has been
+    // silently broken). If the canon is empty, the page should look
+    // empty — that's the signal that something upstream needs
+    // attention.
+    const [repos, integrations, me, rawTopicViews, importSources] =
       await Promise.all([
         listActivatedRepos(workspace.id, token).catch(() => [] as ApiActivatedRepo[]),
         listIntegrations(workspace.id, token).catch(() => [] as ApiIntegration[]),
         getCachedMe(),
-        listBuckets(workspace.id, { token }),
+        listTopicViews(workspace.id, { limit: 200 }, token),
         listKnowledgeImportSources(workspace.id, token).catch(
           () => [] as ApiKnowledgeImportSource[],
         ),
       ]);
 
-    // Fetch the published-and-fresh article set for every bucket in
-    // parallel. Six fixed buckets after the consolidation, so this is
-    // a bounded fan-out — no pagination needed in the UI surface.
-    const articlePairs = await Promise.all(
-      rawBuckets.map(async (bucket) => ({
-        bucket,
-        articles: await listBucketArticles(
-          workspace.id,
-          bucket.slug,
-          {},
-          token,
-        ).catch(() => [] as ApiBucketArticle[]),
-      })),
-    );
-
-    // Per-bucket counts feed the "Browse by area" list; flat
-    // top-N (sorted by updated_at) feeds the "Recent" section.
-    const articleCounts = new Map<string, number>();
-    for (const { bucket, articles } of articlePairs) {
-      articleCounts.set(bucket.slug, articles.length);
-    }
-    const buckets: KnowledgeBucketRow[] = rawBuckets.map((bucket) =>
-      toBucketRow(bucket, articleCounts.get(bucket.slug) ?? 0),
-    );
-    const articles: KnowledgeArticleRow[] = articlePairs
-      .flatMap(({ bucket, articles }) =>
-        articles.map((article) => toArticleRow(article, bucket)),
-      )
-      .sort((a, b) => Date.parse(b.updatedAt) - Date.parse(a.updatedAt))
-      .slice(0, 10);
+    const topicViews: KnowledgeTopicViewRow[] = rawTopicViews.map(toTopicViewRow);
     const sources: KnowledgeSourceRow[] = importSources.map(toSourceRow);
 
     return {
@@ -116,8 +90,7 @@ async function load(
           slug: workspace.slug,
           name: workspace.name,
         },
-        buckets,
-        articles,
+        topicViews,
         sources,
         repos,
         integrations,
@@ -153,7 +126,7 @@ export default async function KnowledgeIndexPage({
     );
   }
 
-  const { workspace, buckets, articles, sources, repos, integrations, me } =
+  const { workspace, topicViews, sources, repos, integrations, me } =
     result.data;
 
   const scopePill = (
@@ -181,8 +154,7 @@ export default async function KnowledgeIndexPage({
       <PageBody>
         <KnowledgeControlCenter
           workspace={workspace}
-          buckets={buckets}
-          articles={articles}
+          topicViews={topicViews}
           sources={sources}
           repos={repos}
           integrations={integrations}
@@ -198,30 +170,15 @@ export default async function KnowledgeIndexPage({
 // ---------------------------------------------------------------------------
 
 
-function toBucketRow(bucket: ApiBucket, articleCount: number): KnowledgeBucketRow {
+function toTopicViewRow(
+  view: import("@/lib/api/client").ApiTopicViewSummary,
+): KnowledgeTopicViewRow {
   return {
-    id: bucket.id,
-    slug: bucket.slug,
-    name: bucket.name,
-    description: bucket.description ?? "",
-    archived: Boolean(bucket.archived_at),
-    articleCount,
-  };
-}
-
-
-function toArticleRow(
-  article: ApiBucketArticle,
-  bucket: ApiBucket,
-): KnowledgeArticleRow {
-  return {
-    id: article.id,
-    bucketSlug: bucket.slug,
-    bucketName: bucket.name,
-    slug: article.slug,
-    title: article.title || article.slug,
-    snippet: firstParagraph(article.body_md),
-    updatedAt: article.updated_at,
+    topicTag: view.topic_tag,
+    title: view.title || view.topic_tag,
+    claimCount: view.claim_count,
+    renderedByModel: view.rendered_by_model,
+    lastRenderedAt: view.last_rendered_at,
   };
 }
 
@@ -238,17 +195,3 @@ function toSourceRow(source: ApiKnowledgeImportSource): KnowledgeSourceRow {
 }
 
 
-function firstParagraph(body: string): string {
-  if (!body) return "";
-  const text = body.trim();
-  if (!text) return "";
-  for (const chunk of text.split("\n\n")) {
-    const candidate = chunk.replace(/^#+\s+/, "").trim();
-    if (candidate) {
-      return candidate.length > 220
-        ? candidate.slice(0, 219).trimEnd() + "…"
-        : candidate;
-    }
-  }
-  return text.length > 220 ? text.slice(0, 219).trimEnd() + "…" : text;
-}

--- a/console/src/lib/api/client.ts
+++ b/console/src/lib/api/client.ts
@@ -3155,6 +3155,32 @@ export async function listBucketArticles(
   return Array.isArray(payload) ? payload : [];
 }
 
+// --- Topic views (claim-graph canon, P3+P4) -------------------------------
+
+export type ApiTopicViewSummary = {
+  topic_tag: string;
+  title: string;
+  claim_count: number;
+  rendered_by_model: string | null;
+  last_rendered_at: string;
+  updated_at: string;
+};
+
+export async function listTopicViews(
+  workspaceId: string,
+  opts: { limit?: number } = {},
+  token?: string,
+): Promise<ApiTopicViewSummary[]> {
+  const qs = new URLSearchParams();
+  if (opts.limit) qs.set("limit", String(opts.limit));
+  const suffix = qs.size ? `?${qs.toString()}` : "";
+  const payload = await apiFetch<ApiTopicViewSummary[]>(
+    `/v1/workspaces/${workspaceId}/knowledge/topic-views${suffix}`,
+    { token },
+  );
+  return Array.isArray(payload) ? payload : [];
+}
+
 // --- API tokens ------------------------------------------------------------
 
 export function mintToken(


### PR DESCRIPTION
## Summary

The Knowledge page was still reading ``bucket_articles`` from the legacy synth pipeline. After the claim-graph rollout that meant the operator looked at days-old hand-curated articles while the new extractor / reconciler / renderer chain was silently broken upstream — pipeline failures became invisible because the page masked them with stale legacy content.

Strip the legacy paths. The index now fetches only ``GET /v1/workspaces/{ws}/knowledge/topic-views`` and renders that list. If the canon is empty, the page shows an explicit empty state instead of falling back to bucket_articles. **Pipeline failures now surface as an empty page** — exactly the signal we want.

### Surface changes

- "Recent" → "Topics", with a count chip (``Topics · 67``).
- "Browse by area" panel removed — topic views are multi-tag, single-bucket directory doesn't fit; the topic_tag itself acts as the grouping handle.
- Each row links to ``/knowledge/topics/<topic_tag>`` (route lands in a follow-up; URL is encoded for forward compat).
- Empty state instructs the operator: connect a source if none exist, otherwise wait + escalate if no topics within an hour.
- Rows rendered by the deterministic fallback (no LLM client at the time) display a coral ``deterministic fallback`` badge so a degraded canon is visible at a glance.

### Removed

- ``listBuckets`` / ``listBucketArticles`` calls from the page loader.
- ``KnowledgeBucketRow`` / ``KnowledgeArticleRow`` types, ``BucketDirectory`` / ``LedeArticle`` / ``ArticleRow`` components, ``firstParagraph`` snippet helper.

### What's NOT in this PR

- ``/knowledge/topics/<topic_tag>`` detail page — follow-up.
- Legacy bucket detail routes (``/knowledge/<slug>``) are orphans (no longer linked from index) but still functional. Retire after the topic detail page lands.

## Test plan

- [ ] CI: console build (typecheck + ESLint)
- [ ] Manual after deploy: Knowledge page on Ship workspace shows the 67 topic_views ordered by ``claim_count``, top entry is ``Security`` (36 claims). Pipeline failure scenarios show empty state instead of stale ``ADR: …`` articles.