### PR TITLE
priorities: sync child ticket states with project state (Linear ELS-91)

### DIFF
--- a/backend/app/api/v1/routes/agent_runs.py
+++ b/backend/app/api/v1/routes/agent_runs.py
@@ -530,6 +530,9 @@ async def _flip_drafts_row_to_active(
     workspace_id: uuid.UUID,
     ticket_ref: str,
     resolved,  # ResolvedTracker; avoid circular type import
+    *,
+    actor_user_id: uuid.UUID | None = None,
+    actor_token_id: uuid.UUID | None = None,
 ) -> bool:
     """Flip the project's priorities row from ``planning`` → ``active``.
 
@@ -602,6 +605,36 @@ async def _flip_drafts_row_to_active(
         return False
     row.state = "active"
     await session.flush()
+
+    # ELS-91: sync child tickets to match the new state (Backlog →
+    # Todo for active). Best-effort — tracker errors log but do NOT
+    # roll back the priorities-row flip. ``actor_user_id`` is the
+    # operator who triggered the agent finish (threaded through from
+    # the route handler) so audit-row FKs stay valid.
+    if actor_user_id is not None:
+        from backend.app.services.agent.project_state_sync import (
+            sync_project_tickets_for_state,
+        )
+
+        try:
+            await sync_project_tickets_for_state(
+                session,
+                workspace_id=workspace_id,
+                project_id=str(project_id),
+                new_state="active",
+                gateway=resolved.gateway,
+                tracker_kind=resolved.kind,
+                actor_user_id=actor_user_id,
+                actor_token_id=actor_token_id,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "decomposition completion: ticket-state sync failed "
+                "workspace=%s project=%s err=%s",
+                workspace_id,
+                project_id,
+                exc,
+            )
     return True
 
 
@@ -735,7 +768,12 @@ async def finish_agent_run(
                 and payload.stage_next == "planning_done"
             ):
                 flipped = await _flip_drafts_row_to_active(
-                    session, workspace_id, payload.ticket_ref, resolved
+                    session,
+                    workspace_id,
+                    payload.ticket_ref,
+                    resolved,
+                    actor_user_id=auth.user.id,
+                    actor_token_id=auth.token.id if auth.token else None,
                 )
                 if flipped:
                     actions.append("priorities:active")

--- a/backend/app/api/v1/routes/dashboard_priorities.py
+++ b/backend/app/api/v1/routes/dashboard_priorities.py
@@ -786,6 +786,29 @@ async def set_priority_state(
     )
     await session.flush()
 
+    # ELS-91: bring the project's child tickets into line with the
+    # new state — Active → Todo, Parked / Drafts → Backlog. Best-
+    # effort: tracker errors log + audit but DON'T roll back the
+    # state flip the operator just made.
+    from backend.app.services.tracker_resolver import resolve_for_workspace
+    from backend.app.services.agent.project_state_sync import (
+        sync_project_tickets_for_state,
+    )
+
+    resolved = await resolve_for_workspace(
+        session=session, settings=settings, workspace_id=workspace_id
+    )
+    await sync_project_tickets_for_state(
+        session,
+        workspace_id=workspace_id,
+        project_id=payload.project_native_id,
+        new_state=payload.state,
+        gateway=resolved.gateway if resolved is not None else None,
+        tracker_kind=resolved.kind if resolved is not None else None,
+        actor_user_id=auth.user.id,
+        actor_token_id=auth.token.id if auth.token else None,
+    )
+
     return await get_priorities(
         workspace_id=workspace_id,
         auth=auth,

--- a/backend/app/integrations/linear/tracker_adapter.py
+++ b/backend/app/integrations/linear/tracker_adapter.py
@@ -242,6 +242,79 @@ class LinearTracker:
             )
         return out
 
+    async def list_project_tickets_in_state(
+        self,
+        *,
+        project_id: str,
+        linear_state_name: str,
+        limit: int = 100,
+    ) -> list[dict[str, Any]]:
+        """List tickets attached to ``project_id`` whose Linear workflow
+        state matches ``linear_state_name`` (case-sensitive match against
+        the team's state names — ``Backlog`` / ``Todo`` / ``In Progress`` /
+        ``Review`` / ``Done`` / etc.).
+
+        Used by the project-state ↔ ticket-state sync helper (Linear
+        ELS-91) to bulk-move children when a project flips Active ↔
+        Parked. We deliberately enumerate by **Linear state name**
+        instead of FSM stage, because the sync moves between Backlog
+        and Todo regardless of which FSM stage the ticket is in
+        (any stage assigned to ``Todo`` should park together).
+
+        Returns a flat list of ``{"id", "identifier", "title", "url",
+        "state_name"}`` dicts. ``id`` is the Linear UUID (suitable for
+        ``transition``); ``identifier`` is the human ref (``ELS-99``).
+
+        Hard-capped at ``limit`` (default 100). Pagination not exposed
+        — projects with >100 children in a single Linear state would be
+        unusual; if it ever comes up we add a cursor loop.
+        """
+        if not project_id:
+            return []
+        target_state_id = self._state_id_by_name.get(linear_state_name)
+        if not target_state_id:
+            # The team may not have provisioned this state name; bail
+            # quietly so the sync degrades to a no-op rather than 5xx.
+            return []
+        gql = """
+        query ShipProjectTicketsInState(
+            $first: Int!,
+            $filter: IssueFilter
+        ) {
+          issues(first: $first, orderBy: updatedAt, filter: $filter) {
+            nodes {
+              id
+              identifier
+              title
+              url
+              state { name }
+            }
+          }
+        }
+        """
+        issue_filter: dict[str, Any] = {
+            "and": [
+                {"project": {"id": {"eq": project_id}}},
+                {"state": {"id": {"eq": target_state_id}}},
+            ]
+        }
+        if self._team_id:
+            issue_filter["and"].append({"team": {"id": {"eq": self._team_id}}})
+        first = max(1, min(limit, 250))
+        data = await self._gql(gql, {"first": first, "filter": issue_filter})
+        out: list[dict[str, Any]] = []
+        for n in (data.get("issues") or {}).get("nodes") or []:
+            out.append(
+                {
+                    "id": str(n.get("id") or ""),
+                    "identifier": str(n.get("identifier") or ""),
+                    "title": str(n.get("title") or ""),
+                    "url": str(n.get("url") or ""),
+                    "state_name": str((n.get("state") or {}).get("name") or ""),
+                }
+            )
+        return out
+
     async def fetch_workflow_states(
         self, *, team_id: str | None = None
     ) -> list[dict[str, Any]]:

--- a/backend/app/services/agent/project_state_sync.py
+++ b/backend/app/services/agent/project_state_sync.py
@@ -1,0 +1,239 @@
+"""Project state ↔ child-ticket state sync (Linear ELS-91).
+
+When the PO flips a project's ``WorkspaceProjectPriority.state``
+between ``active`` / ``planning`` (Drafts) / ``parked``, the picker
+already gates pickup correctly (Linear ELS-80 / ELS-83 / ELS-84 /
+ELS-92). But the **tickets stay in their Linear workflow state** —
+opening Linear, the operator sees a queue of "Todo" tickets that
+agents are silently ignoring. This module closes that loop by
+moving children together with the project:
+
+* ``active``                 — children in ``Backlog`` → ``Todo``
+                                (ready, picker takes them).
+* ``planning`` / ``parked``  — children in ``Todo`` → ``Backlog``
+                                (frozen, picker skips them, operator
+                                sees a clean Backlog with no
+                                unaddressable queue).
+
+Tickets in ``In Progress`` / ``Review`` / ``Done`` are **never moved**
+— parking a project doesn't yank an in-flight ticket back to Backlog
+(that would lose work and require manual recovery); it just stops
+*new* pickups. The single in-flight ticket completes, then no new
+work starts on that project until the operator re-promotes.
+
+Best-effort: an adapter that doesn't model project containment, or a
+tracker 5xx mid-sync, returns ``ProjectSyncReport(errored=…)`` and
+the caller logs but does **not** roll back the priorities row flip.
+The audit trail captures both halves so a re-run reconciles cleanly.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from dataclasses import dataclass, field
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.app.db.models.tenancy import AuditLog
+from backend.app.integrations.gateway.tracker import TicketRef
+
+
+logger = logging.getLogger(__name__)
+
+
+# Project priority state → (from-Linear-state, to-Linear-state) for
+# the sync transition. ``None`` means "no sync action for this state"
+# — useful for terminal states or transitions we deliberately ignore.
+_TRANSITION_PLAN: dict[str, tuple[str, str] | None] = {
+    "active": ("Backlog", "Todo"),
+    "planning": ("Todo", "Backlog"),
+    "parked": ("Todo", "Backlog"),
+}
+
+
+@dataclass(slots=True)
+class ProjectSyncReport:
+    """Return value of :func:`sync_project_tickets_for_state`.
+
+    ``moved`` and ``errored`` count individual tickets the helper
+    walked. ``skipped_reason`` is set on the *whole-call* skip paths
+    (no adapter support, unknown new state, no project_id) — it does
+    NOT accumulate per ticket.
+    """
+
+    project_id: str
+    new_state: str
+    moved: int = 0
+    errored: int = 0
+    skipped_reason: str | None = None
+    moved_tickets: list[str] = field(default_factory=list)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "project_id": self.project_id,
+            "new_state": self.new_state,
+            "moved": self.moved,
+            "errored": self.errored,
+            "skipped_reason": self.skipped_reason,
+            "moved_tickets": list(self.moved_tickets),
+        }
+
+
+def _derive_tracker_kind(gateway: Any) -> str:
+    """Best-effort kind from the gateway's class name.
+
+    ``LinearTracker`` → ``"linear"``, ``NotionTracker`` → ``"notion"``.
+    Used when callers pass the bare adapter without a paired
+    ``ResolvedTracker.kind``. Returns ``"unknown"`` if the class
+    doesn't follow the ``<Vendor>Tracker`` convention — non-fatal
+    (the kind only flavours the audit row + TicketRef).
+    """
+    name = type(gateway).__name__
+    suffix = "Tracker"
+    if name.endswith(suffix):
+        name = name[: -len(suffix)]
+    return name.lower() or "unknown"
+
+
+async def sync_project_tickets_for_state(
+    session: AsyncSession,
+    *,
+    workspace_id: uuid.UUID,
+    project_id: str | None,
+    new_state: str,
+    gateway,  # TrackerGateway adapter (e.g. LinearTracker)
+    tracker_kind: str | None = None,
+    actor_user_id: uuid.UUID,
+    actor_token_id: uuid.UUID | None = None,
+) -> ProjectSyncReport:
+    """Move child tickets to match the project's new priority state.
+
+    Returns a :class:`ProjectSyncReport`. Always returns — even on
+    full failure — so callers can audit the outcome alongside the
+    priorities-row flip.
+
+    ``gateway`` is the bare tracker adapter (LinearTracker instance).
+    ``tracker_kind`` is optional; when omitted we derive it from the
+    gateway's class name. The kind only flavours the audit row + the
+    ``TicketRef`` used for transitions, not the dispatch logic.
+
+    The function flushes its audit rows but does **not** commit; the
+    caller's transaction owns the lifecycle so a tracker error
+    rolling back the flip also rolls back the partial sync audit.
+    """
+    report = ProjectSyncReport(project_id=project_id or "", new_state=new_state)
+    if tracker_kind is None and gateway is not None:
+        tracker_kind = _derive_tracker_kind(gateway)
+
+    if not project_id:
+        report.skipped_reason = "no_project_id"
+        return report
+    if gateway is None:
+        report.skipped_reason = "no_tracker_bound"
+        return report
+
+    plan = _TRANSITION_PLAN.get(new_state)
+    if plan is None:
+        report.skipped_reason = f"unknown_state:{new_state}"
+        return report
+    from_state_name, to_state_name = plan
+
+    list_fn = getattr(gateway, "list_project_tickets_in_state", None)
+    if list_fn is None:
+        report.skipped_reason = (
+            f"adapter_no_project_list:{tracker_kind or 'unknown'}"
+        )
+        return report
+
+    try:
+        rows = await list_fn(
+            project_id=project_id,
+            linear_state_name=from_state_name,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "project_state_sync: list_project_tickets failed "
+            "workspace=%s project=%s from=%s err=%s",
+            workspace_id,
+            project_id,
+            from_state_name,
+            exc,
+        )
+        report.errored = 1
+        report.skipped_reason = "list_failed"
+        return report
+
+    for row in rows:
+        ticket_uuid = row.get("id") or ""
+        ticket_ref = row.get("identifier") or ticket_uuid
+        if not ticket_uuid:
+            continue
+        try:
+            await gateway.transition(
+                TicketRef(
+                    kind=tracker_kind or "linear",
+                    workspace_hint=None,
+                    id=str(ticket_uuid),
+                ),
+                to_state=to_state_name,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "project_state_sync: transition failed "
+                "workspace=%s project=%s ticket=%s from=%s to=%s err=%s",
+                workspace_id,
+                project_id,
+                ticket_ref,
+                from_state_name,
+                to_state_name,
+                exc,
+            )
+            report.errored += 1
+            session.add(
+                AuditLog(
+                    workspace_id=workspace_id,
+                    actor_user_id=actor_user_id,
+                    actor_token_id=actor_token_id,
+                    action="priorities.synced_ticket_state_failed",
+                    target_kind="ticket",
+                    target_id=str(ticket_ref),
+                    payload={
+                        "project_id": project_id,
+                        "from_linear_state": from_state_name,
+                        "to_linear_state": to_state_name,
+                        "trigger_state": new_state,
+                        "error": str(exc)[:500],
+                    },
+                )
+            )
+            continue
+        session.add(
+            AuditLog(
+                workspace_id=workspace_id,
+                actor_user_id=actor_user_id,
+                actor_token_id=actor_token_id,
+                action="priorities.synced_ticket_state",
+                target_kind="ticket",
+                target_id=str(ticket_ref),
+                payload={
+                    "project_id": project_id,
+                    "from_linear_state": from_state_name,
+                    "to_linear_state": to_state_name,
+                    "trigger_state": new_state,
+                },
+            )
+        )
+        report.moved += 1
+        report.moved_tickets.append(str(ticket_ref))
+
+    if report.moved or report.errored:
+        await session.flush()
+    return report
+
+
+__all__ = [
+    "ProjectSyncReport",
+    "sync_project_tickets_for_state",
+]

