### PR TITLE
processes: promote decomposition to first-class peer process (ELS-79)

### DIFF
--- a/backend/app/api/v1/routes/processes.py
+++ b/backend/app/api/v1/routes/processes.py
@@ -104,9 +104,19 @@ _LEGACY_STAGE_TO_STATE: dict[str, CanonicalState] = {
     # yet still bucket correctly.
     "pr_review": "reviewing",
     "code_review": "reviewing",
+    # Decomposition stages (ELS-75 / ELS-79). One specialist per stage
+    # patches its own section of the project body on the planning
+    # anchor; ``planning_done`` is terminal and triggers Drafts →
+    # Parked on the dashboard.
+    "wbs": "planning",
+    "architecture": "planning",
+    "test_architecture": "planning",
+    "tasks": "executing",
+    "planning_done": "reviewing",
 }
 
 PRIMARY_PROCESS_ID = "development"
+DECOMPOSITION_PROCESS_ID = "decomposition"
 
 _SEEDED_PROCESSES: tuple[dict[str, Any], ...] = (
     {
@@ -141,6 +151,35 @@ _SEEDED_PROCESSES: tuple[dict[str, Any], ...] = (
         "node_type": "subprocess",
         "template_id": "subprocess-qa",
     },
+    # Decomposition is a peer top-level process (ELS-79), distinct
+    # from the per-ticket SDLC. It runs against the planning anchor
+    # of each new project: BA → Tech-arch → QA-arch → Developer slice
+    # the brief into a coarse WBS + child tickets. Customer cron
+    # drives it via ``shipctl run --routine wbs|architecture|...``;
+    # ``planning_done`` flips Drafts → Parked.
+    {
+        "id": "decomposition",
+        "name": "Decomposition",
+        "description": (
+            "Project-first delivery: BA, Tech-architect, QA-architect "
+            "and Developer turn a project brief into a WBS and child "
+            "tickets on the planning anchor. Drafts → Parked when done."
+        ),
+        "parent_process_id": None,
+        "node_type": "process",
+        "template_id": "process-decomposition",
+    },
+)
+
+# Decomposition stage order (ELS-79). Mirrors
+# ``DECOMPOSITION_STAGE_ORDER`` in ``linear_provisioner.py`` and the
+# stage list in ``catalog.default_planning_process_config``.
+_DECOMPOSITION_STATE_ORDER: tuple[str, ...] = (
+    "wbs",
+    "architecture",
+    "test_architecture",
+    "tasks",
+    "planning_done",
 )
 
 _PROCESS_STATE_ORDER: tuple[str, ...] = (
@@ -468,7 +507,8 @@ async def list_processes(
 ) -> ProcessListOut:
     await _require_membership(session, workspace_id, auth.user.id, ROLES_READ)
     process = await _build_development_process(session, workspace_id)
-    summaries = _seeded_process_summaries(process)
+    decomposition = await _build_decomposition_process(session, workspace_id)
+    summaries = _seeded_process_summaries(process, decomposition)
     return ProcessListOut(
         primary_process_id=PRIMARY_PROCESS_ID,
         processes=summaries,
@@ -524,6 +564,8 @@ async def get_process(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="process not found",
         )
+    if process_id == DECOMPOSITION_PROCESS_ID:
+        return await _build_decomposition_process(session, workspace_id)
     return await _build_development_process(
         session,
         workspace_id,
@@ -942,6 +984,132 @@ def _add_process_audit(
     )
 
 
+async def _build_decomposition_process(
+    session: AsyncSession,
+    workspace_id: uuid.UUID,
+) -> ProcessOut:
+    """Project the decomposition FSM as a peer top-level process.
+
+    Source of truth is :func:`catalog.default_planning_process_config`.
+    Today decomposition has no separate ``Lane`` / ``Pipeline`` rows
+    (the planning anchor is a tracker concept, not a workspace
+    pipeline), so this projection is static — runtime aggregation is
+    intentionally omitted until decomposition picks up its own runs
+    table. The dashboard renders the canvas + routine cards from the
+    static states + the four routines defined in the catalog.
+    """
+    from backend.app.services.catalog import default_planning_process_config
+
+    config = default_planning_process_config()
+    specialists = _specialists()
+    raw_states = config.get("states") or []
+    states: list[ProcessStateOut] = []
+    for entry in raw_states:
+        if not isinstance(entry, dict):
+            continue
+        stage_id = str(entry.get("id") or "")
+        if not stage_id:
+            continue
+        spec = entry.get("specialist") or {}
+        specialist_id = str(spec.get("id") or "developer")
+        # ``_specialists`` is keyed by role-template id (``business_analyst``
+        # etc.), not the kebab-case agent-role slug, so a direct lookup
+        # often misses for decomposition specialists. Fall back to the
+        # SDLC stage's specialist when the kebab-case slug is unknown.
+        if specialist_id not in specialists:
+            specialist_id = _specialist_for_lane(stage_id)
+        states.append(
+            ProcessStateOut(
+                id=stage_id,
+                name=str(entry.get("name") or _titleize(stage_id)),
+                specialist_id=specialist_id,
+                specialist_name=specialists[specialist_id].name,
+                instructions=str(entry.get("instructions") or ""),
+                state=_canonical_state_for(stage_id),
+                triggers=[ProcessTriggerOut(type="event", event="anchor_handoff")],
+                exit_conditions=[],
+                block_conditions=[],
+                runtime=ProcessStateRuntimeOut(health="ok"),
+            )
+        )
+
+    transitions: list[ProcessTransitionOut] = []
+    for left, right in zip(states, states[1:]):
+        transitions.append(
+            ProcessTransitionOut(
+                id=f"{left.id}_to_{right.id}",
+                from_state_id=left.id,
+                to_state_id=right.id,
+                conditions=[],
+                requires_human=False,
+                trigger_actor=_transition_actor(left.state, right.state),
+            )
+        )
+
+    routines: list[ProcessRoutineOut] = []
+    raw_routines = config.get("routines") or {}
+    if isinstance(raw_routines, dict):
+        for routine_id, routine in raw_routines.items():
+            if not isinstance(routine, dict):
+                continue
+            specialist_slug = str(routine.get("specialist") or "")
+            specialist_template_id = _specialist_for_lane(routine_id)
+            specialist_template = specialists.get(specialist_template_id)
+            specialist_name = (
+                specialist_template.name
+                if specialist_template
+                else specialist_slug or routine_id
+            )
+            trigger = routine.get("trigger") or {}
+            cron = (
+                str(trigger.get("cron"))
+                if isinstance(trigger, dict) and trigger.get("cron")
+                else None
+            )
+            routines.append(
+                ProcessRoutineOut(
+                    id=str(routine_id),
+                    name=str(routine.get("name") or _titleize(str(routine_id))),
+                    specialist_id=specialist_template_id,
+                    specialist_name=specialist_name,
+                    schedule=cron,
+                    prompt="",
+                    instructions=str(routine.get("description") or ""),
+                    last_run=None,
+                    status=None,
+                    enabled=bool(routine.get("enabled", True)),
+                    description=str(routine.get("description") or ""),
+                    trigger=trigger if isinstance(trigger, dict) else None,
+                )
+            )
+
+    process_meta = _seeded_process_meta(DECOMPOSITION_PROCESS_ID)
+    adapter_diagnostics = await _adapter_diagnostics(session, workspace_id)
+    return ProcessOut(
+        id=DECOMPOSITION_PROCESS_ID,
+        name=str(process_meta["name"]),
+        primary=False,
+        state_count=len(states),
+        task_count=0,
+        blocked_count=0,
+        health="ok",
+        description=str(process_meta["description"]),
+        parent_process_id=process_meta["parent_process_id"],
+        node_type=process_meta["node_type"],
+        template_id=process_meta["template_id"],
+        specialists=list(specialists.values()),
+        states=states,
+        transitions=transitions,
+        tasks=[],
+        routines=routines,
+        schedule=_default_schedule(states),
+        process_graph=_inner_process_graph(
+            DECOMPOSITION_PROCESS_ID, states, transitions
+        ),
+        adapter_diagnostics=adapter_diagnostics,
+    )
+
+
 async def _build_development_process(
     session: AsyncSession,
     workspace_id: uuid.UUID,
@@ -1157,19 +1325,38 @@ def _seeded_process_meta(process_id: str) -> dict[str, Any]:
     )
 
 
-def _seeded_process_summaries(process: ProcessOut) -> list[ProcessSummaryOut]:
+def _seeded_process_summaries(
+    process: ProcessOut,
+    decomposition: ProcessOut | None = None,
+) -> list[ProcessSummaryOut]:
     summaries: list[ProcessSummaryOut] = []
     for row in _SEEDED_PROCESSES:
         is_primary = row["id"] == PRIMARY_PROCESS_ID
+        is_decomp = row["id"] == DECOMPOSITION_PROCESS_ID
+        if is_primary:
+            state_count = process.state_count
+            task_count = process.task_count
+            blocked_count = process.blocked_count
+            health = process.health
+        elif is_decomp and decomposition is not None:
+            state_count = decomposition.state_count
+            task_count = decomposition.task_count
+            blocked_count = decomposition.blocked_count
+            health = decomposition.health
+        else:
+            state_count = 0
+            task_count = 0
+            blocked_count = 0
+            health = "ok"
         summaries.append(
             ProcessSummaryOut(
                 id=str(row["id"]),
                 name=str(row["name"]),
                 primary=is_primary,
-                state_count=process.state_count if is_primary else 0,
-                task_count=process.task_count if is_primary else 0,
-                blocked_count=process.blocked_count if is_primary else 0,
-                health=process.health if is_primary else "ok",
+                state_count=state_count,
+                task_count=task_count,
+                blocked_count=blocked_count,
+                health=health,
                 description=str(row["description"]),
                 parent_process_id=row["parent_process_id"],
                 node_type=row["node_type"],
@@ -1186,6 +1373,7 @@ def _workspace_process_graph(summaries: list[ProcessSummaryOut]) -> ProcessGraph
     positions = {
         "workspace": (340, 270),
         "development": (340, 42),
+        "decomposition": (620, 42),
     }
     nodes = [
         ProcessNodeOut(
@@ -1228,6 +1416,21 @@ def _workspace_process_graph(summaries: list[ProcessSummaryOut]) -> ProcessGraph
                 label="Development process",
                 conditions=[ProcessConditionOut(expression="workspace.process == 'development'")],
                 io_contract={"passes": ["workspace_policies", "canonical_state"]},
+            ),
+            ProcessLinkOut(
+                id="workspace-to-decomposition",
+                from_process_id="workspace",
+                from_node_id="node-workspace",
+                to_process_id="decomposition",
+                to_node_id="node-decomposition",
+                type="handoff",
+                label="Decomposition process",
+                conditions=[
+                    ProcessConditionOut(
+                        expression="workspace.process == 'decomposition'"
+                    )
+                ],
+                io_contract={"passes": ["project_brief", "planning_anchor"]},
             ),
         ],
     )

--- a/backend/app/api/v1/routes/processes.py
+++ b/backend/app/api/v1/routes/processes.py
@@ -171,17 +171,6 @@ _SEEDED_PROCESSES: tuple[dict[str, Any], ...] = (
     },
 )
 
-# Decomposition stage order (ELS-79). Mirrors
-# ``DECOMPOSITION_STAGE_ORDER`` in ``linear_provisioner.py`` and the
-# stage list in ``catalog.default_planning_process_config``.
-_DECOMPOSITION_STATE_ORDER: tuple[str, ...] = (
-    "wbs",
-    "architecture",
-    "test_architecture",
-    "tasks",
-    "planning_done",
-)
-
 _PROCESS_STATE_ORDER: tuple[str, ...] = (
     # Phase 1.5 canon — nine pipeline stages in execution order. The
     # dashboard's process projector iterates this tuple to render the
@@ -1582,6 +1571,18 @@ def _specialist_for_lane(lane_id: str) -> str:
         "qa_automation": "qa_engineer",
         "code_review": "code_reviewer",
         "pr_review": "code_reviewer",
+        # Decomposition stages (ELS-79). Without these the substring
+        # fallback below maps ``wbs`` / ``tasks`` / ``planning_done``
+        # to the default ``devops_platform`` (or fails entirely),
+        # which mis-renders the canvas badge AND raises a KeyError
+        # when ``_build_decomposition_process`` looks up the
+        # specialist by id. Pin them explicitly so the canvas shows
+        # the right role and the projection never blows up.
+        "wbs": "business_analyst",
+        "architecture": "technical_architect",
+        "test_architecture": "qa_engineer",
+        "tasks": "developer",
+        "planning_done": "developer",
     }
     if lane_id in direct:
         return direct[lane_id]

--- a/backend/app/services/catalog.py
+++ b/backend/app/services/catalog.py
@@ -241,6 +241,13 @@ def bundle_routine_entries(
             routine["patterns"] = list(lane["patterns"])
         if isinstance(lane.get("fanout"), str):
             routine["fanout"] = str(lane["fanout"])
+        # ``fsm_stage`` overrides the role's default stage when set —
+        # lets one role drive multiple processes (e.g. ``ba`` runs at
+        # ``ba_requirements`` for SDLC and ``wbs`` for decomposition).
+        if isinstance(lane.get("fsm_stage"), str):
+            routine["fsm_stage"] = str(lane["fsm_stage"])
+        if isinstance(lane.get("description"), str):
+            routine["description"] = str(lane["description"])
         routines[str(routine_id)] = routine
     return routines
 
@@ -420,7 +427,8 @@ def default_planning_process_config() -> dict[str, object]:
         # No human gates today — the operator's gate is the manual
         # **Hand off to decomposition** click on the dashboard. Once
         # they hit it, the chain runs autonomously through to
-        # ``planning_done`` and the project flips Drafts → Active.
+        # ``planning_done`` and the project flips Drafts → Parked
+        # (the PO promotes Parked → Active when ready to ship).
         "gates": "after_pr",
         "states": [
             {
@@ -490,7 +498,8 @@ def default_planning_process_config() -> dict[str, object]:
                 "specialist": {"id": "developer", "name": "Developer"},
                 "instructions": (
                     "Terminal — no work. Reaching this stage flips the "
-                    "project from Drafts to Active on the dashboard."
+                    "project from Drafts to Parked on the dashboard "
+                    "(the PO then promotes Parked → Active when ready)."
                 ),
             },
         ],
@@ -500,11 +509,82 @@ def default_planning_process_config() -> dict[str, object]:
             {"from": "test_architecture", "to": "tasks"},
             {"from": "tasks", "to": "planning_done"},
         ],
-        # No routines — decomposition is anchor-driven, not cron-
-        # driven. The handoff endpoint sets the first stage label;
-        # subsequent stages move via ``/agent-runs/finish`` like any
-        # other FSM run.
-        "routines": {},
+        # Cron-driven, symmetric to the development process. Each
+        # non-terminal stage gets a routine that the customer-side
+        # GitHub Actions cron polls via ``shipctl run --routine X``;
+        # the routine carries an explicit ``fsm_stage`` so one role
+        # (``ba``) can serve both decomposition (``stage:wbs``) and
+        # SDLC (``ba_requirements``) without per-process role clones.
+        # ``planning_done`` is terminal — no routine — and the finish
+        # hook on the ``tasks`` stage flips the dashboard row Drafts →
+        # Parked.
+        "routines": {
+            "wbs": {
+                "name": "Decomposition WBS",
+                "enabled": True,
+                "specialist": "ba",
+                "fsm_stage": "wbs",
+                "trigger": {
+                    "type": "schedule",
+                    "cron": "*/30 * * * *",
+                    "window": "30m",
+                    "catchup": "latest",
+                },
+                "description": (
+                    "Customer cron polls planning anchors in stage:wbs "
+                    "and dispatches BA to produce the WBS section."
+                ),
+            },
+            "architecture": {
+                "name": "Decomposition Architecture",
+                "enabled": True,
+                "specialist": "tech-architect",
+                "fsm_stage": "architecture",
+                "trigger": {
+                    "type": "schedule",
+                    "cron": "*/30 * * * *",
+                    "window": "30m",
+                    "catchup": "latest",
+                },
+                "description": (
+                    "Customer cron polls anchors in stage:architecture "
+                    "and dispatches Tech-architect."
+                ),
+            },
+            "test_architecture": {
+                "name": "Decomposition Test architecture",
+                "enabled": True,
+                "specialist": "qa-architect",
+                "fsm_stage": "test_architecture",
+                "trigger": {
+                    "type": "schedule",
+                    "cron": "*/30 * * * *",
+                    "window": "30m",
+                    "catchup": "latest",
+                },
+                "description": (
+                    "Customer cron polls anchors in "
+                    "stage:test_architecture and dispatches QA-architect."
+                ),
+            },
+            "tasks": {
+                "name": "Decomposition Task slicing",
+                "enabled": True,
+                "specialist": "developer",
+                "fsm_stage": "tasks",
+                "trigger": {
+                    "type": "schedule",
+                    "cron": "*/30 * * * *",
+                    "window": "30m",
+                    "catchup": "latest",
+                },
+                "description": (
+                    "Customer cron polls anchors in stage:tasks and "
+                    "dispatches Developer to slice the WBS into child "
+                    "tickets. On finish the project flips Drafts to Parked."
+                ),
+            },
+        },
     }
 
 

--- a/backend/app/services/seed_bundle.py
+++ b/backend/app/services/seed_bundle.py
@@ -326,7 +326,22 @@ def compose_seed_files(
     # contribute a routine (request-only templates, missing trigger)
     # silently fall out of the runtime mapping; they still belong in
     # the bundle accounting (v2 marker) so the wizard can show them.
+    #
+    # Decomposition routines (ELS-79) are merged into the same
+    # ``process.routines`` map so customer-side ``shipctl run
+    # --routine wbs`` resolves them like any SDLC routine. Each
+    # decomposition routine carries an explicit ``fsm_stage`` that
+    # overrides the role's default — that's how one role (``ba``)
+    # serves both ``ba_requirements`` (SDLC) and ``wbs``
+    # (decomposition) without per-process role clones.
     routine_entries = catalog_service.bundle_routine_entries(default_seed_lanes())
+    decomp_routines = catalog_service.default_planning_process_config().get(
+        "routines", {}
+    )
+    if isinstance(decomp_routines, dict):
+        for routine_id, routine in decomp_routines.items():
+            if routine_id not in routine_entries:
+                routine_entries[routine_id] = dict(routine)
     config_yaml = catalog_service.emit_config_yaml(
         preset_id="default",
         repo_full_name=repo_full_name,

--- a/backend/app/services/seed_bundle.py
+++ b/backend/app/services/seed_bundle.py
@@ -144,7 +144,7 @@ from backend.app.services.tracker_fsm import (
 #         the seed PR merged. The ``shipctl init`` / ``sync`` /
 #         ``--copy-rules`` flow + the ``/collections`` + ``/fetch``
 #         endpoints are gone in this bundle.
-BUNDLE_VERSION: str = "0.20"
+BUNDLE_VERSION: str = "0.21"
 
 # Default knowledge starters for PR 1. Empty by design: generated knowledge is
 # analyzed post-merge and proposed in a second PR. Historical callers can still

--- a/backend/tests/test_decomposition_role_modes.py
+++ b/backend/tests/test_decomposition_role_modes.py
@@ -66,3 +66,49 @@ def test_role_carries_decomposition_block(slug: str, section: str | None) -> Non
             f'``section="{section}"`` so the prompt and the tracker '
             f"helper agree on the heading"
         )
+
+
+def test_planning_process_config_emits_routines_with_fsm_stage() -> None:
+    """ELS-79 — decomposition is now cron-driven (symmetric to SDLC).
+
+    Each non-terminal stage gets a routine in
+    ``default_planning_process_config()['routines']`` carrying an
+    explicit ``fsm_stage``. ``shipctl run --routine wbs`` reads
+    ``fsm_stage: wbs`` and queries ``GET /tracker/next?state=wbs``,
+    overriding the BA role's SDLC-default ``ba_requirements``.
+
+    ``planning_done`` is terminal and gets no routine — the finish
+    hook on ``tasks`` flips Drafts → Parked.
+    """
+    from backend.app.services.catalog import default_planning_process_config
+
+    cfg = default_planning_process_config()
+    routines = cfg.get("routines") or {}
+    assert isinstance(routines, dict)
+
+    expected = {
+        "wbs": ("ba", "wbs"),
+        "architecture": ("tech-architect", "architecture"),
+        "test_architecture": ("qa-architect", "test_architecture"),
+        "tasks": ("developer", "tasks"),
+    }
+    for routine_id, (specialist, fsm_stage) in expected.items():
+        routine = routines.get(routine_id)
+        assert isinstance(routine, dict), (
+            f"missing decomposition routine: {routine_id}"
+        )
+        assert routine.get("specialist") == specialist, (
+            f"{routine_id}.specialist should be {specialist!r}, "
+            f"got {routine.get('specialist')!r}"
+        )
+        assert routine.get("fsm_stage") == fsm_stage, (
+            f"{routine_id}.fsm_stage should be {fsm_stage!r}, "
+            f"got {routine.get('fsm_stage')!r}"
+        )
+
+    # ``planning_done`` is terminal — explicitly NOT a routine.
+    assert "planning_done" not in routines, (
+        "``planning_done`` is the terminal stage; it must not have a "
+        "routine — the finish hook on ``tasks`` triggers the Drafts "
+        "→ Parked flip without an extra agent run."
+    )

--- a/backend/tests/test_processes_decomposition_specialists.py
+++ b/backend/tests/test_processes_decomposition_specialists.py
@@ -1,0 +1,79 @@
+"""Decomposition specialist mapping (ELS-79 follow-up).
+
+``_build_decomposition_process`` looks up specialists by template-id
+via ``_specialists`` (a dict keyed on ``role_templates.py`` ids).
+``_specialist_for_lane`` is the fallback that resolves a stage id
+to one of those template-ids. Pre-this fix the decomposition
+stages weren't in the ``direct`` map, so the substring fallback
+caught some (``architecture`` / ``test_architecture`` matched
+``arch``) and the rest fell through to ``devops_platform``.
+``planning_done`` and ``wbs`` and ``tasks`` then ended up rendering
+with the wrong canvas badge and — depending on whether the
+template id resolved — could KeyError on the projection's
+``specialists[specialist_id].name`` lookup.
+
+Pin the explicit mapping so a future grammar / role bump catches
+the regression in CI.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from backend.app.api.v1.routes.processes import (
+    _specialist_for_lane,
+    _specialists,
+)
+
+
+@pytest.mark.parametrize(
+    "stage,expected_template_id",
+    [
+        ("wbs", "business_analyst"),
+        ("architecture", "technical_architect"),
+        ("test_architecture", "qa_engineer"),
+        ("tasks", "developer"),
+        ("planning_done", "developer"),
+    ],
+)
+def test_decomposition_stages_map_to_canon_template_ids(
+    stage: str, expected_template_id: str
+) -> None:
+    assert _specialist_for_lane(stage) == expected_template_id
+
+
+@pytest.mark.parametrize(
+    "stage",
+    ["wbs", "architecture", "test_architecture", "tasks", "planning_done"],
+)
+def test_decomposition_specialist_resolves_in_specialists_dict(stage: str) -> None:
+    """Round-trip: lane → template_id → specialist name. The
+    projection in ``_build_decomposition_process`` does this lookup
+    on every render; if it KeyErrors the dashboard 500s on the
+    decomposition page."""
+    template_id = _specialist_for_lane(stage)
+    specialists = _specialists()
+    assert template_id in specialists, (
+        f"specialist template_id {template_id!r} for stage {stage!r} "
+        f"is not in _specialists; decomposition projection will KeyError"
+    )
+    # ``.name`` is what the canvas actually renders.
+    assert specialists[template_id].name
+
+
+def test_sdlc_stages_unchanged_by_decomposition_additions() -> None:
+    """Adding decomposition stages to the direct map must not break
+    the existing SDLC stage mappings."""
+    sdlc = {
+        "task_intake": "intake",
+        "bug_triage": "intake",
+        "ba_requirements": "business_analyst",
+        "tech_arch_plan": "technical_architect",
+        "qa_arch_plan": "qa_engineer",
+        "dev_implementation": "developer",
+        "qa_manual": "qa_engineer",
+        "qa_automation": "qa_engineer",
+        "code_review": "code_reviewer",
+    }
+    for stage, expected in sdlc.items():
+        assert _specialist_for_lane(stage) == expected

--- a/backend/tests/test_services_seed_bundle.py
+++ b/backend/tests/test_services_seed_bundle.py
@@ -115,6 +115,57 @@ def test_compose_default_bundle_emits_config_yml() -> None:
         )
 
 
+def test_compose_default_bundle_emits_decomposition_routines() -> None:
+    """Decomposition routines (ELS-79) land in ``process.routines``
+    so customer-side ``shipctl run --routine wbs|architecture|...``
+    drives the decomposition chain through customer cron.
+
+    Each decomposition routine carries an explicit ``fsm_stage`` that
+    overrides the role's default — that's how one role (``ba``) serves
+    both ``ba_requirements`` for SDLC and ``wbs`` for decomposition
+    without needing per-process role clones.
+    """
+
+    from backend.app.services.lane_recipes import DEFAULT_BUNDLE
+    from backend.app.services.seed_bundle import (
+        CONFIG_PATH,
+        compose_seed_files,
+    )
+
+    bundle = compose_seed_files(
+        bundle=DEFAULT_BUNDLE,
+        knowledge_slugs=[],
+        tracker_kind=None,
+        repo_full_name="acme/widgets",
+        seeded_at=_seeded_at(),
+    )
+
+    config_body = next(c for p, c in bundle.files if p == CONFIG_PATH)
+
+    # The four non-terminal decomposition stages each get a routine.
+    # ``planning_done`` is terminal — no routine — and the finish hook
+    # on the ``tasks`` stage flips Drafts → Parked.
+    for routine_id in ("wbs", "architecture", "test_architecture", "tasks"):
+        assert f"    {routine_id}:" in config_body, (
+            f"missing decomposition routine {routine_id} in seeded YAML"
+        )
+
+    # Each decomposition routine carries an ``fsm_stage`` so the CLI
+    # can override the role's default stage — this is the key wire that
+    # makes ``shipctl run --routine wbs`` poll ``stage:wbs`` instead of
+    # the BA role's SDLC default ``ba_requirements``.
+    for fsm_stage in ("wbs", "architecture", "test_architecture", "tasks"):
+        assert f"fsm_stage: {fsm_stage}" in config_body, (
+            f"missing fsm_stage: {fsm_stage} on decomposition routine"
+        )
+
+    # Specialists are reused from the SDLC role corpus.
+    assert "specialist: ba" in config_body
+    assert "specialist: tech-architect" in config_body
+    assert "specialist: qa-architect" in config_body
+    assert "specialist: developer" in config_body
+
+
 def test_compose_default_bundle_emits_dedup_workflows() -> None:
     """Multiple patterns sharing a starter workflow collapse to one
     YAML on disk (path uniqueness is the tree builder's invariant)."""

--- a/cli/lib/commands/run.mjs
+++ b/cli/lib/commands/run.mjs
@@ -158,7 +158,10 @@ export async function runCommand(ctx, rest) {
   if (!roleResolved) {
     die(EXIT_USAGE, `unknown agent role '${specialistSlug}' for this workspace`);
   }
-  const fsmStage = roleResolved.fsm_stage || null;
+  // Per-routine FSM stage override takes precedence over the role's
+  // default. Lets one role (``ba``) drive both ``ba_requirements`` for
+  // SDLC and ``wbs`` for decomposition without per-process role clones.
+  const fsmStage = resolved.executable?.fsm_stage || roleResolved.fsm_stage || null;
   const roleBody = roleResolved.prompt || "";
   const systemBody = systemResolved?.prompt || "";
 

--- a/cli/lib/config/schema.mjs
+++ b/cli/lib/config/schema.mjs
@@ -558,6 +558,10 @@ function validateProcessRoutines(value, errors, warnings) {
         "schedule",
         "window",
         "event",
+        // ``fsm_stage`` overrides the role's default stage so one role
+        // can drive multiple processes (BA serves both
+        // ``ba_requirements`` for SDLC and ``wbs`` for decomposition).
+        "fsm_stage",
       ]),
       prefix,
       warnings,
@@ -616,6 +620,7 @@ function validateProcessRoutines(value, errors, warnings) {
       );
     }
     validateProcessAgentProfile(routine.agent_profile, `${prefix}.agent_profile`, errors);
+    requireOptionalString(routine.fsm_stage, `${prefix}.fsm_stage`, errors, { required: false });
     validateRoutineTrigger(routine.trigger, `${prefix}.trigger`, errors);
     if (routine.schedule !== undefined && routine.schedule !== null) {
       if (typeof routine.schedule !== "string" && !isPlainObject(routine.schedule)) {

--- a/cli/lib/runtime/routines.mjs
+++ b/cli/lib/runtime/routines.mjs
@@ -64,6 +64,11 @@ export function routineToExecutable(id, routine) {
     idempotency: routine.idempotency || null,
     prompt: stringOrNull(routine.prompt) || stringOrNull(routine.instructions),
     agent_profile: stringOrNull(routine.agent_profile) || stringOrNull(routine.specialist?.agent_profile),
+    // Per-routine FSM stage override. When set, ``shipctl run`` uses
+    // it instead of the role's default ``fsm_stage`` — that's how a
+    // single role (e.g. ``ba``) serves both SDLC (``ba_requirements``)
+    // and decomposition (``wbs``) without per-process role clones.
+    fsm_stage: stringOrNull(routine.fsm_stage),
   };
 }
 


### PR DESCRIPTION
## Summary

Decomposition was defined server-side in `default_planning_process_config` but had `routines: {}` and zero client-side dispatch — once `start_decomposition` put the planning anchor in `stage:wbs`, nothing triggered BA. Customer cron only knew about the development process. Closes the gap so decomposition runs symmetric to SDLC.

- **catalog.py** — populated the four non-terminal stage routines (`wbs`, `architecture`, `test_architecture`, `tasks`) with explicit `fsm_stage` + `specialist`. Extended `bundle_routine_entries` to pass `fsm_stage` / `description` through.
- **seed_bundle.py** — merged decomposition routines into the same `process.routines` block customers see in `.ship/config.yml`, so `shipctl run --routine wbs` resolves them like any SDLC routine.
- **processes.py** — added `decomposition` as a peer top-level process alongside `development` (workspace canvas link + summary + static state/routine projection via `_build_decomposition_process`).
- **CLI** — `fsm_stage` is now a valid routine field; `routineToExecutable` surfaces it; `run.mjs` prefers `executable.fsm_stage` over the role's default. One role (`ba`) drives both `ba_requirements` (SDLC) and `wbs` (decomposition) without per-process role clones.
- Doc/comment sweep: Drafts flips to **Parked** (not Active) at `planning_done` — wiring lands in ELS-81.

## Test plan

- [x] `pytest backend/tests/test_services_seed_bundle.py` — 14 pass (incl. new `test_compose_default_bundle_emits_decomposition_routines`)
- [x] `pytest backend/tests/test_decomposition_role_modes.py` — 6 pass (incl. new `test_planning_process_config_emits_routines_with_fsm_stage`)
- [x] `cd cli && npm test` — 91 pass
- [ ] Smoke: a workspace with anchors in `stage:wbs` returns one to `shipctl run --routine wbs` and dispatches BA against it. (Lands in ELS-89 end-to-end smoke.)