### PR TITLE
agent_tools: repo_symbols on-demand tree-sitter parser (ELS-72)

### DIFF
--- a/backend/app/services/agent/symbol_parser.py
+++ b/backend/app/services/agent/symbol_parser.py
@@ -1,0 +1,553 @@
+"""On-demand symbol extraction with tree-sitter (ELS-72).
+
+The ``repo_symbols`` agent tool parses one file at a time using
+GitHub-App-fetched contents (no on-disk checkout, no preindex). The
+shape of each emitted row is fixed across languages so the agent
+gets the same structure whether it asked about a Python module or
+a Go file:
+
+    {
+      "file": "<repo-relative path>",
+      "symbol": "<identifier>",
+      "kind": "function" | "class" | "method" | "interface" | "type" |
+              "struct" | "enum" | "var" | "const",
+      "line": 1-based int,
+      "signature": "<one-line signature>",
+    }
+
+Why tree-sitter and not the stdlib ``ast`` for Python?
+
+* One traversal shape and one symbol-row schema covers all three
+  pilot languages, so the tool's output stays uniform.
+* tree-sitter parsers tolerate syntax errors gracefully — the agent
+  often points the tool at a file that's mid-edit; a strict parser
+  would explode where tree-sitter recovers and still surfaces the
+  reachable symbols.
+
+Caching: parsers and languages are loaded once at process scope
+(both are thread-safe and cheap to share). Per-call we build a fresh
+``tree_sitter.Parser`` instance? No — Parser is also reusable; we
+re-use it as ``Parser.set_language`` is a no-op once set. We don't
+cache per-file *parses* in this module — that's the job of the
+optional ``RepoCodeSymbol`` table the ticket marks as v1+.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Any
+
+
+logger = logging.getLogger(__name__)
+
+
+# Languages this module knows how to extract symbols from. Add more by
+# (1) wiring up a tree-sitter language pack name, (2) registering an
+# extractor below, (3) extending ``LANGUAGE_BY_EXTENSION``.
+SUPPORTED_LANGUAGES: tuple[str, ...] = ("python", "typescript", "tsx", "go")
+
+
+# File extension → tree-sitter language name. ``.tsx`` parses through
+# the ``tsx`` grammar (a superset that tolerates JSX), not vanilla
+# ``typescript`` — keeps React component files from blowing up.
+LANGUAGE_BY_EXTENSION: dict[str, str] = {
+    ".py": "python",
+    ".ts": "typescript",
+    ".tsx": "tsx",
+    ".go": "go",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class Symbol:
+    """One extracted symbol. Matches the agent-facing JSON row shape."""
+
+    file: str
+    symbol: str
+    kind: str
+    line: int
+    signature: str
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "file": self.file,
+            "symbol": self.symbol,
+            "kind": self.kind,
+            "line": self.line,
+            "signature": self.signature,
+        }
+
+
+def language_for_path(path: str) -> str | None:
+    """Return the tree-sitter language name for ``path``, or ``None``
+    when the file extension isn't one this module parses.
+
+    The ``.spec.ts`` / ``.test.tsx`` etc. compound suffixes still match
+    on the *last* component (``.ts`` / ``.tsx``) — the matcher walks
+    extensions right-to-left and bails at the first hit.
+    """
+    lower = path.lower()
+    for ext, lang in LANGUAGE_BY_EXTENSION.items():
+        if lower.endswith(ext):
+            return lang
+    return None
+
+
+@lru_cache(maxsize=8)
+def _parser(language: str):
+    """Return a process-scoped parser for ``language``.
+
+    ``tree_sitter_language_pack`` lazy-loads grammar wheels — the
+    import cost is paid on first call per language and cached for
+    the lifetime of the process. ``lru_cache`` size 8 covers the four
+    pilot grammars with headroom; bumps don't cost anything.
+    """
+    from tree_sitter_language_pack import get_parser
+
+    return get_parser(language)
+
+
+def extract_symbols(*, file: str, content: str) -> list[Symbol]:
+    """Parse ``content`` and return the symbols it declares.
+
+    ``file`` is the repo-relative path; it's only used to (a) infer
+    the language and (b) stamp it on the returned rows. Returns
+    ``[]`` for unsupported extensions, empty content, or unparseable
+    files (rather than raising — the agent tool wraps multiple files
+    and one broken file shouldn't fail the whole call).
+    """
+    if not content:
+        return []
+    language = language_for_path(file)
+    if language is None:
+        return []
+    try:
+        parser = _parser(language)
+        source = content.encode("utf-8")
+        tree = parser.parse(source)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug(
+            "symbol_parser: parse failed file=%s lang=%s err=%s",
+            file,
+            language,
+            exc,
+        )
+        return []
+
+    extractor = _EXTRACTORS.get(language)
+    if extractor is None:
+        return []
+    try:
+        return extractor(file=file, source=source, root=tree.root_node)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug(
+            "symbol_parser: extractor failed file=%s lang=%s err=%s",
+            file,
+            language,
+            exc,
+        )
+        return []
+
+
+# ---------------------------------------------------------------------------
+# Per-language extractors
+# ---------------------------------------------------------------------------
+
+
+def _node_text(source: bytes, node: Any) -> str:
+    """Decode the byte slice ``[node.start_byte, node.end_byte)``."""
+    return source[node.start_byte : node.end_byte].decode(
+        "utf-8", errors="replace"
+    )
+
+
+def _first_line(text: str, *, max_chars: int = 240) -> str:
+    """Collapse multi-line declarations into one signature-shaped line.
+
+    Function signatures spanning multiple lines (typed Python defs,
+    Go function with grouped params) get squished to single-line so
+    the agent's row stays compact. Caps at ``max_chars`` so a giant
+    parameter list doesn't blow the response budget.
+    """
+    flat = " ".join(text.split())
+    if len(flat) > max_chars:
+        flat = flat[: max_chars - 1].rstrip() + "…"
+    return flat
+
+
+def _line_of(node: Any) -> int:
+    """1-based line number of ``node``'s start point."""
+    return int(node.start_point[0]) + 1
+
+
+def _python_signature(source: bytes, node: Any) -> str:
+    """Python: take everything from ``def``/``class`` to the colon."""
+    text = _node_text(source, node)
+    head, _, _ = text.partition(":")
+    return _first_line(head + ":")
+
+
+def _extract_python(*, file: str, source: bytes, root: Any) -> list[Symbol]:
+    """Walk the AST and emit definitions.
+
+    Recognised: top-level `def`/`async def` (function), classes,
+    methods inside a class body, module-level `var = ...` /
+    `CONST = ...` / `TYPE: <ann> = ...`. We stop at the first level
+    of class nesting — symbols inside nested functions are usually
+    closures the operator doesn't need exposed.
+    """
+    out: list[Symbol] = []
+    stack: list[tuple[Any, str | None]] = [(root, None)]
+    while stack:
+        node, parent_kind = stack.pop()
+        kind_name = node.type
+        if kind_name in ("function_definition",):
+            name_node = node.child_by_field_name("name")
+            if name_node is None:
+                continue
+            sig = _python_signature(source, node)
+            kind = "method" if parent_kind == "class" else "function"
+            out.append(
+                Symbol(
+                    file=file,
+                    symbol=_node_text(source, name_node),
+                    kind=kind,
+                    line=_line_of(node),
+                    signature=sig,
+                )
+            )
+            # Don't descend into nested defs — too noisy.
+            continue
+        if kind_name == "class_definition":
+            name_node = node.child_by_field_name("name")
+            if name_node is None:
+                continue
+            sig = _python_signature(source, node)
+            out.append(
+                Symbol(
+                    file=file,
+                    symbol=_node_text(source, name_node),
+                    kind="class",
+                    line=_line_of(node),
+                    signature=sig,
+                )
+            )
+            # Walk one level deeper to grab methods on this class.
+            body_node = node.child_by_field_name("body")
+            if body_node is not None:
+                for child in body_node.children:
+                    stack.append((child, "class"))
+            continue
+        if (
+            kind_name in ("assignment", "expression_statement")
+            and parent_kind is None
+        ):
+            # Module-level constants. We pick up bare ``NAME = ...`` /
+            # ``NAME: ann = ...`` only; tuple/star unpacks would clutter
+            # the output without helping.
+            target = None
+            if kind_name == "assignment":
+                target = node.child_by_field_name("left")
+            else:
+                child = node.child(0)
+                if child is not None and child.type == "assignment":
+                    target = child.child_by_field_name("left")
+            if target is not None and target.type in (
+                "identifier",
+                "type_alias_statement",
+            ):
+                name = _node_text(source, target)
+                if name and name.isidentifier():
+                    out.append(
+                        Symbol(
+                            file=file,
+                            symbol=name,
+                            kind="const" if name.isupper() else "var",
+                            line=_line_of(node),
+                            signature=_first_line(_node_text(source, node)),
+                        )
+                    )
+            continue
+        for child in node.children:
+            stack.append((child, parent_kind))
+    return out
+
+
+def _ts_signature(source: bytes, node: Any) -> str:
+    """TypeScript: signature is the head up to the first `{` (body open)."""
+    text = _node_text(source, node)
+    head, _, _ = text.partition("{")
+    head = head.rstrip()
+    if not head.endswith(("{", ":", ";")):
+        head += " {"
+    return _first_line(head)
+
+
+def _extract_typescript(*, file: str, source: bytes, root: Any) -> list[Symbol]:
+    """TS / TSX: function/class/interface/type/enum + top-level const/let/var."""
+    out: list[Symbol] = []
+    cursor = [(root, None)]
+    while cursor:
+        node, parent_kind = cursor.pop()
+        kind_name = node.type
+        if kind_name in (
+            "function_declaration",
+            "generator_function_declaration",
+        ):
+            name_node = node.child_by_field_name("name")
+            if name_node is None:
+                continue
+            out.append(
+                Symbol(
+                    file=file,
+                    symbol=_node_text(source, name_node),
+                    kind="function",
+                    line=_line_of(node),
+                    signature=_ts_signature(source, node),
+                )
+            )
+            continue
+        if kind_name in ("class_declaration", "abstract_class_declaration"):
+            name_node = node.child_by_field_name("name")
+            if name_node is None:
+                continue
+            out.append(
+                Symbol(
+                    file=file,
+                    symbol=_node_text(source, name_node),
+                    kind="class",
+                    line=_line_of(node),
+                    signature=_ts_signature(source, node),
+                )
+            )
+            body_node = node.child_by_field_name("body")
+            if body_node is not None:
+                for child in body_node.children:
+                    cursor.append((child, "class"))
+            continue
+        if kind_name == "method_definition" and parent_kind == "class":
+            name_node = node.child_by_field_name("name")
+            if name_node is None:
+                continue
+            out.append(
+                Symbol(
+                    file=file,
+                    symbol=_node_text(source, name_node),
+                    kind="method",
+                    line=_line_of(node),
+                    signature=_ts_signature(source, node),
+                )
+            )
+            continue
+        if kind_name in ("interface_declaration",):
+            name_node = node.child_by_field_name("name")
+            if name_node is None:
+                continue
+            out.append(
+                Symbol(
+                    file=file,
+                    symbol=_node_text(source, name_node),
+                    kind="interface",
+                    line=_line_of(node),
+                    signature=_ts_signature(source, node),
+                )
+            )
+            continue
+        if kind_name == "type_alias_declaration":
+            name_node = node.child_by_field_name("name")
+            if name_node is None:
+                continue
+            out.append(
+                Symbol(
+                    file=file,
+                    symbol=_node_text(source, name_node),
+                    kind="type",
+                    line=_line_of(node),
+                    signature=_first_line(_node_text(source, node)),
+                )
+            )
+            continue
+        if kind_name == "enum_declaration":
+            name_node = node.child_by_field_name("name")
+            if name_node is None:
+                continue
+            out.append(
+                Symbol(
+                    file=file,
+                    symbol=_node_text(source, name_node),
+                    kind="enum",
+                    line=_line_of(node),
+                    signature=_ts_signature(source, node),
+                )
+            )
+            continue
+        if (
+            kind_name == "lexical_declaration"
+            or kind_name == "variable_declaration"
+        ) and parent_kind is None:
+            # ``const x = …``, ``let x = …``, ``var x = …`` at top level.
+            for declarator in node.children:
+                if declarator.type != "variable_declarator":
+                    continue
+                name_node = declarator.child_by_field_name("name")
+                if name_node is None or name_node.type != "identifier":
+                    continue
+                value_node = declarator.child_by_field_name("value")
+                arrow = (
+                    value_node is not None
+                    and value_node.type == "arrow_function"
+                )
+                kind = "function" if arrow else "var"
+                out.append(
+                    Symbol(
+                        file=file,
+                        symbol=_node_text(source, name_node),
+                        kind=kind,
+                        line=_line_of(node),
+                        signature=_ts_signature(source, node),
+                    )
+                )
+            continue
+        for child in node.children:
+            cursor.append((child, parent_kind))
+    return out
+
+
+def _go_signature(source: bytes, node: Any) -> str:
+    text = _node_text(source, node)
+    head, _, _ = text.partition("{")
+    head = head.rstrip()
+    if not head.endswith(("{", ";")):
+        head += " {"
+    return _first_line(head)
+
+
+def _extract_go(*, file: str, source: bytes, root: Any) -> list[Symbol]:
+    """Go: func/method declarations + type spec (struct/interface/alias)."""
+    out: list[Symbol] = []
+    for node in _walk(root):
+        kind_name = node.type
+        if kind_name == "function_declaration":
+            name_node = node.child_by_field_name("name")
+            if name_node is None:
+                continue
+            out.append(
+                Symbol(
+                    file=file,
+                    symbol=_node_text(source, name_node),
+                    kind="function",
+                    line=_line_of(node),
+                    signature=_go_signature(source, node),
+                )
+            )
+        elif kind_name == "method_declaration":
+            name_node = node.child_by_field_name("name")
+            if name_node is None:
+                continue
+            out.append(
+                Symbol(
+                    file=file,
+                    symbol=_node_text(source, name_node),
+                    kind="method",
+                    line=_line_of(node),
+                    signature=_go_signature(source, node),
+                )
+            )
+        elif kind_name == "type_declaration":
+            # Two shapes the Go grammar uses:
+            #   type Foo struct { ... } / type Foo interface { ... }
+            #     → ``type_spec`` child with ``name`` + ``type`` fields.
+            #   type ID = int
+            #     → ``type_alias`` child where the first identifier is
+            #       the new name and field lookup returns null (the
+            #       grammar doesn't surface a ``name`` field).
+            for spec in node.children:
+                if spec.type == "type_spec":
+                    name_node = spec.child_by_field_name("name")
+                    type_node = spec.child_by_field_name("type")
+                    if name_node is None:
+                        continue
+                    kind = "type"
+                    if type_node is not None:
+                        if type_node.type == "struct_type":
+                            kind = "struct"
+                        elif type_node.type == "interface_type":
+                            kind = "interface"
+                    out.append(
+                        Symbol(
+                            file=file,
+                            symbol=_node_text(source, name_node),
+                            kind=kind,
+                            line=_line_of(spec),
+                            signature=_first_line(_node_text(source, spec)),
+                        )
+                    )
+                elif spec.type == "type_alias":
+                    name_node = next(
+                        (
+                            c
+                            for c in spec.children
+                            if c.type == "type_identifier"
+                        ),
+                        None,
+                    )
+                    if name_node is None:
+                        continue
+                    out.append(
+                        Symbol(
+                            file=file,
+                            symbol=_node_text(source, name_node),
+                            kind="type",
+                            line=_line_of(spec),
+                            signature=_first_line(_node_text(source, spec)),
+                        )
+                    )
+        elif kind_name in ("const_declaration", "var_declaration"):
+            for spec in node.children:
+                if spec.type not in ("const_spec", "var_spec"):
+                    continue
+                name_node = spec.child_by_field_name("name")
+                if name_node is None:
+                    continue
+                out.append(
+                    Symbol(
+                        file=file,
+                        symbol=_node_text(source, name_node),
+                        kind="const" if kind_name == "const_declaration" else "var",
+                        line=_line_of(spec),
+                        signature=_first_line(_node_text(source, spec)),
+                    )
+                )
+    return out
+
+
+def _walk(root: Any):
+    """Iterate the AST in DFS order (top-level first); used by extractors
+    that don't care about parent context.
+    """
+    stack = [root]
+    while stack:
+        node = stack.pop()
+        yield node
+        # Push children in reverse so iteration is left-to-right.
+        for i in range(node.child_count - 1, -1, -1):
+            stack.append(node.children[i])
+
+
+_EXTRACTORS = {
+    "python": _extract_python,
+    "typescript": _extract_typescript,
+    "tsx": _extract_typescript,  # same grammar shape modulo JSX
+    "go": _extract_go,
+}
+
+
+__all__ = [
+    "LANGUAGE_BY_EXTENSION",
+    "SUPPORTED_LANGUAGES",
+    "Symbol",
+    "extract_symbols",
+    "language_for_path",
+]

--- a/backend/app/services/agent/tools.py
+++ b/backend/app/services/agent/tools.py
@@ -21,6 +21,9 @@ Tool inventory (C12 Phase 2.2):
   source.
 - :meth:`list_code_map` — flat file list of an activated repo (what
   the Code Map page already renders, but as a tool call).
+- :meth:`repo_symbols` — on-demand tree-sitter symbol extraction
+  (Python / TypeScript / TSX / Go). Resolves a name → file/line/
+  signature without a preindex. ELS-72.
 - :meth:`list_activated_repos` — enumerate the workspace's activated
   repos with their UUIDs, so the LLM can call ``get_repo_file`` /
   ``list_code_map`` without having to ask the user for an id.
@@ -404,6 +407,85 @@ class ToolBox:
                                 "set; otherwise the next segment below "
                                 "the prefix). Useful for exploring a "
                                 "repo layout."
+                            ),
+                        },
+                    },
+                    "required": ["repo_id"],
+                    "additionalProperties": False,
+                },
+            ),
+            ToolSpec(
+                name="repo_symbols",
+                description=(
+                    "Resolve symbol names → file/line/signature without a "
+                    "preindex. On-demand tree-sitter parse of the requested "
+                    "files (Python / TypeScript / TSX / Go in v1). Two modes:\n"
+                    "  • ``paths``: pass a list of repo-relative files, get "
+                    "every symbol in those files.\n"
+                    "  • ``query``: pass a symbol name (e.g. ``UserRepo``); "
+                    "GitHub code search narrows down to candidate files, "
+                    "then the parser filters per-file results to symbols "
+                    "whose name matches (case-insensitive substring).\n\n"
+                    "Use this when you need to *find* a symbol by name "
+                    "(``where is class Foo defined?``) or *enumerate* the "
+                    "symbols in a known file. For full file contents, fall "
+                    "back to ``get_repo_file``. Output rows: ``{file, "
+                    "symbol, kind, line, signature}`` with ``kind`` ∈ "
+                    "``function|class|method|interface|type|struct|enum|"
+                    "var|const``."
+                ),
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "repo_id": {
+                            "type": "string",
+                            "description": "UUID of the activated repo.",
+                        },
+                        "query": {
+                            "type": "string",
+                            "description": (
+                                "Symbol name (case-insensitive substring) "
+                                "to search for. Required when ``paths`` is "
+                                "omitted."
+                            ),
+                        },
+                        "paths": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": (
+                                "Repo-relative file paths to parse. Use "
+                                "instead of ``query`` when you already know "
+                                "which files to inspect (faster, deterministic)."
+                            ),
+                        },
+                        "kinds": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": (
+                                "Optional filter on symbol kind, e.g. "
+                                "``[\"function\", \"method\"]`` to skip "
+                                "classes / vars."
+                            ),
+                        },
+                        "limit": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 200,
+                            "default": 50,
+                            "description": (
+                                "Max symbols to return across all parsed "
+                                "files."
+                            ),
+                        },
+                        "max_files": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "default": 25,
+                            "description": (
+                                "Max files to fetch + parse per call. "
+                                "Keeps latency bounded; reduce when only a "
+                                "few hits are needed."
                             ),
                         },
                     },
