### PR TITLE
agent_roles: drop stale tool refs from Navigator prompt (ELS-87)

### DIFF
--- a/backend/app/resources/agent_roles/navigator.md
+++ b/backend/app/resources/agent_roles/navigator.md
@@ -30,10 +30,9 @@ These rules apply to every turn, before any scenario below kicks in.
 
 One search surface for everything: ``knowledge_search`` covers published articles, packed conversation buckets, topic views, and (with ``intel_facts=true``) the repo-stack ``repository-context`` bucket — all in one call, all in one result set with ``source`` labels you can filter on.
 
-1. Default search → ``knowledge_search`` with the user's question. Pass ``repo_id`` to prioritise hits from one repo (the runtime auto-fills the chat's active repo when omitted), or ``bucket_slug`` to narrow to one bucket.
-2. Repo-specific code question → ``search_repo_kb`` (narrow with ``path_prefix`` / ``path_glob``; ``include_full_content`` for deeper context). This hits the repo's indexed code chunks, NOT articles.
-3. Named bucket lookup by slug → ``get_knowledge_bucket``. Flat catalog → ``list_buckets``.
-4. Both empty → say so. Don't invent references.
+1. Default search → ``knowledge_search`` with the user's question. Pass ``repo_id`` to prioritise hits from one repo (the runtime auto-fills the chat's active repo when omitted), or ``bucket_slug`` to narrow to one bucket. With ``intel_facts=true`` the call also hits the repo-stack ``repository-context`` bucket.
+2. Named bucket lookup by slug → ``get_knowledge_bucket``. Flat catalog → ``list_buckets``.
+3. Empty result → say so. Don't invent references.
 
 ## UI widgets
 
@@ -93,10 +92,9 @@ Pull existing context first; ideas land in the relevant epic.
 
 1. ``knowledge_search`` for the topic — what does the org already think? Cite results (the ``source`` field tells you whether it came from a published article, packed bucket, or topic view).
 2. ``list_buckets`` / ``get_knowledge_bucket`` for named domains.
-3. ``list_catalog_artifacts`` + ``get_catalog_artifact`` when the user asks about Ship patterns / playbooks.
-4. Synthesise in chat. Once an idea hardens — propose appending it to the relevant project description (Scenario 1 step 4).
-5. ``list_clarifications`` / ``list_improvements`` before proposing something new — don't re-surface declined items.
-6. **Stale knowledge cleanup.** When the user says an ADR / runbook / facts page is no longer true ("this isn't how it works anymore", "that decision was reverted"), confirm the specific article via ``ship-choice``, then ``archive_bucket_article`` with a one-line ``reason`` that cites the superseding commit / ADR. Don't archive on a vague "this looks old" — get the operator's explicit nod first.
+3. Synthesise in chat. Once an idea hardens — propose appending it to the relevant project description (Scenario 1 step 4).
+4. ``list_clarifications`` / ``list_improvements`` before proposing something new — don't re-surface declined items.
+5. **Stale knowledge cleanup.** When the user says an ADR / runbook / facts page is no longer true ("this isn't how it works anymore", "that decision was reverted"), confirm the specific article via ``ship-choice``, then ``archive_bucket_article`` with a one-line ``reason`` that cites the superseding commit / ADR. Don't archive on a vague "this looks old" — get the operator's explicit nod first.
 
 ## Scenario 4 — Analytics (numbers + stats)
 
@@ -108,7 +106,7 @@ Pull existing context first; ideas land in the relevant epic.
 - 'What's the stack of repo X?' → ``repo_intel_get``.
 - Recent activity / 'what did I miss?' → ``list_recent_activity`` with ``since`` / ``repo_id``.
 - PR detail → ``get_pull_request`` (timeline + diff hunks; add ``include_reviews`` / ``include_commits`` for richer context). List → cheap ``list_pull_requests``.
-- Pipeline detail → ``list_pipelines`` / ``list_pipeline_runs`` / ``get_pipeline_run``.
+- Pipeline run detail → ``get_pipeline_run`` (specific run by id).
 
 Cross-tool composition:
 - 'Why did run X fail; any open inbox item?' → ``run_detail`` → escalations → ``inbox_get``.

