### PR TITLE
knowledge: editorial layout for the topic-views index

### DIFF
--- a/backend/app/api/v1/routes/knowledge_canon.py
+++ b/backend/app/api/v1/routes/knowledge_canon.py
@@ -71,10 +71,18 @@ router = APIRouter(
 class TopicViewSummary(BaseModel):
     """List-view shape — body_md is intentionally omitted to keep the
     list response small. Operators paginate this; the agent's RAG
-    flow only ever wants the bodies of the topics it ranks first."""
+    flow only ever wants the bodies of the topics it ranks first.
+
+    A short ``snippet`` is included so the index UI can render an
+    editorial-style preview (lede + rows) without a follow-up
+    ``getTopicView`` per visible card. Truncated server-side to
+    ``_SNIPPET_MAX_CHARS`` so the JSON payload stays small even
+    when a workspace has hundreds of topics.
+    """
 
     topic_tag: str
     title: str
+    snippet: str | None
     claim_count: int
     rendered_by_model: str | None
     last_rendered_at: datetime
@@ -240,6 +248,7 @@ async def list_topic_views(
         TopicViewSummary(
             topic_tag=row.topic_tag,
             title=row.title,
+            snippet=_extract_snippet(row.body_md),
             claim_count=row.claim_count,
             rendered_by_model=row.rendered_by_model,
             last_rendered_at=row.last_rendered_at,
@@ -247,6 +256,43 @@ async def list_topic_views(
         )
         for row in rows
     ]
+
+
+_SNIPPET_MAX_CHARS = 220
+
+
+def _extract_snippet(body_md: str) -> str | None:
+    """First non-heading paragraph of the rendered body, capped at 220 chars.
+
+    The renderer's output starts with ``# <Title>``; we skip that and any
+    immediate ``##`` section headers, then return the first paragraph of
+    actual prose. Mirrors the Console's old ``firstParagraph`` helper so
+    the editorial layout has a consistent excerpt across topics rendered
+    by Haiku and topics rendered by the deterministic fallback.
+    """
+    if not body_md:
+        return None
+    for chunk in body_md.split("\n\n"):
+        stripped = chunk.strip()
+        if not stripped:
+            continue
+        # Skip headings (``# Title`` / ``## Section``) — we want prose.
+        if stripped.startswith("#"):
+            # Check if the chunk is heading-only (i.e. a single line)
+            # or heading + body collapsed. Headings on their own line
+            # have no following content in this chunk, so they get
+            # skipped. Mixed chunks fall through.
+            non_heading = "\n".join(
+                line for line in stripped.splitlines()
+                if not line.lstrip().startswith("#")
+            ).strip()
+            if not non_heading:
+                continue
+            stripped = non_heading
+        if len(stripped) > _SNIPPET_MAX_CHARS:
+            return stripped[: _SNIPPET_MAX_CHARS - 1].rstrip() + "…"
+        return stripped
+    return None
 
 
 @router.get("/topic-views/{topic_tag}", response_model=TopicViewDetail)

--- a/console/src/app/(authed)/knowledge/knowledge-control-center.tsx
+++ b/console/src/app/(authed)/knowledge/knowledge-control-center.tsx
@@ -43,6 +43,7 @@ import { KnowledgeImportWizard } from "./import-wizard";
 export type KnowledgeTopicViewRow = {
   topicTag: string;
   title: string;
+  snippet: string | null;
   claimCount: number;
   renderedByModel: string | null;
   lastRenderedAt: string;
@@ -155,69 +156,241 @@ export function KnowledgeControlCenter({
 
       {isSearching ? (
         <SearchResults hits={searchHits ?? []} queriedFor={searchedFor} />
+      ) : topicViews.length === 0 ? (
+        <EmptyTopics hasSources={sources.length > 0} />
       ) : (
-        <div className="grid grid-cols-1 gap-x-12 gap-y-12 lg:grid-cols-12 2xl:gap-x-16">
-          <section className="space-y-8 lg:col-span-8 2xl:col-span-9">
-            <SectionKicker tone="aqua">
-              Topics
-              {topicViews.length > 0 && (
-                <span className="ml-2 text-white/40">
-                  · {topicViews.length}
-                </span>
-              )}
-            </SectionKicker>
-            {topicViews.length === 0 ? (
-              <EmptyTopics hasSources={sources.length > 0} />
-            ) : (
-              <ul className="divide-y divide-white/5">
-                {topicViews.map((view) => (
-                  <li key={view.topicTag} className="py-5 first:pt-6">
-                    <TopicViewRow view={view} />
-                  </li>
-                ))}
-              </ul>
-            )}
-          </section>
-
-          {sources.length > 0 && (
-            <aside className="space-y-3 lg:col-span-4 lg:sticky lg:top-24 lg:self-start 2xl:col-span-3">
-              <SectionKicker tone="muted">Sources</SectionKicker>
-              <ConnectedSources sources={sources} />
-            </aside>
-          )}
-        </div>
+        <EditorialLayout topicViews={topicViews} sources={sources} />
       )}
     </div>
   );
 }
 
 
-function TopicViewRow({ view }: { view: KnowledgeTopicViewRow }) {
-  const isAuto = view.renderedByModel && view.renderedByModel !== "deterministic";
+// ---------------------------------------------------------------------------
+// Editorial layout — Lede + Recent rows + Browse-by-area sidebar
+// ---------------------------------------------------------------------------
+
+
+function EditorialLayout({
+  topicViews,
+  sources,
+}: {
+  topicViews: KnowledgeTopicViewRow[];
+  sources: KnowledgeSourceRow[];
+}) {
+  // Topic views arrive sorted by claim_count desc from the API. The
+  // first row is the lede (deepest topic = most-attested area in the
+  // workspace canon); the next ~12 are the recent stack. Anything
+  // past that lives only in the sidebar so the main column stays
+  // scannable on a laptop screen.
+  const lede = topicViews[0];
+  const rest = topicViews.slice(1, 13);
+  const areas = clusterTopicsByPrefix(topicViews);
+
+  return (
+    <div className="grid grid-cols-1 gap-x-12 gap-y-12 lg:grid-cols-12 2xl:gap-x-16">
+      <section className="space-y-8 lg:col-span-8 2xl:col-span-7">
+        <SectionKicker tone="aqua">
+          Recent
+          <span className="ml-2 text-white/40">· {topicViews.length}</span>
+        </SectionKicker>
+        <LedeTopic view={lede} />
+        {rest.length > 0 && (
+          <ul className="divide-y divide-white/5">
+            {rest.map((view) => (
+              <li key={view.topicTag} className="py-5 first:pt-6">
+                <TopicRow view={view} />
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <aside className="space-y-6 lg:col-span-4 lg:sticky lg:top-24 lg:self-start 2xl:col-span-3">
+        <SectionKicker tone="lilac">Browse by area</SectionKicker>
+        <AreaDirectory areas={areas} />
+      </aside>
+
+      {sources.length > 0 && (
+        <section className="space-y-3 lg:col-span-12 2xl:col-span-2 2xl:sticky 2xl:top-24 2xl:self-start">
+          <SectionKicker tone="muted">Sources</SectionKicker>
+          <ConnectedSources sources={sources} />
+        </section>
+      )}
+    </div>
+  );
+}
+
+
+function LedeTopic({ view }: { view: KnowledgeTopicViewRow }) {
+  const isAuto =
+    view.renderedByModel && view.renderedByModel !== "deterministic";
   return (
     <Link
       href={`/knowledge/topics/${encodeURIComponent(view.topicTag)}`}
-      className="group block"
+      className="group block space-y-3 border-b border-aqua/30 pb-8"
     >
-      <h3 className="text-base font-medium text-white transition-colors group-hover:text-aqua">
+      <h3 className="font-display text-2xl font-bold leading-tight text-white group-hover:text-aqua md:text-3xl">
         {view.title}
       </h3>
-      <p className="mt-1 text-xs text-white/45">
-        <span className="font-mono">{view.topicTag}</span>
-        <span className="mx-2">·</span>
+      {view.snippet && (
+        <p className="line-clamp-3 text-base leading-relaxed text-white/65">
+          {view.snippet}
+        </p>
+      )}
+      <p className="flex flex-wrap items-center gap-x-2 text-[11px] uppercase tracking-widest text-white/40">
         <span>
           {view.claimCount} claim{view.claimCount === 1 ? "" : "s"}
         </span>
-        <span className="mx-2">·</span>
+        <span className="text-white/20">·</span>
         <span>{relativeDate(view.lastRenderedAt)}</span>
         {!isAuto && (
           <>
-            <span className="mx-2">·</span>
+            <span className="text-white/20">·</span>
             <span className="text-coral/70">deterministic fallback</span>
           </>
         )}
       </p>
     </Link>
+  );
+}
+
+
+function TopicRow({ view }: { view: KnowledgeTopicViewRow }) {
+  const isAuto =
+    view.renderedByModel && view.renderedByModel !== "deterministic";
+  return (
+    <Link
+      href={`/knowledge/topics/${encodeURIComponent(view.topicTag)}`}
+      className="group block space-y-1.5"
+    >
+      <div className="text-base font-semibold text-white group-hover:text-aqua">
+        {view.title}
+      </div>
+      {view.snippet && (
+        <p className="line-clamp-2 text-sm leading-relaxed text-white/55">
+          {view.snippet}
+        </p>
+      )}
+      <div className="text-[11px] text-white/40">
+        <span>
+          {view.claimCount} claim{view.claimCount === 1 ? "" : "s"}
+        </span>
+        <span className="mx-2 text-white/20">·</span>
+        <span>{relativeDate(view.lastRenderedAt)}</span>
+        {!isAuto && (
+          <>
+            <span className="mx-2 text-white/20">·</span>
+            <span className="text-coral/70">deterministic</span>
+          </>
+        )}
+      </div>
+    </Link>
+  );
+}
+
+
+// ---------------------------------------------------------------------------
+// Browse by area — auto-clustered topics
+// ---------------------------------------------------------------------------
+
+
+type Area = {
+  key: string;
+  label: string;
+  topics: KnowledgeTopicViewRow[];
+};
+
+
+function clusterTopicsByPrefix(views: KnowledgeTopicViewRow[]): Area[] {
+  // Heuristic: cluster on the first ``-``-separated token of the
+  // topic_tag. ``inbox-disposition`` + ``inbox-routing`` group under
+  // ``inbox``; standalone tags whose token has no other members go
+  // into a synthetic ``Other`` bucket so the sidebar stays compact.
+  const buckets = new Map<string, KnowledgeTopicViewRow[]>();
+  for (const view of views) {
+    const token = view.topicTag.split("-", 1)[0] || view.topicTag;
+    const list = buckets.get(token) ?? [];
+    list.push(view);
+    buckets.set(token, list);
+  }
+  const areas: Area[] = [];
+  const orphans: KnowledgeTopicViewRow[] = [];
+  for (const [key, topics] of buckets) {
+    if (topics.length === 1) {
+      orphans.push(topics[0]);
+      continue;
+    }
+    areas.push({
+      key,
+      label: humaniseTag(key),
+      topics: topics.sort((a, b) => b.claimCount - a.claimCount),
+    });
+  }
+  if (orphans.length > 0) {
+    areas.push({
+      key: "_other",
+      label: "Other",
+      topics: orphans.sort((a, b) => b.claimCount - a.claimCount),
+    });
+  }
+  return areas.sort((a, b) => {
+    // Bigger clusters first, "_other" pinned to the bottom.
+    if (a.key === "_other") return 1;
+    if (b.key === "_other") return -1;
+    const aTotal = a.topics.reduce((sum, t) => sum + t.claimCount, 0);
+    const bTotal = b.topics.reduce((sum, t) => sum + t.claimCount, 0);
+    return bTotal - aTotal;
+  });
+}
+
+
+function humaniseTag(tag: string): string {
+  return tag
+    .split(/[-_]/)
+    .filter(Boolean)
+    .map((part) => part[0].toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+
+function AreaDirectory({ areas }: { areas: Area[] }) {
+  if (areas.length === 0) return null;
+  return (
+    <ul className="divide-y divide-white/5">
+      {areas.map((area) => (
+        <li key={area.key} className="py-3 first:pt-0">
+          <div className="flex items-baseline justify-between gap-3">
+            <div className="font-display text-sm font-bold uppercase tracking-wider text-white/85">
+              {area.label}
+            </div>
+            <span className="shrink-0 font-mono text-xs text-white/35">
+              {area.topics.length}
+            </span>
+          </div>
+          <ul className="mt-2 space-y-1.5">
+            {area.topics.slice(0, 5).map((topic) => (
+              <li key={topic.topicTag}>
+                <Link
+                  href={`/knowledge/topics/${encodeURIComponent(topic.topicTag)}`}
+                  className="group flex items-baseline justify-between gap-3 text-xs text-white/55 hover:text-lilac"
+                >
+                  <span className="truncate">{topic.title}</span>
+                  <span className="shrink-0 font-mono text-white/30">
+                    {topic.claimCount}
+                  </span>
+                </Link>
+              </li>
+            ))}
+            {area.topics.length > 5 && (
+              <li className="text-[11px] text-white/30">
+                + {area.topics.length - 5} more
+              </li>
+            )}
+          </ul>
+        </li>
+      ))}
+    </ul>
   );
 }
 

--- a/console/src/app/(authed)/knowledge/page.tsx
+++ b/console/src/app/(authed)/knowledge/page.tsx
@@ -176,6 +176,7 @@ function toTopicViewRow(
   return {
     topicTag: view.topic_tag,
     title: view.title || view.topic_tag,
+    snippet: view.snippet,
     claimCount: view.claim_count,
     renderedByModel: view.rendered_by_model,
     lastRenderedAt: view.last_rendered_at,

--- a/console/src/lib/api/client.ts
+++ b/console/src/lib/api/client.ts
@@ -3118,6 +3118,7 @@ export function searchKnowledge(
 export type ApiTopicViewSummary = {
   topic_tag: string;
   title: string;
+  snippet: string | null;
   claim_count: number;
   rendered_by_model: string | null;
   last_rendered_at: string;


### PR DESCRIPTION
## Summary

Operator complaint: the post-cutover Knowledge index was a flat list of 67 identical rows, no body preview, no grouping, ``Authentication`` styled like an accidental hover. Looked like a settings page.

Restore the editorial multi-column the legacy buckets surface had, but feed it from the topic-views API:

```
   ┌──────────────────────────────┬──────────────────┐
   │  Recent · 67                 │  Browse by area   │
   │  LEDE topic (deepest)        │   Inbox · 4       │
   │  ─ aqua hairline ─           │   Auth · 3        │
   │  TopicRow                    │   Other · n       │
   │  …                           │     ...           │
   └──────────────────────────────┴──────────────────┘
```

### Backend (one commit, no migration)

- ``TopicViewSummary.snippet`` — new field. First non-heading paragraph of ``body_md``, capped at 220 chars, computed at serialise time. Skips ``# Title`` + leading ``## Section`` lines so previews are prose, not the auto-generated header.

### Frontend

- ``LedeTopic`` + ``TopicRow`` revive the lede + recent-rows shape the legacy ``LedeArticle`` / ``ArticleRow`` had — title, snippet (line-clamped), claim count + last-rendered meta. Coral ``deterministic`` badge stays on rows where the LLM was unavailable at last render.
- ``clusterTopicsByPrefix`` heuristic groups topics on the first ``-``-separated token (``inbox-*`` → ``Inbox``, ``auth0-setup`` + ``authentication`` + ``security`` could land separately; that's fine for the v1). Singletons go into a synthetic ``Other`` bucket pinned to the bottom; named clusters sort by total ``claim_count`` desc so the workspace's heaviest area is on top.
- ``AreaDirectory`` sidebar lists each cluster with its top 5 topics and a ``+ N more`` hint. Topic links deep into the detail page.

### Heuristic clustering trade-off

Prefix-token grouping fails for unrelated topics that share a prefix (none in the current Ship data set, but possible). When that bites either:
1. Let operators curate areas explicitly (small UI on top).
2. Replace heuristic with embedding-cluster pass over ``KnowledgeTopicView.embedding``.

The dumb-prefix version ships today and produces sensible groups for ~90% of canon shapes.

## Test plan

- [x] ``pytest backend/tests/test_v1_knowledge_canon_unit.py backend/tests/test_services_knowledge_search_canon.py`` — 7/7
- [ ] CI: full backend + console build (typecheck must catch any leftover field rename I missed)
- [ ] Post-deploy: reload ``/knowledge`` on Ship workspace. Expect lede = ``Security`` (deepest 36 claims) with first-paragraph snippet, recent rows below, ``Browse by area`` sidebar with auto-clustered groups (``Inbox``, ``Auth``, ``Knowledge``, ``Other``).