### PR TITLE
agent_runs: drop overlay-frozen tickets from picker (ELS-84)

### DIFF
--- a/backend/app/api/v1/routes/agent_runs.py
+++ b/backend/app/api/v1/routes/agent_runs.py
@@ -61,6 +61,9 @@ from backend.app.db.models.inbox import InboxItem
 from backend.app.db.models.tenancy import AuditLog
 from backend.app.db.session import get_session
 from backend.app.integrations.gateway.tracker import TicketRef
+from backend.app.services.linear_provisioner import (
+    OVERLAY_FREEZE_LABEL_PREFIXES,
+)
 from backend.app.services.tracker_resolver import resolve_for_workspace
 
 
@@ -245,11 +248,18 @@ async def get_next_task(
 ) -> TaskResponseOut:
     """Return the next ticket the agent should work on for ``state``.
 
-    Picker filters (ELS-83): tickets without a tracker ``project_id``
-    are orphans — created outside the dashboard's project flow.
-    They're skipped here and a one-shot inbox item plus an
-    ``agent_run.orphan_skipped`` audit row land so an operator can see
-    them and re-home the work or close it.
+    Picker filters:
+
+    * **ELS-83 — orphans.** Tickets without a tracker ``project_id``
+      are skipped. A one-shot inbox item plus
+      ``agent_run.orphan_skipped`` audit rows land so an operator can
+      re-home or close them.
+    * **ELS-84 — overlay-frozen.** Tickets carrying a label whose
+      prefix is in :data:`OVERLAY_FREEZE_LABEL_PREFIXES`
+      (``needs:clarification`` / ``blocked`` / ``blocked-on-…``) are
+      skipped silently with an ``agent_run.overlay_frozen_skipped``
+      audit row — the operator already owes a reply on these and
+      doesn't need an inbox notification telling them so.
     """
     await _require_membership(session, workspace_id, auth.user.id, ROLES_ADMIN)
 
