### PR TITLE
agent_runs: pick-race protection via advisory xact lock (ELS-85)

### DIFF
--- a/backend/app/api/v1/routes/agent_runs.py
+++ b/backend/app/api/v1/routes/agent_runs.py
@@ -42,13 +42,16 @@ the agent never hold the tracker credential.
 
 from __future__ import annotations
 
+import hashlib
 import logging
+import struct
 import uuid
 from datetime import datetime, timezone
 from typing import Any, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field
+from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.app.api.v1.deps import AuthContext, get_current_auth
@@ -180,6 +183,34 @@ class FinishOut(BaseModel):
 # ---------------------------------------------------------------------------
 
 
+def _pickup_lock_key(
+    workspace_id: uuid.UUID, fsm_stage: str
+) -> tuple[int, int]:
+    """Stable (int4, int4) key for the picker's advisory lock (ELS-85).
+
+    Postgres ``pg_try_advisory_xact_lock`` accepts a single 64-bit int
+    or a pair of 32-bit ints. The pair form lines up nicely with our
+    natural lock key — ``(workspace_id, fsm_stage)`` — so we hash each
+    side to a signed int32 and pass them separately. Collisions across
+    different ``(ws, stage)`` pairs are theoretically possible
+    (``2^-32`` per pair) but the cost of a false positive is just
+    "the second caller noops and retries on the next cron tick" —
+    well within tolerance.
+
+    BLAKE2b is used over Python's built-in ``hash`` because the latter
+    is randomised per-process: two replicas would compute different
+    keys for the same workspace and the lock would stop working
+    altogether.
+    """
+    ws_digest = hashlib.blake2b(workspace_id.bytes, digest_size=4).digest()
+    stage_digest = hashlib.blake2b(
+        fsm_stage.encode("utf-8"), digest_size=4
+    ).digest()
+    ws_key = struct.unpack("<i", ws_digest)[0]
+    stage_key = struct.unpack("<i", stage_digest)[0]
+    return ws_key, stage_key
+
+
 def _vendor_kind_to_ticket_kind(vendor_kind: str) -> Literal[
     "github_issues", "linear", "notion", "jira"
 ]:
@@ -245,6 +276,14 @@ async def get_next_task(
 ) -> TaskResponseOut:
     """Return the next ticket the agent should work on for ``state``.
 
+    Pick-race protection (ELS-85): a Postgres advisory lock keyed on
+    ``(workspace_id, fsm_stage)`` serialises concurrent
+    ``shipctl run --routine X`` calls. The second caller gets
+    ``ticket=null`` immediately and noops cleanly — the next cron
+    tick re-fires and picks up. Lock is transactional
+    (``pg_try_advisory_xact_lock``), so it auto-releases when the
+    handler's transaction commits or rolls back; no manual unlock.
+
     Picker filters (ELS-83): tickets without a tracker ``project_id``
     are orphans — created outside the dashboard's project flow.
     They're skipped here and a one-shot inbox item plus an
@@ -252,6 +291,20 @@ async def get_next_task(
     them and re-home the work or close it.
     """
     await _require_membership(session, workspace_id, auth.user.id, ROLES_ADMIN)
