### PR TITLE
agent_runs: reject orphan tickets in get_next_task (ELS-83)

### DIFF
--- a/backend/app/api/v1/routes/agent_runs.py
+++ b/backend/app/api/v1/routes/agent_runs.py
@@ -243,7 +243,14 @@ async def get_next_task(
     session: AsyncSession = Depends(get_session),
     settings: Settings = Depends(get_settings),
 ) -> TaskResponseOut:
-    """Return the next ticket the agent should work on for ``state``."""
+    """Return the next ticket the agent should work on for ``state``.
+
+    Picker filters (ELS-83): tickets without a tracker ``project_id``
+    are orphans — created outside the dashboard's project flow.
+    They're skipped here and a one-shot inbox item plus an
+    ``agent_run.orphan_skipped`` audit row land so an operator can see
+    them and re-home the work or close it.
+    """
     await _require_membership(session, workspace_id, auth.user.id, ROLES_ADMIN)
 
     resolved = await resolve_for_workspace(
@@ -254,13 +261,44 @@ async def get_next_task(
     if resolved is None:
         return TaskResponseOut(ticket=None, fsm_stage=state, tracker_kind=None)
 
+    # Pull a few extra rows so an orphan at the head of the list
+    # doesn't starve the picker — we drop the orphans and pick the
+    # first non-orphan that remains.
     rows = await resolved.gateway.list_tickets(state=state, limit=10)
     if not rows:
         return TaskResponseOut(
             ticket=None, fsm_stage=state, tracker_kind=resolved.kind
         )
 
-    pick = rows[0]
+    pick: dict[str, Any] | None = None
+    skipped_orphans: list[dict[str, Any]] = []
+    for row in rows:
+        # ``project_id`` is surfaced by adapters that can populate it
+        # (Linear today). Adapters that can't (Notion / Jira / GitHub
+        # Issues) return ``None``; we accept those rows for backward
+        # compatibility — orphan filtering only kicks in when the
+        # adapter actually distinguishes "no project" from "unknown".
+        project_id = row.get("project_id")
+        if "project_id" in row and project_id is None:
+            skipped_orphans.append(row)
+            continue
+        pick = row
+        break
+
+    if skipped_orphans:
+        await _record_orphan_skips(
+            session,
+            workspace_id=workspace_id,
+            auth=auth,
+            tracker_kind=resolved.kind,
+            fsm_stage=state,
+            orphans=skipped_orphans,
+        )
+
+    if pick is None:
+        return TaskResponseOut(
+            ticket=None, fsm_stage=state, tracker_kind=resolved.kind
+        )
     return TaskResponseOut(
         fsm_stage=state,
         tracker_kind=resolved.kind,
@@ -275,6 +313,69 @@ async def get_next_task(
             fsm_stage=state,
         ),
     )
+
+
+async def _record_orphan_skips(
+    session: AsyncSession,
+    *,
+    workspace_id: uuid.UUID,
+    auth: AuthContext,
+    tracker_kind: str,
+    fsm_stage: str,
+    orphans: list[dict[str, Any]],
+) -> None:
+    """Audit + inbox notification for tickets the picker dropped.
+
+    One inbox row total per pick (not per orphan) so a single bad day
+    doesn't flood the operator's inbox; the row's payload carries the
+    list of skipped ticket refs so they can re-home them in bulk. The
+    audit log gets one row per orphan for traceability.
+    """
+    refs = [
+        str(row.get("id") or "")
+        for row in orphans
+        if row.get("id")
+    ]
+    refs = [r for r in refs if r]
+    if not refs:
+        return
+    for row in orphans:
+        session.add(
+            AuditLog(
+                workspace_id=workspace_id,
+                actor_user_id=auth.user.id,
+                actor_token_id=auth.token.id if auth.token else None,
+                action="agent_run.orphan_skipped",
+                target_kind="ticket",
+                target_id=str(row.get("id") or ""),
+                payload={
+                    "tracker_kind": tracker_kind,
+                    "fsm_stage": fsm_stage,
+                    "title": str(row.get("title") or "")[:200],
+                    "url": str(row.get("url") or "") or None,
+                    "reason": "no_project_id",
+                },
+            )
+        )
+    session.add(
+        InboxItem(
+            workspace_id=workspace_id,
+            type="improvement",
+            title=f"Orphan tickets skipped at stage {fsm_stage}"[:300],
+            summary=(
+                f"{len(refs)} ticket(s) at FSM stage {fsm_stage!r} have no "
+                "tracker project attached and were skipped by the agent "
+                "picker. Re-home them under a project (or close)."
+            )[:2000],
+            payload={
+                "kind": "orphan_skipped",
+                "tracker_kind": tracker_kind,
+                "fsm_stage": fsm_stage,
+                "ticket_refs": refs,
+            },
+        )
+    )
+    await session.flush()
 
 
 @router.post("/tracker/transition", response_model=WriteOut)

--- a/backend/app/integrations/gateway/tracker.py
+++ b/backend/app/integrations/gateway/tracker.py
@@ -99,7 +99,13 @@ class TrackerGateway(Protocol):
 
         Used by the dashboard and the daily-standup pipeline. Vendor
         adapters normalise to ``{"id", "title", "url", "status",
-        "updated_at"}`` at minimum.
+        "updated_at"}`` at minimum, plus the optional fields
+        ``project_id`` (tracker-native project UUID; ELS-83 — the
+        agent picker rejects orphan tickets that have no project)
+        and ``labels`` (a list of strings; ELS-84 — the picker drops
+        tickets carrying signal-label overlays such as
+        ``needs:clarification`` / ``blocked``). Adapters that can't
+        produce a field set it to ``None`` / ``[]``.
 
         ``state`` is a coarse hint: ``open`` / ``closed`` / ``all``
         (interpretation is vendor-specific). ``assignee_me`` limits to

--- a/backend/app/integrations/linear/tracker_adapter.py
+++ b/backend/app/integrations/linear/tracker_adapter.py
@@ -182,6 +182,8 @@ class LinearTracker:
                   title
                   url
                   state { name type }
+                  project { id }
+                  labels { nodes { name } }
                   updatedAt
                 }
               }
