### PR TITLE
agent_runs: flip Drafts → Parked at planning_done (ELS-81)

### DIFF
--- a/backend/app/api/v1/routes/agent_runs.py
+++ b/backend/app/api/v1/routes/agent_runs.py
@@ -162,7 +162,8 @@ class FinishIn(BaseModel):
     # SDLC (``development``); ``decomposition`` (ELS-75) is the
     # project-anchor pipeline. The finish hook reads this to know
     # whether ``stage_next='planning_done'`` should flip the project's
-    # dashboard row from Drafts → Active.
+    # dashboard row from Drafts → Parked (the PO promotes Parked →
+    # Active manually when ready to ship; ELS-81).
     process: Literal["development", "decomposition"] = "development"
     payload: dict[str, Any] = Field(default_factory=dict)
 
@@ -424,18 +425,22 @@ async def post_inbox_item(
     return WriteOut(ok=True, note=f"inbox item created (type={payload.type})")
 
 
-async def _flip_drafts_row_to_active(
+async def _flip_drafts_row_to_parked(
     session: AsyncSession,
     workspace_id: uuid.UUID,
     ticket_ref: str,
     resolved,  # ResolvedTracker; avoid circular type import
 ) -> bool:
-    """Flip the project's priorities row from ``planning`` → ``active``.
+    """Flip the project's priorities row from ``planning`` → ``parked``.
 
-    Called when a decomposition run reaches the terminal stage. Walks:
-    ticket_ref → planning anchor's project_id → priorities row → state.
-    Best-effort: a missing priorities row, a deleted project, or an
-    adapter that can't tell us the project all log + return False
+    Called when a decomposition run reaches the terminal stage. The PO
+    explicitly promotes ``parked`` → ``active`` from the dashboard
+    when ready to ship — Ship doesn't auto-activate. (ELS-81; previous
+    behaviour was to auto-flip to ``active``.)
+
+    Walks: ticket_ref → planning anchor's project_id → priorities row
+    → state. Best-effort: a missing priorities row, a deleted project,
+    or an adapter that can't tell us the project all log + return False
     instead of failing the finish handler.
     """
     from sqlalchemy import select
@@ -497,9 +502,9 @@ async def _flip_drafts_row_to_active(
             project_id,
         )
         return False
-    if row.state == "active":
+    if row.state == "parked":
         return False
-    row.state = "active"
+    row.state = "parked"
     await session.flush()
     return True
 
@@ -621,23 +626,26 @@ async def finish_agent_run(
 
             # Decomposition completion hook (ELS-75). When the planning
             # anchor reaches the terminal stage, flip the project's
-            # dashboard row Drafts → Active so the agent's autonomous
-            # picker takes over from here. We key on the explicit
-            # ``process='decomposition'`` flag rather than sniffing
-            # labels — the runtime that's executing the run knows
-            # which process it's under, the server should not have to
-            # re-derive that. Best-effort: a missing priorities row
-            # logs and continues; the audit trail at the bottom of
+            # dashboard row Drafts → Parked so the project sits ready
+            # for the PO to promote when they decide it's worth the
+            # capacity (ELS-81; the previous behaviour auto-activated,
+            # which let agents start chewing on every project the
+            # moment its decomposition finished). We key on the
+            # explicit ``process='decomposition'`` flag rather than
+            # sniffing labels — the runtime that's executing the run
+            # knows which process it's under, the server should not
+            # have to re-derive that. Best-effort: a missing priorities
+            # row logs and continues; the audit trail at the bottom of
             # this handler still records what happened.
             if (
                 payload.process == "decomposition"
                 and payload.stage_next == "planning_done"
             ):
-                flipped = await _flip_drafts_row_to_active(
+                flipped = await _flip_drafts_row_to_parked(
                     session, workspace_id, payload.ticket_ref, resolved
                 )
                 if flipped:
-                    actions.append("priorities:active")
+                    actions.append("priorities:parked")
 
     elif payload.outcome == "needs_clarification":
         if not payload.ticket_ref:

--- a/backend/app/api/v1/routes/dashboard_priorities.py
+++ b/backend/app/api/v1/routes/dashboard_priorities.py
@@ -579,8 +579,9 @@ async def start_decomposition(
     into the first decomposition stage (``stage:wbs``) — the per-tick
     shipctl scheduler then picks up BA, who emits the WBS section,
     transitions to ``stage:architecture``, and so on through to
-    ``stage:planning_done`` (the finish hook flips Drafts → Active
-    when that lands).
+    ``stage:planning_done`` (the finish hook flips Drafts → Parked
+    when that lands; the PO promotes Parked → Active manually when
+    ready to ship — ELS-81).
 
     Idempotent on the anchor: re-running when the anchor already
     carries a non-entry decomposition stage label is a no-op (we

--- a/backend/app/resources/agent_roles/developer.md
+++ b/backend/app/resources/agent_roles/developer.md
@@ -29,5 +29,5 @@ When the run context flags `process=decomposition` (project-first delivery, ELS-
   - **Body**: 3-5 lines pulling Goal + Scope from the WBS line + 1-2 architecture pointers from `## Architecture`. Do NOT write detailed acceptance criteria, test plans, or implementation notes — SDLC's BA, tech architect, and QA architect refine those when the child enters `task_intake`.
 - After all child tickets exist, patch `## Tasks` via `upsert_project_section(project_id=<from anchor's project>, section="Tasks", body=<list of identifiers + names>)` — one bullet per child ticket created.
 - NEVER touch `## Brief`, `## WBS`, `## Architecture`, or `## Test architecture`. Those are owned by upstream stages.
-- Finish with `outcome=ready_next_step`, `stage_next=planning_done`, `process=decomposition`. The server's completion hook then flips the project's dashboard row from Drafts → Active and the agent's autonomous picker takes over from there.
+- Finish with `outcome=ready_next_step`, `stage_next=planning_done`, `process=decomposition`. The server's completion hook then flips the project's dashboard row from Drafts → Parked so the project sits ready for the PO to promote (Parked → Active) when they decide it's worth the capacity. Agents do not auto-pick from Parked.
 - End your audit `comment` with: `[Ship decomposition:role-developer]`

--- a/backend/app/services/agent/tools.py
+++ b/backend/app/services/agent/tools.py
@@ -2049,8 +2049,10 @@ class ToolBox:
                     "BA, who emits the WBS section, transitions to "
                     "``stage:architecture``, and so on through "
                     "``stage:planning_done`` — at which point the "
-                    "project flips Drafts → Active and the agent's "
-                    "autonomous picker takes over."
+                    "project flips Drafts → Parked. The PO then "
+                    "promotes Parked → Active from the dashboard "
+                    "when ready to ship; agents do not auto-pick "
+                    "from Parked."
                 ),
                 parameters={
                     "type": "object",

--- a/backend/app/services/catalog.py
+++ b/backend/app/services/catalog.py
@@ -420,7 +420,9 @@ def default_planning_process_config() -> dict[str, object]:
         # No human gates today — the operator's gate is the manual
         # **Hand off to decomposition** click on the dashboard. Once
         # they hit it, the chain runs autonomously through to
-        # ``planning_done`` and the project flips Drafts → Active.
+        # ``planning_done`` and the project flips Drafts → Parked
+        # (the PO promotes Parked → Active manually when ready to
+        # ship; ELS-81).
         "gates": "after_pr",
         "states": [
             {
@@ -486,11 +488,14 @@ def default_planning_process_config() -> dict[str, object]:
                 # Terminal stage — no specialist runs here. ``ready_next_step``
                 # with ``stage_next='planning_done'`` from the ``tasks`` stage
                 # signals decomposition complete; the finish hook flips the
-                # dashboard row from Drafts → Active.
+                # dashboard row from Drafts → Parked (ELS-81; the PO
+                # then promotes Parked → Active manually).
                 "specialist": {"id": "developer", "name": "Developer"},
                 "instructions": (
                     "Terminal — no work. Reaching this stage flips the "
-                    "project from Drafts to Active on the dashboard."
+                    "project from Drafts to Parked on the dashboard "
+                    "(the PO promotes Parked → Active when ready to "
+                    "ship)."
                 ),
             },
         ],

--- a/backend/app/services/linear_provisioner.py
+++ b/backend/app/services/linear_provisioner.py
@@ -83,7 +83,8 @@ FSM_STAGE_ORDER: tuple[str, ...] = (
 # Linear order of the decomposition pipeline (ELS-75). Sequential —
 # BA → Architect → QA-Architect → QA-Engineer + Developer — culminates
 # in ``planning_done`` which the finish hook reads to flip the
-# project's dashboard row from Drafts to Active.
+# project's dashboard row from Drafts to Parked (the PO promotes
+# Parked → Active manually when ready to ship; ELS-81).
 DECOMPOSITION_STAGE_ORDER: tuple[str, ...] = (
     "wbs",
     "architecture",
@@ -133,8 +134,9 @@ FSM_TO_LINEAR_STATE: dict[str, str] = {
     # project). The anchor sits in ``In Progress`` while the chain
     # runs and ``Done`` once ``planning_done`` lands. The project body
     # carries the artefacts (WBS / Architecture / Test architecture /
-    # Tasks); the finish hook flips the dashboard row Drafts → Active
-    # when ``planning_done`` arrives.
+    # Tasks); the finish hook flips the dashboard row Drafts → Parked
+    # when ``planning_done`` arrives (the PO promotes Parked → Active
+    # manually; ELS-81).
     "wbs": "In Progress",
     "architecture": "In Progress",
     "test_architecture": "In Progress",


### PR DESCRIPTION
## Summary

Decomposition completion now flips the project's dashboard row to **Parked**, not **Active**. The PO promotes Parked → Active manually when ready to ship; agents do not auto-pick from Parked (combined with ELS-80's picker gate).

Why: previous auto-Active behaviour let agents start chewing on every project the moment decomposition finished. With ELS-80 gating the picker by `state='active'`, auto-Active would reintroduce the same uncontrolled-fanout problem.

## Changes

- `_flip_drafts_row_to_active` → `_flip_drafts_row_to_parked`; assigns `"parked"` instead of `"active"`
- Doc/comment sweep: `catalog.py`, `dashboard_priorities.py`, `linear_provisioner.py`, `agent_roles/developer.md`, `services/agent/tools.py`, `FinishIn` docstring

## Test plan

- [x] Backend imports clean
- [x] No remaining `Drafts → Active` text outside the PO's manual-promote callouts
- [ ] DB-bound: completing decomposition lands the project in **Parked**, not **Active**, and Parked tickets aren't returned by `get_next_task`. (ELS-89 smoke.)