### PR TITLE
agent_runs: pick-race protection via advisory xact lock (ELS-85)

### DIFF
--- a/backend/app/api/v1/routes/agent_runs.py
+++ b/backend/app/api/v1/routes/agent_runs.py
@@ -42,13 +42,16 @@ the agent never hold the tracker credential.
 
 from __future__ import annotations
 
+import hashlib
 import logging
+import struct
 import uuid
 from datetime import datetime, timezone
 from typing import Any, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field
+from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from sqlalchemy import select as sa_select
@@ -195,6 +198,34 @@ class FinishOut(BaseModel):
 # ---------------------------------------------------------------------------
 
 
+def _pickup_lock_key(
+    workspace_id: uuid.UUID, fsm_stage: str
+) -> tuple[int, int]:
+    """Stable (int4, int4) key for the picker's advisory lock (ELS-85).
+
+    Postgres ``pg_try_advisory_xact_lock`` accepts a single 64-bit int
+    or a pair of 32-bit ints. The pair form lines up nicely with our
+    natural lock key — ``(workspace_id, fsm_stage)`` — so we hash each
+    side to a signed int32 and pass them separately. Collisions across
+    different ``(ws, stage)`` pairs are theoretically possible
+    (``2^-32`` per pair) but the cost of a false positive is just
+    "the second caller noops and retries on the next cron tick" —
+    well within tolerance.
+
+    BLAKE2b is used over Python's built-in ``hash`` because the latter
+    is randomised per-process: two replicas would compute different
+    keys for the same workspace and the lock would stop working
+    altogether.
+    """
+    ws_digest = hashlib.blake2b(workspace_id.bytes, digest_size=4).digest()
+    stage_digest = hashlib.blake2b(
+        fsm_stage.encode("utf-8"), digest_size=4
+    ).digest()
+    ws_key = struct.unpack("<i", ws_digest)[0]
+    stage_key = struct.unpack("<i", stage_digest)[0]
+    return ws_key, stage_key
+
+
 def _vendor_kind_to_ticket_kind(vendor_kind: str) -> Literal[
     "github_issues", "linear", "notion", "jira"
 ]:
@@ -279,6 +310,23 @@ async def get_next_task(
       and skipped too.
     """
     await _require_membership(session, workspace_id, auth.user.id, ROLES_ADMIN)
+
+    # ELS-85: pick-race protection. Two parallel ``shipctl run
+    # --routine X`` calls on the same FSM stage would otherwise both
+    # fetch the same head-of-list ticket and start two Cursor runs.
+    # ``pg_try_advisory_xact_lock(int4, int4)`` keyed on
+    # ``(workspace_id, fsm_stage)`` serialises them — second caller
+    # gets ``ticket=null`` and noops cleanly. Lock is transactional
+    # so it auto-releases at commit / rollback; no manual unlock.
+    ws_key, stage_key = _pickup_lock_key(workspace_id, state)
+    got = (
+        await session.execute(
+            text("SELECT pg_try_advisory_xact_lock(:k1, :k2)"),
+            {"k1": ws_key, "k2": stage_key},
+        )
+    ).scalar_one()
+    if not got:
+        return TaskResponseOut(ticket=None, fsm_stage=state, tracker_kind=None)
 
     resolved = await resolve_for_workspace(
         session=session,

--- a/backend/tests/test_agent_runs_pick_lock.py
+++ b/backend/tests/test_agent_runs_pick_lock.py
@@ -1,0 +1,88 @@
+"""Picker advisory-lock key (ELS-85).
+
+The lock binds to ``(workspace_id, fsm_stage)``. The mapping must be
+deterministic across replicas (so two API pods compute the same key),
+distinct across both axes, and fit in Postgres's int4 range — anything
+outside that range trips ``pg_try_advisory_xact_lock``'s argument check
+at run time.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from backend.app.api.v1.routes.agent_runs import _pickup_lock_key
+
+
+def test_lock_key_is_deterministic() -> None:
+    ws = uuid.UUID("d591af28-225e-477e-8448-7a4b9b06fbfc")
+    assert _pickup_lock_key(ws, "task_intake") == _pickup_lock_key(
+        ws, "task_intake"
+    )
+
+
+def test_lock_key_distinguishes_stages() -> None:
+    ws = uuid.UUID("d591af28-225e-477e-8448-7a4b9b06fbfc")
+    assert _pickup_lock_key(ws, "task_intake") != _pickup_lock_key(ws, "wbs")
+    assert _pickup_lock_key(ws, "ba_requirements") != _pickup_lock_key(
+        ws, "tech_arch_plan"
+    )
+
+
+def test_lock_key_distinguishes_workspaces() -> None:
+    a = uuid.UUID("d591af28-225e-477e-8448-7a4b9b06fbfc")
+    b = uuid.UUID("11111111-1111-1111-1111-111111111111")
+    assert _pickup_lock_key(a, "task_intake") != _pickup_lock_key(
+        b, "task_intake"
+    )
+
+
+def test_lock_key_components_fit_in_int4() -> None:
+    """``pg_try_advisory_xact_lock(int, int)`` requires signed int32."""
+    ws = uuid.UUID("d591af28-225e-477e-8448-7a4b9b06fbfc")
+    for stage in (
+        "task_intake",
+        "ba_requirements",
+        "tech_arch_plan",
+        "wbs",
+        "architecture",
+        "test_architecture",
+        "tasks",
+        "planning_done",
+        "code_review",
+    ):
+        ws_key, stage_key = _pickup_lock_key(ws, stage)
+        assert -(2**31) <= ws_key < 2**31, (ws_key, stage)
+        assert -(2**31) <= stage_key < 2**31, (stage_key, stage)
+
+
+def test_lock_key_is_process_stable_pinned_bytes() -> None:
+    """Pin literal byte values so a switch to a non-deterministic
+    hash function (e.g. Python's built-in ``hash`` which is seeded
+    per-process via PEP 456) fails the test loudly.
+
+    The two replicas serving picker requests must compute **identical**
+    keys for the same ``(workspace, fsm_stage)`` — otherwise the
+    advisory lock doesn't actually serialise across replicas and
+    the race-protection guarantee silently disappears. A previous
+    iteration of this test only round-tripped the function with
+    itself in the same process; that passes for both BLAKE2b AND
+    Python's seeded hash, which is exactly the regression we want
+    to catch.
+
+    Expected values are BLAKE2b digests of the inputs; if you
+    intentionally change the hashing scheme, regenerate them
+    locally — that's the trade-off for catching the regression.
+    """
+    nil_ws = uuid.UUID("00000000-0000-0000-0000-000000000000")
+    assert _pickup_lock_key(nil_ws, "task_intake") == (
+        1_222_067_678,
+        -845_439_783,
+    )
+    ship_on_ship = uuid.UUID("d591af28-225e-477e-8448-7a4b9b06fbfc")
+    assert _pickup_lock_key(ship_on_ship, "wbs") == (
+        670_875_352,
+        -1_080_360_883,
+    )


### PR DESCRIPTION
Re-applied cleanly on top of merged stack (replaces #177). Postgres advisory lock keyed on (workspace, fsm_stage) serialises concurrent picker calls; second caller noops via ticket=null, cron retries.