@@ -272,6 +282,7 @@ async def get_next_task(
 
     pick: dict[str, Any] | None = None
     skipped_orphans: list[dict[str, Any]] = []
+    skipped_overlay: list[tuple[dict[str, Any], list[str]]] = []
     for row in rows:
         # ``project_id`` is surfaced by adapters that can populate it
         # (Linear today). Adapters that can't (Notion / Jira / GitHub
@@ -281,6 +292,15 @@ async def get_next_task(
         project_id = row.get("project_id")
         if "project_id" in row and project_id is None:
             skipped_orphans.append(row)
+            continue
+        # ELS-84: overlay-frozen tickets — anything carrying a
+        # ``needs:clarification`` or ``blocked*`` label means the
+        # operator owes a reply. Skip silently; reviving happens when
+        # the operator clears the label (then the ticket flows through
+        # the picker again on the next tick).
+        matched_overlays = _matched_overlay_labels(row.get("labels") or [])
+        if matched_overlays:
+            skipped_overlay.append((row, matched_overlays))
             continue
         pick = row
         break
@@ -293,6 +313,15 @@ async def get_next_task(
             tracker_kind=resolved.kind,
             fsm_stage=state,
             orphans=skipped_orphans,
+        )
+    if skipped_overlay:
+        await _record_overlay_skips(
+            session,
+            workspace_id=workspace_id,
+            auth=auth,
+            tracker_kind=resolved.kind,
+            fsm_stage=state,
+            skipped=skipped_overlay,
         )
 
     if pick is None:
@@ -313,6 +342,75 @@ async def get_next_task(
             fsm_stage=state,
         ),
     )
+
+
+def _matched_overlay_labels(labels: list[str]) -> list[str]:
+    """Return labels on ``labels`` that match an overlay-freeze prefix.
+
+    Match is case-insensitive — for each prefix ``p`` in
+    :data:`OVERLAY_FREEZE_LABEL_PREFIXES`, a label ``l`` is a hit if
+    ``l == p`` (exact), ``l.startswith(p + "-")`` (operator-friendly
+    suffix like ``blocked-on-acme``), or ``l.startswith(p + ":")``
+    (label-namespace suffix like ``blocked:foo``). Returns the
+    *original* label strings (not lowercased) so the audit row
+    surfaces what the operator actually sees in Linear.
+    """
+    matched: list[str] = []
+    for raw in labels:
+        if not isinstance(raw, str):
+            continue
+        candidate = raw.strip().lower()
+        if not candidate:
+            continue
+        for prefix in OVERLAY_FREEZE_LABEL_PREFIXES:
+            if (
+                candidate == prefix
+                or candidate.startswith(prefix + "-")
+                or candidate.startswith(prefix + ":")
+            ):
+                matched.append(raw)
+                break
+    return matched
+
+
+async def _record_overlay_skips(
+    session: AsyncSession,
+    *,
+    workspace_id: uuid.UUID,
+    auth: AuthContext,
+    tracker_kind: str,
+    fsm_stage: str,
+    skipped: list[tuple[dict[str, Any], list[str]]],
+) -> None:
+    """Audit rows for tickets the overlay-label gate dropped (ELS-84).
+
+    No inbox spam — the operator already owes a reply on these
+    (``needs:clarification`` is *their* TODO, ``blocked`` is theirs to
+    unblock). The audit log keeps the breadcrumb so debugging "why
+    didn't the agent pick X" stays tractable.
+    """
+    for row, matched in skipped:
+        ticket_ref = str(row.get("id") or "")
+        if not ticket_ref:
+            continue
+        session.add(
+            AuditLog(
+                workspace_id=workspace_id,
+                actor_user_id=auth.user.id,
+                actor_token_id=auth.token.id if auth.token else None,
+                action="agent_run.overlay_frozen_skipped",
+                target_kind="ticket",
+                target_id=ticket_ref,
+                payload={
+                    "tracker_kind": tracker_kind,
+                    "fsm_stage": fsm_stage,
+                    "matched_labels": matched,
+                    "title": str(row.get("title") or "")[:200],
+                    "url": str(row.get("url") or "") or None,
+                },
+            )
+        )
+    await session.flush()
 
 
 async def _record_orphan_skips(

--- a/backend/app/services/linear_provisioner.py
+++ b/backend/app/services/linear_provisioner.py
@@ -161,6 +161,23 @@ SIGNAL_LABELS: dict[str, str] = {
 }
 
 
+# Overlay labels that freeze a ticket — the agent picker drops any
+# row carrying one of these (ELS-84). Distinct from ``SIGNAL_LABELS``
+# (what the agent emits): freeze-overlay labels include both Ship-
+# emitted ones and operator-friendly aliases (``blocked`` /
+# ``blocker``) so a hand-tagged ticket is also respected.
+#
+# Match is case-insensitive and ``label.startswith(...)`` against this
+# set's lowercase entries — covers ``needs:clarification`` exactly,
+# and ``blocked`` / ``blocked-on-foo`` with one rule.
+OVERLAY_FREEZE_LABEL_PREFIXES: frozenset[str] = frozenset(
+    {
+        "needs:clarification",
+        "blocked",
+    }
+)
+
+
 @dataclass(frozen=True)
 class ProvisionResult:
     team_id: str

--- a/backend/tests/test_agent_runs_overlay_filter.py
+++ b/backend/tests/test_agent_runs_overlay_filter.py
@@ -1,0 +1,65 @@
+"""Picker overlay-label filter (ELS-84).
+
+The picker drops tickets carrying overlay labels that mean the
+operator owes a reply: ``needs:clarification`` and the ``blocked``
+family (``blocked``, ``blocked-on-acme``, ``blocked:foo``). Match is
+case-insensitive; stage labels (``stage:wbs`` / ``stage:wbs-foo``)
+must NOT match — they're how the FSM filters tickets *into* the
+picker, not freeze overlays.
+"""
+
+from __future__ import annotations
+
+from backend.app.api.v1.routes.agent_runs import _matched_overlay_labels
+
+
+def test_exact_match_needs_clarification() -> None:
+    assert _matched_overlay_labels(["needs:clarification"]) == [
+        "needs:clarification"
+    ]
+
+
+def test_exact_match_blocked() -> None:
+    assert _matched_overlay_labels(["blocked"]) == ["blocked"]
+
+
+def test_dash_suffix_matches_blocked() -> None:
+    """Operator-friendly form: ``blocked-on-acme`` is a freeze too."""
+    assert _matched_overlay_labels(["blocked-on-acme"]) == ["blocked-on-acme"]
+
+
+def test_colon_suffix_matches_blocked() -> None:
+    """Namespace form: ``blocked:foo`` is a freeze."""
+    assert _matched_overlay_labels(["blocked:foo"]) == ["blocked:foo"]
+
+
+def test_case_insensitive_match() -> None:
+    """Linear permits arbitrary casing on label names."""
+    assert _matched_overlay_labels(["BLOCKED", "Needs:Clarification"]) == [
+        "BLOCKED",
+        "Needs:Clarification",
+    ]
+
+
+def test_stage_label_does_not_match() -> None:
+    """``stage:wbs`` is the FSM filter, not a freeze. Picker keeps it."""
+    assert _matched_overlay_labels(["stage:wbs", "stage:wbs-anchor"]) == []
+
+
+def test_unrelated_label_does_not_match() -> None:
+    """Random project labels stay invisible to the freeze filter."""
+    assert _matched_overlay_labels(["bug", "p1", "frontend"]) == []
+
+
+def test_mixed_labels_returns_only_freeze_matches() -> None:
+    """Non-freeze labels travel with the row; only freeze matches return."""
+    matched = _matched_overlay_labels(
+        ["stage:wbs", "needs:clarification", "p1", "blocked"]
+    )
+    assert matched == ["needs:clarification", "blocked"]
+
+
+def test_empty_or_invalid_inputs_skip_silently() -> None:
+    """Garbage input doesn't blow the matcher — empty / non-strings drop."""
+    matched = _matched_overlay_labels(["", "  ", None, 42, "blocked"])  # type: ignore[list-item]
+    assert matched == ["blocked"]


### PR DESCRIPTION
Re-target of #173 onto main after #169 merged. Picker drops tickets carrying `needs:clarification` or `blocked*` labels. New `OVERLAY_FREEZE_LABEL_PREFIXES` const, case-insensitive matcher with `:`/`-` suffix support, audit row per skip.