@@ -2168,6 +2250,7 @@ class ToolBox:
         return {
             "get_repo_file": self._tool_get_repo_file,
             "list_code_map": self._tool_list_code_map,
+            "repo_symbols": self._tool_repo_symbols,
             "list_activated_repos": self._tool_list_activated_repos,
             "create_ticket": self._tool_create_ticket,
             "list_tickets": self._tool_list_tickets,
@@ -2422,6 +2505,158 @@ class ToolBox:
                 "matched": len(files),
                 "truncated": truncated,
                 "files": files[:_MAX_CODE_MAP_ENTRIES],
+            }
+        )
+
+    async def _tool_repo_symbols(self, args: dict[str, Any]) -> str:
+        """On-demand symbol extraction (ELS-72).
+
+        Resolves a symbol name → ``[{file, symbol, kind, line, signature}]``
+        by parsing the requested files with tree-sitter on the fly. The
+        agent points this tool at a known file (``paths=["backend/app/main.py"]``)
+        OR a free-text ``query`` — the latter pre-filters with GitHub
+        code search to find candidate files, then parses only those.
+
+        No preindex, no DB writes — same fetch path
+        ``_tool_get_repo_file`` already uses. Languages in v1: Python,
+        TypeScript / TSX, Go.
+        """
+        from backend.app.services.agent.symbol_parser import (
+            LANGUAGE_BY_EXTENSION,
+            extract_symbols,
+            language_for_path,
+        )
+
+        repo_id = _parse_uuid(args, "repo_id")
+        query = args.get("query")
+        if query is not None and not isinstance(query, str):
+            raise ToolInvocationError("query must be a string when provided")
+        query_str = query.strip() if isinstance(query, str) else ""
+        paths_arg = args.get("paths")
+        paths: list[str] = []
+        if isinstance(paths_arg, list):
+            for raw in paths_arg:
+                if isinstance(raw, str) and raw.strip():
+                    paths.append(raw.strip())
+        kinds_arg = args.get("kinds")
+        kinds: set[str] | None = None
+        if isinstance(kinds_arg, list):
+            picked = {
+                str(k).strip().lower() for k in kinds_arg if isinstance(k, str)
+            }
+            kinds = picked or None
+        # Hard cap on rows so a giant file doesn't blow the response
+        # budget. Default 50 keeps the agent's context tight; the tool
+        # caller can ask for up to 200 explicitly.
+        limit = _clamp_int(args.get("limit"), default=50, low=1, high=200)
+        # Hard cap on files we'll parse per call. Tree-sitter is fast
+        # but each file is one GitHub fetch, so per-call latency scales
+        # linearly. 25 files is enough for "find me the Foo class"
+        # without becoming a denial-of-service against ourselves.
+        max_files = _clamp_int(
+            args.get("max_files"), default=25, low=1, high=50
+        )
+
+        if not paths and not query_str:
+            raise ToolInvocationError(
+                "repo_symbols needs either ``paths`` (list of repo-relative "
+                "files to parse) or ``query`` (symbol name; we'll find the "
+                "candidate files via code search before parsing)"
+            )
+
+        repo, install = await self._resolve_repo_with_install(repo_id)
+        gateway = GitHubCodeHost(install.installation_id, settings=self._settings)
+        owner, _, name = repo.full_name.partition("/")
+        ref = RepoRef(kind="github", owner=owner, repo=name)
+
+        # Build the list of files to parse. Explicit ``paths`` win;
+        # otherwise GitHub code search narrows down by ``query``.
+        selected: list[str] = []
+        skipped_unsupported: list[str] = []
+        if paths:
+            for p in paths:
+                if language_for_path(p) is None:
+                    skipped_unsupported.append(p)
+                    continue
+                selected.append(p)
+        elif query_str:
+            # Pull candidates from GitHub code search, then filter to the
+            # extensions we actually parse. Code search returns up to 100
+            # rows; we cap at ``max_files`` after filtering.
+            try:
+                candidates = await gateway.search_code(
+                    ref, query=query_str, limit=max_files * 4
+                )
+            except Exception as exc:  # noqa: BLE001
+                raise ToolInvocationError(
+                    f"code search failed: {exc}"
+                ) from exc
+            for hit in candidates:
+                path = (
+                    hit.get("path") if isinstance(hit, dict) else None
+                ) or ""
+                if not path or language_for_path(path) is None:
+                    continue
+                if path not in selected:
+                    selected.append(path)
+                if len(selected) >= max_files:
+                    break
+
+        selected = selected[:max_files]
+
+        rows: list[dict[str, Any]] = []
+        files_parsed: list[str] = []
+        files_failed: list[dict[str, Any]] = []
+        for path in selected:
+            try:
+                blob = await gateway.get_blob(ref, path=path)
+            except FileNotFoundError:
+                files_failed.append({"path": path, "reason": "not_found"})
+                continue
+            except IsADirectoryError:
+                files_failed.append({"path": path, "reason": "directory"})
+                continue
+            except Exception as exc:  # noqa: BLE001
+                logger.debug(
+                    "repo_symbols: fetch failed path=%s err=%s", path, exc
+                )
+                files_failed.append({"path": path, "reason": "fetch_error"})
+                continue
+            if blob.encoding != "utf-8":
+                files_failed.append({"path": path, "reason": "binary"})
+                continue
+            files_parsed.append(path)
+            for sym in extract_symbols(file=path, content=blob.content):
+                if kinds and sym.kind not in kinds:
+                    continue
+                if query_str and query_str.lower() not in sym.symbol.lower():
+                    # When the agent asked by name, filter the per-file
+                    # results down to ones whose symbol matches —
+                    # otherwise a "find Foo" query that picks 25 files
+                    # via code-search returns *every* symbol in those
+                    # files, which is the wrong shape.
+                    continue
+                rows.append(sym.as_dict())
+                if len(rows) >= limit:
+                    break
+            if len(rows) >= limit:
+                break
+
+        truncated = len(rows) >= limit
+        return _json_result(
+            {
+                "repo_id": str(repo.id),
+                "full_name": repo.full_name,
+                "query": query_str or None,
+                "kinds": sorted(kinds) if kinds else None,
+                "supported_extensions": sorted(LANGUAGE_BY_EXTENSION.keys()),
+                "files_requested": len(selected),
+                "files_parsed": len(files_parsed),
+                "matched": len(rows),
+                "truncated": truncated,
+                "skipped_unsupported": skipped_unsupported or None,
+                "files_failed": files_failed or None,
+                "symbols": rows,
             }
         )
 