--- a/backend/app/services/agent/tools.py
+++ b/backend/app/services/agent/tools.py
@@ -7361,11 +7361,30 @@ class ToolBox:
         )
         await self._session.flush()
 
+        # ELS-91: bring child tickets into line with the new state.
+        # Best-effort — tracker errors log + audit but do not roll back
+        # the operator's flip.
+        from backend.app.services.agent.project_state_sync import (
+            sync_project_tickets_for_state,
+        )
+
+        gateway = await self._resolve_tracker(None, None)
+        sync_report = await sync_project_tickets_for_state(
+            self._session,
+            workspace_id=self._workspace_id,
+            project_id=project_native_id,
+            new_state=state,
+            gateway=gateway,
+            actor_user_id=self._user_id,
+            actor_token_id=None,
+        )
+
         return _json_result(
             {
                 "project_native_id": project_native_id,
                 "state": state,
                 "prior_state": prior_state,
+                "synced_tickets": sync_report.as_dict(),
             }
         )
 

--- a/backend/tests/test_project_state_sync.py
+++ b/backend/tests/test_project_state_sync.py
@@ -1,0 +1,326 @@
+"""Project-state ↔ ticket-state sync helper (Linear ELS-91).
+
+Covers the helper's branching: skip paths (no project, no tracker,
+unknown state, adapter without project listing), happy path
+(transition each child + audit), partial failure (one transition
+errors, others succeed), and the kind derivation fallback.
+
+The helper takes a bare ``gateway`` and an :class:`AsyncSession`
+mock so we don't need a live DB to exercise the branching. Stub
+gateways implement the two methods the helper uses
+(``list_project_tickets_in_state`` + ``transition``).
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from backend.app.services.agent.project_state_sync import (
+    ProjectSyncReport,
+    _derive_tracker_kind,
+    sync_project_tickets_for_state,
+)
+
+
+class _StubGateway:
+    """Minimal Linear-shaped adapter.
+
+    Records every ``transition`` call so tests can assert on the
+    sequence + arguments. ``raise_on`` lets a test simulate a
+    per-ticket transition failure.
+    """
+
+    def __init__(
+        self,
+        rows: list[dict[str, Any]],
+        *,
+        raise_on_list: bool = False,
+        raise_on_transition: set[str] | None = None,
+    ) -> None:
+        self._rows = rows
+        self.raise_on_list = raise_on_list
+        self.raise_on_transition = raise_on_transition or set()
+        self.transitions: list[tuple[str, str]] = []
+
+    async def list_project_tickets_in_state(
+        self, *, project_id: str, linear_state_name: str, limit: int = 100
+    ) -> list[dict[str, Any]]:
+        if self.raise_on_list:
+            raise RuntimeError("simulated Linear 5xx")
+        return self._rows
+
+    async def transition(self, ticket, *, to_state: str) -> None:
+        if ticket.id in self.raise_on_transition:
+            raise RuntimeError(f"transition failed for {ticket.id}")
+        self.transitions.append((ticket.id, to_state))
+
+
+class _StubGatewayWithoutProjectList:
+    """Adapter that doesn't surface the project-list method —
+    helper must skip cleanly with ``adapter_no_project_list:<kind>``.
+    """
+
+    async def transition(self, ticket, *, to_state: str) -> None:
+        raise AssertionError("transition should not be called on skip path")
+
+
+class _Session:
+    """Async-session stub with the methods the helper uses
+    (``add`` is sync; ``flush`` is async). Records every audit row
+    appended so tests can assert on the audit shape."""
+
+    def __init__(self) -> None:
+        self.added: list[Any] = []
+        self.flushes: int = 0
+
+    def add(self, obj: Any) -> None:
+        self.added.append(obj)
+
+    async def flush(self) -> None:
+        self.flushes += 1
+
+
+def _ws() -> uuid.UUID:
+    return uuid.UUID("00000000-0000-0000-0000-deadbeef0001")
+
+
+def _user() -> uuid.UUID:
+    return uuid.UUID("00000000-0000-0000-0000-cafef00d0001")
+
+
+# ---------------------------------------------------------------------
+# Skip paths
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_skip_when_project_id_missing() -> None:
+    session = _Session()
+    report = await sync_project_tickets_for_state(
+        session,
+        workspace_id=_ws(),
+        project_id=None,
+        new_state="active",
+        gateway=_StubGateway([]),
+        actor_user_id=_user(),
+    )
+    assert report.skipped_reason == "no_project_id"
+    assert report.moved == 0 and report.errored == 0
+    assert session.added == []
+
+
+@pytest.mark.asyncio
+async def test_skip_when_no_tracker_bound() -> None:
+    session = _Session()
+    report = await sync_project_tickets_for_state(
+        session,
+        workspace_id=_ws(),
+        project_id="proj-1",
+        new_state="active",
+        gateway=None,
+        actor_user_id=_user(),
+    )
+    assert report.skipped_reason == "no_tracker_bound"
+
+
+@pytest.mark.asyncio
+async def test_skip_for_unknown_state() -> None:
+    session = _Session()
+    report = await sync_project_tickets_for_state(
+        session,
+        workspace_id=_ws(),
+        project_id="proj-1",
+        new_state="frobnicated",  # not in the transition plan
+        gateway=_StubGateway([]),
+        actor_user_id=_user(),
+    )
+    assert report.skipped_reason == "unknown_state:frobnicated"
+
+
+@pytest.mark.asyncio
+async def test_skip_when_adapter_lacks_project_list() -> None:
+    """An adapter without ``list_project_tickets_in_state`` (Notion /
+    Jira / GitHub Issues today) skips with a kind-tagged reason so
+    the operator sees which adapter is the gap."""
+    session = _Session()
+    report = await sync_project_tickets_for_state(
+        session,
+        workspace_id=_ws(),
+        project_id="proj-1",
+        new_state="active",
+        gateway=_StubGatewayWithoutProjectList(),
+        tracker_kind="notion",
+        actor_user_id=_user(),
+    )
+    assert report.skipped_reason == "adapter_no_project_list:notion"
+
+
+# ---------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_active_moves_backlog_to_todo() -> None:
+    session = _Session()
+    rows = [
+        {"id": "tkt-uuid-1", "identifier": "ELS-100"},
+        {"id": "tkt-uuid-2", "identifier": "ELS-101"},
+    ]
+    gateway = _StubGateway(rows)
+    report = await sync_project_tickets_for_state(
+        session,
+        workspace_id=_ws(),
+        project_id="proj-1",
+        new_state="active",
+        gateway=gateway,
+        tracker_kind="linear",
+        actor_user_id=_user(),
+    )
+    assert report.moved == 2
+    assert report.errored == 0
+    assert report.skipped_reason is None
+    assert report.moved_tickets == ["ELS-100", "ELS-101"]
+    # Both transitioned to Todo (Active → Todo plan).
+    assert gateway.transitions == [
+        ("tkt-uuid-1", "Todo"),
+        ("tkt-uuid-2", "Todo"),
+    ]
+    # One audit row per transition.
+    assert len(session.added) == 2
+
+
+@pytest.mark.asyncio
+async def test_parked_moves_todo_to_backlog() -> None:
+    session = _Session()
+    gateway = _StubGateway(
+        [{"id": "tkt-x", "identifier": "ELS-9"}]
+    )
+    report = await sync_project_tickets_for_state(
+        session,
+        workspace_id=_ws(),
+        project_id="proj-x",
+        new_state="parked",
+        gateway=gateway,
+        actor_user_id=_user(),
+    )
+    assert report.moved == 1
+    assert gateway.transitions == [("tkt-x", "Backlog")]
+
+
+@pytest.mark.asyncio
+async def test_planning_also_moves_todo_to_backlog() -> None:
+    """Drafts (``planning``) shares the parked plan — child tickets
+    in Todo go back to Backlog so they're not visible as queued
+    work while the PO is still shaping."""
+    session = _Session()
+    gateway = _StubGateway([{"id": "x", "identifier": "ELS-1"}])
+    report = await sync_project_tickets_for_state(
+        session,
+        workspace_id=_ws(),
+        project_id="proj-y",
+        new_state="planning",
+        gateway=gateway,
+        actor_user_id=_user(),
+    )
+    assert gateway.transitions == [("x", "Backlog")]
+    assert report.moved == 1
+
+
+# ---------------------------------------------------------------------
+# Failure paths
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_failure_returns_errored_report() -> None:
+    session = _Session()
+    gateway = _StubGateway([], raise_on_list=True)
+    report = await sync_project_tickets_for_state(
+        session,
+        workspace_id=_ws(),
+        project_id="proj-1",
+        new_state="active",
+        gateway=gateway,
+        actor_user_id=_user(),
+    )
+    assert report.errored == 1
+    assert report.skipped_reason == "list_failed"
+    # No audit rows — listing failed before any per-ticket work.
+    assert session.added == []
+
+
+@pytest.mark.asyncio
+async def test_partial_transition_failure_continues_with_others() -> None:
+    """One bad ticket doesn't take down the whole sync."""
+    session = _Session()
+    rows = [
+        {"id": "ok-1", "identifier": "ELS-1"},
+        {"id": "fail-1", "identifier": "ELS-2"},
+        {"id": "ok-2", "identifier": "ELS-3"},
+    ]
+    gateway = _StubGateway(rows, raise_on_transition={"fail-1"})
+    report = await sync_project_tickets_for_state(
+        session,
+        workspace_id=_ws(),
+        project_id="proj-1",
+        new_state="active",
+        gateway=gateway,
+        actor_user_id=_user(),
+    )
+    assert report.moved == 2
+    assert report.errored == 1
+    assert report.moved_tickets == ["ELS-1", "ELS-3"]
+    # Audit: 2 success rows + 1 failure row = 3 total.
+    assert len(session.added) == 3
+
+
+# ---------------------------------------------------------------------
+# Kind derivation
+# ---------------------------------------------------------------------
+
+
+def test_derive_kind_from_class_name() -> None:
+    class LinearTracker:
+        pass
+
+    class NotionTracker:
+        pass
+
+    class CustomTracker:
+        pass
+
+    class WeirdShape:
+        pass
+
+    assert _derive_tracker_kind(LinearTracker()) == "linear"
+    assert _derive_tracker_kind(NotionTracker()) == "notion"
+    assert _derive_tracker_kind(CustomTracker()) == "custom"
+    # No ``Tracker`` suffix → fall through to lowercased class name.
+    assert _derive_tracker_kind(WeirdShape()) == "weirdshape"
+
+
+def test_report_as_dict_shape() -> None:
+    """The report's serialised shape is what the audit / tool
+    response carries — pin the keys."""
+    r = ProjectSyncReport(
+        project_id="p",
+        new_state="active",
+        moved=2,
+        errored=1,
+        skipped_reason=None,
+        moved_tickets=["ELS-1", "ELS-2"],
+    )
+    d = r.as_dict()
+    assert set(d.keys()) == {
+        "project_id",
+        "new_state",
+        "moved",
+        "errored",
+        "skipped_reason",
+        "moved_tickets",
+    }