@@ -199,6 +201,8 @@ class LinearTracker:
                   title
                   url
                   state { name type }
+                  project { id }
+                  labels { nodes { name } }
                   updatedAt
                 }
               }
@@ -208,10 +212,15 @@ class LinearTracker:
                 gql, {"first": first, "filter": issue_filter}
             )
             nodes = (data.get("issues") or {}).get("nodes") or []
-        nodes = (data.get("issues") or {}).get("nodes") or []
         out: list[dict[str, Any]] = []
         for n in nodes:
             state_name = (n.get("state") or {}).get("name")
+            project_id = (n.get("project") or {}).get("id")
+            label_nodes = (n.get("labels") or {}).get("nodes") or []
+            labels = [
+                str(item.get("name") or "") for item in label_nodes
+                if isinstance(item, dict) and item.get("name")
+            ]
             out.append(
                 {
                     "id": n.get("identifier") or n.get("id"),
@@ -219,6 +228,16 @@ class LinearTracker:
                     "url": n.get("url"),
                     "status": state_name,
                     "updated_at": n.get("updatedAt"),
+                    # ELS-83: surface ``project_id`` so the agent picker
+                    # can reject orphans (tickets created outside the
+                    # dashboard flow that have no project attached).
+                    # ``None`` when the issue isn't part of any Linear
+                    # project — the picker treats that as "skip".
+                    "project_id": project_id,
+                    # Labels surface ELS-84 (clarification/blocked overlays)
+                    # filtering one layer up; see ``signal_labels`` keys
+                    # in linear_provisioner.py.
+                    "labels": labels,
                 }
             )
         return out