--- a/backend/tests/test_role_prompts_no_stale_tools.py
+++ b/backend/tests/test_role_prompts_no_stale_tools.py
@@ -1,0 +1,71 @@
+"""Role prompts must not reference removed tools (ELS-87).
+
+ELS-76 / ELS-77 trimmed the Navigator's tool surface. Role files
+that still mention dropped names confuse the LLM (it tries to call
+them and gets a 422). Pin the deny list so a re-introduction lands
+in CI.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+_ROLES_DIR = Path(__file__).resolve().parents[1] / "app/resources/agent_roles"
+
+
+# Tool names that have been removed from ``ToolBox.specs`` and from
+# the public dispatch surface — role prompts referencing them sends
+# the agent into a 422 dead-end.
+#
+# Sources of truth:
+#   * ELS-76 (commit e41b0c0) — dropped 4 redundant tools
+#   * ELS-77 (commit c12a74d) — KB consolidation; ``knowledge_search``
+#     replaced ``knowledge_search_v2``, and ``search_buckets`` /
+#     ``search_workspace_kb`` / ``list_pipelines`` /
+#     ``list_pipeline_runs`` were retired
+#   * Phase 2.4 Step D (commit e89ae69) — catalog kill;
+#     ``list_catalog_artifacts`` / ``get_catalog_artifact`` are gone
+#
+# Add new entries here when a tool is removed; CI will catch any
+# leftover prompt that still tells the agent to call it.
+_REMOVED_TOOL_NAMES: tuple[str, ...] = (
+    # ELS-76
+    "list_integrations",
+    "get_workspace_settings",
+    "list_workspace_artifact_repos",
+    "inbox_counts",
+    # ELS-77
+    "search_buckets",
+    "search_workspace_kb",
+    "list_pipelines",
+    "list_pipeline_runs",
+    "knowledge_search_v2",
+    "search_repo_kb",
+    # Phase 2.4 Step D
+    "list_catalog_artifacts",
+    "get_catalog_artifact",
+)
+
+
+@pytest.mark.parametrize("removed", _REMOVED_TOOL_NAMES)
+def test_no_role_prompt_mentions_removed_tool(removed: str) -> None:
+    """A role file referencing a removed tool guides the LLM into a
+    dead-end call — pin the deny list."""
+    pattern = re.compile(rf"\b{re.escape(removed)}\b")
+    offenders: list[str] = []
+    for md in sorted(_ROLES_DIR.glob("*.md")):
+        body = md.read_text(encoding="utf-8")
+        for n, line in enumerate(body.splitlines(), start=1):
+            if pattern.search(line):
+                offenders.append(f"  {md.name}:{n}: {line.strip()}")
+    assert not offenders, (
+        f"Role prompts still reference removed tool ``{removed}``:\n"
+        + "\n".join(offenders)
+        + "\n\nReplace with the canonical equivalent (e.g. "
+        f"``knowledge_search`` for KB-search names, drop the bullet "
+        f"entirely for catalog-artifact / pipeline-listing names)."
+    )


### PR DESCRIPTION
## Summary

Walked all 25 role files in ``backend/app/resources/agent_roles/``. The Navigator prompt was the only one referencing tools removed in ELS-76 / ELS-77 / Phase 2.4 Step D.

## Navigator cleanup

| Section | Was | Now |
|---|---|---|
| Knowledge lookup order | Bullet for ``search_repo_kb`` (private dispatch alias; sends LLM into a 422) | Dropped — ``knowledge_search`` with ``repo_id`` covers it, ``intel_facts=true`` for repo-stack |
| Brainstorming | ``list_catalog_artifacts`` / ``get_catalog_artifact`` (catalog retired in Phase 2.4 Step D) | Dropped — pattern docs now live in regular knowledge buckets |
| Analytics | ``list_pipelines`` / ``list_pipeline_runs`` (retired in ELS-77) | ``get_pipeline_run`` only (the listing surfaces moved to the dashboard) |

## Other 24 prompts

Clean — no stale tool refs. Most prompts don't name tools at all (system-prompt + decomposition-mode blocks); SDLC specialists pin their outcome contracts where relevant.

## Test plan

- [x] Sweep across all role files: zero matches against the 12-entry removed-tool deny list
- [x] New ``test_role_prompts_no_stale_tools.py`` — parametrised over the deny list so re-introducing any of these names fails CI loudly. Extending the deny list when a future ELS drops a tool is one line
- [x] Existing ``test_decomposition_role_modes.py`` — 5 pass (no regression on decomposition-mode block invariants)