### PR TITLE
linear: fix intake's empty-label exclusion (Linear ELS-90)

### DIFF
--- a/backend/app/integrations/linear/tracker_adapter.py
+++ b/backend/app/integrations/linear/tracker_adapter.py
@@ -348,10 +348,31 @@ class LinearTracker:
         * To pick a ticket for stage X:
             - Linear state matches ``FSM_TO_LINEAR_STATE[X]``.
             - The ``stage:<previous>`` label is present (previous role
-              has produced its output) — except for the entry stage,
-              which has no previous.
+              has produced its output) — except for the entry stages
+              (``task_intake`` / ``bug_triage``), which have no
+              previous.
             - The ``stage:<X>`` label is **not** present (this role
               hasn't run on this ticket yet) — guarantees idempotency.
+
+        Entry-stage asymmetry (ELS-90 follow-up): ``task_intake`` is
+        the **default** entry — it picks any Todo ticket that hasn't
+        been classified yet, including Linear-native tickets the
+        operator filed directly with no Ship labels at all. The
+        previous-stage check is skipped for entry stages, so the
+        filter becomes purely "Todo + own-stage label not present".
+        ``bug_triage`` is the **explicit** entry — operator labels a
+        ticket ``stage:bug_triage`` themselves to route it through bug
+        intake; the standard idempotency rule applies.
+
+        Empty-collection trap (also ELS-90): Linear's
+        ``IssueLabelCollectionFilter`` interprets a bare
+        ``{"labels": {"id": {"nin": [...]}}}`` as ``some`` semantics —
+        a label exists whose id is not in the list. On a ticket with
+        **no labels at all**, that's vacuously false, so the
+        unlabeled ticket is excluded. We use the explicit ``none``
+        operator (``"labels": {"none": {"id": {"eq": id}}}``) so an
+        empty label collection is vacuously a match for "doesn't
+        have this label" — which is the obvious intent.
 
         ``self_heal`` is intentionally not in ``FSM_STAGE_ORDER``; it
         runs out-of-band against any open ticket and falls back to the
@@ -369,7 +390,7 @@ class LinearTracker:
         # "this role hasn't finished yet" — never re-pick.
         own_label = self._label_id_by_stage.get(stage)
         if own_label:
-            parts.append({"labels": {"id": {"nin": [own_label]}}})
+            parts.append({"labels": {"none": {"id": {"eq": own_label}}}})
 
         # "previous role is done" — for non-entry stages.
         prev = previous_stage(stage)
@@ -384,10 +405,11 @@ class LinearTracker:
         # question for a human. Skip these tickets at every stage so we
         # don't repeatedly comment on a ticket that's waiting on a human
         # answer. The label gets cleared by the human (Linear UI) when
-        # they reply.
+        # they reply. ``none`` (not bare ``nin``) for the same
+        # empty-collection reason as the own-label check above.
         clar = self._signal_label_ids.get("needs_clarification")
         if clar:
-            parts.append({"labels": {"id": {"nin": [clar]}}})
+            parts.append({"labels": {"none": {"id": {"eq": clar}}}})
         return parts
 
     async def add_signal_label(self, ticket: TicketRef, *, key: str) -> None:

--- a/backend/tests/test_linear_tracker_fsm_filter.py
+++ b/backend/tests/test_linear_tracker_fsm_filter.py
@@ -1,0 +1,168 @@
+"""Linear adapter ``_fsm_filter`` shape (ELS-90 Linear).
+
+Two invariants the picker depends on:
+
+1. **Empty-label tickets pass the own-stage exclusion.** Linear's
+   ``IssueLabelCollectionFilter`` treats bare ``{"id": {"nin": ...}}``
+   as ``some`` semantics — vacuously false on tickets with no labels.
+   We must use the explicit ``none.id.eq`` form so a freshly-created
+   ticket without ANY ``stage:*`` label can flow through ``task_intake``.
+
+2. **Asymmetric intake.** ``task_intake`` is the default entry — it
+   picks Todo tickets without ``stage:task_intake`` (own-label
+   absent), regardless of whether they have other labels. No
+   previous-stage label is required because intake has no previous
+   stage.
+
+Reproduction case for the bug being fixed: a Linear-native ticket
+filed directly by an operator (not via Navigator's ``create_ticket``)
+lands in Todo with no Ship labels. With the bare-``nin`` form, the
+filter ``{"labels": {"id": {"nin": [intake_label]}}}`` does NOT
+match because the ticket has zero labels — Linear's GraphQL
+interprets it as "some label exists with id not in [intake_label]",
+and "some" of an empty collection is false. The fix uses
+``{"labels": {"none": {"id": {"eq": intake_label}}}}``: "no label
+exists with id == intake_label", which is vacuously true on empty.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from backend.app.integrations.linear.tracker_adapter import LinearTracker
+
+
+def _make_tracker(stage_labels: dict[str, str] | None = None) -> LinearTracker:
+    """Build a LinearTracker with provisioner data populated but no
+    real network. We don't call any GraphQL methods in these tests;
+    we only inspect ``_fsm_filter`` output."""
+    return LinearTracker(
+        access_token="lin_oauth_x",
+        team_id="00000000-0000-0000-0000-team",
+        team_key="ELS",
+        state_id_by_name={
+            "Todo": "todo_state_id",
+            "In Progress": "ip_state_id",
+            "Review": "rev_state_id",
+            "Done": "done_state_id",
+        },
+        fsm_to_linear_state={
+            "task_intake": "Todo",
+            "bug_triage": "Todo",
+            "ba_requirements": "Todo",
+            "tech_arch_plan": "Todo",
+            "dev_implementation": "In Progress",
+            "qa_manual": "In Progress",
+            "pr_review": "Review",
+        },
+        label_id_by_stage=stage_labels
+        or {
+            "task_intake": "lbl_intake",
+            "bug_triage": "lbl_bug_triage",
+            "ba_requirements": "lbl_ba",
+            "tech_arch_plan": "lbl_tech_arch",
+            "dev_implementation": "lbl_dev",
+            "qa_manual": "lbl_qa_manual",
+            "pr_review": "lbl_pr_review",
+        },
+        signal_label_ids={"needs_clarification": "lbl_clar"},
+    )
+
+
+def _find_label_clauses(parts: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [p for p in parts if "labels" in p]
+
+
+def test_intake_filter_uses_none_operator_for_own_label_exclusion() -> None:
+    """The own-label exclusion must use ``none`` (not bare ``nin``)
+    so a ticket with zero labels passes the filter — that's the
+    common shape for a freshly-filed Linear-native ticket."""
+    tracker = _make_tracker()
+    parts = tracker._fsm_filter("task_intake")  # noqa: SLF001 - shape test
+
+    label_clauses = _find_label_clauses(parts)
+    # At minimum: own-stage exclusion + needs:clarification exclusion.
+    assert len(label_clauses) == 2
+
+    own = label_clauses[0]
+    # ELS-90: bare ``nin`` is the bug being fixed. ``none`` is the
+    # vacuous-truth-on-empty-collection form.
+    assert "none" in own["labels"], (
+        f"intake's own-label exclusion must use ``none`` operator (got {own!r})"
+    )
+    assert own["labels"]["none"] == {"id": {"eq": "lbl_intake"}}
+
+
+def test_intake_filter_has_no_previous_stage_clause() -> None:
+    """``task_intake`` is the entry — no previous stage label
+    required. The filter must NOT have a ``some`` clause demanding
+    some prior label, otherwise Linear-native tickets are stuck."""
+    tracker = _make_tracker()
+    parts = tracker._fsm_filter("task_intake")
+    for p in parts:
+        if "labels" in p:
+            # ``some`` would mean "previous stage label is present" —
+            # that's the bug for entry stages.
+            assert "some" not in p["labels"], (
+                f"intake filter must not require a ``some`` label "
+                f"(got {p!r})"
+            )
+
+
+def test_intake_filter_state_clause_is_todo() -> None:
+    tracker = _make_tracker()
+    parts = tracker._fsm_filter("task_intake")
+    state_parts = [p for p in parts if "state" in p]
+    assert len(state_parts) == 1
+    assert state_parts[0] == {"state": {"id": {"eq": "todo_state_id"}}}
+
+
+def test_ba_requirements_filter_requires_previous_stage_label() -> None:
+    """Subsequent stages still depend on the previous stage's label
+    being set (intake adds ``stage:task_intake`` on transition)."""
+    tracker = _make_tracker()
+    parts = tracker._fsm_filter("ba_requirements")
+    label_clauses = _find_label_clauses(parts)
+    has_some = any("some" in p["labels"] for p in label_clauses)
+    assert has_some, (
+        "ba_requirements must require the previous (intake) stage "
+        "label via the ``some`` operator"
+    )
+    # The own-label exclusion must still use ``none``.
+    has_none = any("none" in p["labels"] for p in label_clauses)
+    assert has_none
+
+
+def test_needs_clarification_exclusion_uses_none_too() -> None:
+    """Same empty-collection issue applies to the ``needs:clarification``
+    exclusion. A ticket with no labels at all must not be silently
+    excluded by it."""
+    tracker = _make_tracker()
+    parts = tracker._fsm_filter("ba_requirements")
+    clar_clauses = [
+        p
+        for p in parts
+        if "labels" in p
+        and "none" in p["labels"]
+        and p["labels"]["none"].get("id", {}).get("eq") == "lbl_clar"
+    ]
+    assert len(clar_clauses) == 1, (
+        "``needs:clarification`` exclusion should be a single ``none.id.eq`` clause"
+    )
+
+
+def test_self_heal_falls_back_to_coarse_open_filter() -> None:
+    """``self_heal`` runs out-of-band; ``_fsm_filter`` returns no
+    label clauses for it (the caller routes it through ``state="open"``).
+
+    Today this means ``_fsm_filter("self_heal")`` returns an empty
+    parts list because there's no entry in ``fsm_to_linear_state`` for
+    self_heal — confirm we don't accidentally start filtering by it.
+    """
+    tracker = _make_tracker()
+    parts = tracker._fsm_filter("self_heal")
+    # No ``state`` clause and no own-label since FSM_TO_LINEAR_STATE
+    # doesn't include self_heal in the test fixture's mapping.
+    assert all("state" not in p for p in parts)


### PR DESCRIPTION
## Summary

Closes Linear ELS-90 (the asymmetric-intake-filter ticket; Linear's ID assignment shuffled vs my title prefix — see body).

The picker's filter for ``task_intake`` used ``{"labels": {"id": {"nin": [own_label]}}}`` to mean "ticket doesn't yet have the ``stage:task_intake`` label". Linear's ``IssueLabelCollectionFilter`` interprets that bare-``nin`` form as ``some`` semantics — "exists a label whose id is not in the list". **On a ticket with zero labels, ``some`` is vacuously false**, so the unlabeled ticket is excluded.

Effect: a freshly-filed Linear-native ticket (operator clicks "New issue" in Linear → lands in Todo with no Ship labels) is invisible to intake. The pipeline is dead-on-arrival for any workflow that isn't Navigator's ``create_ticket``.

## Fix

Switch from bare ``nin`` to the explicit ``none`` form: ``{"labels": {"none": {"id": {"eq": id}}}}`` reads as "no label exists with id == id", vacuously **true** on an empty collection. Same operator change for the ``needs:clarification`` exclusion (same shape bug).

Subsequent stages (``ba_requirements``, …) still require their previous stage's label via the correct ``some.id.eq`` form. Entry-stage asymmetry (intake has no previous-label requirement) is preserved by ``previous_stage()`` returning ``None`` for ``task_intake`` / ``bug_triage``.

## Why this gates the launch

Without it, every Linear-native ticket the operator files directly stays in Todo forever — the picker thinks intake has nothing to do. Combined with Linear ELS-92 (auto-onboard Linear-native projects), this restores Ship's "wraps your existing tracker" promise.

## Test plan

- [x] `pytest backend/tests/test_linear_tracker_fsm_filter.py` — 6 cases pinning shape (``none`` on own-label, ``none`` on clarification, ``some`` still required on subsequent stages, no ``some`` on intake)
- [x] `pytest backend/tests/test_linear_tracker_default_team.py` — 4 pass (no regression on existing GraphQL)
- [ ] DB-bound: a fresh Linear ticket in Todo with zero labels is returned by ``GET /tracker/next?state=task_intake``. (ELS-89 smoke H1 / new H1-bis.)