--- a/backend/tests/test_linear_tracker_list_tickets.py
+++ b/backend/tests/test_linear_tracker_list_tickets.py
@@ -1,0 +1,146 @@
+"""Linear adapter ``list_tickets`` shape (ELS-83 + ELS-84).
+
+Two invariants the agent picker depends on:
+
+1. **``project_id``** — Linear projects each issue under exactly one
+   project (or ``null``). The picker uses this to reject orphan
+   tickets created outside the dashboard's ``_tool_create_project``
+   flow. Without ``project_id`` in the projection, ELS-80 cannot
+   filter by ``WorkspaceProjectPriority`` either.
+
+2. **``labels``** — overlay labels (``needs:clarification`` /
+   ``blocked``) freeze a ticket while a human owes a reply. The
+   picker drops these so an agent doesn't burn a Cursor run on a
+   ticket the operator is already triaging.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from backend.app.integrations.linear.tracker_adapter import LinearTracker
+
+
+@pytest.mark.asyncio
+async def test_list_tickets_surfaces_project_id_and_labels() -> None:
+    """The GraphQL projection pulls ``project { id }`` + ``labels``."""
+
+    seen_queries: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = request.read().decode()
+        seen_queries.append(body)
+        return httpx.Response(
+            200,
+            json={
+                "data": {
+                    "issues": {
+                        "nodes": [
+                            {
+                                "id": "issue-uuid-1",
+                                "identifier": "ELS-100",
+                                "title": "Has project + labels",
+                                "url": "https://linear.app/elship/issue/ELS-100/x",
+                                "state": {"name": "Todo", "type": "unstarted"},
+                                "project": {"id": "project-uuid-1"},
+                                "labels": {
+                                    "nodes": [
+                                        {"name": "stage:wbs"},
+                                        {"name": "needs:clarification"},
+                                    ]
+                                },
+                                "updatedAt": "2026-05-06T10:00:00Z",
+                            },
+                            {
+                                "id": "issue-uuid-2",
+                                "identifier": "ELS-101",
+                                "title": "Orphan — no project",
+                                "url": "https://linear.app/elship/issue/ELS-101/x",
+                                "state": {"name": "Todo", "type": "unstarted"},
+                                "project": None,
+                                "labels": {"nodes": []},
+                                "updatedAt": "2026-05-06T11:00:00Z",
+                            },
+                        ]
+                    }
+                }
+            },
+        )
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as client:
+        tracker = LinearTracker(
+            "lin_oauth_x",
+            client=client,
+            team_id="854ffe38-aaaa-bbbb-cccc-dddddddddddd",
+            team_key="ELS",
+        )
+        rows = await tracker.list_tickets(state="all", limit=10)
+
+    # Both issues come back; orphan distinction is in the project_id
+    # field, not "missing from list".
+    assert len(rows) == 2
+    payload = json.loads(seen_queries[0])
+    assert "project { id }" in payload["query"]
+    assert "labels { nodes { name } }" in payload["query"]
+
+    [first, second] = rows
+    assert first["project_id"] == "project-uuid-1"
+    assert first["labels"] == ["stage:wbs", "needs:clarification"]
+
+    # Orphan: ``project_id`` is explicitly ``None`` (key present, value
+    # null). The picker keys off this exact shape — key-present + null
+    # value — to distinguish "tracker says no project" from "adapter
+    # doesn't know how to surface project". Adapters that don't
+    # surface project (Notion / Jira / GitHub Issues today) omit the
+    # key entirely so the picker doesn't accidentally drop their rows.
+    assert "project_id" in second
+    assert second["project_id"] is None
+    assert second["labels"] == []
+
+
+@pytest.mark.asyncio
+async def test_list_tickets_handles_unfiltered_query() -> None:
+    """No filter (state=all, no team) still pulls project_id + labels."""
+
+    seen_queries: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = request.read().decode()
+        seen_queries.append(body)
+        return httpx.Response(
+            200,
+            json={
+                "data": {
+                    "issues": {
+                        "nodes": [
+                            {
+                                "id": "issue-uuid-x",
+                                "identifier": "ELS-99",
+                                "title": "x",
+                                "url": "https://linear.app/elship/issue/ELS-99/x",
+                                "state": {"name": "Todo", "type": "unstarted"},
+                                "project": {"id": "p-x"},
+                                "labels": {"nodes": [{"name": "stage:wbs"}]},
+                                "updatedAt": "2026-05-06T12:00:00Z",
+                            }
+                        ]
+                    }
+                }
+            },
+        )
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as client:
+        # No team_id / team_key → unfiltered branch
+        tracker = LinearTracker("lin_oauth_x", client=client)
+        rows = await tracker.list_tickets(state="all", limit=10)
+
+    assert len(rows) == 1
+    payload = json.loads(seen_queries[0])
+    assert "project { id }" in payload["query"]
+    assert rows[0]["project_id"] == "p-x"
+    assert rows[0]["labels"] == ["stage:wbs"]


### PR DESCRIPTION
## Summary

The agent picker now sees ``project_id`` from the Linear adapter and drops tickets with no tracker project attached. Orphans (tickets created outside the dashboard's project-first flow) shouldn't burn a Cursor run — the operator should re-home or close them.

- **`linear/tracker_adapter.list_tickets`** — extends the GraphQL projection to include `project { id }` and `labels { nodes { name } }`. Returns `project_id` (or `None` when an issue isn't projectised) and a flat `labels` array per row. Labels feed ELS-84's overlay-label filter without a second round-trip.
- **`gateway/tracker.py`** — documents the new optional fields on the protocol so Notion / Jira / GitHub Issues adapters know what to surface when they catch up.
- **`agent_runs.get_next_task`** — pulls 10 rows, filters out orphans (`project_id` key present and `None`), picks the first survivor. Adapters that don't surface `project_id` at all still pass through untouched.
- **`_record_orphan_skips`** — one inbox notification per pick (payload carries the full list of skipped refs) plus a per-orphan `agent_run.orphan_skipped` audit row. Bulk re-homing on the operator side, granular audit trail.

## Unblocks

- **ELS-80** — `WorkspaceProjectPriority` filter joins on `project_id` returned here.
- **ELS-84** — overlay-label filter consumes the same `labels` field.

## Test plan

- [x] `pytest backend/tests/test_linear_tracker_list_tickets.py` — 2 pass (projection + unfiltered query)
- [x] `pytest backend/tests/test_linear_tracker_default_team.py` — 4 pass (no regression on existing GraphQL)
- [ ] DB-bound smoke: a workspace with a mix of orphan + projectised tickets at the same FSM stage returns only the projectised one to `shipctl run --routine X`. (Lands in ELS-89.)