### PR TITLE
priorities: default state to 'planning' for new projects (ELS-82)

### DIFF
--- a/backend/app/db/models/dashboard_priorities.py
+++ b/backend/app/db/models/dashboard_priorities.py
@@ -74,14 +74,20 @@ class WorkspaceProjectPriority(Base):
     project_native_id: Mapped[str] = mapped_column(String(128), nullable=False)
     ordinal: Mapped[int] = mapped_column(Integer, nullable=False)
     # Bucket on the prioritizer:
-    # ``active`` (agent may pick) | ``planning`` (operator is shaping)
-    # | ``parked`` (explicitly hold). Only ``active`` is visible to the
-    # agent's project picker. Default ``active`` matches the pre-state
-    # contract where any saved row was pickable.
+    # ``active`` (agent may pick) | ``planning`` (operator is shaping —
+    # UI label "Drafts") | ``parked`` (explicitly hold). Only
+    # ``active`` is visible to the agent's project picker.
+    #
+    # Default is ``planning`` (ELS-82): newly created projects need to
+    # go through the dashboard's drafting + decomposition flow before
+    # the agent picks them up. Decomposition completion flips the row
+    # to ``parked`` (ELS-81), and the PO promotes ``parked`` → ``active``
+    # manually when ready to ship. The previous default of ``active``
+    # let any new project bypass the gate.
     state: Mapped[str] = mapped_column(
         String(16),
         nullable=False,
-        server_default=text("'active'"),
+        server_default=text("'planning'"),
     )
     # Backref to the Navigator thread this project was drafted in.
     # Powers the "Continue shaping" link on Drafts-bucket rows: clicking

--- a/backend/migrations/versions/0062_priority_state_default_planning.py
+++ b/backend/migrations/versions/0062_priority_state_default_planning.py
@@ -1,0 +1,61 @@
+"""workspace project priorities — default state to 'planning' (ELS-82)
+
+When the priority axis landed (0057), the column's default was
+``'active'`` to match the pre-state contract: any saved row was
+pickable. ELS-82 flips that default to ``'planning'`` so newly
+created projects stop bypassing the dashboard's drafting +
+decomposition flow. The agent picker (ELS-80) only sees ``active``
+projects; new projects now sit in Drafts (``planning``) until the
+operator hands them off through the dashboard, decomposition runs,
+the row flips to ``parked`` (ELS-81), and the PO promotes to
+``active`` manually.
+
+Existing rows are deliberately NOT touched. Live work in ``active``
+should keep flowing; an operator who wants to gate an in-flight
+project parks it explicitly. Backfilling everyone to ``planning``
+would freeze workspaces overnight without warning.
+
+Revision ID: 0062_priority_state_default_planning
+Revises: 0061_knowledge_topic_views
+Create Date: 2026-05-06
+"""
+
+from __future__ import annotations
+
+from typing import Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "0062_priority_state_default_planning"
+down_revision: Union[str, None] = "0061_knowledge_topic_views"
+branch_labels: Union[str, tuple[str, ...], None] = None
+depends_on: Union[str, tuple[str, ...], None] = None
+
+
+_TABLE = "workspace_project_priorities"
+
+
+def upgrade() -> None:
+    # Default-only migration: alter the server default; existing rows
+    # keep their current state. The CHECK constraint already pins the
+    # accepted enum at the DB layer, so the new default value remains
+    # valid without further work.
+    op.alter_column(
+        _TABLE,
+        "state",
+        existing_type=sa.String(length=16),
+        existing_nullable=False,
+        server_default=sa.text("'planning'"),
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        _TABLE,
+        "state",
+        existing_type=sa.String(length=16),
+        existing_nullable=False,
+        server_default=sa.text("'active'"),
+    )


### PR DESCRIPTION
## Summary

Flip ``WorkspaceProjectPriority.state``'s server-default from ``'active'`` to ``'planning'`` so newly created projects land in Drafts instead of being immediately pickable. Combined with ELS-80 (picker gate) and ELS-81 (Drafts → Parked at decomposition done), the lifecycle is now:

```
PO drafts in Navigator → planning (Drafts)
→ Hand off to decomposition → chain runs → parked
→ PO promotes → active → picker consumes
```

## Changes

- `db/models/dashboard_priorities.py` — `server_default=text("'planning'")`, doc updated
- `migrations/versions/0062_priority_state_default_planning.py` — `alter_column` to change the default. **Existing rows are NOT touched** — backfilling everyone to ``planning`` would freeze live workspaces overnight.

## Test plan

- [x] Model + migration import clean
- [x] Existing test suite (`test_v1_dashboard_priorities.py`) doesn't rely on the default — tests pass `state` explicitly
- [ ] DB-bound: a fresh insert without ``state`` lands in ``planning``; the picker (ELS-80) doesn't return its tickets. (ELS-89 smoke.)