--- a/backend/tests/test_symbol_parser.py
+++ b/backend/tests/test_symbol_parser.py
@@ -1,0 +1,222 @@
+"""Tree-sitter symbol extractor (ELS-72).
+
+Pin the row shape and per-language coverage so a grammar bump or a
+parser regression doesn't silently drop a kind of symbol the agent
+relies on.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from backend.app.services.agent.symbol_parser import (
+    LANGUAGE_BY_EXTENSION,
+    SUPPORTED_LANGUAGES,
+    Symbol,
+    extract_symbols,
+    language_for_path,
+)
+
+
+def test_language_for_path_known_extensions() -> None:
+    assert language_for_path("foo.py") == "python"
+    assert language_for_path("BACKEND/main.py") == "python"
+    assert language_for_path("src/api.ts") == "typescript"
+    assert language_for_path("components/Button.tsx") == "tsx"
+    assert language_for_path("cmd/server.go") == "go"
+    # Compound suffixes still resolve via the trailing extension.
+    assert language_for_path("foo.spec.ts") == "typescript"
+    assert language_for_path("page.test.tsx") == "tsx"
+
+
+def test_language_for_path_unknown_extensions() -> None:
+    assert language_for_path("README.md") is None
+    assert language_for_path("Makefile") is None
+    assert language_for_path("config.yaml") is None
+
+
+def test_supported_languages_match_extension_map() -> None:
+    """Pin the supported set so a future grammar add lands cleanly."""
+    assert set(SUPPORTED_LANGUAGES) == {
+        "python",
+        "typescript",
+        "tsx",
+        "go",
+    }
+    assert set(LANGUAGE_BY_EXTENSION.values()) == set(SUPPORTED_LANGUAGES)
+
+
+def test_extract_python_class_method_function_const() -> None:
+    src = """
+import os
+
+VERSION = "1.0"
+default_timeout = 30
+
+
+def top_level(x: int) -> str:
+    return str(x)
+
+
+async def async_helper() -> None:
+    pass
+
+
+class Repo:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    def greet(self) -> str:
+        return "hi " + self.name
+"""
+    syms = {(s.symbol, s.kind) for s in extract_symbols(file="x.py", content=src)}
+    assert ("VERSION", "const") in syms
+    assert ("default_timeout", "var") in syms
+    assert ("top_level", "function") in syms
+    assert ("Repo", "class") in syms
+    assert ("__init__", "method") in syms
+    assert ("greet", "method") in syms
+
+
+def test_extract_python_async_function_recognised() -> None:
+    src = "async def fetch_one(url: str) -> bytes:\n    return b''\n"
+    syms = extract_symbols(file="x.py", content=src)
+    # tree-sitter-python parses ``async def`` as a function_definition
+    # with an ``async`` modifier — extractor must still pick it up.
+    names = [s.symbol for s in syms]
+    assert "fetch_one" in names
+
+
+def test_extract_python_signature_keeps_one_line() -> None:
+    src = (
+        "def long_signature(\n"
+        "    a: int,\n"
+        "    b: int,\n"
+        "    c: int,\n"
+        ") -> int:\n"
+        "    return a + b + c\n"
+    )
+    syms = extract_symbols(file="x.py", content=src)
+    sig = syms[0].signature
+    assert "\n" not in sig
+    assert sig.startswith("def long_signature(")
+    assert sig.endswith(":")
+
+
+def test_extract_typescript_function_class_interface_type() -> None:
+    src = """
+export interface User { id: string; name: string; }
+export type Status = "ok" | "fail";
+
+export class Repo<T> {
+  private name: string;
+  constructor(n: string) { this.name = n; }
+  greet(): string { return "hi " + this.name; }
+}
+
+export function loadAll(): Promise<User[]> { return Promise.resolve([]); }
+const arrow = (x: number) => x * 2;
+const data = { x: 1 };
+enum Color { Red, Green, Blue }
+"""
+    rows = extract_symbols(file="x.ts", content=src)
+    by = {(s.symbol, s.kind) for s in rows}
+    assert ("User", "interface") in by
+    assert ("Status", "type") in by
+    assert ("Repo", "class") in by
+    assert ("greet", "method") in by
+    assert ("loadAll", "function") in by
+    assert ("arrow", "function") in by  # arrow = function-shape const
+    assert ("data", "var") in by
+    assert ("Color", "enum") in by
+
+
+def test_extract_tsx_file_is_parsed_as_tsx_grammar() -> None:
+    """A React component file with JSX must not break parsing."""
+    src = """
+import * as React from "react";
+
+export interface Props { title: string; }
+
+export function Page(props: Props) {
+  return <div className="page"><h1>{props.title}</h1></div>;
+}
+"""
+    rows = extract_symbols(file="components/Page.tsx", content=src)
+    names = {s.symbol for s in rows}
+    assert "Props" in names
+    assert "Page" in names
+
+
+def test_extract_go_func_method_struct_interface() -> None:
+    src = """
+package main
+
+type Repo struct {
+\tName string
+}
+
+type Cloner interface {
+\tClone(url string) error
+}
+
+type ID = int
+
+func New(name string) *Repo {
+\treturn &Repo{Name: name}
+}
+
+func (r *Repo) Greet() string {
+\treturn "hi " + r.Name
+}
+
+const Version = "0.1"
+var debug = false
+"""
+    rows = extract_symbols(file="x.go", content=src)
+    by = {(s.symbol, s.kind) for s in rows}
+    assert ("Repo", "struct") in by
+    assert ("Cloner", "interface") in by
+    assert ("ID", "type") in by
+    assert ("New", "function") in by
+    assert ("Greet", "method") in by
+    assert ("Version", "const") in by
+    assert ("debug", "var") in by
+
+
+def test_extract_unsupported_extension_returns_empty() -> None:
+    """Markdown / YAML / random filenames don't blow up — they return [].
+
+    The agent tool wraps multiple files; a passthrough-on-unsupported
+    keeps the call going for the rest of the batch.
+    """
+    assert extract_symbols(file="README.md", content="# heading\n") == []
+    assert extract_symbols(file="ci.yml", content="name: x\n") == []
+    assert extract_symbols(file="empty.py", content="") == []
+
+
+def test_extract_handles_syntax_errors_gracefully() -> None:
+    """Tree-sitter recovers from broken code; we still return reachable syms."""
+    src = "def foo(:\n    pass\n\ndef bar():\n    pass\n"
+    rows = extract_symbols(file="broken.py", content=src)
+    names = {s.symbol for s in rows}
+    # ``foo`` is too broken to extract a name; ``bar`` should survive.
+    assert "bar" in names
+
+
+def test_symbol_as_dict_shape_is_stable() -> None:
+    """The agent contract pins these five keys — don't drift."""
+    sym = Symbol(
+        file="x.py",
+        symbol="foo",
+        kind="function",
+        line=12,
+        signature="def foo():",
+    )
+    assert sym.as_dict() == {
+        "file": "x.py",
+        "symbol": "foo",
+        "kind": "function",
+        "line": 12,
+        "signature": "def foo():",
+    }

