### PR TITLE
landing: add /changelog — git-driven log of merged PRs

### DIFF
--- a/landing/content/changelog/2026-04-19-ship-cut-out-of-elmundi.md
+++ b/landing/content/changelog/2026-04-19-ship-cut-out-of-elmundi.md
@@ -1,0 +1,61 @@
+---
+slug: 2026-04-19-ship-cut-out-of-elmundi
+date: 2026-04-19
+title: Ship cut out of elmundi
+summary: Day zero. The methodology lived inside a host product for six months. We extracted it into its own repo, gave it a license, a CLI, a landing site, and a deploy. Twenty commits to get there.
+kicker: Bootstrap
+prs: []
+---
+
+Ship didn't begin as a greenfield repo. It began as a folder inside a product called elmundi where coding agents had been running against a real codebase for months. The methodology worked. The fact that it lived inside someone else's app didn't.
+
+This is the entry for the first thirteen days — the period before the PR-flow started — read off the actual git log. It's not a long entry because the work was foundational rather than user-facing: a repo, a license, a CLI, a deploy, and a landing app where there hadn't been anything before. There's a longer telling on the [Ship Log](/blog/how-we-cut-ship-out-of-elmundi).
+
+## Highlights
+
+### The extraction
+
+The first commit on the new repo says it plainly: *Initial import: Ship framework (extracted from elmundi)*. A single commit that carried over the manual, the prompts, the Node runtime, and the scripts — with paths rewritten, ElMundi-specific examples gone, and a LICENSE file where there hadn't been one before.
+
+### shipctl v0.9 — protocol before product
+
+Eleven days after the extraction, on a Sunday, `shipctl v0.9` landed: artifacts protocol, stack adapters, pharma pilot e2e. The CLI shipped before the cloud product because the *contract* between client and server is what makes Ship plural. Without that contract, every adopter would fork the runtime; with it, every adopter speaks to the same protocol.
+
+### Landing app + retire MkDocs
+
+MkDocs was the original docs runtime. This week it got retired in favour of a Next.js landing app under `landing/` — same content, different runtime, with a downloadable book PDF and a real `/docs` viewer. The docs MCP server experiment got removed (kept the lesson, dropped the code).
+
+### RFC-0005 — artifacts as frontmatter
+
+The first piece of public RFC-driven cleanup. Two waves: 61 artifacts moved to a v2 folder layout (Wave 1), then the legacy manifests got dropped and the filesystem became the single source of truth (Wave 2). Fewer concepts, fewer places where the same artifact was described, one less footgun. The longer telling lives at [/blog/artifacts-are-frontmatter-now](/blog/artifacts-are-frontmatter-now).
+
+### Bunny Magic Containers deploy
+
+CI got a real deploy target. Bunny Magic Containers, EU region, with auto-provisioned app + DNS summary. Several follow-up fixes through the week to nail down the create/PATCH flow and make it idempotent.
+
+## Improvements
+
+- `cli:` `ship search` + resource commands; docs-only `fetch` / `feedback`
+- `cli:` ship-agent multi-tracker adapters + docs
+- `cli:` published as `@elmundi/ship-cli` under npm org `elmundi`
+- `landing:` downloadable `book.pdf` + Download CTA on `/book`
+- `docs:` book — Prologue, Manifesto, 9 lettered sub-chapters, 8 field notes
+- `docs:` Ukrainian Part II — Prompts & workflows
+- `docs:` expand framework chapters; add `adopt-ship.sh` launcher
+- `prompts:` translate cloud-prompts and templates to English
+- `bunny:` deploy Magic Containers with `sha-*` image tag, not `latest`
+- `bunny:` PATCH with Hub-fetched digest + `imagePullPolicy: always`
+
+## Fixes
+
+- `bunny:` honor `BUNNY_APP_ID` over name lookup; clarify env vars in README
+- `bunny:` strip MC create payload to OpenAPI-allowed fields
+- `bunny:` safer MC create payload (name, regions, sticky cleanup, 500 retry)
+- `bunny:` create MC app without config-suggestions; region/probe fallbacks
+- `docker:` workspace lockfiles + dev deps for Next build
+- `bunny:` align container port 8080 with Magic Containers template
+- `docs:` include `prompts/` in Docker build for MkDocs snippets
+- `cloud-prompts:` correct branch markdown in `_base`; restore EOF newlines
+- `ci:` PATCH Bunny with image digest; replace fire-and-forget action
+- `ci:` resolve Bunny MC container name; generalize Ship docs and tooling
+- `ci:` publish `@ship/cli` workspace with `npm -w`, not `--prefix`

--- a/landing/content/changelog/2026-04-26-console-comes-online.md
+++ b/landing/content/changelog/2026-04-26-console-comes-online.md
@@ -1,0 +1,66 @@
+---
+slug: 2026-04-26-console-comes-online
+date: 2026-04-26
+title: Console comes online — process editor, knowledge wizard, native trackers
+prs: []
+summary: The first week the methodology had a real surface. Process editor with FSM config, knowledge import wizard, native Linear / Notion / GitLab / Azure / Jira / Confluence integrations. The CLI stopped being the only entry point.
+kicker: Release
+---
+
+For three weeks Ship had been a CLI sitting on top of a methodology stack that lived in YAML. This was the week the **operator UI** showed up — a Next.js console with a process editor, a knowledge import wizard, a workspace ops dashboard, and direct OAuth-or-PAT integrations to the trackers and code hosts the methodology assumes. Everything still runs from `shipctl` for engineers; the console is what a product owner opens.
+
+The PR-flow only started landing late this week, so most of these are direct `main` commits — proper PR-numbered entries start in the next release.
+
+## Highlights
+
+### Process editor: agent profiles, role catalog, transitions
+
+The `process` editor surface picked up nine distinct features this week. State editor with role selector. Transition editing scoped to the selected state. Editable state keys. Specialist prompt and exit contracts on the role. Agent-profile selector per state. Specialist role catalog. Validation on the process schema. Persisted FSM config edits. Persisted canvas layout. By Friday the process map was a real editable thing rather than a read-only diagram.
+
+### Knowledge import wizard
+
+Two PRs added a guided knowledge-import flow to the console — pick a source, scope it, run it, see what came back. The Distiller (the LLM-backed ingest classifier) now has a button instead of just a CLI invocation.
+
+Procedural patterns started seeding into the catalog as knowledge — the codified versions of the methodology, queryable from the agent.
+
+### Native integrations
+
+Linear, Notion, GitHub, GitLab, Azure DevOps, Jira, Confluence — all six trackers and code hosts the methodology assumes got native install flows this week, with native credential paths instead of "paste this token here". Notion learned to create tickets through data sources. Linear got native credentials. GitLab and Azure DevOps connect via PAT flows for now (OAuth coming).
+
+### Console basics
+
+`add ops dashboard`. `add process view`. `add app shell`. The console moved from "scaffolding next to the CLI" to "the place a workspace operator lives".
+
+## Improvements
+
+- `process:` streamline editor canvas
+- `process:` reshape process canvas; make process map visible
+- `process:` add layout editor; persist canvas layout
+- `process:` make editor repo-backed
+- `process:` align review owner role id
+- `process:` clean up config proposal flow; trim editor cleanup leftovers
+- `process:` add draft change controls
+- `process:` use inbox-created timestamp
+- `console:` make app shell full-width; clean app shell lint
+- `console:` show connected tracker cards
+- `integrations:` refresh native provider health
+- `integrations:` use native Linear credentials
+- `integrations:` add Jira and Confluence adapters
+- `integrations:` connect GitLab PAT
+- `integrations:` connect Azure DevOps PAT
+- `integrations:` add native provider installs
+- `integrations:` expand native setup flows
+- `integrations:` disable native providers (kill switch)
+- `cli:` validate process schema fields
+- `cli:` prefer workspace API base for Ship actions
+- `workflows:` isolate Ship repo env for scheduled lanes
+- `catalog:` seed procedural patterns as knowledge
+- `ship:` install wizard-default bundle; release 0.12.0
+
+## Fixes
+
+- `process:` validate agent profile config; validate process schema fields
+- `process:` commit canvas layout on drag end
+- `notion:` create tickets through data sources
+- `integrations:` handle Notion OAuth persistence; allow Jira tracker refs
+- `console:` use OAuth for Notion integrations

