### PR TITLE
console: style topic detail markdown (no Tailwind Typography needed)

### DIFF
--- a/console/src/app/(authed)/knowledge/topics/[topic_tag]/page.tsx
+++ b/console/src/app/(authed)/knowledge/topics/[topic_tag]/page.tsx
@@ -20,7 +20,7 @@
  */
 
 import { redirect } from "next/navigation";
-import ReactMarkdown from "react-markdown";
+import ReactMarkdown, { type Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
 
 import { ApiUnavailable } from "@/components/api-unavailable";
@@ -152,9 +152,12 @@ export default async function TopicViewPage({
           </header>
 
           <div className="grid grid-cols-1 gap-x-12 gap-y-12 lg:grid-cols-12 2xl:gap-x-16">
-            <article className="prose prose-invert max-w-none lg:col-span-8 2xl:col-span-9">
-              <ReactMarkdown remarkPlugins={[remarkGfm]}>
-                {view.body_md}
+            <article className="max-w-3xl lg:col-span-8 2xl:col-span-9">
+              <ReactMarkdown
+                remarkPlugins={[remarkGfm]}
+                components={MARKDOWN_COMPONENTS}
+              >
+                {stripLeadingH1(view.body_md)}
               </ReactMarkdown>
             </article>
 
@@ -176,6 +179,131 @@ export default async function TopicViewPage({
     </>
   );
 }
+
+
+// ---------------------------------------------------------------------------
+// Markdown rendering — explicit component map.
+//
+// Tailwind Typography (the ``prose`` class) isn't installed in the
+// console build, so the default ReactMarkdown output rendered every
+// element with browser-default styling and the body looked like an
+// undifferentiated wall. We map each tag to a styled element instead;
+// keeps the bundle slim and matches the editorial dark theme exactly.
+// ---------------------------------------------------------------------------
+
+
+function stripLeadingH1(body: string): string {
+  // Renderer prompt instructs the LLM to lead with ``# <Title>``;
+  // the page header already shows that title, so duplicating it
+  // inside the body adds visual noise. Strip the first H1 + any
+  // blank lines that immediately follow it. Subsequent headings
+  // (``# Section``) — rare but possible — survive untouched.
+  const lines = (body || "").split("\n");
+  let cursor = 0;
+  while (cursor < lines.length && lines[cursor].trim() === "") cursor++;
+  if (cursor < lines.length && /^#\s+/.test(lines[cursor])) {
+    cursor++;
+    while (cursor < lines.length && lines[cursor].trim() === "") cursor++;
+  }
+  return lines.slice(cursor).join("\n");
+}
+
+
+const MARKDOWN_COMPONENTS: Components = {
+  h1: ({ children }) => (
+    <h1 className="mt-10 mb-4 font-display text-2xl font-bold leading-tight text-white first:mt-0 md:text-3xl">
+      {children}
+    </h1>
+  ),
+  h2: ({ children }) => (
+    <h2 className="mt-10 mb-3 font-display text-xl font-bold leading-tight text-white first:mt-0">
+      {children}
+    </h2>
+  ),
+  h3: ({ children }) => (
+    <h3 className="mt-8 mb-2 font-display text-base font-semibold uppercase tracking-wider text-white/85 first:mt-0">
+      {children}
+    </h3>
+  ),
+  h4: ({ children }) => (
+    <h4 className="mt-6 mb-2 text-sm font-semibold uppercase tracking-wider text-white/70 first:mt-0">
+      {children}
+    </h4>
+  ),
+  p: ({ children }) => (
+    <p className="my-4 text-base leading-relaxed text-white/75">{children}</p>
+  ),
+  ul: ({ children }) => (
+    <ul className="my-4 list-disc space-y-2 pl-6 text-base leading-relaxed text-white/75 marker:text-white/30">
+      {children}
+    </ul>
+  ),
+  ol: ({ children }) => (
+    <ol className="my-4 list-decimal space-y-2 pl-6 text-base leading-relaxed text-white/75 marker:text-white/30">
+      {children}
+    </ol>
+  ),
+  li: ({ children }) => <li className="pl-1">{children}</li>,
+  a: ({ children, href }) => (
+    <a
+      href={href}
+      className="text-aqua underline-offset-4 transition hover:underline"
+      target={href?.startsWith("http") ? "_blank" : undefined}
+      rel={href?.startsWith("http") ? "noopener noreferrer" : undefined}
+    >
+      {children}
+    </a>
+  ),
+  code: ({ children, className }) => {
+    // ReactMarkdown gives ``code`` both for inline ``code`` and for
+    // fenced blocks (the parent wraps in ``pre``). The className
+    // ``language-foo`` is only attached to fenced ones, so we route
+    // on its presence.
+    if (className) {
+      return (
+        <code className={`${className} block`}>{children}</code>
+      );
+    }
+    return (
+      <code className="rounded bg-white/[0.07] px-1.5 py-0.5 font-mono text-[0.92em] text-mist">
+        {children}
+      </code>
+    );
+  },
+  pre: ({ children }) => (
+    <pre className="my-5 overflow-x-auto rounded-md bg-white/[0.04] p-4 font-mono text-sm leading-relaxed text-mist">
+      {children}
+    </pre>
+  ),
+  blockquote: ({ children }) => (
+    <blockquote className="my-5 border-l-2 border-aqua/40 pl-4 text-base italic leading-relaxed text-white/65">
+      {children}
+    </blockquote>
+  ),
+  hr: () => <hr className="my-8 border-white/10" />,
+  strong: ({ children }) => (
+    <strong className="font-semibold text-white">{children}</strong>
+  ),
+  em: ({ children }) => (
+    <em className="italic text-white/80">{children}</em>
+  ),
+  table: ({ children }) => (
+    <div className="my-5 overflow-x-auto">
+      <table className="w-full border-collapse text-sm">{children}</table>
+    </div>
+  ),
+  thead: ({ children }) => (
+    <thead className="border-b border-white/15 text-left text-xs uppercase tracking-wider text-white/55">
+      {children}
+    </thead>
+  ),
+  th: ({ children }) => <th className="px-3 py-2 font-semibold">{children}</th>,
+  td: ({ children }) => (
+    <td className="border-b border-white/5 px-3 py-2 align-top text-white/75">
+      {children}
+    </td>
+  ),
+};
 
 
 function ClaimEntry({ claim }: { claim: ApiClaimSummary }) {


### PR DESCRIPTION
## Summary

Topic detail page rendered as one undifferentiated wall of text — H1/H2/H3, lists, code spans all came out with browser-default styling. Root cause: I'd reached for ``className="prose prose-invert"`` thinking Tailwind Typography was wired up, but the plugin isn't installed in the console build. The classes were dead strings; ReactMarkdown emitted naked HTML.

### Fix without adding a dep

Pass an explicit ``components`` map to ReactMarkdown so every tag picks up the editorial dark theme:

- **Headings** — display font, descending weight + size, ``mt-*`` cadence so sections breathe.
- **Paragraphs** — base size, relaxed leading, ``text-white/75`` for comfort on the dark bg.
- **Lists** — proper bullets / numerals, ``marker:`` puts the dot at ``white/30`` so it sits behind the text.
- **Inline code** — chip with rounded subtle bg, matches the editorial accent without yelling.
- **Fenced code** — full block, scroll-x for long shell lines, mono font, mist text on a subtle dark panel.
- **Links** — aqua underline-on-hover; external open new tab.
- ``blockquote``, ``hr``, tables covered too.

Body now reads as an article — ``Overview``, ``Tracked Files``, ``Local Files (Not Tracked)`` show up as visible headings; file lists like ``AGENTS.md``, ``CLAUDE.md`` render as proper bullets; inline code paths like ``.ship/config.yml`` get the chip treatment.

### Bonus

``stripLeadingH1`` removes the body's leading ``# Title`` (the renderer prompt tells the LLM to start with one). The page header already shows the title; rendering it twice was visual noise.

## Test plan

- [ ] CI: console build (typecheck)
- [ ] Manual after deploy: open ``/knowledge/topics/ship-folder`` (or any deep topic) — body now reads as a structured article instead of a wall.