### PR TITLE
fix: ingestion sync survives long-running connector walks

### DIFF
--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -96,6 +96,17 @@ def _engine_kwargs(database_url: str, original_url: str) -> dict[str, Any]:
         # sent to create_engine()`` that SQLAlchemy 2.0 raises when the
         # option is passed as a top-level engine kwarg with NullPool.
         connect_args["statement_cache_size"] = 0
+        # ``server_settings`` runs ``SET <k> = <v>`` immediately after
+        # connect on every backend asyncpg checks out. Pinning
+        # ``default_transaction_read_only=off`` defends against a
+        # PgBouncer-multiplexed backend whose previous tenant left
+        # the GUC at ``on`` (Neon has been observed to recycle
+        # backends in read-only mode after a scale event; without
+        # this pin we'd see ``cannot execute UPDATE in a read-only
+        # transaction`` on the first write of the next tenant).
+        connect_args["server_settings"] = {
+            "default_transaction_read_only": "off",
+        }
     if connect_args:
         kwargs["connect_args"] = connect_args
     return kwargs

--- a/backend/app/services/connectors/notion.py
+++ b/backend/app/services/connectors/notion.py
@@ -95,13 +95,44 @@ async def _get(
     token: str,
     params: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    response = await client.get(
-        f"{NOTION_API_ROOT}{path}",
-        headers=_headers(token),
-        params=params,
-    )
-    response.raise_for_status()
-    return response.json()
+    # One retry on transient upstream blips. Notion regularly emits
+    # 502 / 503 / 504 / 429 mid-flight on long walks (a hub page with
+    # 200+ embedded child_databases hammers ``/blocks/{id}/children``
+    # back-to-back, and any one of those returning a transient error
+    # used to abort the entire sync). The retry-once policy gets us
+    # past single-request hiccups; persistent upstream outages still
+    # surface to the walker for soft-skip.
+    last_exc: httpx.HTTPStatusError | None = None
+    for attempt in range(2):
+        response = await client.get(
+            f"{NOTION_API_ROOT}{path}",
+            headers=_headers(token),
+            params=params,
+        )
+        try:
+            response.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            status_code = (
+                exc.response.status_code if exc.response is not None else 0
+            )
+            if status_code in (429, 500, 502, 503, 504) and attempt == 0:
+                # Tiny backoff so we don't hammer a degraded backend
+                # in tight loop. asyncio.sleep is fine inside an
+                # async http call.
+                import asyncio
+
+                await asyncio.sleep(0.5)
+                last_exc = exc
+                continue
+            raise
+        return response.json()
+    # Defensive — ``raise`` inside the loop should re-raise on the
+    # second attempt; this branch only triggers if both attempts hit
+    # the retry path (logically impossible because attempt == 0
+    # gates retry).
+    if last_exc is not None:  # pragma: no cover
+        raise last_exc
+    return {}  # pragma: no cover
 
 
 async def _fetch_page(
@@ -406,20 +437,21 @@ async def _walk_page_tree(
             status_code = (
                 exc.response.status_code if exc.response is not None else 0
             )
-            if status_code in (401, 403, 404):
-                # Seed pages are operator-pointed — surfacing the
-                # share-hint loudly is the whole point of having
-                # ConfigError on the dispatcher path. Deeper pages
-                # we discovered ourselves: one being locked is normal
-                # in a tree (e.g. an HR subpage off a hub) and should
-                # not poison the rest of the walk.
-                if page_id in seeds:
-                    raise ConnectorConfigError(
-                        f"notion returned HTTP {status_code} for page {page_id} — "
-                        "is the integration shared with the page?"
-                    ) from exc
+            # Seed pages are operator-pointed: 401/403/404 mean the
+            # integration isn't shared and the wizard needs to teach
+            # that loudly. 5xx / 429 on a seed is also worth surfacing
+            # as a real error, since the operator can't proceed.
+            if page_id in seeds and status_code in (401, 403, 404):
+                raise ConnectorConfigError(
+                    f"notion returned HTTP {status_code} for page {page_id} — "
+                    "is the integration shared with the page?"
+                ) from exc
+            # Non-seed pages: any HTTP error is a soft-skip. One
+            # locked HR subpage, one transient 502, one 429 from
+            # rate-limit shouldn't take down a 100-page walk.
+            if page_id not in seeds:
                 logger.warning(
-                    "notion walker: skipping page %s (HTTP %s — not shared?)",
+                    "notion walker: skipping page %s (HTTP %s)",
                     page_id,
                     status_code,
                 )
@@ -446,15 +478,18 @@ async def _walk_page_tree(
                 status_code = (
                     exc.response.status_code if exc.response is not None else 0
                 )
-                if status_code in (401, 403, 404):
-                    logger.warning(
-                        "notion walker: skipping embedded database %s "
-                        "(HTTP %s — not shared?)",
-                        dbid,
-                        status_code,
-                    )
-                    continue
-                raise
+                # Any HTTP error on a child_database we discovered
+                # mid-walk is a soft-skip. One legacy un-migrated DB
+                # (404), one rate-limit (429), one transient 502
+                # shouldn't kill the whole tree. The walker still
+                # logs so operators can grep for systemic share
+                # issues if a workspace's canon stays sparse.
+                logger.warning(
+                    "notion walker: skipping embedded database %s (HTTP %s)",
+                    dbid,
+                    status_code,
+                )
+                continue
             except ConnectorConfigError as exc:
                 # ``_resolve_data_source_id`` raises this when a database
                 # we discovered via a ``child_database`` block has no

--- a/backend/app/services/knowledge_ingestion.py
+++ b/backend/app/services/knowledge_ingestion.py
@@ -187,6 +187,29 @@ async def sync_import_source(
     trigger: str = "manual",
     settings: Settings | None = None,
 ) -> KnowledgeIngestionRun:
+    """Sync one import source through the connector + persist documents.
+
+    The work is split into three transactions so the underlying DB
+    connection isn't held idle during the connector's HTTP fan-out:
+
+    1. **Mark SYNCING** — insert a ``RUNNING`` ingestion run row, flip
+       the source's status to ``SYNCING``, commit. The connection
+       returns to the pool while the walker hits the upstream API.
+    2. **Fetch documents** — pure HTTP, no DB. For Notion hub pages
+       with hundreds of embedded child_databases this can take
+       several minutes; that's exactly the window where Neon's
+       pooler used to kill the idle connection mid-transaction
+       (PendingRollbackError on the next flush).
+    3. **Persist + mark DONE/ERROR** — re-acquire a connection,
+       upsert source items + write claims, then commit final state.
+
+    Caller doesn't see the staging — it gets back a
+    ``KnowledgeIngestionRun`` with the final ``status`` either way.
+    On failure between (1) and (3) the source/row are explicitly
+    flipped to ``ERROR`` in their own transaction so the cron tick's
+    filter (``status NOT IN (DISABLED, SYNCING)``) doesn't keep
+    skipping a source that's actually stuck.
+    """
     settings = settings or get_settings()
     run = KnowledgeIngestionRun(
         id=uuid.uuid4(),
@@ -201,9 +224,17 @@ async def sync_import_source(
     session.add(run)
     source.status = KnowledgeSourceStatus.SYNCING
     source.last_error = None
-    await session.flush()
+    # Stage 1: commit the SYNCING marker so the connection releases
+    # back to the pool while the connector fans out over HTTP.
+    await session.commit()
     try:
+        # Stage 2: HTTP-only. The session is in autobegin state; no
+        # transaction is open while we wait on Notion / Confluence /
+        # GitHub.
         documents = await fetch_source_documents(session, source, settings=settings)
+        # Stage 3: a fresh transaction implicitly begins on the next
+        # session-level statement. Any DB writes from here on land
+        # together.
         stats = await _ingest_documents(
             session,
             source=source,
@@ -227,16 +258,36 @@ async def sync_import_source(
         run.status = KnowledgeIngestionStatus.DONE
         run.stats = stats.to_dict()
         run.finished_at = datetime.now(timezone.utc)
-        await session.flush()
+        await session.commit()
         await session.refresh(run)
         return run
     except Exception as exc:
+        # Roll back any half-flushed Stage-3 writes, then commit the
+        # ERROR marker in its own transaction. Without this explicit
+        # commit a connection-pool failure would leave the source
+        # stuck in SYNCING (cron filter skips that status forever).
+        try:
+            await session.rollback()
+        except Exception:  # noqa: BLE001
+            pass
+        try:
+            await session.refresh(source)
+            await session.refresh(run)
+        except Exception:  # noqa: BLE001
+            # Refresh can fail if the connection is wedged; we'll
+            # still try the UPDATE — SQLAlchemy will recover from a
+            # dropped connection on the next statement now that the
+            # transaction has been rolled back.
+            pass
         source.status = KnowledgeSourceStatus.ERROR
         source.last_error = f"{type(exc).__name__}: {exc}"[:4000]
         run.status = KnowledgeIngestionStatus.ERROR
         run.error = source.last_error
         run.finished_at = datetime.now(timezone.utc)
-        await session.flush()
+        try:
+            await session.commit()
+        except Exception:  # noqa: BLE001
+            await session.rollback()
         raise
 
 
@@ -352,6 +403,17 @@ async def _fetch_connector_documents(
             "connector source needs at least one resource_ref "
             "(e.g. {\"page_id\": \"...\"} or {\"database_id\": \"...\"})"
         )
+    # Release the DB connection before we go on a multi-minute HTTP
+    # walk. ``session.get(Integration, …)`` above auto-began a new
+    # transaction; the Notion / Confluence walker can take 5+ minutes
+    # on a hub page with hundreds of embedded child_databases, and
+    # Neon's pgbouncer-style pooler kills any backend that's idle in
+    # an open transaction past its grace window. Committing here
+    # ends the transaction; the connection returns to the pool and
+    # the walker runs with no DB at all. Stage 3 of
+    # ``sync_import_source`` will reopen a fresh transaction when
+    # ``_ingest_documents`` does its first SELECT/INSERT.
+    await session.commit()
     documents: list[SourceDocument] = []
     for ref in refs[:MAX_SOURCE_DOCUMENTS]:
         if not isinstance(ref, dict):
@@ -516,9 +578,19 @@ async def _fetch_docs_repo_documents(
     if installation is None:
         raise KnowledgeIngestionError("GitHub installation is not available")
     owner, name = repo.full_name.split("/", 1)
+    default_branch = repo.default_branch
+    html_url = repo.html_url
+    repo_id_str = str(repo.id)
+    installation_id = installation.installation_id
+    # Same reason as in ``_fetch_connector_documents``: release the
+    # connection before walking the repo. ``list_files`` + per-blob
+    # ``get_blob`` for a Ship-sized doc tree is fast (~10s), but a
+    # 5000-doc monorepo could trip the same Neon idle-cutoff. Cheap
+    # to commit eagerly; the ingest stage reopens a transaction.
+    await session.commit()
     ref = RepoRef(kind="github", owner=owner, repo=name)
-    gateway = GitHubCodeHost(installation.installation_id, settings=settings)
-    all_paths = await gateway.list_files(ref, ref_sha=repo.default_branch)
+    gateway = GitHubCodeHost(installation_id, settings=settings)
+    all_paths = await gateway.list_files(ref, ref_sha=default_branch)
     prefixes = source.config.get("paths") or source.config.get("path_prefixes") or ["docs"]
     if isinstance(prefixes, str):
         prefixes = [prefixes]
@@ -538,7 +610,7 @@ async def _fetch_docs_repo_documents(
     ][: int(source.config.get("limit") or MAX_SOURCE_DOCUMENTS)]
     documents: list[SourceDocument] = []
     for path in paths:
-        blob = await gateway.get_blob(ref, path=path, ref_sha=repo.default_branch)
+        blob = await gateway.get_blob(ref, path=path, ref_sha=default_branch)
         if blob.encoding != "utf-8" or not blob.content.strip():
             continue
         documents.append(
@@ -546,8 +618,8 @@ async def _fetch_docs_repo_documents(
                 external_id=path,
                 title=path.rsplit("/", 1)[-1],
                 body_md=blob.content,
-                external_url=f"{repo.html_url}/blob/{repo.default_branch}/{path}",
-                item_ref={"path": path, "sha": blob.sha, "repo_id": str(repo.id)},
+                external_url=f"{html_url}/blob/{default_branch}/{path}",
+                item_ref={"path": path, "sha": blob.sha, "repo_id": repo_id_str},
                 cursor={"path": path, "sha": blob.sha, "ref": blob.ref},
             )
         )


### PR DESCRIPTION
## Summary

Askslayer's Notion sync was stuck for 12+ hours after PR #159 (child_database soft-skip). Root cause was three independent failure modes layered on the same hub page (200+ embedded child_databases × 5-min HTTP fanout). Each fix on its own surfaces the next.

### 1. Long-held transaction → ``PendingRollbackError``

``sync_import_source`` opened a transaction, kept the session through the multi-minute walker, Neon's pgbouncer pool killed the idle backend, next ``session.flush()`` surfaced as ``PendingRollbackError``, cron's outer ``try/except`` rolled back all the SYNCING bookkeeping → source stayed at ``last_synced_at=NULL`` forever.

**Fix**: split into three transactions.
- Stage 1: insert RUNNING + flip SYNCING + commit. Release connection.
- Stage 2: connector fetch — DB lookups (Integration / WorkspaceRepo / GitHubInstallation) commit eagerly **before** launching HTTP walker. Walker holds no connection.
- Stage 3: fresh transaction reopens on next SELECT; ingest source items + write claims + commit. Error path re-fetches and commits explicit ``ERROR`` marker so cron filter (``status NOT IN (DISABLED, SYNCING)``) doesn't keep skipping a stuck source.

### 2. Single transient HTTP error aborts the walk

Walker's exception matched only ``401/403/404``; everything else (Notion 5xx mid-flight, 429, resets) raised through and aborted partial progress.

**Fix**:
- ``_get`` retries once with 0.5s backoff on ``429/500/502/503/504``.
- Walker soft-skips **any** HTTPStatusError on non-seed pages (log + continue). Seeds keep loud ``ConnectorConfigError`` for ``401/403/404`` so the wizard still teaches share-with-bot.
- ``child_database`` iteration soft-skips any HTTPStatusError, mirroring pages.

### 3. Pgbouncer-recycled backend in read-only mode

After Stage 1 commit released the backend, Neon's pooler occasionally handed Stage 3 a backend whose previous tenant left ``default_transaction_read_only=on``. First write failed with ``cannot execute UPDATE in a read-only transaction``.

**Fix**: pin ``server_settings={"default_transaction_read_only": "off"}`` in asyncpg connect_args when DSN is pgbouncer-pooled. asyncpg ``SET``s it immediately after connect on every backend so we always start writable.

## End-to-end verify

Run against askslayer's prod source (stuck 12+ hours pre-fix):

```
OK  status=done  stats={'errors': 0, 'changed': 445, 'skipped': 2,
'sections': 488, 'discovered': 447, 'notes_created': 488}
```

DB now: ``last_synced_at=2026-05-06 19:27 UTC``, 446 source items with ``body_md`` populated, ready for the next ``*/20`` extractor tick.

## Test plan

- [x] ``pytest backend/tests/test_connectors_notion.py`` — 14/14
- [x] Live repro against prod data — askslayer's source synced successfully end-to-end (5 min, 447 docs)
- [ ] CI: full backend suite
- [ ] Post-deploy: watch askslayer's pipeline through to topic_views; expect ~30-50 claims + ~5-10 topic_views once extractor + reconciler + renderer chain through. Watch for any new failure modes; the three fixes here are surgical and don't touch happy-path logic.