+
+    ws_key, stage_key = _pickup_lock_key(workspace_id, state)
+    got = (
+        await session.execute(
+            text("SELECT pg_try_advisory_xact_lock(:k1, :k2)"),
+            {"k1": ws_key, "k2": stage_key},
+        )
+    ).scalar_one()
+    if not got:
+        # Another picker call is already mid-handler for the same
+        # (workspace, stage). Returning null here is the same shape
+        # as "no eligible ticket"; ``shipctl run`` treats both as a
+        # clean noop and the cron's next tick re-tries.
+        return TaskResponseOut(ticket=None, fsm_stage=state, tracker_kind=None)
 
     resolved = await resolve_for_workspace(
         session=session,

--- a/backend/tests/test_agent_runs_pick_lock.py
+++ b/backend/tests/test_agent_runs_pick_lock.py
@@ -58,19 +58,31 @@ def test_lock_key_components_fit_in_int4() -> None:
         assert -(2**31) <= stage_key < 2**31, (stage_key, stage)
 
 
-def test_lock_key_is_not_python_hash_seeded() -> None:
-    """If we ever switched to Python's built-in ``hash``, this catches it.
+def test_lock_key_is_process_stable_pinned_bytes() -> None:
+    """Pin literal byte values so a switch to a non-deterministic
+    hash function (e.g. Python's built-in ``hash`` which is seeded
+    per-process via PEP 456) fails the test loudly.
 
-    Python hashes string-like inputs through a per-process random seed
-    (PEP 456), so the same call on two replicas would produce
-    different keys and the lock would silently stop working.
-    BLAKE2b is process-stable; we pin the bytes so a regression here
-    breaks the test loudly.
+    The two replicas serving picker requests must compute **identical**
+    keys for the same ``(workspace, fsm_stage)`` — otherwise the
+    advisory lock doesn't actually serialise across replicas and
+    the race-protection guarantee silently disappears. A previous
+    iteration of this test only round-tripped the function with
+    itself in the same process; that passes for both BLAKE2b AND
+    Python's seeded hash, which is exactly the regression we want
+    to catch.
+
+    Expected values are BLAKE2b digests of the inputs; if you
+    intentionally change the hashing scheme, regenerate them
+    locally — that's the trade-off for catching the regression.
     """
-    ws = uuid.UUID("00000000-0000-0000-0000-000000000000")
-    # Pin a specific byte sequence so a switch to a non-deterministic
-    # hash function fails this test (any change to the hashing scheme
-    # also fails it — that's intentional, regenerate locally then).
-    ws_key, stage_key = _pickup_lock_key(ws, "task_intake")
-    expected_ws, expected_stage = _pickup_lock_key(ws, "task_intake")
-    assert (ws_key, stage_key) == (expected_ws, expected_stage)
+    nil_ws = uuid.UUID("00000000-0000-0000-0000-000000000000")
+    assert _pickup_lock_key(nil_ws, "task_intake") == (
+        1_222_067_678,
+        -845_439_783,
+    )
+    ship_on_ship = uuid.UUID("d591af28-225e-477e-8448-7a4b9b06fbfc")
+    assert _pickup_lock_key(ship_on_ship, "wbs") == (
+        670_875_352,
+        -1_080_360_883,
+    )

--- a/backend/tests/test_agent_runs_pick_lock.py
+++ b/backend/tests/test_agent_runs_pick_lock.py
@@ -1,0 +1,76 @@
+"""Picker advisory-lock key (ELS-85).
+
+The lock binds to ``(workspace_id, fsm_stage)``. The mapping must be
+deterministic across replicas (so two API pods compute the same key),
+distinct across both axes, and fit in Postgres's int4 range — anything
+outside that range trips ``pg_try_advisory_xact_lock``'s argument check
+at run time.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from backend.app.api.v1.routes.agent_runs import _pickup_lock_key
+
+
+def test_lock_key_is_deterministic() -> None:
+    ws = uuid.UUID("d591af28-225e-477e-8448-7a4b9b06fbfc")
+    assert _pickup_lock_key(ws, "task_intake") == _pickup_lock_key(
+        ws, "task_intake"
+    )
+
+
+def test_lock_key_distinguishes_stages() -> None:
+    ws = uuid.UUID("d591af28-225e-477e-8448-7a4b9b06fbfc")
+    assert _pickup_lock_key(ws, "task_intake") != _pickup_lock_key(ws, "wbs")
+    assert _pickup_lock_key(ws, "ba_requirements") != _pickup_lock_key(
+        ws, "tech_arch_plan"
+    )
+
+
+def test_lock_key_distinguishes_workspaces() -> None:
+    a = uuid.UUID("d591af28-225e-477e-8448-7a4b9b06fbfc")
+    b = uuid.UUID("11111111-1111-1111-1111-111111111111")
+    assert _pickup_lock_key(a, "task_intake") != _pickup_lock_key(
+        b, "task_intake"
+    )
+
+
+def test_lock_key_components_fit_in_int4() -> None:
+    """``pg_try_advisory_xact_lock(int, int)`` requires signed int32."""
+    ws = uuid.UUID("d591af28-225e-477e-8448-7a4b9b06fbfc")
+    for stage in (
+        "task_intake",
+        "ba_requirements",
+        "tech_arch_plan",
+        "wbs",
+        "architecture",
+        "test_architecture",
+        "tasks",
+        "planning_done",
+        "code_review",
+    ):
+        ws_key, stage_key = _pickup_lock_key(ws, stage)
+        assert -(2**31) <= ws_key < 2**31, (ws_key, stage)
+        assert -(2**31) <= stage_key < 2**31, (stage_key, stage)
+
+
+def test_lock_key_is_not_python_hash_seeded() -> None:
+    """If we ever switched to Python's built-in ``hash``, this catches it.
+
+    Python hashes string-like inputs through a per-process random seed
+    (PEP 456), so the same call on two replicas would produce
+    different keys and the lock would silently stop working.
+    BLAKE2b is process-stable; we pin the bytes so a regression here
+    breaks the test loudly.
+    """
+    ws = uuid.UUID("00000000-0000-0000-0000-000000000000")
+    # Pin a specific byte sequence so a switch to a non-deterministic
+    # hash function fails this test (any change to the hashing scheme
+    # also fails it — that's intentional, regenerate locally then).
+    ws_key, stage_key = _pickup_lock_key(ws, "task_intake")
+    expected_ws, expected_stage = _pickup_lock_key(ws, "task_intake")
+    assert (ws_key, stage_key) == (expected_ws, expected_stage)


### PR DESCRIPTION
## Summary

Two parallel ``shipctl run --routine X`` calls on the same FSM stage both used to fetch the same head-of-list ticket and start two Cursor runs. The atomic later transition prevented double-write, but the second run was wasted budget.

This PR puts a Postgres advisory lock on ``(workspace_id, fsm_stage)`` at the top of the picker handler. ``pg_try_advisory_xact_lock`` — non-blocking, auto-released at txn end. If the lock isn't grabbed, the handler returns ``ticket=null`` immediately and the cron's next tick retries.

## Key shape

* ``_pickup_lock_key(ws, stage)`` → ``(int4, int4)`` via BLAKE2b digest.
* **Why not ``hash()``?** Python's built-in hash is seeded per-process (PEP 456); two API replicas would compute different keys and the lock would silently stop working.
* ``int4`` range is enforced — that's what ``pg_try_advisory_xact_lock(int, int)`` accepts.

## Test plan

- [x] `pytest backend/tests/test_agent_runs_pick_lock.py` — 5 cases (determinism, axis distinctness, int4 range, non-hash-seeded)
- [x] Backend imports clean
- [ ] DB-bound: two parallel ``shipctl run --routine task_intake`` calls produce one ticket and one ``ticket: null`` noop. (ELS-89 smoke.)