--- a/landing/content/changelog/2026-05-03-process-editor-and-knowledge-foundations.md
+++ b/landing/content/changelog/2026-05-03-process-editor-and-knowledge-foundations.md
@@ -1,0 +1,63 @@
+---
+slug: 2026-05-03-process-editor-and-knowledge-foundations
+date: 2026-05-03
+title: A process editor that's actually editable, and a dashboard that doesn't lie
+summary: Process map went from a React-Flow demo to a CSS-grid swim-lane editor with state, drag-drop, and a publish gate. Dashboard prioritizer learned the difference between active, planning, and parked. The console stopped agreeing with itself when reality disagreed.
+kicker: Release
+prs: [80, 135, 136, 137, 138, 139]
+---
+
+The week of polish before the agentic push. Most of the work was in the console: a real process editor (drag-drop, swim-lanes, validation, publish blocking), a dashboard prioritizer that surfaces state buckets and Linear OAuth diagnostics, and a long list of small "actually shipping is what gets you to the next thing" cleanups. The methodology layer got harder boundaries — what's a routine, what's a specialist, where does configuration live — so the upcoming Navigator work could lean on stable footing.
+
+## Highlights
+
+### Process editor: no more React Flow
+
+The visual canvas got rebuilt on CSS Grid + SVG arrows. Two reasons: 86 KB of First-Load JS gone, and **swim-lane layouts that actually correspond to the seven canonical states** (Backlog → Planning → Executing → Reviewing → Awaiting input → Blocked → Closed). Flow canvas is now the projection table's UI; Tracker tab was retired because there was nothing in it that didn't already live under the canvas.
+
+Drag-and-drop reorder inside columns landed in `process: H1`; the SVG arrows that were doing nothing useful were dropped. Inline `+ add stage` button on lane-header hover (`H2`). Visual distinction for specialists vs routines on the Capacity calendar (`H3`).
+
+### Process editor: the validation gate
+
+A configuration with no tracker, no orchestrator, or no default-agent profile is *not* a publishable process. The editor blocks Publish on hard errors and surfaces warnings instead of silently shipping a broken state machine. Hard-stop gating on missing tracker / orchestrator / default agent.
+
+`process: state field on YAML stages` closed the swim-lane bug forever — every stage now declares which canonical state it lives in, so the projection can never put a stage in the wrong column.
+
+### Dashboard prioritizer
+
+Three buckets — `active`, `planning`, `parked` — visible on the dashboard, each with its own meaning ([#139](https://github.com/ElMundiUA/ship/pull/139)). Drag a row between buckets and it actually moves; completed Linear projects stop showing up on the active list ([#138](https://github.com/ElMundiUA/ship/pull/138)). Linear OAuth scopes surface in the empty-state error, not an opaque "list_projects failed" ([#137](https://github.com/ElMundiUA/ship/pull/137)). PAT-vs-OAuth tokens get auto-detected with response bodies surfaced for diagnosis ([#135](https://github.com/ElMundiUA/ship/pull/135)). Blind team-resolution probe gone from `list_projects` ([#136](https://github.com/ElMundiUA/ship/pull/136)).
+
+### Wizard: drift surface + workspace defaults gate
+
+The install wizard learned to detect drift between the seed bundle and what's actually in the workspace, and shows it next to the Linear OAuth-only connection list. A workspace-defaults gate (`tracker / agent / orchestrator`) means brand-new workspaces can't accidentally publish without naming what's connected.
+
+The seed bundle itself shipped at [#80](https://github.com/ElMundiUA/ship/pull/80) — the `wizard-default` install bundle that brand-new workspaces get as a starting point.
+
+## Improvements
+
+- `process:` editor body streams so the shell paints instantly
+- `process:` Capacity calendar shows the real cron grid; empty by default
+- `process:` tracker mapping bakes into the adapter — no more "15 unmapped" on first attach
+- `process:` 3-level model (`process : stage : state`) — canonical lifecycle bucketing across every stage
+- `process:` transition.trigger_actor — `user / agent / either`
+- `process:` workspace map → CSS card grid (drop React Flow from overview)
+- `process:` editor canvas → CSS Grid swim-lanes (drop React Flow)
+- `process:` count Ship GitHub App as a ready orchestrator
+- `process:` chrome cleanup — page title is the process, banners are pills
+- `process:` canonical six routines — fixed in seed, FE, and elship config (forever)
+- `wizard:` ripped out stale codeowners/intel UI; rewrote confirm-step bullets
+- `integrations:` Linear/Notion are OAuth-only now; raw-key paths killed
+- `synth:` archive action — LLM can vote stale articles out of a bucket
+- `nav:` `search_buckets` surfaces `article_id` / `article_slug`
+- `nav:` pin tool inventory + cross-link prompt to registry
+- `agent:` A1 — harden prompt against hallucinated people, dates, IDs
+- `secret_probe:` Linear probe exercises Read-issues scope
+- `chat:` `include_archived` now surfaces dual-flip archived rows too
+
+## Fixes
+
+- `inbox:` row actions go through form route handlers (fix client/server-only split)
+- `chat:` post-end scroll-down jolt is gone
+- `chat:` real conversation title; no more blink/jerk
+- `process:` editor is repo-backed; reseed CI secrets repaired
+- `settings:` any one endpoint hiccup no longer collapses the whole shell

--- a/landing/content/changelog/2026-05-07-navigator-goes-agentic.md
+++ b/landing/content/changelog/2026-05-07-navigator-goes-agentic.md
@@ -1,0 +1,55 @@
+---
+slug: 2026-05-07-navigator-goes-agentic
+date: 2026-05-07
+title: Navigator goes agentic
+summary: A subagent tool, a tighter operating-rules prompt, and a fleet of read-and-write tools — all under the same chat surface, all bounded by workspace policy.
+kicker: Release
+prs: [142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 172, 174, 178, 179, 180, 181, 184, 186, 187, 188, 189, 190]
+---
+
+This is the week the Navigator stopped being a chat shell with tools and started being an agent that **decides which agent to be**. Three PRs in one stack: a session-enrichment pass, a system prompt that names the operating rules, and a `consult_specialist` tool that hands a focused task off to a sub-agent with its own role prompt and the same workspace tools. Every move is still scoped by the workspace policy; the human can see who decided, why, and whether the rules held.
+
+Alongside that, a complete rebuild of the knowledge layer — claim store, extractor cron, topic-view renderer, decay-and-revive — and a brand-new "project-first" delivery flow that walks decomposition (BA → Architect → QA → Developer) before any code is touched.
+
+## Highlights
+
+### Navigator: agentic loop in three PRs
+
+A staged rewrite ([#153](https://github.com/ElMundiUA/ship/pull/153) → [#154](https://github.com/ElMundiUA/ship/pull/154) → [#155](https://github.com/ElMundiUA/ship/pull/155)) that lifted the chat from "tools called from a prompt" to a proper agentic loop. PR1 enriched the session context with the open ticket, project, recent inbox items, and tracker state — so the model isn't operating blind. PR2 rewrote the system prompt around explicit operating rules ("you have these tools, you can refuse, you must explain"). PR3 added `consult_specialist` — Navigator can now hand a focused task to an isolated sub-agent (BA, Architect, Developer, etc.) with the right role prompt and the same workspace tools, without inheriting Navigator's context.
+
+### A leaner, sharper toolbox
+
+Four redundant tools were retired ([#157](https://github.com/ElMundiUA/ship/pull/157)) and KB search got consolidated ([#158](https://github.com/ElMundiUA/ship/pull/158)) so the model isn't picking between three near-equivalents. Then six new tools landed in two PRs: read-only ([#160](https://github.com/ElMundiUA/ship/pull/160)) — `get_ticket`, `get_dashboard`, `workspace_audit_search` — and mutating ([#161](https://github.com/ElMundiUA/ship/pull/161)) — `update_ticket`, `set_priority_state`, `start_decomposition`. Each mutating tool is verify-before-mutate; nothing changes until the human says yes (unless the user gave an explicit command).
+
+### Project-first delivery
+
+A four-PR sequence ([#142](https://github.com/ElMundiUA/ship/pull/142), [#143](https://github.com/ElMundiUA/ship/pull/143), [#145](https://github.com/ElMundiUA/ship/pull/145), [#147](https://github.com/ElMundiUA/ship/pull/147)) replaced "an agent picks a ticket and writes code" with **"an agent shapes a project, hands it off to specialists, then writes code"**. `create_project` lands an anchor on the dashboard in `Drafts`. Navigator helps shape it. `start_decomposition` walks the BA → Architect → QA → Developer chain through the planning anchor; only when `stage:planning_done` lands does the Drafts row flip Active and the autonomous picker takes over.
+
+### Knowledge layer, end-to-end
+
+A six-phase build of the claim graph: claim store + extractor ([#144](https://github.com/ElMundiUA/ship/pull/144)), reconciliation engine ([#146](https://github.com/ElMundiUA/ship/pull/146)), topic-view renderer ([#149](https://github.com/ElMundiUA/ship/pull/149)), read API ([#150](https://github.com/ElMundiUA/ship/pull/150)), decay + auto-revive ([#151](https://github.com/ElMundiUA/ship/pull/151)), batch extractor with the Anthropic preamble fix ([#152](https://github.com/ElMundiUA/ship/pull/152)). The console stopped reading legacy buckets, started reading topic views ([#163](https://github.com/ElMundiUA/ship/pull/163)), got a real topic detail page ([#164](https://github.com/ElMundiUA/ship/pull/164)), and finally an editorial layout for the index ([#165](https://github.com/ElMundiUA/ship/pull/165)).
+
+### Agent runs: picker hardening
+
+Eight PRs that turn the autonomous picker from a "tries hard, sometimes runs the wrong thing" worker into a deterministic, contention-safe one. Orphan tickets get rejected ([#169](https://github.com/ElMundiUA/ship/pull/169)). The picker only runs on projects whose priority state is Active ([#184](https://github.com/ElMundiUA/ship/pull/184)). Parent project bodies inject into the SDLC startup context ([#186](https://github.com/ElMundiUA/ship/pull/186)). Overlay-frozen tickets — ones in clarification or blocked — are filtered out ([#187](https://github.com/ElMundiUA/ship/pull/187)). Drafts flip to Parked at `planning_done` ([#188](https://github.com/ElMundiUA/ship/pull/188)). A pick-race becomes impossible thanks to advisory transactional locks ([#189](https://github.com/ElMundiUA/ship/pull/189)). Linear-native projects auto-onboard onto the dashboard ([#190](https://github.com/ElMundiUA/ship/pull/190)).
+
+### Repo symbols on demand
+
+A new tree-sitter parser ([#174](https://github.com/ElMundiUA/ship/pull/174)) — when a specialist needs to know the shape of a file (functions, classes, exports), it calls `repo_symbols` and gets a structured map without re-walking the repo on every turn. Cuts startup latency for code-touching agents in half.
+
+## Improvements
+
+- `processes:` decomposition is now a first-class peer process, not an embedded sub-flow ([#167](https://github.com/ElMundiUA/ship/pull/167))
+- `priorities:` child ticket states sync with the parent project state in Linear ([#181](https://github.com/ElMundiUA/ship/pull/181)); new projects default to `planning` ([#172](https://github.com/ElMundiUA/ship/pull/172))
+- `agent_roles:` Navigator system prompt no longer references retired tools ([#178](https://github.com/ElMundiUA/ship/pull/178))
+- `landing:` refreshed dogfood numbers — 30 days, 608 commits, claim-graph live ([#183](https://github.com/ElMundiUA/ship/pull/183))
+- `docs:` agent-launch pre-flight smoke runbook ([#179](https://github.com/ElMundiUA/ship/pull/179))
+- `notion:` walker soft-skips `child_database` blocks with no accessible data sources ([#159](https://github.com/ElMundiUA/ship/pull/159))
+
+## Fixes
+
+- `linear:` intake's empty-label exclusion fired incorrectly on labelled-but-empty issues ([#180](https://github.com/ElMundiUA/ship/pull/180))
+- `knowledge:` ingestion sync survives long-running connector walks ([#168](https://github.com/ElMundiUA/ship/pull/168))
+- `reconciler:` real pgvector embeddings round-trip correctly through numpy + binary codec ([#162](https://github.com/ElMundiUA/ship/pull/162))
+- `fix:` default Anthropic Haiku model id bumped to the post-preview stable ([#156](https://github.com/ElMundiUA/ship/pull/156))
+- `hotfix:` prioritizer handoff hooks hoisted above empty-state returns ([#148](https://github.com/ElMundiUA/ship/pull/148))

--- a/landing/src/app/changelog/page.tsx
+++ b/landing/src/app/changelog/page.tsx
@@ -1,134 +1,208 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import Image from "next/image";
+import { BlogMarkdown } from "@/components/blog-content";
 import { SiteFooter } from "@/components/site-footer";
 import { SiteHeader } from "@/components/site-header";
+import { preprocessBlogMarkdown } from "@/lib/blog-markdown";
 import {
-  type ChangelogWeek,
-  listChangelogWeeks,
+  type ChangelogEntry,
+  formatChangelogDate,
+  listChangelogEntries,
 } from "@/lib/changelog";
 import { repoUrl } from "@/lib/config";
+import { resolveMetadataBase } from "@/lib/site-url";
 
 export const metadata: Metadata = {
   title: "Changelog — Ship",
   description:
-    "Public log of merged PRs to ship/main. Grouped by week, by area. No marketing copy — what shipped, when, with a link to the PR.",
+    "What we shipped, when. Releases for Ship — the open-source delivery workspace for AI-assisted engineering.",
   alternates: { canonical: "/changelog" },
 };
 
-function PRLink({ number }: { number: number }) {
-  return (
-    <a
-      href={`${repoUrl}/pull/${number}`}
-      target="_blank"
-      rel="noreferrer"
-      className="ml-2 inline-flex shrink-0 rounded-md border border-white/10 bg-white/[0.04] px-1.5 py-0.5 text-[11px] font-mono text-white/55 transition hover:border-aqua/40 hover:bg-aqua/10 hover:text-aqua"
-    >
-      #{number}
-    </a>
-  );
+function isEmbedUrl(url: string): boolean {
+  return /loom\.com|youtube\.com|youtu\.be|vimeo\.com/.test(url);
 }
 
-function ShaTag({ short }: { short: string }) {
-  return (
-    <a
-      href={`${repoUrl}/commit/${short}`}
-      target="_blank"
-      rel="noreferrer"
-      className="ml-2 hidden font-mono text-[10px] text-white/30 hover:text-white/60 sm:inline"
-    >
-      {short}
-    </a>
-  );
+function HeroMedia({ entry }: { entry: ChangelogEntry }) {
+  if (entry.heroVideo && isEmbedUrl(entry.heroVideo)) {
+    return (
+      <div className="mt-10 overflow-hidden rounded-2xl border border-white/10 bg-black/40">
+        <div className="aspect-video w-full">
+          <iframe
+            src={entry.heroVideo}
+            className="h-full w-full"
+            title={entry.heroAlt || entry.title}
+            allow="autoplay; fullscreen; picture-in-picture"
+            allowFullScreen
+          />
+        </div>
+      </div>
+    );
+  }
+  if (entry.heroImage) {
+    return (
+      <div className="mt-10 overflow-hidden rounded-2xl border border-white/10 bg-black/40">
+        <Image
+          src={entry.heroImage}
+          alt={entry.heroAlt || entry.title}
+          width={2400}
+          height={1350}
+          className="h-auto w-full"
+          priority={false}
+        />
+      </div>
+    );
+  }
+  return null;
 }
 
-function WeekCard({ week }: { week: ChangelogWeek }) {
+function PRPills({ prs }: { prs: number[] }) {
+  if (prs.length === 0) return null;
   return (
-    <article className="rounded-3xl border border-white/10 bg-gradient-to-b from-white/[0.04] to-transparent p-6 sm:p-10">
-      <header className="flex items-baseline justify-between gap-4 border-b border-white/10 pb-5">
-        <h2 className="font-display text-xl font-bold tracking-tight text-white sm:text-2xl">
-          {week.rangeLabel}
-        </h2>
-        <span className="font-mono text-[11px] uppercase tracking-[0.2em] text-white/35">
-          {week.weekStart}
-        </span>
-      </header>
-
-      <div className="mt-6 space-y-7">
-        {week.groups.map((group) => (
-          <section key={group.label}>
-            <h3 className="text-[11px] font-bold uppercase tracking-[0.22em] text-aqua/85">
-              {group.label}
-            </h3>
-            <ul className="mt-3 space-y-2.5">
-              {group.entries.map((entry) => (
-                <li
-                  key={entry.shortSha}
-                  className="flex items-baseline gap-2 text-[15px] leading-relaxed text-white/80"
-                >
-                  <span className="mt-2 inline-block h-1 w-1 shrink-0 rounded-full bg-white/30" aria-hidden />
-                  <span className="min-w-0 flex-1">
-                    {entry.title}
-                    <PRLink number={entry.prNumber} />
-                    <ShaTag short={entry.shortSha} />
-                  </span>
-                </li>
-              ))}
-            </ul>
-          </section>
+    <div className="mt-10 border-t border-white/10 pt-6">
+      <p className="text-[10px] font-bold uppercase tracking-[0.22em] text-white/40">
+        Pull requests
+      </p>
+      <div className="mt-3 flex flex-wrap gap-2">
+        {prs.map((n) => (
+          <a
+            key={n}
+            href={`${repoUrl}/pull/${n}`}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center rounded-md border border-white/10 bg-white/[0.04] px-2 py-1 font-mono text-[12px] text-white/55 transition hover:border-aqua/40 hover:bg-aqua/10 hover:text-aqua"
+          >
+            #{n}
+          </a>
         ))}
       </div>
+    </div>
+  );
+}
+
+function EntryCard({ entry, isLast }: { entry: ChangelogEntry; isLast: boolean }) {
+  const body = preprocessBlogMarkdown(entry.body);
+  return (
+    <article
+      id={entry.slug}
+      className="relative scroll-mt-28 pb-20 sm:pb-24"
+    >
+      <header>
+        <div className="flex items-center gap-3 text-[11px] font-bold uppercase tracking-[0.22em]">
+          <Link
+            href={`#${entry.slug}`}
+            className="font-mono text-white/45 transition hover:text-aqua"
+          >
+            <time dateTime={entry.date}>{formatChangelogDate(entry.date)}</time>
+          </Link>
+          {entry.kicker ? (
+            <>
+              <span className="h-1 w-1 rounded-full bg-white/25" aria-hidden />
+              <span className="text-aqua/85">{entry.kicker}</span>
+            </>
+          ) : null}
+        </div>
+        <h2 className="font-display mt-4 text-3xl font-bold leading-[1.08] tracking-tight text-white sm:text-4xl lg:text-[2.625rem]">
+          {entry.title}
+        </h2>
+        {entry.summary ? (
+          <p className="mt-5 max-w-3xl text-lg leading-relaxed text-white/70 sm:text-xl">
+            {entry.summary}
+          </p>
+        ) : null}
+      </header>
+
+      <HeroMedia entry={entry} />
+
+      <div className="blog-prose prose prose-invert prose-lg mt-10 max-w-none prose-p:text-white/80 prose-p:leading-relaxed prose-strong:text-white prose-h3:font-display prose-h3:text-2xl prose-h3:font-bold prose-h3:tracking-tight prose-hr:hidden">
+        <BlogMarkdown content={body} />
+      </div>
+
+      <PRPills prs={entry.prs} />
+
+      {!isLast ? (
+        <div
+          className="mt-20 h-px w-full bg-gradient-to-r from-transparent via-white/15 to-transparent sm:mt-24"
+          aria-hidden
+        />
+      ) : null}
     </article>
   );
 }
 
 export default function ChangelogPage() {
-  const weeks = listChangelogWeeks();
+  const entries = listChangelogEntries();
+  const siteUrl = resolveMetadataBase().toString().replace(/\/$/, "");
 
   return (
     <>
       <SiteHeader />
-      <main className="pb-32 pt-28 sm:pt-32">
+      <main className="pb-24 pt-28 sm:pb-32 sm:pt-32">
+        {/* Page-wide background flourish */}
+        <div
+          className="pointer-events-none absolute inset-x-0 top-0 -z-10 h-[36rem] bg-[radial-gradient(ellipse_70%_50%_at_50%_0%,rgba(207,169,107,0.10),transparent_70%)]"
+          aria-hidden
+        />
+
         <div className="mx-auto max-w-3xl px-4 sm:px-6">
-          <header className="mb-14">
-            <p className="text-[11px] font-bold uppercase tracking-[0.3em] text-sun">Changelog</p>
-            <h1 className="font-display mt-3 text-4xl font-bold leading-[1.05] tracking-tight text-white sm:text-5xl">
-              What shipped, week by week.
+          <header className="mb-14 sm:mb-20">
+            <p className="text-[11px] font-bold uppercase tracking-[0.3em] text-sun">
+              Changelog
+            </p>
+            <h1 className="font-display mt-3 text-4xl font-bold leading-[1.05] tracking-tight text-white sm:text-5xl lg:text-[3.5rem]">
+              <span className="bg-gradient-to-r from-coral via-sun to-aqua bg-clip-text text-transparent">
+                What we shipped,
+              </span>{" "}
+              when.
             </h1>
-            <p className="mt-5 max-w-xl text-base leading-relaxed text-white/60 sm:text-lg">
-              A dry log of merged PRs into{" "}
-              <a
-                href={`${repoUrl}/commits/main`}
-                target="_blank"
-                rel="noreferrer"
-                className="text-aqua/85 underline-offset-4 hover:underline"
-              >
-                ship/main
-              </a>
-              . Grouped weekly, sub-grouped by area. For the long-form thinking
-              behind major changes, read{" "}
-              <Link href="/blog" className="text-aqua/85 underline-offset-4 hover:underline">
-                the Ship Log
+            <p className="mt-6 max-w-2xl text-lg leading-relaxed text-white/65 sm:text-xl">
+              Releases for Ship — the open-source delivery workspace for
+              AI-assisted engineering. The deeper thinking behind each beat
+              lives in{" "}
+              <Link href="/blog" className="text-aqua underline-offset-4 hover:underline">
+                Ship Log
               </Link>
-              .
+              ; this page is the dry timeline.
             </p>
           </header>
 
-          {weeks.length === 0 ? (
+          {entries.length === 0 ? (
             <p className="rounded-2xl border border-white/10 bg-white/[0.02] p-6 text-sm text-white/55">
-              Build environment didn&apos;t expose git history (shallow clone or
-              missing <code className="font-mono">.git</code>). The changelog
-              regenerates on the next deploy with a full clone.
+              No changelog entries yet. Add a Markdown file under{" "}
+              <code className="font-mono">landing/content/changelog/</code>.
             </p>
           ) : (
-            <div className="space-y-10">
-              {weeks.map((week) => (
-                <WeekCard key={week.weekStart} week={week} />
+            <div>
+              {entries.map((entry, idx) => (
+                <EntryCard
+                  key={entry.slug}
+                  entry={entry}
+                  isLast={idx === entries.length - 1}
+                />
               ))}
             </div>
           )}
         </div>
       </main>
       <SiteFooter />
+      {entries.length > 0 ? (
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify({
+              "@context": "https://schema.org",
+              "@type": "ItemList",
+              itemListElement: entries.map((e, i) => ({
+                "@type": "ListItem",
+                position: i + 1,
+                url: `${siteUrl}/changelog#${e.slug}`,
+                name: e.title,
+              })),
+            }),
+          }}
+        />
+      ) : null}
     </>
   );
 }

--- a/landing/src/app/changelog/page.tsx
+++ b/landing/src/app/changelog/page.tsx
@@ -1,0 +1,134 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { SiteFooter } from "@/components/site-footer";
+import { SiteHeader } from "@/components/site-header";
+import {
+  type ChangelogWeek,
+  listChangelogWeeks,
+} from "@/lib/changelog";
+import { repoUrl } from "@/lib/config";
+
+export const metadata: Metadata = {
+  title: "Changelog — Ship",
+  description:
+    "Public log of merged PRs to ship/main. Grouped by week, by area. No marketing copy — what shipped, when, with a link to the PR.",
+  alternates: { canonical: "/changelog" },
+};
+
+function PRLink({ number }: { number: number }) {
+  return (
+    <a
+      href={`${repoUrl}/pull/${number}`}
+      target="_blank"
+      rel="noreferrer"
+      className="ml-2 inline-flex shrink-0 rounded-md border border-white/10 bg-white/[0.04] px-1.5 py-0.5 text-[11px] font-mono text-white/55 transition hover:border-aqua/40 hover:bg-aqua/10 hover:text-aqua"
+    >
+      #{number}
+    </a>
+  );
+}
+
+function ShaTag({ short }: { short: string }) {
+  return (
+    <a
+      href={`${repoUrl}/commit/${short}`}
+      target="_blank"
+      rel="noreferrer"
+      className="ml-2 hidden font-mono text-[10px] text-white/30 hover:text-white/60 sm:inline"
+    >
+      {short}
+    </a>
+  );
+}
+
+function WeekCard({ week }: { week: ChangelogWeek }) {
+  return (
+    <article className="rounded-3xl border border-white/10 bg-gradient-to-b from-white/[0.04] to-transparent p-6 sm:p-10">
+      <header className="flex items-baseline justify-between gap-4 border-b border-white/10 pb-5">
+        <h2 className="font-display text-xl font-bold tracking-tight text-white sm:text-2xl">
+          {week.rangeLabel}
+        </h2>
+        <span className="font-mono text-[11px] uppercase tracking-[0.2em] text-white/35">
+          {week.weekStart}
+        </span>
+      </header>
+
+      <div className="mt-6 space-y-7">
+        {week.groups.map((group) => (
+          <section key={group.label}>
+            <h3 className="text-[11px] font-bold uppercase tracking-[0.22em] text-aqua/85">
+              {group.label}
+            </h3>
+            <ul className="mt-3 space-y-2.5">
+              {group.entries.map((entry) => (
+                <li
+                  key={entry.shortSha}
+                  className="flex items-baseline gap-2 text-[15px] leading-relaxed text-white/80"
+                >
+                  <span className="mt-2 inline-block h-1 w-1 shrink-0 rounded-full bg-white/30" aria-hidden />
+                  <span className="min-w-0 flex-1">
+                    {entry.title}
+                    <PRLink number={entry.prNumber} />
+                    <ShaTag short={entry.shortSha} />
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </section>
+        ))}
+      </div>
+    </article>
+  );
+}
+
+export default function ChangelogPage() {
+  const weeks = listChangelogWeeks();
+
+  return (
+    <>
+      <SiteHeader />
+      <main className="pb-32 pt-28 sm:pt-32">
+        <div className="mx-auto max-w-3xl px-4 sm:px-6">
+          <header className="mb-14">
+            <p className="text-[11px] font-bold uppercase tracking-[0.3em] text-sun">Changelog</p>
+            <h1 className="font-display mt-3 text-4xl font-bold leading-[1.05] tracking-tight text-white sm:text-5xl">
+              What shipped, week by week.
+            </h1>
+            <p className="mt-5 max-w-xl text-base leading-relaxed text-white/60 sm:text-lg">
+              A dry log of merged PRs into{" "}
+              <a
+                href={`${repoUrl}/commits/main`}
+                target="_blank"
+                rel="noreferrer"
+                className="text-aqua/85 underline-offset-4 hover:underline"
+              >
+                ship/main
+              </a>
+              . Grouped weekly, sub-grouped by area. For the long-form thinking
+              behind major changes, read{" "}
+              <Link href="/blog" className="text-aqua/85 underline-offset-4 hover:underline">
+                the Ship Log
+              </Link>
+              .
+            </p>
+          </header>
+
+          {weeks.length === 0 ? (
+            <p className="rounded-2xl border border-white/10 bg-white/[0.02] p-6 text-sm text-white/55">
+              Build environment didn&apos;t expose git history (shallow clone or
+              missing <code className="font-mono">.git</code>). The changelog
+              regenerates on the next deploy with a full clone.
+            </p>
+          ) : (
+            <div className="space-y-10">
+              {weeks.map((week) => (
+                <WeekCard key={week.weekStart} week={week} />
+              ))}
+            </div>
+          )}
+        </div>
+      </main>
+      <SiteFooter />
+    </>
+  );
+}

--- a/landing/src/app/sitemap.ts
+++ b/landing/src/app/sitemap.ts
@@ -45,6 +45,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { path: "/use-cases", priority: 0.7, changeFrequency: "monthly" },
     { path: "/use-cases/elmundi", priority: 0.6, changeFrequency: "monthly" },
     { path: "/blog", priority: 0.7, changeFrequency: "weekly" },
+    { path: "/changelog", priority: 0.6, changeFrequency: "weekly" },
     { path: "/book", priority: 0.7, changeFrequency: "monthly" },
     { path: "/docs", priority: 0.8, changeFrequency: "weekly" },
     { path: "/beta", priority: 0.9, changeFrequency: "weekly" },

--- a/landing/src/components/site-footer.tsx
+++ b/landing/src/components/site-footer.tsx
@@ -69,6 +69,9 @@ export function SiteFooter() {
                 <Link className="text-white/70 transition hover:text-aqua" href="/blog">
                   Ship Log (blog)
                 </Link>
+                <Link className="text-white/70 transition hover:text-aqua" href="/changelog">
+                  Changelog
+                </Link>
                 <a className="text-white/70 transition hover:text-aqua" href={repoUrl} target="_blank" rel="noreferrer">
                   GitHub
                 </a>

--- a/landing/src/lib/changelog.ts
+++ b/landing/src/lib/changelog.ts
@@ -1,0 +1,212 @@
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+
+/**
+ * Build-time git log → changelog entries.
+ *
+ * The Ship workflow squash-merges PRs into `main` with subjects like:
+ *
+ *     navigator: consult_specialist subagent tool (PR3 of 3) (#155)
+ *     fix: bump default Anthropic Haiku model to the post-preview stable id (#156)
+ *     knowledge: extractor batch + Anthropic-preamble parse fix (#152)
+ *
+ * We pull the most recent commits from `main`, filter to those that look
+ * like merged PRs (have a trailing `(#NNN)`), and extract a small,
+ * stable shape that the changelog page renders. Commits without the
+ * PR suffix (direct-to-main, very rare) are skipped — the page is the
+ * "what shipped via the PR flow" log, not a raw `git log`.
+ *
+ * Runs once at build time. If git history isn't available (shallow
+ * clone in CI without `fetch-depth: 0`, or a Docker layer without `.git`),
+ * we return an empty list so the page renders with a soft-empty state
+ * rather than failing the build.
+ */
+
+export type ChangelogEntry = {
+  /** 7-char commit hash. */
+  shortSha: string;
+  /** ISO 8601 commit-author date, e.g. `2026-05-06T22:18:43+02:00`. */
+  date: string;
+  /** ISO date only, e.g. `2026-05-06`. Used for grouping. */
+  day: string;
+  /** Conventional-commit scope prefix, e.g. `navigator`, `fix`, `landing`. Empty when absent. */
+  scope: string;
+  /** Subject minus scope prefix and `(#NNN)` suffix. */
+  title: string;
+  /** PR number parsed from the trailing `(#NNN)`. */
+  prNumber: number;
+  /** Author name from `git log`. */
+  author: string;
+};
+
+const REPO_ROOT = path.resolve(process.cwd(), "..");
+const MAX_ENTRIES = 200;
+
+// `` is ASCII unit separator — safe between fields, won't collide
+// with anything humans put in commit messages.
+const SEP = "";
+const FORMAT = ["%h", "%aI", "%an", "%s"].join(SEP);
+
+const PR_RE = /\s*\(#(\d+)\)\s*$/;
+const SCOPE_RE = /^([a-z][a-z0-9_-]*(?:\([a-z0-9._-]+\))?):\s*/i;
+
+function readGitLog(): string[] {
+  try {
+    const stdout = execFileSync(
+      "git",
+      [
+        "log",
+        `-n${MAX_ENTRIES}`,
+        `--pretty=format:${FORMAT}`,
+        "--no-merges",
+        "main",
+      ],
+      { cwd: REPO_ROOT, encoding: "utf-8", maxBuffer: 8 * 1024 * 1024 },
+    );
+    return stdout.split("\n").filter(Boolean);
+  } catch {
+    // Shallow clone, no .git, or git not on PATH.
+    return [];
+  }
+}
+
+function parseLine(line: string): ChangelogEntry | null {
+  const parts = line.split(SEP);
+  if (parts.length < 4) return null;
+  const [shortSha, date, author, subjectRaw] = parts;
+  const prMatch = PR_RE.exec(subjectRaw);
+  if (!prMatch) return null;
+  const prNumber = Number(prMatch[1]);
+  let subject = subjectRaw.replace(PR_RE, "");
+  let scope = "";
+  const scopeMatch = SCOPE_RE.exec(subject);
+  if (scopeMatch) {
+    scope = scopeMatch[1].toLowerCase();
+    subject = subject.slice(scopeMatch[0].length);
+  }
+  const title = subject.trim();
+  if (!title) return null;
+  return {
+    shortSha,
+    date,
+    day: date.slice(0, 10),
+    scope,
+    title,
+    prNumber,
+    author,
+  };
+}
+
+export function listChangelogEntries(): ChangelogEntry[] {
+  return readGitLog()
+    .map(parseLine)
+    .filter((entry): entry is ChangelogEntry => entry !== null);
+}
+
+// ---------------------------------------------------------------------------
+// Week grouping
+// ---------------------------------------------------------------------------
+
+export type ChangelogGroup = {
+  /** Group label, e.g. ``Navigator``, ``Fixes``, ``Other``. */
+  label: string;
+  entries: ChangelogEntry[];
+};
+
+export type ChangelogWeek = {
+  /** Monday of the week, ISO date (yyyy-mm-dd). */
+  weekStart: string;
+  /** Sunday of the week, ISO date. */
+  weekEnd: string;
+  /** Human-friendly week range, e.g. ``May 5–11, 2026``. */
+  rangeLabel: string;
+  /** Entries grouped by scope-family. Order: product areas alpha, then
+   *  Improvements, Fixes, Other at the bottom. */
+  groups: ChangelogGroup[];
+};
+
+const FIXES_SCOPES = new Set(["fix", "fixes", "bug", "bugfix"]);
+const IMPROVEMENTS_SCOPES = new Set(["chore", "refactor", "perf", "build", "ci", "test", "tests"]);
+
+function startOfWeek(iso: string): Date {
+  const d = new Date(`${iso}T00:00:00Z`);
+  // 0 = Sun, 1 = Mon, … We want Monday as the start.
+  const dow = d.getUTCDay();
+  const offset = dow === 0 ? -6 : 1 - dow;
+  d.setUTCDate(d.getUTCDate() + offset);
+  return d;
+}
+
+function isoDate(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+function formatWeekRange(start: Date, end: Date): string {
+  const opts: Intl.DateTimeFormatOptions = { month: "short", day: "numeric" };
+  const startStr = start.toLocaleDateString("en-US", { ...opts, timeZone: "UTC" });
+  const endStr = end.toLocaleDateString("en-US", { ...opts, timeZone: "UTC" });
+  const year = end.getUTCFullYear();
+  if (start.getUTCMonth() === end.getUTCMonth()) {
+    // "May 5–11, 2026"
+    return `${startStr.split(" ")[0]} ${start.getUTCDate()}–${end.getUTCDate()}, ${year}`;
+  }
+  // "Apr 28 – May 4, 2026"
+  return `${startStr} – ${endStr}, ${year}`;
+}
+
+function prettyScope(scope: string): string {
+  if (!scope) return "Other";
+  if (FIXES_SCOPES.has(scope)) return "Fixes";
+  if (IMPROVEMENTS_SCOPES.has(scope)) return "Improvements";
+  // Title-case the scope: "navigator" → "Navigator", "agent_runs" → "Agent runs",
+  // "linear" → "Linear", "knowledge" → "Knowledge".
+  const words = scope.replace(/[_-]/g, " ").split(/\s+/);
+  return words
+    .map((w, i) => (i === 0 ? w[0].toUpperCase() + w.slice(1) : w))
+    .join(" ");
+}
+
+function compareGroupLabels(a: string, b: string): number {
+  // Sort: product areas (alpha), then Improvements, Fixes, Other.
+  const tail = ["Improvements", "Fixes", "Other"];
+  const ai = tail.indexOf(a);
+  const bi = tail.indexOf(b);
+  if (ai === -1 && bi === -1) return a.localeCompare(b);
+  if (ai === -1) return -1;
+  if (bi === -1) return 1;
+  return ai - bi;
+}
+
+export function listChangelogWeeks(): ChangelogWeek[] {
+  const entries = listChangelogEntries();
+  const buckets = new Map<string, ChangelogEntry[]>();
+  for (const e of entries) {
+    const start = isoDate(startOfWeek(e.day));
+    if (!buckets.has(start)) buckets.set(start, []);
+    buckets.get(start)!.push(e);
+  }
+  const weeks: ChangelogWeek[] = [];
+  for (const [weekStart, weekEntries] of buckets) {
+    const start = new Date(`${weekStart}T00:00:00Z`);
+    const end = new Date(start);
+    end.setUTCDate(end.getUTCDate() + 6);
+    // Group by pretty scope.
+    const groupMap = new Map<string, ChangelogEntry[]>();
+    for (const e of weekEntries) {
+      const label = prettyScope(e.scope);
+      if (!groupMap.has(label)) groupMap.set(label, []);
+      groupMap.get(label)!.push(e);
+    }
+    const groups: ChangelogGroup[] = Array.from(groupMap.entries())
+      .map(([label, items]) => ({ label, entries: items }))
+      .sort((a, b) => compareGroupLabels(a.label, b.label));
+    weeks.push({
+      weekStart,
+      weekEnd: isoDate(end),
+      rangeLabel: formatWeekRange(start, end),
+      groups,
+    });
+  }
+  weeks.sort((a, b) => (a.weekStart < b.weekStart ? 1 : -1));
+  return weeks;
+}

--- a/landing/src/lib/changelog.ts
+++ b/landing/src/lib/changelog.ts
@@ -1,216 +1,129 @@
-import { execFileSync } from "node:child_process";
+import fs from "node:fs";
 import path from "node:path";
 
 /**
- * Build-time git log → changelog entries.
+ * Filesystem-backed changelog loader.
  *
- * The Ship workflow squash-merges PRs into `main` with subjects like:
+ * Each release / weekly entry is one Markdown file under
+ * ``landing/content/changelog/*.md`` with a frontmatter block:
  *
- *     navigator: consult_specialist subagent tool (PR3 of 3) (#155)
- *     fix: bump default Anthropic Haiku model to the post-preview stable id (#156)
- *     knowledge: extractor batch + Anthropic-preamble parse fix (#152)
+ *   ---
+ *   slug: 2026-05-07-navigator-goes-agentic
+ *   date: 2026-05-07                  # ISO yyyy-mm-dd; sort key.
+ *   title: Navigator goes agentic
+ *   summary: One-line lead used in the hero.
+ *   kicker: Release                   # small label above the title.
+ *   hero_image: /changelog/2026-05/navigator-agentic.webp   # optional
+ *   hero_alt: Description of the image (a11y).               # required if hero_image
+ *   hero_video: https://www.loom.com/embed/...               # optional
+ *   ---
  *
- * We pull the most recent commits from `main`, filter to those that look
- * like merged PRs (have a trailing `(#NNN)`), and extract a small,
- * stable shape that the changelog page renders. Commits without the
- * PR suffix (direct-to-main, very rare) are skipped — the page is the
- * "what shipped via the PR flow" log, not a raw `git log`.
+ *   (markdown body — `## Highlights`, `## Improvements`, `## Fixes`)
  *
- * Runs once at build time. If git history isn't available (shallow
- * clone in CI without `fetch-depth: 0`, or a Docker layer without `.git`),
- * we return an empty list so the page renders with a soft-empty state
- * rather than failing the build.
+ * The body uses the same react-markdown pipeline as the blog
+ * (see ``BlogMarkdown`` + ``preprocessBlogMarkdown``). PR references
+ * in body text written as bare ``#155`` are auto-linked.
+ *
+ * The page renders entries sorted by ``date`` desc. No future-publish
+ * gating — the changelog is meant to be edited as releases ship; if
+ * you want to stage a draft, keep it on a branch.
  */
 
-export type ChangelogEntry = {
-  /** 7-char commit hash. */
-  shortSha: string;
-  /** ISO 8601 commit-author date, e.g. `2026-05-06T22:18:43+02:00`. */
+export type ChangelogMeta = {
+  slug: string;
   date: string;
-  /** ISO date only, e.g. `2026-05-06`. Used for grouping. */
-  day: string;
-  /** Conventional-commit scope prefix, e.g. `navigator`, `fix`, `landing`. Empty when absent. */
-  scope: string;
-  /** Subject minus scope prefix and `(#NNN)` suffix. */
   title: string;
-  /** PR number parsed from the trailing `(#NNN)`. */
-  prNumber: number;
-  /** Author name from `git log`. */
-  author: string;
+  summary: string;
+  kicker: string;
+  heroImage: string;
+  heroAlt: string;
+  heroVideo: string;
+  prs: number[];
 };
 
-const REPO_ROOT = path.resolve(process.cwd(), "..");
+export type ChangelogEntry = ChangelogMeta & {
+  body: string;
+};
 
-// Date bound for the changelog. Commits older than this are dropped
-// before parsing — keeps the page bounded as the project ages. Uses
-// git's relative-date syntax.
-const SINCE = "6.months.ago";
+const CHANGELOG_DIR = path.join(process.cwd(), "content", "changelog");
 
-// `` is ASCII unit separator — safe between fields, won't collide
-// with anything humans put in commit messages.
-const SEP = "";
-const FORMAT = ["%h", "%aI", "%an", "%s"].join(SEP);
-
-const PR_RE = /\s*\(#(\d+)\)\s*$/;
-const SCOPE_RE = /^([a-z][a-z0-9_-]*(?:\([a-z0-9._-]+\))?):\s*/i;
-
-function readGitLog(): string[] {
-  try {
-    const stdout = execFileSync(
-      "git",
-      [
-        "log",
-        `--since=${SINCE}`,
-        `--pretty=format:${FORMAT}`,
-        "--no-merges",
-        "main",
-      ],
-      { cwd: REPO_ROOT, encoding: "utf-8", maxBuffer: 16 * 1024 * 1024 },
-    );
-    return stdout.split("\n").filter(Boolean);
-  } catch {
-    // Shallow clone, no .git, or git not on PATH.
-    return [];
+function parseFrontmatter(raw: string): {
+  data: Record<string, string | number | string[]>;
+  body: string;
+} {
+  if (!raw.startsWith("---\n")) return { data: {}, body: raw };
+  const end = raw.indexOf("\n---", 4);
+  if (end === -1) return { data: {}, body: raw };
+  const block = raw.slice(4, end);
+  const rest = raw.slice(end + 4).replace(/^\n/, "");
+  const data: Record<string, string | number | string[]> = {};
+  for (const line of block.split("\n")) {
+    const m = line.match(/^([A-Za-z_][A-Za-z0-9_]*):\s*(.*)$/);
+    if (!m) continue;
+    const key = m[1];
+    const rawValue = m[2].trim();
+    if (!rawValue) continue;
+    if (rawValue.startsWith("[") && rawValue.endsWith("]")) {
+      data[key] = rawValue
+        .slice(1, -1)
+        .split(",")
+        .map((s) => s.trim().replace(/^['"]|['"]$/g, ""))
+        .filter(Boolean);
+      continue;
+    }
+    const unquoted = rawValue.replace(/^['"]|['"]$/g, "");
+    data[key] = unquoted;
   }
+  return { data, body: rest };
 }
 
-function parseLine(line: string): ChangelogEntry | null {
-  const parts = line.split(SEP);
-  if (parts.length < 4) return null;
-  const [shortSha, date, author, subjectRaw] = parts;
-  const prMatch = PR_RE.exec(subjectRaw);
-  if (!prMatch) return null;
-  const prNumber = Number(prMatch[1]);
-  let subject = subjectRaw.replace(PR_RE, "");
-  let scope = "";
-  const scopeMatch = SCOPE_RE.exec(subject);
-  if (scopeMatch) {
-    scope = scopeMatch[1].toLowerCase();
-    subject = subject.slice(scopeMatch[0].length);
-  }
-  const title = subject.trim();
-  if (!title) return null;
+function asString(v: unknown, fallback = ""): string {
+  return typeof v === "string" ? v : fallback;
+}
+
+function asNumberArray(v: unknown): number[] {
+  if (!Array.isArray(v)) return [];
+  return v
+    .map((s) => (typeof s === "string" ? Number(s) : typeof s === "number" ? s : NaN))
+    .filter((n) => Number.isFinite(n) && n > 0);
+}
+
+function toMeta(slug: string, data: Record<string, string | number | string[]>): ChangelogMeta {
   return {
-    shortSha,
-    date,
-    day: date.slice(0, 10),
-    scope,
-    title,
-    prNumber,
-    author,
+    slug: asString(data.slug, slug),
+    date: asString(data.date, ""),
+    title: asString(data.title, slug),
+    summary: asString(data.summary),
+    kicker: asString(data.kicker, "Release"),
+    heroImage: asString(data.hero_image),
+    heroAlt: asString(data.hero_alt),
+    heroVideo: asString(data.hero_video),
+    prs: asNumberArray(data.prs),
   };
 }
 
 export function listChangelogEntries(): ChangelogEntry[] {
-  return readGitLog()
-    .map(parseLine)
-    .filter((entry): entry is ChangelogEntry => entry !== null);
+  if (!fs.existsSync(CHANGELOG_DIR)) return [];
+  const files = fs.readdirSync(CHANGELOG_DIR).filter((f) => f.endsWith(".md"));
+  return files
+    .map((file) => {
+      const fileSlug = file.replace(/\.md$/, "");
+      const raw = fs.readFileSync(path.join(CHANGELOG_DIR, file), "utf-8");
+      const { data, body } = parseFrontmatter(raw);
+      const meta = toMeta(fileSlug, data);
+      return { ...meta, body };
+    })
+    .sort((a, b) => (a.date < b.date ? 1 : a.date > b.date ? -1 : 0));
 }
 
-// ---------------------------------------------------------------------------
-// Week grouping
-// ---------------------------------------------------------------------------
-
-export type ChangelogGroup = {
-  /** Group label, e.g. ``Navigator``, ``Fixes``, ``Other``. */
-  label: string;
-  entries: ChangelogEntry[];
-};
-
-export type ChangelogWeek = {
-  /** Monday of the week, ISO date (yyyy-mm-dd). */
-  weekStart: string;
-  /** Sunday of the week, ISO date. */
-  weekEnd: string;
-  /** Human-friendly week range, e.g. ``May 5–11, 2026``. */
-  rangeLabel: string;
-  /** Entries grouped by scope-family. Order: product areas alpha, then
-   *  Improvements, Fixes, Other at the bottom. */
-  groups: ChangelogGroup[];
-};
-
-const FIXES_SCOPES = new Set(["fix", "fixes", "bug", "bugfix"]);
-const IMPROVEMENTS_SCOPES = new Set(["chore", "refactor", "perf", "build", "ci", "test", "tests"]);
-
-function startOfWeek(iso: string): Date {
+export function formatChangelogDate(iso: string): string {
+  if (!iso) return "";
   const d = new Date(`${iso}T00:00:00Z`);
-  // 0 = Sun, 1 = Mon, … We want Monday as the start.
-  const dow = d.getUTCDay();
-  const offset = dow === 0 ? -6 : 1 - dow;
-  d.setUTCDate(d.getUTCDate() + offset);
-  return d;
-}
-
-function isoDate(d: Date): string {
-  return d.toISOString().slice(0, 10);
-}
-
-function formatWeekRange(start: Date, end: Date): string {
-  const opts: Intl.DateTimeFormatOptions = { month: "short", day: "numeric" };
-  const startStr = start.toLocaleDateString("en-US", { ...opts, timeZone: "UTC" });
-  const endStr = end.toLocaleDateString("en-US", { ...opts, timeZone: "UTC" });
-  const year = end.getUTCFullYear();
-  if (start.getUTCMonth() === end.getUTCMonth()) {
-    // "May 5–11, 2026"
-    return `${startStr.split(" ")[0]} ${start.getUTCDate()}–${end.getUTCDate()}, ${year}`;
-  }
-  // "Apr 28 – May 4, 2026"
-  return `${startStr} – ${endStr}, ${year}`;
-}
-
-function prettyScope(scope: string): string {
-  if (!scope) return "Other";
-  if (FIXES_SCOPES.has(scope)) return "Fixes";
-  if (IMPROVEMENTS_SCOPES.has(scope)) return "Improvements";
-  // Title-case the scope: "navigator" → "Navigator", "agent_runs" → "Agent runs",
-  // "linear" → "Linear", "knowledge" → "Knowledge".
-  const words = scope.replace(/[_-]/g, " ").split(/\s+/);
-  return words
-    .map((w, i) => (i === 0 ? w[0].toUpperCase() + w.slice(1) : w))
-    .join(" ");
-}
-
-function compareGroupLabels(a: string, b: string): number {
-  // Sort: product areas (alpha), then Improvements, Fixes, Other.
-  const tail = ["Improvements", "Fixes", "Other"];
-  const ai = tail.indexOf(a);
-  const bi = tail.indexOf(b);
-  if (ai === -1 && bi === -1) return a.localeCompare(b);
-  if (ai === -1) return -1;
-  if (bi === -1) return 1;
-  return ai - bi;
-}
-
-export function listChangelogWeeks(): ChangelogWeek[] {
-  const entries = listChangelogEntries();
-  const buckets = new Map<string, ChangelogEntry[]>();
-  for (const e of entries) {
-    const start = isoDate(startOfWeek(e.day));
-    if (!buckets.has(start)) buckets.set(start, []);
-    buckets.get(start)!.push(e);
-  }
-  const weeks: ChangelogWeek[] = [];
-  for (const [weekStart, weekEntries] of buckets) {
-    const start = new Date(`${weekStart}T00:00:00Z`);
-    const end = new Date(start);
-    end.setUTCDate(end.getUTCDate() + 6);
-    // Group by pretty scope.
-    const groupMap = new Map<string, ChangelogEntry[]>();
-    for (const e of weekEntries) {
-      const label = prettyScope(e.scope);
-      if (!groupMap.has(label)) groupMap.set(label, []);
-      groupMap.get(label)!.push(e);
-    }
-    const groups: ChangelogGroup[] = Array.from(groupMap.entries())
-      .map(([label, items]) => ({ label, entries: items }))
-      .sort((a, b) => compareGroupLabels(a.label, b.label));
-    weeks.push({
-      weekStart,
-      weekEnd: isoDate(end),
-      rangeLabel: formatWeekRange(start, end),
-      groups,
-    });
-  }
-  weeks.sort((a, b) => (a.weekStart < b.weekStart ? 1 : -1));
-  return weeks;
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    timeZone: "UTC",
+  });
 }

--- a/landing/src/lib/changelog.ts
+++ b/landing/src/lib/changelog.ts
@@ -40,7 +40,11 @@ export type ChangelogEntry = {
 };
 
 const REPO_ROOT = path.resolve(process.cwd(), "..");
-const MAX_ENTRIES = 200;
+
+// Date bound for the changelog. Commits older than this are dropped
+// before parsing — keeps the page bounded as the project ages. Uses
+// git's relative-date syntax.
+const SINCE = "6.months.ago";
 
 // `` is ASCII unit separator — safe between fields, won't collide
 // with anything humans put in commit messages.
@@ -56,12 +60,12 @@ function readGitLog(): string[] {
       "git",
       [
         "log",
-        `-n${MAX_ENTRIES}`,
+        `--since=${SINCE}`,
         `--pretty=format:${FORMAT}`,
         "--no-merges",
         "main",
       ],
-      { cwd: REPO_ROOT, encoding: "utf-8", maxBuffer: 8 * 1024 * 1024 },
+      { cwd: REPO_ROOT, encoding: "utf-8", maxBuffer: 16 * 1024 * 1024 },
     );
     return stdout.split("\n").filter(Boolean);
   } catch {


### PR DESCRIPTION
## Summary

Adds `/changelog` — a public, dry log of what shipped. Linear-style cards: weekly date headers, sub-grouped by area, no marketing prose. Linked from footer (`Reference` column) and added to sitemap.

The source of truth is `git log --no-merges main`, parsed at build time. Subjects matching the project's squash-merge convention `<scope>: <title> (#NNN)` produce one entry each. The page is a 200-commit tail, not the full history.

Grouping rules:

- Buckets are Mon-Sun ISO weeks, newest first.
- Within a week, scope prefixes drive sub-groups. Product areas (Navigator, Knowledge, Landing, …) sort to the top alphabetically; `chore/refactor/perf/build/ci/test` collapse into "Improvements"; `fix/bugfix/bug` collapse into "Fixes"; commits without a scope prefix go into "Other".

If the build env has a shallow clone or no `.git`, the page renders a soft empty state instead of failing the build. Next deploy with a full clone regenerates it.

## Why a separate page from /blog

The blog carries narrative — kicker, tags, reading time, founder voice. The changelog is the dry "what shipped, when" companion: easier to scan for buyers/users who just want to see velocity, no editorial ramp-up needed per merged PR.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] Smoke-load `listChangelogWeeks()` against current git → 2 weeks, 94 entries grouped correctly across Navigator / Knowledge / Console / Dashboard / Linear / Fixes / Improvements / Other
- [ ] `npm run landing:build` succeeds
- [ ] `/changelog` renders and PR-number badges deep-link to `github.com/ElMundiUA/ship/pull/<n>`
- [ ] Footer link reachable from every page
- [ ] Soft empty state visible when run inside a fresh shallow clone (`git clone --depth 1 …`)