### PR TITLE
landing: hide future-dated blog posts in production

### DIFF
--- a/landing/src/lib/blog.ts
+++ b/landing/src/lib/blog.ts
@@ -92,6 +92,28 @@ function toMeta(slug: string, data: Record<string, string | number | string[]>):
   };
 }
 
+// Today's date in UTC, recomputed on every call so a long-lived
+// server eventually serves a post once its date arrives without a
+// redeploy. (Static builds still need a fresh build to add new
+// statically-generated routes; see generateStaticParams in
+// app/blog/[slug]/page.tsx.)
+function todayIsoUtc(): string {
+  const d = new Date();
+  const y = d.getUTCFullYear();
+  const m = String(d.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(d.getUTCDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+// Future-dated posts (drafts staged for later) should not appear in
+// production index, sitemap, or single-post routes. In development
+// they remain visible so authors can preview their work.
+function isPublishable(date: string): boolean {
+  if (process.env.NODE_ENV !== "production") return true;
+  if (!date) return false;
+  return date <= todayIsoUtc();
+}
+
 export function listBlogPosts(): BlogMeta[] {
   if (!fs.existsSync(BLOG_DIR)) return [];
   return fs
@@ -103,6 +125,7 @@ export function listBlogPosts(): BlogMeta[] {
       const { data } = parseFrontmatter(raw);
       return toMeta(slug, data);
     })
+    .filter((meta) => isPublishable(meta.date))
     .sort((a, b) => (a.date < b.date ? 1 : a.date > b.date ? -1 : 0));
 }
 
@@ -111,7 +134,9 @@ export function getBlogPost(slug: string): BlogPost | null {
   if (!fs.existsSync(fp)) return null;
   const raw = fs.readFileSync(fp, "utf-8");
   const { data, body } = parseFrontmatter(raw);
-  return { ...toMeta(slug, data), body };
+  const meta = toMeta(slug, data);
+  if (!isPublishable(meta.date)) return null;
+  return { ...meta, body };
 }
 
 export function formatBlogDate(iso: string): string {


### PR DESCRIPTION
## Summary

The blog was surfacing posts whose frontmatter `date:` was still in the future — `champagne-over-teal` (2026-05-11) and `boring-failures-are-good-failures` (2026-05-08) appeared ahead of schedule.

Adds an `isPublishable(date)` gate in `lib/blog.ts` so:

- **Production:** posts with `date > today (UTC)` are filtered from `listBlogPosts()`, hidden from sitemap, and `getBlogPost(slug)` returns `null` (single-post route 404s).
- **Development:** all posts remain visible so authors can preview drafts.

Today is recomputed on every call rather than at module init, so a long-lived server eventually serves a post once its date arrives without a redeploy. Static builds still pick up new routes only on the next build (no behaviour change there).

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] Smoke run with `NODE_ENV=production` → 20 posts (was 22), latest is `the-mapping-table-the-runtime-never-read` (2026-05-06)
- [x] Smoke run with `NODE_ENV=development` → 22 posts, future drafts visible
- [x] `getBlogPost("champagne-over-teal")` in prod → `null` (will trigger `notFound()` in the route)
- [ ] Smoke check landing dev server: `/blog` index + direct `/blog/champagne-over-teal` URL behaves correctly under production build