--- a/requirements-backend.txt
+++ b/requirements-backend.txt
@@ -66,6 +66,15 @@ PyNaCl>=1.5,<2
 # --- YAML for artifact frontmatter ---
 pyyaml>=6.0
 
+# --- Code symbol extraction (ELS-72) ---
+# tree-sitter binding + a single-wheel grammar pack so the
+# ``repo_symbols`` agent tool can parse Python / TypeScript / Go on
+# demand without preindexing repos. Activated only when the tool is
+# called; importing the language pack is gated to first use so module
+# load stays cheap.
+tree-sitter>=0.23,<1
+tree-sitter-language-pack>=0.6,<1
+
 # --- Observability (RFC-0006 / phase 2) ---
 # `fastapi` extra wires the Sentry FastAPI middleware (request spans + error
 # capture); `arq` keeps the background-worker integration on the same SDK.


### PR DESCRIPTION
## Summary

Closes ELS-72. Adds the ``repo_symbols`` agent tool: on-demand tree-sitter parse of Python / TypeScript / TSX / Go files fetched through the same GitHub-App path ``get_repo_file`` already uses.

```
repo_symbols(repo_id, query?, paths?, kinds?, limit?, max_files?)
→ [{file, symbol, kind, line, signature}, ...]
```

Two call modes:

* **``paths``** — parse a known list of files end-to-end. Use when you already know what to look at.
* **``query``** — GitHub code search picks the candidate files, the parser filters per-file results to symbols whose name contains ``query`` (case-insensitive). Default cap: 25 files, 50 rows.

``kind`` ∈ ``function | class | method | interface | type | struct | enum | var | const`` — uniform across all four pilot grammars.

## Why tree-sitter over stdlib `ast`

* One row schema across all grammars; the agent's output stays predictable per language.
* Graceful recovery on syntax errors — agents often point the tool at a file mid-edit, where a strict parser would explode but tree-sitter still surfaces reachable symbols.

## Out of scope (per ticket)

* SCIP / LSIF graph indexers — overkill at our volume.
* ``RepoCodeSymbol`` cache table keyed on ``(repo_id, head_sha, file)`` — skipped for v0; revisit if 25-file latency becomes a problem.

## Deps

* ``tree-sitter>=0.23``
* ``tree-sitter-language-pack>=0.6`` (single-wheel grammar bundle for Python / TS / Go; lazy-loaded on first call so module import stays cheap)

## Test plan

- [x] `pytest backend/tests/test_symbol_parser.py` — 12 cases (per-language extraction + syntax-error recovery + unsupported-extension passthrough + row shape pin)
- [x] Smoke: parser ran on the symbol_parser file itself, finds 20 symbols correctly typed
- [ ] DB-bound: tool call against an activated repo returns a Foo class located by name. (ELS-89 smoke.)