### PR DESCRIPTION
## Summary

Closes Linear ELS-91 (project-state ↔ ticket-state sync). When the PO toggles a project's priorities row Active ↔ Parked / Drafts, the **child tickets follow** so the Linear UI matches the picker's behaviour.

| Project state | Child-ticket transition |
|---|---|
| ``active`` (just promoted) | ``Backlog`` → ``Todo`` |
| ``planning`` (Drafts) | ``Todo`` → ``Backlog`` |
| ``parked`` | ``Todo`` → ``Backlog`` |
| (any) | ``In Progress`` / ``Review`` / ``Done`` left alone |

The ``In Progress`` / ``Review`` carve-out matters: parking a project mid-flight should NOT yank an in-progress ticket back to Backlog — that loses work. Park just stops *new* pickups; the in-flight ticket completes, then nothing new starts.

## Architecture

* New helper ``services/agent/project_state_sync.sync_project_tickets_for_state``. Returns a typed ``ProjectSyncReport`` — always returns (best-effort), so callers can audit alongside the flip.
* New Linear adapter method ``list_project_tickets_in_state(project_id, linear_state_name)``. Linear-only; other adapters skip cleanly with ``adapter_no_project_list:<kind>``.
* Three trigger sites wired:
  - ``dashboard_priorities.py::set_priority_state`` (UI flip)
  - ``services/agent/tools.py::_tool_set_priority_state`` (Navigator command)
  - ``agent_runs.py::_flip_drafts_row_to_active`` (post-decomposition)
* Audit: one ``priorities.synced_ticket_state`` row per moved ticket, plus ``..._failed`` rows for per-ticket transition errors.

## Failure modes handled

- No tracker bound → skip with reason.
- Adapter doesn't model project containment (Notion / Jira / GitHub Issues) → skip with kind-tagged reason.
- Tracker 5xx on list → skip with ``list_failed``, no per-ticket audit.
- Tracker 5xx on individual transition → skip that ticket, continue with the rest, audit failure.
- Tracker 5xx after some moves succeed → priorities flip stands; partial sync visible in audit.

## Test plan

- [x] ``pytest backend/tests/test_project_state_sync.py`` — 11 cases (skip paths × 4, happy path × 3, partial failure × 2, kind derivation, shape pin)
- [x] ``pytest backend/tests/test_linear_tracker_default_team.py`` — 4 pass (no regression on existing GraphQL)
- [ ] DB-bound smoke: park a project with 5 Todo + 1 In Progress children — Todo all move to Backlog, In Progress untouched. Activate — Backlog all move back to Todo. (ELS-89 H6-bis.)