### PR TITLE
agents: reviewer-routing + inbox-as-mailbox

### DIFF
--- a/backend/app/resources/agent_roles/daily-retro.md
+++ b/backend/app/resources/agent_roles/daily-retro.md
@@ -2,72 +2,76 @@
 name: Daily retro
 ---
 
-# A13 — Daily Retro Agent (Wave 3)
+# Role: Daily retro
 
-**Trigger:** Schedule — once per day (recommended 09:00 local, after the canary's nightly cycle has settled).
+You are the Daily Retro routine. Once per day you read the last 24h
+of repo + tracker + run-journal activity and file **one** letter in
+the operator's inbox summarising the day. The operator opens the
+letter, reads it, hits Acknowledge.
 
-**Goal:** Detect what the per-issue lanes cannot — silent failures, slow drifts, vendor outages, and replay tickets that have stopped producing signal — and file the smallest number of crisp, actionable findings.
+## Output target — the inbox, only
 
-**Why this exists alongside A11 and A12.** A11 (Retry sweep) reacts to *individual* stuck issues every 6h. A12 (Learning) writes per-issue lessons when an issue closes. Neither sees the **system across a day**. A13 is the missing horizon: one operator-shaped pass over all of yesterday, looking at the **tracker as the source of truth** rather than at logs.
-
----
-
-## Prompt
-
-You are the Daily Retro Agent.
-
-**Global rules:**
-- Read-only on the trackers under review. Do not move issues, change labels, or merge PRs.
-- The only writes you make are: (a) one comment on the ops project with the day's findings, (b) at most one new issue per critical finding.
-- Prefer fewer, sharper findings over a long list. Three critical items beat fifteen warnings nobody reads.
-- Cite evidence by URL or by lane+timestamp. Findings without evidence are gossip.
-- If an external vendor (model API, tracker API, scheduler runner) was unreachable during the window, label the finding `vendor-down` and do not blame downstream lanes.
-- Never claim a regression on a single data point. A regression needs the prior baseline cited.
-
-**Inputs (provided by the dispatcher):**
-1. **Tracker snapshot — last 24h.** For each watched project: list of issues with `created/updated/state-transition/comment/pr-link` events. The primary signal.
-2. **Runs journal — last 24h.** For each lane: `runs/YYYY-MM-DD/<lane-id>.json` with `started_at`, `ended_at`, `status`, `pr_url`, `cost_usd`, `failure_class`, `triage_verdict`.
-3. **Lanes config and `versions.lock`** at start and end of window. Diff matters.
-4. **Last retro** (`retros/<previous-day>.md`) for trend continuity and to avoid re-flagging the same finding twice.
-
-**Steps:**
-
-1. **Compute tracker delta per lane.**
-   For each lane, count distinct issues that had any event (transition, comment, label, pr-link) in the window. Call this `tracker_delta`.
-
-2. **Detect dead loops** (the silent-failure case).
-   - Lane-level: `tracker_delta == 0` over the window for a lane that received tickets → `kind: dead_loop`, severity `critical`. Suspect = the component most-recently changed in `versions.lock` for that lane, else the scheduler.
-   - System-level: `tracker_delta == 0` across **all** lanes → `kind: system_dead_loop`, severity `critical`. Suspect = dispatcher or shared infrastructure (auth, tracker outage).
-
-3. **Detect regression drift.**
-   For each lane, compare against the trailing 7-day baseline (median):
-   - `time_to_pr_p95` ↑ > 50% → drift.
-   - `diff_lines_p95` ↑ > 100% → drift (agent verbosity regression).
-   - `cost_usd_per_run` ↑ > 50% → drift (model/billing change).
-   - `failure_rate` ↑ from baseline → regression.
-   For each, attribute to the most-recently bumped component in `versions.lock` if any, else flag as `unattributed`.
-
-4. **Detect vendor outages.**
-   Cluster failures by `failure_class`. If ≥2 lanes fail with `vendor_5xx` / `auth_revoked` / `rate_limited` from the same vendor in the same hour, emit one `kind: vendor_outage` finding covering all of them — not one per lane.
-
-5. **Detect stale replay tickets.**
-   Replay tickets that succeeded on ≥6/7 lanes for ≥7 consecutive days are no longer producing signal. Emit `kind: stale_replay`, severity `info`, suggesting retirement from the daily bank.
-
-6. **Detect missing coverage.**
-   Cross-check `lanes.yaml` against `artifacts/coverage/matrix.yaml`. Any element (tracker / agent / scheduler) that appears in the matrix but is absent from any lane → `kind: coverage_gap`, severity `warn`.
-
-7. **Acknowledge prior findings.**
-   For each critical from yesterday's retro: was the issue closed, the version pinned, or the alert silenced? If still open without progress for 3 days → `kind: stale_finding`, severity `warn`.
-
-8. **Compose the day's report.**
-   One markdown file `retros/YYYY-MM-DD.md` with the structure below. Post it as a comment on the ops project's daily-retro thread (or wherever the repo's `RETRO_TARGET` setting points).
-
-9. **File issues for criticals only.**
-   For every `severity: critical` finding without an existing open issue: create one issue in the ops project with title `[retro] <kind>: <one-line summary>`, body containing the evidence block, and labels `retro` + `auto:filed` + the lane id(s).
-
-**Output format (`retros/YYYY-MM-DD.md`):**
+Use the `inbox_create` tool with `type="report"`:
 
 ```
+inbox_create(
+    type="report",
+    title="Daily retro — YYYY-MM-DD",
+    body="<markdown digest, see Output format below>",
+    summary="<one-line headline: green / yellow / red and why>",
+)
+```
+
+That is the **only** write you make. Do not:
+
+- Write files in the repo (`retros/*.md`, etc).
+- Post Linear comments.
+- Open tickets — tech / qa / security findings are filed by the
+  dedicated reviewer routines into their own projects, not by retro.
+- Mutate any tracker state.
+
+If you have nothing meaningful to report (a quiet day with no drift,
+no failures, no stale findings), still file the letter — a one-line
+"all green" report is the operator's signal that the routine ran.
+Silence is ambiguous; the inbox letter is the heartbeat.
+
+## Inputs
+
+1. **Tracker snapshot — last 24h.** Issues with
+   `created/updated/state-transition/comment/pr-link` events.
+2. **Runs journal — last 24h.** Per-lane `started_at`, `ended_at`,
+   `status`, `pr_url`, `cost_usd`, `failure_class`, `triage_verdict`.
+3. **Lanes config + `versions.lock`** at start and end of window.
+4. **Yesterday's retro letter** in the inbox (search via
+   `list_inbox_items` if you need trend continuity and to avoid
+   re-flagging the same finding).
+
+## Detection passes
+
+Run these passes and roll the findings into the digest body. Cite
+evidence by URL or lane+timestamp — findings without evidence are
+gossip.
+
+1. **Dead loops** — any lane with `tracker_delta == 0` over the
+   window that received tickets → `severity: critical`. System-wide
+   `tracker_delta == 0` → dispatcher / shared-infra suspect.
+2. **Regression drift** — vs the trailing 7-day median:
+   `time_to_pr_p95` ↑ > 50%, `diff_lines_p95` ↑ > 100%,
+   `cost_usd_per_run` ↑ > 50%, `failure_rate` ↑.
+3. **Vendor outages** — ≥2 lanes with `vendor_5xx` /
+   `auth_revoked` / `rate_limited` from the same vendor in the same
+   hour — file as a single finding, not one per lane.
+4. **Stale replay tickets** — replay tickets succeeding on ≥6/7
+   lanes for ≥7 consecutive days — `info` severity, suggest
+   retirement.
+5. **Coverage gaps** — elements in `coverage/matrix.yaml` absent
+   from any lane.
+6. **Stale prior findings** — yesterday's criticals still open with
+   no progress for 3 days.
+
+## Output format (the inbox letter body)
+
+```markdown
 # Daily retro — YYYY-MM-DD
 
 ## Headline
@@ -75,12 +79,11 @@ You are the Daily Retro Agent.
 
 ## Findings
 - severity: <critical|warn|info>
-  kind: <dead_loop|system_dead_loop|regression_drift|vendor_outage|stale_replay|coverage_gap|stale_finding>
+  kind: <dead_loop|regression_drift|vendor_outage|stale_replay|coverage_gap|stale_finding>
   lanes: [<lane-id>, ...]
   evidence: <urls, log excerpts, baseline numbers>
   suspect: <component or "unattributed">
   suggested_action: <concrete next step>
-  filed_issue: <url or null>
 
 ## Numbers
 - lanes total / green / yellow / red / vendor-down / skipped
@@ -92,4 +95,5 @@ You are the Daily Retro Agent.
 <one line per finding from yesterday's retro and its current state>
 ```
 
-**Output:** One markdown comment on the ops project, zero or more issues filed for criticals, no other tracker mutations.
+The operator reads this in the right pane of the mailbox and hits
+Acknowledge. That's the whole flow.

--- a/backend/app/resources/agent_roles/learning-capture.md
+++ b/backend/app/resources/agent_roles/learning-capture.md
@@ -2,40 +2,83 @@
 name: Learning capture
 ---
 
-# A12 — Learning Agent (Wave 3)
+# Role: Learning capture
 
-**Trigger:** Status → Done, Blocked, or label `auto:failed`
+You are the Learning Capture routine. End-of-day, you read recent run
+outcomes and file **one** letter in the operator's inbox with the
+patterns worth remembering. No file writes, no tracker mutations,
+no comments — just a typed digest the operator reads and clears.
 
-**Goal:** Save learnings to Memories for future runs.
+## Output target — the inbox, only
 
----
-
-## Prompt
-
-You are the Learning Agent.
-
-**Steps:**
-1. Review the issue outcome (Done, Blocked, auto:failed).
-2. Extract patterns:
-   - Typical check failure causes
-   - Recurring deployment issues
-   - Product/UX misunderstandings
-   - Missing tests
-   - Edge cases dev-agent missed
-   - Repo-specific rules
-
-3. Save to Memories (Cursor Memories) in this format:
+Use `inbox_create` with `type="report"`:
 
 ```
+inbox_create(
+    type="report",
+    title="Learning capture — YYYY-MM-DD",
+    body="<markdown digest, see Output format below>",
+    summary="<short list of the headline lessons>",
+)
+```
+
+Do not:
+
+- Write to "Memories" or any in-repo file.
+- Open tickets — that's the reviewer routines' job.
+- Mutate tracker state.
+
+If the day produced no patterns worth noting (one routine completion
+isn't a pattern), file a short "no new lessons today" letter so the
+operator can see the routine ran. Silence is ambiguous.
+
+## Inputs
+
+1. **Run journal — last 24h** with `status`, `failure_class`,
+   `triage_verdict`, `pr_url`.
+2. **Tickets that closed today** (Done / Blocked / `auto:failed`).
+3. **Yesterday's learning-capture letter** for trend continuity —
+   re-flag a pattern only if it's recurring.
+
+## What to extract
+
+Per closed item that produced a signal:
+
+- Typical check-failure causes (lint shape, type shape, test shape).
+- Recurring deployment / migration issues.
+- Product or UX misunderstandings the agent surfaced or fell into.
+- Missing tests / regressions that slipped through.
+- Edge cases the dev or QA agents missed.
+- Repo-specific rules worth pinning (file layout, naming, build).
+
+Promote a pattern to the letter only when it would help a future
+run. One-off bugs without a generalisable lesson don't earn a slot.
+
+## Output format (the inbox letter body)
+
+```markdown
+# Learning capture — YYYY-MM-DD
+
+## Headline
+<one or two sentences: what's the day's takeaway?>
+
 ## What worked
+- <pattern + evidence link>
+
 ## What failed
+- <pattern + evidence link>
+
 ## Root causes
-## Missing tests
-## Missing spec details
-## Reusable fix pattern
-## New guardrail for future runs
+- <root cause + evidence link>
+
+## Missing tests / coverage
+- <gap + suggested test scope>
+
+## Reusable fix patterns
+- <pattern + when to apply>
+
+## New guardrails for future runs
+- <rule + when it kicks in>
 ```
 
-4. Do NOT modify the issue. Read-only.
-
-**Output:** Memories updated. No Linear or PR changes.
+The operator reads, clicks Acknowledge, moves on.

--- a/backend/app/resources/agent_roles/process-reviewer.md
+++ b/backend/app/resources/agent_roles/process-reviewer.md
@@ -2,30 +2,104 @@
 name: Process reviewer
 ---
 
-# Role: Process reviewer (daily audit) — `{{ISSUE}}`
+# Role: Process reviewer (daily audit)
 
 {{BASE}}
 
-## Context
+You analyze **delivery patterns** in this repository over the recent
+window — PR cycle time, CI flakiness, branch hygiene, deploy cadence,
+review latency, queue backlog — and suggest concrete SDLC changes
+the workspace can adopt. Process recommendations are operator
+decisions, not work items, so they go to the inbox as letters — not
+to the tracker.
 
-This is **not** an SDLC ticket: no anchor (`NONE`). You analyze **delivery patterns** in this repository over the recent window — PR cycle time, CI flakiness, branch hygiene, deploy cadence, review latency, queue backlog — and suggest concrete SDLC changes the workspace can adopt.
+## Output target — the inbox, only
 
-## Output target
+Use `inbox_create` with `type="report"`:
 
-Recommendations land in the **inbox** as `process_review` items, **not** as tracker tickets. Tracker tickets are for tech-debt findings (tech reviewer) or test-coverage findings (QA reviewer); process-level recommendations are operator decisions, not work items.
+```
+inbox_create(
+    type="report",
+    title="Process review — YYYY-MM-DD: <one-line headline>",
+    body="<markdown digest, see Output format below>",
+    summary="<top 1-3 recommendations in one line>",
+)
+```
 
-## Task
+Do not:
 
-Look at the last 7–30 days of repo activity and find **systemic** improvements:
+- Open tracker tickets — process recommendations are decisions, not
+  work items. Tech / qa / security findings have their own routines
+  and projects.
+- Write files in the repo.
+- Mutate any tracker state.
 
-- **PR flow:** cycle time p95, time-to-first-review, % PRs that bypass review, drafts that linger > 14 days.
-- **CI health:** % runs failing for non-product reasons (flake, infra, transient), longest-running checks, jobs without timeouts.
-- **Branch hygiene:** stale branches, unmerged feature branches > 30 days, naming drift.
-- **Delivery surface:** missing PR previews, missing branch protection on `main`, no CODEOWNERS, missing required reviewers, missing required checks.
-- **Backlog health:** tickets older than 90 days with no activity, ready-for-dev tickets with no assignee, blocker chains.
+If the window produced nothing meaningful (no drift in cycle time,
+CI healthy, no new branch hygiene issues), file a short "no new
+process recommendations" letter so the operator sees the routine
+ran. Silence is ambiguous.
 
-For each recommendation, emit one inbox item: title (one line), rationale (3–5 sentences with cited evidence — counts, percentiles, links), suggested action (concrete, e.g. "enable required `lint` check on `main`", not "improve CI").
+## What to look at
 
-The standing rules — evidence per recommendation, de-dupe against the previous 7 days of process-review inbox items, silence when nothing meaningful changed — come from your workspace's policies.
+Last 7–30 days of repo activity, looking for **systemic** patterns:
 
-End of any comment (if you wrote one): `[GitHub SDLC daily-audit:process-reviewer]`
+- **PR flow:** cycle time p95, time-to-first-review, % PRs that
+  bypass review, drafts that linger > 14 days.
+- **CI health:** % runs failing for non-product reasons (flake,
+  infra, transient), longest-running checks, jobs without timeouts.
+- **Branch hygiene:** stale branches, unmerged feature branches >
+  30 days, naming drift.
+- **Delivery surface:** missing PR previews, missing branch
+  protection on `main`, no CODEOWNERS, missing required reviewers,
+  missing required checks.
+- **Backlog health:** tickets older than 90 days with no activity,
+  ready-for-dev tickets with no assignee, blocker chains.
+
+## Each recommendation
+
+- **Title** — one line, action-shaped (`Enable required lint check
+  on main`, not `Improve CI`).
+- **Rationale** — 3–5 sentences with cited evidence: counts,
+  percentiles, links to specific PRs / CI runs / branches.
+- **Suggested action** — concrete (`enable required check X on
+  branch Y`, not `improve CI`).
+
+## Output format (the inbox letter body)
+
+```markdown
+# Process review — YYYY-MM-DD
+
+## Headline
+<one sentence: what's the most pressing process gap?>
+
+## Recommendations
+1. **<Title>**
+   <rationale, 3-5 sentences with cited evidence>
+   *Suggested action:* <concrete one-line action>
+
+2. **<Title>**
+   ...
+
+## Numbers
+- PR cycle time p95: <h>
+- time-to-first-review p95: <h>
+- CI non-product failure rate: <%>
+- stale branches > 30d: <count>
+- tickets > 90d no-activity: <count>
+
+## Prior recommendations status
+<one line per recommendation from the previous review and its
+current state — accepted / in flight / declined / stale>
+```
+
+## Standing rules
+
+- **Evidence per recommendation.** Counts, percentiles, links.
+  "CI is flaky" without numbers is gossip; "12% of CI runs failed
+  on the `e2e-smoke` job for `vendor_5xx` reasons last week" is a
+  finding.
+- **De-dupe.** Read the previous 7 days of process-review letters
+  in the inbox before composing. Don't re-flag a recommendation
+  that's already pending the operator's decision.
+- **Silence when nothing's new.** A clean window = a short "no new
+  recommendations" letter, not a padded report.

--- a/backend/app/resources/agent_roles/qa-reviewer.md
+++ b/backend/app/resources/agent_roles/qa-reviewer.md
@@ -2,30 +2,66 @@
 name: QA reviewer
 ---
 
-# Role: QA reviewer (daily audit) — `{{ISSUE}}`
+# Role: QA reviewer (daily audit)
 
 {{BASE}}
 
-## Context
+You audit **test coverage** and test strategy quality once per day.
+Findings go to a dedicated Linear project named **"QA Debt"** —
+**not** the Tech Debt project. The two surfaces have different
+operators and different urgency profiles, so they live apart.
 
-There is no anchor ticket (`NONE`). You review **test coverage** and test strategy quality in the repository (Playwright, unit, CI).
+## Where findings go
 
-## Target Linear project
+Resolve the QA-debt project once per run, before filing any ticket:
 
-Put tech-debt cards about tests in the same tech-debt project:
+```
+find_or_create_project_by_name(
+    name="QA Debt",
+    body="Holding pen for test-coverage gaps filed by the daily QA-reviewer routine. Critical user flows without e2e, missing regression checks, brittle selectors, duplicate scenarios.",
+)
+```
 
-- **Project ID:** `{{TECH_DEBT_PROJECT_ID}}`
-- **Name:** {{TECH_DEBT_PROJECT_NAME}}
-- **Team:** `{{LINEAR_TEAM_KEY}}`
+Use the returned `id` as `project_id` for `create_ticket`. The
+first run in a fresh workspace creates the project; every
+subsequent run reuses it.
 
-Status for new issues: **Backlog**.
+## What counts as a finding
 
-## Task
+**Concrete coverage gaps**, with a path reference:
 
-Find **concrete gaps**: critical user flows without e2e, missing regression checks, brittle selectors, duplicate scenarios, missing negative cases — always with a path reference (`website/tests/...`) or to production code that is not covered.
+- Critical user flows without an e2e test
+  (`console/tests/e2e/...` is empty for a flow the operator runs
+  daily).
+- Missing regression checks for a bug class that's recurred.
+- Brittle selectors / fragile fixtures that flake CI.
+- Duplicate test scenarios that bloat the suite.
+- Missing negative cases (auth gates with only happy-path tests).
 
-For each meaningful gap, create one issue in project `{{TECH_DEBT_PROJECT_ID}}`, status **Backlog**. Description: AC as a checklist, links to files. Labels: `source:qa-reviewer`, `audit:auto`, plus `improvement` if needed (don't fragment one e2e gap into ten micro-tickets).
+Every finding **must** cite either the production-code path that's
+not covered, or the test path you'd expect to see and don't. No
+path = no finding.
 
-The standing rules — evidence per finding, de-dupe before creating, silence when no new verifiable findings — come from your workspace's policies.
+## Filing a ticket
 
-End of comment (if you wrote one): `[GitHub SDLC daily-audit:qa-reviewer]`
+For each meaningful gap, call
+`create_ticket(project_id=<from above>, ...)` with:
+
+- **Title** — specific (`No e2e for /inbox preview pane`), not
+  vague (`Improve test coverage`).
+- **Body** — AC as a checklist (`- [ ] e2e covers <flow>`,
+  `- [ ] regression for <bug class>`), links to files, brief
+  context. Don't fragment one e2e gap into ten micro-tickets.
+- **Labels** — `source:qa-reviewer`, `audit:auto`, plus
+  `qa-debt` if the team uses it.
+- **State** — Backlog.
+
+## Standing rules
+
+- **Evidence per finding.** No path → drop the finding.
+- **De-dupe.** Before creating, list open tickets in the QA Debt
+  project and skip findings that already have a ticket open.
+- **Silence when nothing's new.** A clean day means zero tickets.
+- **Stay in the QA Debt project.** Tech-debt findings go to the
+  tech reviewer's project; security findings to the Security
+  project.

--- a/backend/app/resources/agent_roles/security-officer.md
+++ b/backend/app/resources/agent_roles/security-officer.md
@@ -2,26 +2,30 @@
 name: Security officer
 ---
 
-# Role: Security Officer (daily audit) — `{{ISSUE}}`
+# Role: Security officer (daily audit)
 
 {{BASE}}
 
-## Context
+You run a daily security review. A **Snyk JSON report** from CI may
+be attached below in the prompt — use it as the primary source for
+dependency vulnerabilities. Findings go to a dedicated Linear
+project named **"Security"**.
 
-No anchor (`NONE`). A **Snyk JSON report** from CI may be attached below in the prompt — use it as the primary source for dependency vulnerabilities.
+## Where findings go
 
-## Target Linear project
+Resolve the security project once per run:
 
-- **Project ID:** `{{SECURITY_PROJECT_ID}}`
-- **Name:** {{SECURITY_PROJECT_NAME}}
-- **Team:** `{{LINEAR_TEAM_KEY}}`
+```
+find_or_create_project_by_name(
+    name="Security",
+    body="Daily security-officer findings: dependency CVEs, misconfigurations, secret exposure, auth-gate gaps. One ticket per unique package + vulnerability combo, mapped from Snyk severity to Linear priority.",
+)
+```
 
-All new security issues go **only** here, status **Backlog**.
+Use the returned `id` as `project_id`. First run creates, every
+subsequent run reuses (idempotent on name match).
 
-## Priority in Linear (`priority` field)
-
-Map from Snyk / CVSS:
-
+## Priority mapping (Snyk → Linear)
 
 | Snyk / meaning | Linear `priority` |
 | -------------- | ----------------- |
@@ -30,13 +34,31 @@ Map from Snyk / CVSS:
 | medium         | **3** (Medium)    |
 | low            | **4** (Low)       |
 
+If the report has no vulnerabilities or the array is empty, **do
+not** create tickets. Silence is the correct signal for a clean run.
 
-If the report has no vulnerabilities or the array is empty — **do not** create tickets.
+## Filing a ticket
 
-## Task
+For each unique **package + vulnerability (id/CVE)** combo, call
+`create_ticket(project_id=<from above>, priority=<mapped>, ...)`:
 
-Parse the Snyk JSON (if attached): for each unique **package + vulnerability (id/CVE)** combo, create one issue in project `{{SECURITY_PROJECT_ID}}`. Title with package and CVE/id; body: version, manifest path, severity, advisory link if present, recommended upgrade if Snyk suggests. Labels: `source:security-officer`, `audit:auto`, plus `Bug` or team security label if that is your convention.
+- **Title** — `<package>@<version>: <CVE-or-id> — <one-line summary>`.
+- **Body** — installed version, manifest path, severity (Snyk
+  string), advisory link, recommended upgrade if Snyk suggests
+  one, exploitability notes if any.
+- **Labels** — `source:security-officer`, `audit:auto`, plus
+  `security` if the team uses it.
+- **State** — Backlog.
 
-The standing rules — issues only in the security project with the priority mapping, no fabricated CVEs / fake JSON, evidence per finding, de-dupe before creating, silence when no new findings — come from your workspace's policies.
+## Standing rules
 
-End of comment (if you wrote one): `[GitHub SDLC daily-audit:security-officer]`
+- **No fabricated CVEs.** If the JSON wasn't attached or didn't
+  parse, file zero tickets — don't invent findings.
+- **Evidence per finding.** Every ticket cites the manifest path
+  and the advisory link.
+- **De-dupe.** Before creating, list open tickets in the Security
+  project and skip vulnerabilities that already have a ticket open
+  (match on package + CVE, not title).
+- **Silence when nothing's new.** Clean Snyk run = no tickets.
+- **Stay in the Security project.** Don't cross-file into Tech
+  Debt or QA Debt.

--- a/backend/app/resources/agent_roles/tech-reviewer.md
+++ b/backend/app/resources/agent_roles/tech-reviewer.md
@@ -2,28 +2,73 @@
 name: Tech reviewer
 ---
 
-# Role: Tech reviewer (daily audit) — `{{ISSUE}}`
+# Role: Tech reviewer (daily audit)
 
 {{BASE}}
 
-## Context
+You audit the **repository** for tech-debt and architectural risk
+once per day. Findings go to a dedicated Linear project named
+**"Tech Debt"** so the operator can sweep the backlog in one place
+without it polluting the active SDLC pipeline.
 
-This is **not** an SDLC ticket: no anchor (`NONE`). You analyze the **repository** (checkout on the agent branch).
+## Where findings go
 
-## Target Linear project
+Resolve the tech-debt project once per run, before filing any
+ticket:
 
-- **Project ID:** `{{TECH_DEBT_PROJECT_ID}}`
-- **Name:** {{TECH_DEBT_PROJECT_NAME}}
-- **Team:** `{{LINEAR_TEAM_KEY}}`
+```
+find_or_create_project_by_name(
+    name="Tech Debt",
+    body="Holding pen for tech-debt findings filed by the daily tech-reviewer routine. Operator works through these as bandwidth allows; nothing here is an active SDLC item until promoted.",
+)
+```
 
-Create new cards **only** in this project, status **Backlog**, when the rules below are satisfied.
+The tool returns `{ id, created, ... }`. Use that `id` as the
+`project_id` argument when you call `create_ticket`. The first run
+in a fresh workspace creates the project; every subsequent run
+reuses it (case-insensitive name match, idempotent on repeat).
 
-## Task
+## What counts as a finding
 
-From code and configs find **real** tech debt or architectural risk: duplication, layer-boundary violations, outdated patterns, risky architectural dependencies, unclear modules, "god" files — always with a path reference (`website/...`, `tools/...`) and brief factual evidence (structure, imports, size, coupling).
+Real, evidence-backed tech debt or architectural risk:
 
-For each finding, create one issue in project `{{TECH_DEBT_PROJECT_ID}}`, status **Backlog**. Specific title, description: context, file paths, why it matters, suggested direction. Labels: `source:tech-reviewer`, `audit:auto`, plus `improvement` or `tech-debt` if they exist for the team.
+- Duplication across modules (cite paths).
+- Layer-boundary violations (a low-level layer reaching up).
+- Outdated patterns the rest of the codebase has moved past.
+- Risky architectural dependencies (cycles, fan-in hot spots).
+- Unclear modules ("god" files, mixed responsibilities).
+- Configuration drift, dead code paths.
 
-The standing rules — evidence per finding, de-dupe before creating, silence when no new verifiable findings, tech-debt findings only in the tech-debt project — come from your workspace's policies.
+Every finding **must** carry a path reference (`backend/...`,
+`console/...`) and brief factual evidence (structure, imports,
+size, coupling). No path = no finding.
 
-End of any Linear comment (if you wrote one): `[GitHub SDLC daily-audit:tech-reviewer]`
+## Filing a ticket
+
+For each finding, call `create_ticket(project_id=<from above>, ...)`
+with:
+
+- **Title** — specific (`backend/app/services/agent: 2.4k-line
+  module mixing tracker, intake, knowledge`), not vague (`Refactor
+  agent service`).
+- **Body** — context, file paths, why it matters now, suggested
+  direction. Keep the body short enough that the operator can read
+  it in one sitting.
+- **Labels** — `source:tech-reviewer`, `audit:auto`, plus
+  `tech-debt` if the team uses it.
+- **State** — Backlog (the default for a fresh ticket).
+
+## Standing rules
+
+- **Evidence per finding.** No path or brief structural evidence →
+  drop the finding.
+- **De-dupe.** Before creating, list open tickets in the Tech Debt
+  project and skip findings that already have a ticket open. Update
+  the existing ticket's body if you have new evidence; don't open
+  a duplicate.
+- **Silence when nothing's new.** A clean day means zero tickets.
+  The routine ran and found no new debt — that's a valid outcome,
+  no comment, no inbox letter.
+- **Stay in the Tech Debt project.** QA gaps go to the QA reviewer's
+  project; security findings to the Security project. Don't cross
+  streams.

--- a/backend/app/services/agent/tools.py
+++ b/backend/app/services/agent/tools.py
@@ -640,6 +640,122 @@ class ToolBox:
                 },
             ),
             ToolSpec(
+                name="find_or_create_project_by_name",
+                description=(
+                    "Idempotent project-by-name lookup. Returns an "
+                    "existing project whose name matches ``name`` "
+                    "(case-insensitive exact match), or creates a new "
+                    "one with the given ``body`` and returns its id. "
+                    "Use this for reviewer-style routing — tech-debt "
+                    "findings → ``Tech Debt`` project, qa findings → "
+                    "``QA Debt`` project, security findings → "
+                    "``Security`` project — without a race condition "
+                    "between ``list_projects`` and ``create_project``. "
+                    "The returned ``created`` flag tells you which "
+                    "branch fired."
+                ),
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": (
+                                "Project name to find or create (case-"
+                                "insensitive exact match against the "
+                                "tracker's existing projects)."
+                            ),
+                        },
+                        "body": {
+                            "type": "string",
+                            "description": (
+                                "Markdown body for the new project (used "
+                                "only when no existing project matches). "
+                                "Should explain the project's purpose so "
+                                "future tickets pull context from it — "
+                                "e.g. ``Holding pen for tech-debt "
+                                "findings filed by the daily tech-"
+                                "reviewer routine.``"
+                            ),
+                        },
+                        "description": {
+                            "type": "string",
+                            "description": (
+                                "Optional one-line blurb (Linear caps at "
+                                "240 chars). Used only on create."
+                            ),
+                        },
+                    },
+                    "required": ["name", "body"],
+                    "additionalProperties": False,
+                },
+            ),
+            ToolSpec(
+                name="inbox_create",
+                description=(
+                    "Drop a new item in the operator's inbox. The inbox "
+                    "is a mailbox-style read surface — supporting "
+                    "routines (daily-retro, learning-capture, "
+                    "process-reviewer) file ``type=report`` items with a "
+                    "full markdown body the operator reads like a "
+                    "letter; agentic actions that need a yes/no go "
+                    "through the typed surface (clarification, "
+                    "approval, improvement). Use ``type=report`` when "
+                    "the only action the operator should take is "
+                    "reading and acknowledging."
+                ),
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "enum": [
+                                "report",
+                                "improvement",
+                                "approval",
+                                "exception",
+                            ],
+                            "description": (
+                                "Inbox item type. ``report`` for read-"
+                                "only digests (daily/retro/process-"
+                                "review). ``improvement`` for "
+                                "actionable suggestions. ``approval`` "
+                                "for gated decisions. ``exception`` "
+                                "for policy edge cases."
+                            ),
+                        },
+                        "title": {
+                            "type": "string",
+                            "description": (
+                                "One-line subject (≤300 chars). Like "
+                                "an email subject — operator scans "
+                                "this in the list view."
+                            ),
+                        },
+                        "body": {
+                            "type": "string",
+                            "description": (
+                                "Markdown body. Rendered as the letter "
+                                "content in the preview pane. For "
+                                "reports: digest sections, links, "
+                                "evidence. For approvals: what's being "
+                                "approved + rationale."
+                            ),
+                        },
+                        "summary": {
+                            "type": "string",
+                            "description": (
+                                "Optional short blurb shown next to "
+                                "the title in the list view (≤2KB). "
+                                "Falls back to the first 200 chars of "
+                                "``body`` when omitted."
+                            ),
+                        },
+                    },
+                    "required": ["type", "title", "body"],
+                    "additionalProperties": False,
+                },
+            ),
+            ToolSpec(
                 name="append_project_description",
                 description=(
                     "Append markdown to an existing project's body. Use "
@@ -2257,6 +2373,8 @@ class ToolBox:
             "list_projects": self._tool_list_projects,
             "get_project": self._tool_get_project,
             "create_project": self._tool_create_project,
+            "find_or_create_project_by_name": self._tool_find_or_create_project_by_name,
+            "inbox_create": self._tool_inbox_create,
             "append_project_description": self._tool_append_project_description,
             "list_recent_activity": self._tool_list_recent_activity,
             "get_pull_request": self._tool_get_pull_request,
@@ -2884,6 +3002,107 @@ class ToolBox:
             )
         )
         await self._session.flush()
+
+    async def _tool_find_or_create_project_by_name(
+        self, args: dict[str, Any]
+    ) -> str:
+        name = _require_str(args, "name")
+        body = _require_str(args, "body")
+        description = args.get("description")
+        if description is not None and not isinstance(description, str):
+            raise ToolInvocationError("description must be a string")
+
+        tracker = await self._resolve_tracker(None, None)
+        try:
+            existing = await tracker.list_projects(limit=100)
+        except NotImplementedError as exc:
+            raise ToolInvocationError(str(exc)) from exc
+        except ValueError as exc:
+            raise ToolInvocationError(str(exc)) from exc
+
+        wanted = name.strip().casefold()
+        for project in existing:
+            project_name = project.get("name") or ""
+            if isinstance(project_name, str) and project_name.casefold() == wanted:
+                return _json_result({**dict(project), "created": False})
+
+        try:
+            created = await tracker.create_project(
+                name=name, body=body, description=description
+            )
+        except NotImplementedError as exc:
+            raise ToolInvocationError(str(exc)) from exc
+        except ValueError as exc:
+            raise ToolInvocationError(str(exc)) from exc
+
+        project_native_id = str(created.get("id") or "")
+        if project_native_id:
+            await self._ensure_drafts_priorities_row(
+                project_native_id=project_native_id
+            )
+
+        return _json_result({**dict(created), "created": True})
+
+    async def _tool_inbox_create(self, args: dict[str, Any]) -> str:
+        type_ = _require_str(args, "type")
+        if type_ not in {"report", "improvement", "approval", "exception"}:
+            raise ToolInvocationError(
+                "type must be one of report | improvement | approval | exception"
+            )
+        title = _require_str(args, "title")
+        body = _require_str(args, "body")
+        summary = args.get("summary")
+        if summary is not None and not isinstance(summary, str):
+            raise ToolInvocationError("summary must be a string")
+
+        title_clean = title.strip()
+        if not title_clean:
+            raise ToolInvocationError("title must not be blank")
+        body_clean = body.strip()
+        if not body_clean:
+            raise ToolInvocationError("body must not be blank")
+
+        from backend.app.services.inbox.intake import (
+            _SUMMARY_MAX_LEN,
+            _TITLE_MAX_LEN,
+            _truncate,
+        )
+
+        if summary is None:
+            summary_text = body_clean[:200]
+        else:
+            summary_text = summary
+
+        item = InboxItem(
+            workspace_id=self._workspace_id,
+            repo_id=self._active_repo_id,
+            type=type_,
+            title=_truncate(title_clean, _TITLE_MAX_LEN),
+            summary=_truncate(summary_text, _SUMMARY_MAX_LEN) or None,
+            payload={"body": body_clean, "source": "agent_tool"},
+            status="new",
+        )
+        self._session.add(item)
+        await self._session.flush()
+        self._session.add(
+            InboxItemEvent(
+                item_id=item.id,
+                actor_user_id=None,
+                actor_kind="agent",
+                action="created",
+                payload={"via": "inbox_create"},
+            )
+        )
+        await self._session.flush()
+
+        return _json_result(
+            {
+                "id": str(item.id),
+                "type": item.type,
+                "status": item.status,
+                "title": item.title,
+            }
+        )
 
     async def _tool_append_project_description(self, args: dict[str, Any]) -> str:
         project_id = _require_str(args, "project_id")

--- a/backend/app/services/inbox/profiles.py
+++ b/backend/app/services/inbox/profiles.py
@@ -46,6 +46,13 @@ INBOX_TYPES: tuple[str, ...] = (
     "stuck",
     # Self-heal lane failed — only minted from pipeline result callback.
     "blocker",
+    # Read-only digest from supporting routines (daily / retro /
+    # process-review). Operator opens it like a letter, reads the
+    # markdown body, and the only action is "Acknowledge" — no
+    # branching, no quick-reply, no follow-up tracker work. The
+    # mailbox-style inbox UI keys off this type to render the body
+    # full-width with no buttons besides Acknowledge.
+    "report",
 )
 
 # Meta-keys that may appear inside a profile body but are NOT inbox

--- a/backend/app/services/lane_recipes.py
+++ b/backend/app/services/lane_recipes.py
@@ -63,13 +63,13 @@ DEFAULT_BUNDLE: tuple[str, ...] = (
 )
 
 DEFAULT_BUNDLE_REASONS: dict[str, str] = {
-    "daily-retro": "Posts a morning summary of what shipped in the last 24 hours.",
-    "learning-capture": "Closes the day with a retro that turns recent runs into improvement notes.",
+    "daily-retro": "Files a morning digest letter in the operator's inbox — read it, hit Acknowledge.",
+    "learning-capture": "End-of-day digest of patterns worth remembering, filed as an inbox letter.",
     "workflow-self-heal": "Watches Ship workflows; opens a fix ticket or pings a human when something breaks.",
-    "tech-reviewer": "Sweeps the repo daily for tech-debt and architectural risk; files dedup tickets.",
-    "qa-reviewer": "Sweeps the repo daily for test-coverage gaps; files dedup tickets.",
-    "security-officer": "Runs the daily security review and routes actionable findings.",
-    "process-reviewer": "Suggests SDLC improvements (PR previews, CI health, branch hygiene) to the inbox.",
+    "tech-reviewer": "Sweeps the repo daily for tech-debt findings; files dedup tickets in the Tech Debt project.",
+    "qa-reviewer": "Sweeps the repo daily for test-coverage gaps; files dedup tickets in the QA Debt project.",
+    "security-officer": "Runs the daily security review; files dedup tickets in the Security project.",
+    "process-reviewer": "SDLC improvement recommendations land as inbox letters — operator decisions, not work items.",
     "intake": "Shapes new work into a structured ticket before BA picks it up.",
     "bug-triage": "Structures bug reports into reproducible tickets before BA writes the fix spec.",
     "ba": "Writes the implementation-grade specification on top of intake.",

--- a/backend/app/services/seed_bundle.py
+++ b/backend/app/services/seed_bundle.py
@@ -144,7 +144,7 @@ from backend.app.services.tracker_fsm import (
 #         the seed PR merged. The ``shipctl init`` / ``sync`` /
 #         ``--copy-rules`` flow + the ``/collections`` + ``/fetch``
 #         endpoints are gone in this bundle.
-BUNDLE_VERSION: str = "0.22"
+BUNDLE_VERSION: str = "0.23"
 
 # Default knowledge starters for PR 1. Empty by design: generated knowledge is
 # analyzed post-merge and proposed in a second PR. Historical callers can still

--- a/backend/tests/test_agent_tools_inbox_and_routing.py
+++ b/backend/tests/test_agent_tools_inbox_and_routing.py
@@ -1,0 +1,289 @@
+"""Tests for ``inbox_create`` + ``find_or_create_project_by_name``.
+
+These tools back the reviewer-routing and report-routing redesign:
+
+- ``inbox_create`` — supporting routines (daily-retro, learning-capture,
+  process-reviewer) write a typed letter into the operator's mailbox
+  instead of touching the repo or filing Linear noise.
+- ``find_or_create_project_by_name`` — reviewers (tech / qa / security)
+  funnel findings into a dedicated project per kind, idempotent on name
+  so re-runs accumulate tickets in the same Linear project rather than
+  spawning a fresh one each day.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from sqlalchemy import select
+
+
+class _StubProjectsTracker:
+    """Captures list/create calls and lets tests pre-seed projects."""
+
+    kind = "linear"
+
+    def __init__(self, *, projects: list[dict[str, Any]] | None = None) -> None:
+        self.projects: list[dict[str, Any]] = list(projects or [])
+        self.list_calls: list[dict[str, Any]] = []
+        self.create_calls: list[dict[str, Any]] = []
+
+    async def list_projects(
+        self,
+        *,
+        limit: int = 50,
+        state: str | None = None,
+        query: str | None = None,
+    ) -> list[dict[str, Any]]:
+        self.list_calls.append(
+            {"limit": limit, "state": state, "query": query}
+        )
+        return list(self.projects)
+
+    async def create_project(
+        self,
+        *,
+        name: str,
+        body: str,
+        description: str | None = None,
+    ) -> dict[str, Any]:
+        self.create_calls.append(
+            {"name": name, "body": body, "description": description}
+        )
+        new = {
+            "id": f"proj-{len(self.create_calls)}",
+            "name": name,
+            "url": f"https://linear.app/elship/project/{name.lower()}",
+            "slug": name.lower().replace(" ", "-"),
+        }
+        self.projects.append(new)
+        return new
+
+    # The create-project tool helper probes for an anchor; this tracker
+    # doesn't model anchors, so the helper degrades to a no-op on
+    # NotImplementedError — but ``find_or_create_project_by_name``
+    # doesn't even call the anchor helper, so the stub doesn't need to
+    # implement it.
+
+
+def _toolbox(db_session, workspace, user):
+    from backend.app.core.config import get_settings
+    from backend.app.services.agent.tools import ToolBox
+
+    return ToolBox(
+        db_session,
+        settings=get_settings(),
+        workspace_id=workspace.id,
+        user_id=user.id,
+    )
+
+
+def _patch_tracker(toolbox, monkeypatch, stub: _StubProjectsTracker) -> None:
+    async def _stub_resolve(_self, _kind, _hint):
+        return stub
+
+    monkeypatch.setattr(
+        type(toolbox), "_resolve_tracker", _stub_resolve, raising=True
+    )
+
+
+# ---------------------------------------------------------------------------
+# find_or_create_project_by_name
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_find_or_create_returns_existing_match_case_insensitive(
+    db_session, seed_workspace, monkeypatch
+) -> None:
+    user, _, workspace = seed_workspace
+    toolbox = _toolbox(db_session, workspace, user)
+    stub = _StubProjectsTracker(
+        projects=[
+            {"id": "p-tech", "name": "Tech Debt", "url": "u/1"},
+            {"id": "p-qa", "name": "QA Debt", "url": "u/2"},
+        ]
+    )
+    _patch_tracker(toolbox, monkeypatch, stub)
+
+    out = await toolbox._tool_find_or_create_project_by_name(
+        {
+            "name": "tech debt",
+            "body": "Holding pen for tech-debt findings.",
+        }
+    )
+    payload = json.loads(out)
+    assert payload["id"] == "p-tech"
+    assert payload["created"] is False
+    # MUST NOT have hit create.
+    assert stub.create_calls == []
+
+
+@pytest.mark.asyncio
+async def test_find_or_create_makes_new_project_when_missing(
+    db_session, seed_workspace, monkeypatch
+) -> None:
+    from backend.app.db.models.dashboard_priorities import (
+        WorkspaceProjectPriority,
+    )
+
+    user, _, workspace = seed_workspace
+    toolbox = _toolbox(db_session, workspace, user)
+    stub = _StubProjectsTracker(projects=[])
+    _patch_tracker(toolbox, monkeypatch, stub)
+
+    out = await toolbox._tool_find_or_create_project_by_name(
+        {
+            "name": "Security",
+            "body": "Daily security-officer findings land here.",
+            "description": "Security findings (auto-routed).",
+        }
+    )
+    payload = json.loads(out)
+    assert payload["created"] is True
+    assert payload["name"] == "Security"
+    assert len(stub.create_calls) == 1
+    assert stub.create_calls[0]["name"] == "Security"
+    assert stub.create_calls[0]["description"] == "Security findings (auto-routed)."
+
+    # Drafts row must be inserted so the freshly minted project shows up
+    # on the dashboard immediately, same as plain ``create_project``.
+    rows = (
+        await db_session.execute(
+            select(WorkspaceProjectPriority).where(
+                WorkspaceProjectPriority.workspace_id == workspace.id
+            )
+        )
+    ).scalars().all()
+    assert [r.project_native_id for r in rows] == [payload["id"]]
+    assert rows[0].state == "planning"
+
+
+@pytest.mark.asyncio
+async def test_find_or_create_idempotent_on_repeat_call(
+    db_session, seed_workspace, monkeypatch
+) -> None:
+    """Calling twice with the same name must not double-create — the second
+    call sees the freshly minted project in ``list_projects`` and short-
+    circuits."""
+    user, _, workspace = seed_workspace
+    toolbox = _toolbox(db_session, workspace, user)
+    stub = _StubProjectsTracker(projects=[])
+    _patch_tracker(toolbox, monkeypatch, stub)
+
+    first = json.loads(
+        await toolbox._tool_find_or_create_project_by_name(
+            {"name": "Tech Debt", "body": "Body."}
+        )
+    )
+    second = json.loads(
+        await toolbox._tool_find_or_create_project_by_name(
+            {"name": "Tech Debt", "body": "Body."}
+        )
+    )
+    assert first["created"] is True
+    assert second["created"] is False
+    assert second["id"] == first["id"]
+    assert len(stub.create_calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# inbox_create
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_inbox_create_writes_report_item_with_body_in_payload(
+    db_session, seed_workspace
+) -> None:
+    from backend.app.db.models.inbox import InboxItem, InboxItemEvent
+
+    user, _, workspace = seed_workspace
+    toolbox = _toolbox(db_session, workspace, user)
+
+    out = await toolbox._tool_inbox_create(
+        {
+            "type": "report",
+            "title": "Daily summary 2026-05-06",
+            "body": "## Shipped\n- ELS-72\n- ELS-79\n\n## Open\n- ELS-80",
+        }
+    )
+    payload = json.loads(out)
+    assert payload["type"] == "report"
+    assert payload["status"] == "new"
+
+    rows = (
+        await db_session.execute(
+            select(InboxItem).where(
+                InboxItem.workspace_id == workspace.id
+            )
+        )
+    ).scalars().all()
+    assert len(rows) == 1
+    item = rows[0]
+    assert item.type == "report"
+    assert item.title == "Daily summary 2026-05-06"
+    assert item.payload["body"].startswith("## Shipped")
+    assert item.payload["source"] == "agent_tool"
+    # Summary auto-derived from body when not provided.
+    assert item.summary is not None
+    assert item.summary.startswith("## Shipped")
+
+    events = (
+        await db_session.execute(
+            select(InboxItemEvent).where(InboxItemEvent.item_id == item.id)
+        )
+    ).scalars().all()
+    assert len(events) == 1
+    assert events[0].action == "created"
+    assert events[0].actor_kind == "agent"
+
+
+@pytest.mark.asyncio
+async def test_inbox_create_rejects_unknown_type(
+    db_session, seed_workspace
+) -> None:
+    from backend.app.services.agent.tools import ToolInvocationError
+
+    user, _, workspace = seed_workspace
+    toolbox = _toolbox(db_session, workspace, user)
+
+    with pytest.raises(ToolInvocationError):
+        await toolbox._tool_inbox_create(
+            {
+                "type": "failure",  # not in the agent-allowed enum
+                "title": "x",
+                "body": "y",
+            }
+        )
+
+
+@pytest.mark.asyncio
+async def test_inbox_create_explicit_summary_wins_over_body_prefix(
+    db_session, seed_workspace
+) -> None:
+    from backend.app.db.models.inbox import InboxItem
+
+    user, _, workspace = seed_workspace
+    toolbox = _toolbox(db_session, workspace, user)
+
+    await toolbox._tool_inbox_create(
+        {
+            "type": "report",
+            "title": "Retro",
+            "summary": "3 wins, 1 blocker",
+            "body": "Long markdown body here…" * 50,
+        }
+    )
+
+    item = (
+        await db_session.execute(
+            select(InboxItem).where(
+                InboxItem.workspace_id == workspace.id
+            )
+        )
+    ).scalar_one()
+    assert item.summary == "3 wins, 1 blocker"
+    assert item.payload["body"].startswith("Long markdown body")

--- a/console/src/app/(authed)/inbox/[id]/page.tsx
+++ b/console/src/app/(authed)/inbox/[id]/page.tsx
@@ -166,6 +166,14 @@ const DISPOSITION_BY_TYPE: Record<
       },
     ],
   },
+  report: {
+    // ``report`` is the read-only digest type (daily / retro / process
+    // review). The only operator action is mark-read; ``resolve``
+    // writes resolution=acknowledged via the open-ended path. No
+    // dismiss — there's nothing to refuse, just letters to read.
+    primary: { action: "resolve", label: "Acknowledge", style: "primary" },
+    secondary: [],
+  },
 };
 
 // ---------------------------------------------------------------------------

--- a/console/src/app/(authed)/inbox/page.tsx
+++ b/console/src/app/(authed)/inbox/page.tsx
@@ -1,15 +1,16 @@
 /**
- * Unified Inbox list page.
+ * Inbox — mailbox layout.
  *
- * Editorial layout: a typographic stats ribbon (mine · unassigned ·
- * all open) replaces the segmented control; type chips sit on a
- * single line with no bordered container; items group into three
- * triage tiers (Tier 1 — needs you, Tier 2 — autonomy escapes,
- * Tier 3 — later) with section kickers and a hairline rule.
+ * Outlook-style split pane: list on the left, preview on the right.
+ * URL drives selection (``?selected=<id>``); the preview pane
+ * server-fetches that item's full detail and renders the body plus a
+ * type-aware footer (acknowledge / quick-reply / decision buttons).
  *
- * Per design rec we drop the bordered Filters card, the
- * "X items" header, and the per-row card chrome. Per-row colour
- * lives on a left-edge spine inside ``InboxItemRow``.
+ * The earlier tier-sectioned editorial layout was simplified per
+ * operator feedback: less chrome, fewer cards, "I just want to read
+ * letters and click answer." Deep-link ``/inbox/[id]`` still renders
+ * the bigger detail surface (events timeline, snooze controls,
+ * reassign) for power-user flows.
  */
 
 import Link from "next/link";
@@ -17,13 +18,13 @@ import { redirect } from "next/navigation";
 
 import { ApiUnavailable } from "@/components/api-unavailable";
 import { PageBody, PageHeader } from "@/components/app-shell";
-import { InboxFiltersControlled } from "@/components/inbox/inbox-filters-controlled";
-import { InboxItemRow } from "@/components/inbox/inbox-item-row";
-import { buildInboxUrl, countActiveFilters } from "@/components/inbox/inbox-url";
-import { EmptyState } from "@/components/ui";
+import { MailboxFooter } from "@/components/inbox/mailbox-footer";
+import { StaleBadge } from "@/components/inbox/stale-badge";
+import { MarkdownBlock } from "@/components/markdown-block";
 import { cn } from "@/lib/cn";
 import {
   ApiHttpError,
+  getInboxItem,
   listInboxItems,
 } from "@/lib/api/client";
 import {
@@ -32,39 +33,24 @@ import {
 } from "@/lib/api/session-cache.server";
 import { getResolvedWorkspaceId } from "@/lib/workspace-resolve.server";
 import {
-  DEFAULT_INBOX_FILTERS,
   INBOX_LIST_DEFAULT_STATUSES,
-  INBOX_TIER_LABEL,
-  INBOX_TYPES,
-  inboxTier,
-  isInboxType,
-  type InboxFilterState,
+  INBOX_TYPE_META,
   type InboxItem,
+  type InboxItemDetail,
   type InboxListResponse,
-  type InboxTier,
   type InboxType,
 } from "@/lib/inbox-types";
-import {
-  pickWorkspace,
-  withWorkspaceQuery,
-} from "@/lib/workspace-scope";
+import { pickWorkspace, withWorkspaceQuery } from "@/lib/workspace-scope";
 
 export const dynamic = "force-dynamic";
 
-const PAGE_LIMIT = 25;
-const TIERS: InboxTier[] = [1, 2, 3];
+const PAGE_LIMIT = 50;
 
-const TIER_KICKER_TONE: Record<InboxTier, string> = {
-  1: "text-sun/80",
-  2: "text-coral/80",
-  3: "text-white/40",
-};
+type Ownership = "mine" | "unassigned" | "all";
 
 type ParsedParams = {
-  filters: InboxFilterState;
-  cursor: string | null;
-  repo: string | null;
-  play: string | null;
+  ownership: Ownership;
+  selectedId: string | null;
   errorCode: string | null;
 };
 
@@ -74,27 +60,27 @@ type Mode =
       workspaceId: string;
       multiWs: boolean;
       list: InboxListResponse;
-      filters: InboxFilterState;
-      cursor: string | null;
-      repo: string | null;
-      play: string | null;
+      detail: InboxItemDetail | null;
+      detailError: string | null;
+      ownership: Ownership;
+      selectedId: string | null;
     }
   | { source: "down"; reason: string };
 
 function errorMessage(code: string): string {
   switch (code) {
     case "forbidden":
-      return "You don't have permission to act on that inbox item.";
+      return "You don't have permission to act on that item.";
     case "not_found":
-      return "That inbox item is gone — it may have been resolved in another tab.";
-    case "bad_input":
-      return "The action couldn't be applied — required fields were missing.";
-    case "stale":
-      return "Item changed since you opened it. Refresh and try again.";
+      return "That item is gone — it may have been resolved in another tab.";
+    case "validation_failed":
+      return "Reply was empty — write something before sending.";
+    case "state_invalid":
+      return "Item state changed since you opened it. Refresh and try again.";
     case "api_unavailable":
       return "Backend is unreachable. Try again in a moment.";
     default:
-      return `Couldn't apply the change (${code}). Try again or refresh.`;
+      return `Couldn't apply the change (${code}).`;
   }
 }
 
@@ -102,38 +88,18 @@ function parseSearchParams(
   raw: Record<string, string | string[] | undefined>,
 ): ParsedParams {
   const ownershipRaw = typeof raw.ownership === "string" ? raw.ownership : null;
-  const ownership: InboxFilterState["ownership"] =
+  const ownership: Ownership =
     ownershipRaw === "mine" ||
     ownershipRaw === "unassigned" ||
     ownershipRaw === "all"
       ? ownershipRaw
-      : DEFAULT_INBOX_FILTERS.ownership;
+      : "all";
 
-  const typeRaw = raw.type;
-  const typeArr = Array.isArray(typeRaw)
-    ? typeRaw
-    : typeof typeRaw === "string"
-      ? [typeRaw]
-      : [];
-  const types = typeArr.filter(
-    (v): v is InboxType => typeof v === "string" && isInboxType(v),
-  );
-
-  const cursorRaw = typeof raw.cursor === "string" ? raw.cursor : null;
-  const cursor = cursorRaw && cursorRaw.length > 0 ? cursorRaw : null;
-  const repoRaw = typeof raw.repo === "string" ? raw.repo : null;
-  const repo = repoRaw && repoRaw.length > 0 ? repoRaw : null;
-  const playRaw = typeof raw.play === "string" ? raw.play : null;
-  const play = playRaw && playRaw.length > 0 ? playRaw : null;
+  const selectedRaw = typeof raw.selected === "string" ? raw.selected : null;
+  const selectedId = selectedRaw && selectedRaw.length > 0 ? selectedRaw : null;
   const errorCode = typeof raw.error === "string" ? raw.error : null;
 
-  return {
-    filters: { ownership, types },
-    cursor,
-    repo,
-    play,
-    errorCode,
-  };
+  return { ownership, selectedId, errorCode };
 }
 
 async function load(
@@ -149,30 +115,17 @@ async function load(
   const resolved = await getResolvedWorkspaceId(searchParams, ws);
   const workspace = pickWorkspace(ws, resolved);
 
+  let list: InboxListResponse;
   try {
-    const list = await listInboxItems(
+    list = await listInboxItems(
       workspace.id,
       {
-        ownership: parsed.filters.ownership,
-        types: parsed.filters.types,
+        ownership: parsed.ownership,
         statuses: INBOX_LIST_DEFAULT_STATUSES,
-        repo_id: parsed.repo ?? undefined,
-        play_key: parsed.play ?? undefined,
-        cursor: parsed.cursor,
         limit: PAGE_LIMIT,
       },
       token,
     );
-    return {
-      source: "live",
-      workspaceId: workspace.id,
-      multiWs: ws.length > 1,
-      list,
-      filters: parsed.filters,
-      cursor: parsed.cursor,
-      repo: parsed.repo,
-      play: parsed.play,
-    };
   } catch (err) {
     if (err instanceof ApiHttpError && err.status === 401) {
       redirect("/login?next=%2Finbox&reason=session_expired");
@@ -182,35 +135,39 @@ async function load(
       reason: err instanceof Error ? err.message : "Could not load inbox items.",
     };
   }
-}
 
-function pickTypeCounts(
-  raw: Record<string, number>,
-): Partial<Record<InboxType, number>> {
-  const out: Partial<Record<InboxType, number>> = {};
-  for (const t of INBOX_TYPES) {
-    if (typeof raw[t] === "number") out[t] = raw[t];
+  // If nothing is explicitly selected but the list is non-empty, auto-
+  // select the first row so the right pane is never blank when there's
+  // a letter ready to read. The operator can always click another row.
+  const effectiveSelected =
+    parsed.selectedId ?? (list.items[0]?.id ?? null);
+
+  let detail: InboxItemDetail | null = null;
+  let detailError: string | null = null;
+  if (effectiveSelected) {
+    try {
+      detail = await getInboxItem(workspace.id, effectiveSelected, token);
+    } catch (err) {
+      detailError =
+        err instanceof ApiHttpError && err.status === 404
+          ? "not_found"
+          : "load_failed";
+    }
   }
-  return out;
+
+  return {
+    source: "live",
+    workspaceId: workspace.id,
+    multiWs: ws.length > 1,
+    list,
+    detail,
+    detailError,
+    ownership: parsed.ownership,
+    selectedId: effectiveSelected,
+  };
 }
 
-function sumInboxTypeCounts(
-  c: Partial<Record<InboxType, number>>,
-): number {
-  let n = 0;
-  for (const t of INBOX_TYPES) n += c[t] ?? 0;
-  return n;
-}
-
-function partitionByTier(items: InboxItem[]): Record<InboxTier, InboxItem[]> {
-  const out: Record<InboxTier, InboxItem[]> = { 1: [], 2: [], 3: [] };
-  for (const item of items) {
-    out[inboxTier(item.type)].push(item);
-  }
-  return out;
-}
-
-export default async function InboxPage({
+export default async function InboxMailboxPage({
   searchParams,
 }: {
   searchParams?: Promise<Record<string, string | string[] | undefined>>;
@@ -228,9 +185,9 @@ export default async function InboxPage({
         <PageHeader kicker="attention" title="Inbox" />
         <PageBody>
           {parsed.errorCode && (
-            <div className="mb-5 text-xs text-coral/95">
+            <p className="mb-5 text-xs text-coral/95">
               {errorMessage(parsed.errorCode)}
-            </div>
+            </p>
           )}
           <ApiUnavailable scope="inbox" details={data.reason} />
         </PageBody>
@@ -238,108 +195,34 @@ export default async function InboxPage({
     );
   }
 
-  const { workspaceId, multiWs, list, filters, cursor, repo, play } = data;
-  const typeCounts = pickTypeCounts(list.counts_by_type);
-  const allTypesCount = sumInboxTypeCounts(typeCounts);
-  const activeFilterCount = countActiveFilters(filters, { repo, play });
-  const inboxWs = multiWs ? workspaceId : undefined;
-  const tiers = partitionByTier(list.items);
+  const { workspaceId, multiWs, list, detail, detailError, ownership, selectedId } =
+    data;
+  const wsScope = multiWs ? workspaceId : undefined;
 
   return (
     <>
-      <PageHeader
-        kicker="attention"
-        title="Inbox"
-        actions={
-          <RefreshButton
-            filters={filters}
-            repo={repo}
-            play={play}
-            cursor={cursor}
-            workspaceScope={inboxWs}
-          />
-        }
-      />
+      <PageHeader kicker="attention" title="Inbox" />
       <PageBody>
-        <div className="mx-auto max-w-5xl space-y-8">
-          {parsed.errorCode && (
-            <p className="text-xs text-coral/95">
-              {errorMessage(parsed.errorCode)}
-            </p>
-          )}
+        {parsed.errorCode && (
+          <p className="mb-4 text-xs text-coral/95">
+            {errorMessage(parsed.errorCode)}
+          </p>
+        )}
 
-          <OwnershipRibbon
-            current={filters.ownership}
-            filters={filters}
-            repo={repo}
-            play={play}
-            workspaceScope={inboxWs}
+        <div className="grid gap-4 lg:grid-cols-[26rem_minmax(0,1fr)]">
+          <MailboxList
+            items={list.items}
+            ownership={ownership}
+            selectedId={selectedId}
+            workspaceScope={wsScope}
           />
 
-          <InboxFiltersControlled
-            value={filters}
-            counts={{ types: typeCounts, allTypes: allTypesCount }}
-            repo={repo}
-            play={play}
-            workspaceScope={inboxWs}
-          />
-
-          {(repo || play) && (
-            <div className="flex flex-wrap items-center gap-2 text-[11px] text-white/55">
-              {repo && (
-                <span>
-                  scope:{" "}
-                  <code className="font-mono text-white/80">{repo}</code>
-                </span>
-              )}
-              {play && (
-                <span>
-                  play:{" "}
-                  <code className="font-mono text-white/80">{play}</code>
-                </span>
-              )}
-              <a
-                href={buildInboxUrl(filters, { workspaceScope: inboxWs })}
-                className="font-semibold text-sun hover:text-white"
-              >
-                clear scope
-              </a>
-            </div>
-          )}
-
-          {list.items.length === 0 ? (
-            <InboxEmpty
-              filters={filters}
-              activeFilterCount={activeFilterCount}
-              repo={repo}
-              play={play}
-              workspaceScope={inboxWs}
-            />
-          ) : (
-            <div className="space-y-10">
-              {TIERS.map((tier) => {
-                const items = tiers[tier];
-                if (items.length === 0) return null;
-                return (
-                  <TierSection
-                    key={tier}
-                    tier={tier}
-                    items={items}
-                    workspaceId={workspaceId}
-                    workspaceScope={inboxWs}
-                  />
-                );
-              })}
-            </div>
-          )}
-
-          <Pager
-            nextCursor={list.next_cursor}
-            currentCursor={cursor}
-            filters={filters}
-            repo={repo}
-            play={play}
-            workspaceScope={inboxWs}
+          <MailboxPreview
+            detail={detail}
+            detailError={detailError}
+            workspaceId={workspaceId}
+            workspaceScope={wsScope}
+            empty={list.items.length === 0}
           />
         </div>
       </PageBody>
@@ -347,282 +230,297 @@ export default async function InboxPage({
   );
 }
 
-
 // ---------------------------------------------------------------------------
-// Ownership stats ribbon — typographic
-// ---------------------------------------------------------------------------
-
-
-function OwnershipRibbon({
-  current,
-  filters,
-  repo,
-  play,
-  workspaceScope,
-}: {
-  current: InboxFilterState["ownership"];
-  filters: InboxFilterState;
-  repo: string | null;
-  play: string | null;
-  workspaceScope?: string;
-}) {
-  const lenses: { key: InboxFilterState["ownership"]; label: string }[] = [
-    { key: "mine", label: "Mine" },
-    { key: "unassigned", label: "Unassigned" },
-    { key: "all", label: "All open" },
-  ];
-  return (
-    <nav
-      aria-label="Inbox ownership"
-      className="flex flex-wrap items-baseline gap-x-3 gap-y-1 text-sm"
-    >
-      {lenses.map((lens, idx) => {
-        const active = current === lens.key;
-        const href = buildInboxUrl(
-          { ...filters, ownership: lens.key },
-          { repo, play, workspaceScope },
-        );
-        return (
-          <span key={lens.key} className="flex items-baseline">
-            <Link
-              href={href}
-              aria-current={active ? "page" : undefined}
-              className={cn(
-                "transition",
-                active
-                  ? "font-semibold text-white"
-                  : "text-white/45 hover:text-white",
-              )}
-            >
-              {lens.label}
-            </Link>
-            {idx < lenses.length - 1 && (
-              <span className="ml-3 text-white/15">·</span>
-            )}
-          </span>
-        );
-      })}
-    </nav>
-  );
-}
-
-
-// ---------------------------------------------------------------------------
-// Tier section — kicker + divide-y rows
+// Left pane: the list
 // ---------------------------------------------------------------------------
 
-
-function TierSection({
-  tier,
+function MailboxList({
   items,
-  workspaceId,
+  ownership,
+  selectedId,
   workspaceScope,
 }: {
-  tier: InboxTier;
   items: InboxItem[];
-  /** The actual workspace id — always set; passed to row actions so
-   *  POST disposition knows which workspace to act on, regardless of
-   *  whether the user happens to belong to one workspace or many. */
-  workspaceId: string;
-  /** URL-scope override — only set when the user has multiple
-   *  workspaces and we need to disambiguate via ``?ws=…`` on links. */
+  ownership: Ownership;
+  selectedId: string | null;
   workspaceScope?: string;
 }) {
   return (
-    <section>
-      <header className="mb-3 flex items-center gap-3">
-        <h2
-          className={cn(
-            "text-[11px] font-bold uppercase tracking-[0.22em]",
-            TIER_KICKER_TONE[tier],
-          )}
-        >
-          {INBOX_TIER_LABEL[tier]}
-        </h2>
-        <div className="h-px flex-1 bg-white/[0.06]" />
-        <span className="font-mono text-[11px] text-white/35">
-          {items.length}
-        </span>
-      </header>
-      <ul className="divide-y divide-white/[0.06]">
-        {items.map((item) => (
-          <li key={item.id}>
-            <InboxItemRow
-              item={item}
-              workspaceId={workspaceId}
-              href={
-                workspaceScope
-                  ? `/inbox/${item.id}?ws=${encodeURIComponent(workspaceScope)}`
-                  : `/inbox/${item.id}`
-              }
-            />
-          </li>
-        ))}
-      </ul>
-    </section>
-  );
-}
+    <div className="flex min-h-[60vh] flex-col rounded-xl border border-white/[0.08] bg-white/[0.015]">
+      <OwnershipTabs current={ownership} workspaceScope={workspaceScope} />
 
-
-// ---------------------------------------------------------------------------
-// Empty states
-// ---------------------------------------------------------------------------
-
-
-function InboxEmpty({
-  filters,
-  activeFilterCount,
-  repo,
-  play,
-  workspaceScope,
-}: {
-  filters: InboxFilterState;
-  activeFilterCount: number;
-  repo: string | null;
-  play: string | null;
-  workspaceScope?: string;
-}) {
-  if (activeFilterCount > 0) {
-    return (
-      <EmptyState
-        title="No items match these filters"
-        body="Try widening the ownership lens to All, clearing the type chips, or dropping the repo/play scope."
-        action={
-          <Link
-            href={buildInboxUrl(DEFAULT_INBOX_FILTERS, { workspaceScope })}
-            className="text-xs font-semibold text-aqua hover:text-white"
-          >
-            Clear all filters
-          </Link>
-        }
-      />
-    );
-  }
-  if (filters.ownership === "mine") {
-    return (
-      <EmptyState
-        title="Nothing on your plate"
-        body="Either you're caught up or nobody's routing things your way. Switch to All open to see the workspace firehose."
-        action={
-          <a
-            href={buildInboxUrl(
-              { ...filters, ownership: "all" },
-              { repo, play, workspaceScope },
-            )}
-            className="text-xs font-semibold text-white/85 hover:text-white"
-          >
-            Switch to All open
-          </a>
-        }
-      />
-    );
-  }
-  return (
-    <EmptyState
-      title="Inbox empty"
-      body="Either nothing has fired or your team coverage needs attention — check who can answer under Settings → Members."
-      action={
-        <a
-          href={withWorkspaceQuery(
-            "/settings?tab=members",
-            workspaceScope ?? "",
-            Boolean(workspaceScope),
-          )}
-          className="text-xs font-semibold text-aqua hover:text-white"
-        >
-          Open Members
-        </a>
-      }
-    />
-  );
-}
-
-
-// ---------------------------------------------------------------------------
-// Pager + Refresh
-// ---------------------------------------------------------------------------
-
-
-function Pager({
-  nextCursor,
-  currentCursor,
-  filters,
-  repo,
-  play,
-  workspaceScope,
-}: {
-  nextCursor: string | null;
-  currentCursor: string | null;
-  filters: InboxFilterState;
-  repo: string | null;
-  play: string | null;
-  workspaceScope?: string;
-}) {
-  if (!nextCursor && !currentCursor) return null;
-  return (
-    <div className="flex items-center justify-between text-[11px]">
-      {currentCursor ? (
-        <a
-          href={buildInboxUrl(filters, { repo, play, workspaceScope })}
-          className="font-semibold text-white/55 hover:text-white"
-        >
-          ← First page
-        </a>
+      {items.length === 0 ? (
+        <div className="flex-1 px-4 py-10 text-center text-sm text-white/55">
+          {ownership === "mine"
+            ? "Nothing on your plate."
+            : "Inbox empty."}
+        </div>
       ) : (
-        <span />
-      )}
-      {nextCursor && (
-        <a
-          href={buildInboxUrl(filters, {
-            repo,
-            play,
-            cursor: nextCursor,
-            workspaceScope,
-          })}
-          className="font-semibold text-white/55 hover:text-white"
-        >
-          Load older →
-        </a>
+        <ul className="divide-y divide-white/[0.06] overflow-y-auto">
+          {items.map((item) => (
+            <li key={item.id}>
+              <MailboxRow
+                item={item}
+                selected={item.id === selectedId}
+                ownership={ownership}
+                workspaceScope={workspaceScope}
+              />
+            </li>
+          ))}
+        </ul>
       )}
     </div>
   );
 }
 
-
-function RefreshButton({
-  filters,
-  repo,
-  play,
-  cursor,
+function buildSelectHref({
+  id,
+  ownership,
   workspaceScope,
 }: {
-  filters: InboxFilterState;
-  repo: string | null;
-  play: string | null;
-  cursor: string | null;
+  id: string;
+  ownership: Ownership;
+  workspaceScope?: string;
+}): string {
+  const params = new URLSearchParams();
+  params.set("selected", id);
+  if (ownership !== "all") params.set("ownership", ownership);
+  if (workspaceScope) params.set("ws", workspaceScope);
+  const qs = params.toString();
+  return qs ? `/inbox?${qs}` : "/inbox";
+}
+
+function buildOwnershipHref({
+  ownership,
+  workspaceScope,
+}: {
+  ownership: Ownership;
+  workspaceScope?: string;
+}): string {
+  const params = new URLSearchParams();
+  if (ownership !== "all") params.set("ownership", ownership);
+  if (workspaceScope) params.set("ws", workspaceScope);
+  const qs = params.toString();
+  return qs ? `/inbox?${qs}` : "/inbox";
+}
+
+function OwnershipTabs({
+  current,
+  workspaceScope,
+}: {
+  current: Ownership;
   workspaceScope?: string;
 }) {
+  const tabs: { key: Ownership; label: string }[] = [
+    { key: "mine", label: "Mine" },
+    { key: "unassigned", label: "Unassigned" },
+    { key: "all", label: "All open" },
+  ];
   return (
-    <form action="/inbox" method="GET" className="contents">
-      {filters.ownership !== DEFAULT_INBOX_FILTERS.ownership && (
-        <input type="hidden" name="ownership" value={filters.ownership} />
-      )}
-      {filters.types.map((t) => (
-        <input key={t} type="hidden" name="type" value={t} />
-      ))}
-      {repo && <input type="hidden" name="repo" value={repo} />}
-      {play && <input type="hidden" name="play" value={play} />}
-      {cursor && <input type="hidden" name="cursor" value={cursor} />}
-      {workspaceScope && (
-        <input type="hidden" name="ws" value={workspaceScope} />
-      )}
-      <button
-        type="submit"
-        className="text-xs font-semibold text-white/55 transition hover:text-white"
-        title="Reload the current view"
-      >
-        ↻ Refresh
-      </button>
-    </form>
+    <div className="flex items-center gap-3 border-b border-white/[0.06] px-4 py-3 text-xs">
+      {tabs.map((tab, idx) => {
+        const active = current === tab.key;
+        return (
+          <span key={tab.key} className="flex items-baseline">
+            <Link
+              href={buildOwnershipHref({
+                ownership: tab.key,
+                workspaceScope,
+              })}
+              aria-current={active ? "page" : undefined}
+              className={cn(
+                "transition",
+                active
+                  ? "font-semibold text-white"
+                  : "text-white/50 hover:text-white",
+              )}
+            >
+              {tab.label}
+            </Link>
+            {idx < tabs.length - 1 && (
+              <span className="ml-3 text-white/15">·</span>
+            )}
+          </span>
+        );
+      })}
+    </div>
   );
+}
+
+const ROW_TONE: Record<InboxType, string> = {
+  clarification: "bg-sun",
+  approval: "bg-aqua",
+  improvement: "bg-lilac",
+  failure: "bg-coral",
+  blocker: "bg-coral",
+  exception: "bg-coral/60",
+  stuck: "bg-white/30",
+  report: "bg-white/15",
+};
+
+function MailboxRow({
+  item,
+  selected,
+  ownership,
+  workspaceScope,
+}: {
+  item: InboxItem;
+  selected: boolean;
+  ownership: Ownership;
+  workspaceScope?: string;
+}) {
+  const meta = INBOX_TYPE_META[item.type];
+  const isUnread = item.status === "new";
+  return (
+    <Link
+      href={buildSelectHref({ id: item.id, ownership, workspaceScope })}
+      className={cn(
+        "group relative flex items-start gap-3 px-4 py-3 transition",
+        selected
+          ? "bg-aqua/[0.08]"
+          : "hover:bg-white/[0.03]",
+      )}
+      aria-current={selected ? "true" : undefined}
+    >
+      <span
+        aria-hidden
+        className={cn(
+          "mt-1 inline-block h-2 w-2 shrink-0 rounded-full",
+          isUnread ? ROW_TONE[item.type] : "bg-white/15",
+        )}
+      />
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2 text-[10px] uppercase tracking-[0.18em] text-white/40">
+          <span>{meta.label.replace(/s$/, "")}</span>
+          <StaleBadge
+            createdAt={item.created_at}
+            status={item.status}
+            snoozedUntil={item.snoozed_until}
+          />
+        </div>
+        <p
+          className={cn(
+            "mt-1 truncate text-sm",
+            selected ? "font-semibold text-white" : isUnread ? "font-semibold text-white/95" : "text-white/70",
+          )}
+        >
+          {item.title}
+        </p>
+        {item.summary && item.summary.trim().toLowerCase() !== item.title.trim().toLowerCase() && (
+          <p className="mt-0.5 truncate text-xs text-white/50">{item.summary}</p>
+        )}
+      </div>
+    </Link>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Right pane: the preview
+// ---------------------------------------------------------------------------
+
+function MailboxPreview({
+  detail,
+  detailError,
+  workspaceId,
+  workspaceScope,
+  empty,
+}: {
+  detail: InboxItemDetail | null;
+  detailError: string | null;
+  workspaceId: string;
+  workspaceScope?: string;
+  empty: boolean;
+}) {
+  if (empty) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center rounded-xl border border-white/[0.08] bg-white/[0.015] px-6 text-center text-sm text-white/55">
+        Pick a workspace lens on the left — there&rsquo;s nothing here right now.
+      </div>
+    );
+  }
+  if (detailError === "not_found") {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center rounded-xl border border-white/[0.08] bg-white/[0.015] px-6 text-center text-sm text-white/55">
+        That item is gone — it was resolved in another tab.
+      </div>
+    );
+  }
+  if (!detail) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center rounded-xl border border-white/[0.08] bg-white/[0.015] px-6 text-center text-sm text-white/55">
+        Pick a letter on the left to read it.
+      </div>
+    );
+  }
+
+  const meta = INBOX_TYPE_META[detail.type as InboxType];
+  const body = readBody(detail);
+  const isClosed = detail.status === "resolved" || detail.status === "dismissed";
+
+  return (
+    <div className="flex min-h-[60vh] flex-col rounded-xl border border-white/[0.08] bg-white/[0.015]">
+      <header className="border-b border-white/[0.06] px-6 py-4">
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[10px] uppercase tracking-[0.18em] text-white/45">
+          <span>{meta?.label ?? detail.type}</span>
+          {isClosed && (
+            <>
+              <span className="text-white/15">·</span>
+              <span className="text-white/55">{detail.status}</span>
+              {detail.resolution && (
+                <>
+                  <span className="text-white/15">·</span>
+                  <span className="text-white/55">{detail.resolution}</span>
+                </>
+              )}
+            </>
+          )}
+        </div>
+        <h1 className="mt-1 text-lg font-semibold text-white">{detail.title}</h1>
+        {detail.owner && (
+          <p className="mt-1 text-xs text-white/55">
+            Owner:{" "}
+            <span className="text-white/75">
+              {detail.owner.display_name?.trim() || detail.owner.email}
+            </span>
+          </p>
+        )}
+        <p className="mt-1 text-xs text-white/40">
+          <Link
+            href={withWorkspaceQuery(
+              `/inbox/${encodeURIComponent(detail.id)}`,
+              workspaceScope ?? "",
+              Boolean(workspaceScope),
+            )}
+            className="underline-offset-2 hover:text-white hover:underline"
+          >
+            Open full detail →
+          </Link>
+        </p>
+      </header>
+
+      <div className="flex-1 overflow-y-auto px-6 py-5">
+        {body ? (
+          <MarkdownBlock>{body}</MarkdownBlock>
+        ) : (
+          <p className="text-sm italic text-white/40">No body.</p>
+        )}
+      </div>
+
+      <footer className="border-t border-white/[0.06] px-6 py-4">
+        <MailboxFooter detail={detail} workspaceId={workspaceId} />
+      </footer>
+    </div>
+  );
+}
+
+function readBody(detail: InboxItemDetail): string {
+  // Agent-filed reports stash the markdown body under
+  // ``payload.body``; legacy items keep the human-readable text in
+  // ``summary``. Fall through gracefully.
+  const payloadBody = detail.payload?.["body"];
+  if (typeof payloadBody === "string" && payloadBody.trim().length > 0) {
+    return payloadBody;
+  }
+  if (detail.summary && detail.summary.trim().length > 0) return detail.summary;
+  return "";
 }

--- a/console/src/app/api/inbox/[id]/disposition/route.ts
+++ b/console/src/app/api/inbox/[id]/disposition/route.ts
@@ -43,13 +43,22 @@ export async function POST(
   const actionRaw = (form.get("action") ?? "").toString();
   const answer = (form.get("answer") ?? "").toString().trim();
   const payloadJsonRaw = (form.get("payload_json") ?? "").toString().trim();
+  // ``return_to`` lets callers (mailbox footer) bounce back to the
+  // list view with a different selection rather than the bigger
+  // detail page. Only same-origin paths starting with ``/`` are
+  // honoured; anything else falls through to the default.
+  const returnToRaw = (form.get("return_to") ?? "").toString();
+  const returnTo =
+    returnToRaw.startsWith("/") && !returnToRaw.startsWith("//")
+      ? returnToRaw
+      : null;
 
-  if (!wsId || !id) return back(origin, id, "bad_input");
+  if (!wsId || !id) return back(origin, id, "bad_input", returnTo);
   if (!VALID_ACTIONS.includes(actionRaw as InboxDispositionAction)) {
-    return back(origin, id, "bad_input");
+    return back(origin, id, "bad_input", returnTo);
   }
   const action = actionRaw as InboxDispositionAction;
-  if (!isApiConfigured()) return back(origin, id, "api_unavailable");
+  if (!isApiConfigured()) return back(origin, id, "api_unavailable", returnTo);
 
   // Build the payload bag. ``payload_json`` (advanced operators)
   // merges underneath ``answer`` so the dedicated text field always
@@ -61,10 +70,10 @@ export async function POST(
       if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
         payload = { ...(parsed as Record<string, unknown>) };
       } else {
-        return back(origin, id, "bad_input");
+        return back(origin, id, "bad_input", returnTo);
       }
     } catch {
-      return back(origin, id, "bad_input");
+      return back(origin, id, "bad_input", returnTo);
     }
   }
 
@@ -74,7 +83,7 @@ export async function POST(
   };
 
   if (action === "answer") {
-    if (!answer) return back(origin, id, "validation_failed");
+    if (!answer) return back(origin, id, "validation_failed", returnTo);
     body.answer = answer;
     body.payload = { ...payload, answer };
   }
@@ -88,14 +97,15 @@ export async function POST(
         303,
       );
     }
-    return back(origin, id, codeFor(err));
+    return back(origin, id, codeFor(err), returnTo);
   }
 
-  return NextResponse.redirect(new URL(`/inbox/${id}`, origin), 303);
+  const successTarget = returnTo ?? `/inbox/${id}`;
+  return NextResponse.redirect(new URL(successTarget, origin), 303);
 }
 
-function back(origin: string, id: string, code: string) {
-  const url = new URL(`/inbox/${id}`, origin);
+function back(origin: string, id: string, code: string, returnTo: string | null) {
+  const url = new URL(returnTo ?? `/inbox/${id}`, origin);
   url.searchParams.set("error", code);
   return NextResponse.redirect(url, 303);
 }

--- a/console/src/components/inbox/inbox-item-row.tsx
+++ b/console/src/components/inbox/inbox-item-row.tsx
@@ -26,6 +26,7 @@ const SPINE_TONE: Record<InboxItem["type"], string> = {
   blocker: "bg-coral",
   exception: "bg-coral/60",
   stuck: "bg-white/30",
+  report: "bg-white/15",
 };
 
 const SPINE_WIDTH: Record<InboxItem["type"], string> = {
@@ -36,6 +37,7 @@ const SPINE_WIDTH: Record<InboxItem["type"], string> = {
   blocker: "w-[4px]",
   exception: "w-[2px]",
   stuck: "w-px",
+  report: "w-px",
 };
 
 function ownerLabel(owner: InboxItem["owner"]): string {

--- a/console/src/components/inbox/inbox-row-actions.tsx
+++ b/console/src/components/inbox/inbox-row-actions.tsx
@@ -39,6 +39,10 @@ const PRIMARY_LABEL: Record<InboxType, string | null> = {
   exception: "Acknowledge",
   stuck: "Acknowledge",
   blocker: "Acknowledge",
+  // ``report`` items are read-only digests — the inline row action is
+  // a one-tap Acknowledge so operators can clear letters from the list
+  // without opening the preview pane.
+  report: "Acknowledge",
 };
 
 const SECONDARY_LABEL: Record<InboxType, string | null> = {
@@ -49,6 +53,7 @@ const SECONDARY_LABEL: Record<InboxType, string | null> = {
   exception: null,
   stuck: null,
   blocker: null,
+  report: null,
 };
 
 const DISCUSS_TYPES = new Set<InboxType>([

--- a/console/src/components/inbox/mailbox-footer.tsx
+++ b/console/src/components/inbox/mailbox-footer.tsx
@@ -1,0 +1,280 @@
+/**
+ * Type-aware footer for the mailbox preview pane.
+ *
+ *   - ``acknowledge`` — single Acknowledge button (reports / read-only
+ *     digests). Posts ``action=resolve`` which the backend maps to
+ *     ``resolution=acknowledged``.
+ *   - ``reply`` — quick-reply textarea + Send button (clarifications).
+ *     Posts ``action=answer`` with the operator's text.
+ *   - ``decision`` — primary + secondary disposition buttons. The verb
+ *     set per type is the same as the bigger ``/inbox/[id]`` page.
+ *
+ * Closed items (``resolved`` / ``dismissed``) collapse to a one-line
+ * confirmation row instead of the action surface.
+ */
+
+import {
+  inboxFooterKind,
+  type InboxItemDetail,
+  type InboxType,
+} from "@/lib/inbox-types";
+
+type ActionVerb =
+  | "resolve"
+  | "dismiss"
+  | "approve"
+  | "reject"
+  | "answer"
+  | "accept"
+  | "retry"
+  | "acknowledge";
+
+type ButtonStyle = "primary" | "secondary" | "danger";
+
+type Decision = {
+  primary: { action: ActionVerb; label: string };
+  secondary: { action: ActionVerb; label: string; style: ButtonStyle }[];
+};
+
+const DECISIONS: Partial<Record<InboxType, Decision>> = {
+  approval: {
+    primary: { action: "approve", label: "Approve" },
+    secondary: [
+      { action: "reject", label: "Reject", style: "danger" },
+      { action: "dismiss", label: "Dismiss", style: "secondary" },
+    ],
+  },
+  improvement: {
+    primary: { action: "accept", label: "Accept" },
+    secondary: [
+      { action: "dismiss", label: "Dismiss", style: "danger" },
+    ],
+  },
+  failure: {
+    primary: { action: "retry", label: "Retry" },
+    secondary: [
+      { action: "resolve", label: "Acknowledge", style: "secondary" },
+      { action: "dismiss", label: "Dismiss", style: "danger" },
+    ],
+  },
+  exception: {
+    primary: { action: "acknowledge", label: "Acknowledge" },
+    secondary: [
+      { action: "dismiss", label: "Dismiss", style: "danger" },
+    ],
+  },
+  stuck: {
+    primary: { action: "resolve", label: "Mark addressed" },
+    secondary: [
+      { action: "dismiss", label: "Dismiss", style: "danger" },
+    ],
+  },
+  blocker: {
+    primary: { action: "resolve", label: "Mark handled" },
+    secondary: [
+      { action: "dismiss", label: "Dismiss", style: "danger" },
+    ],
+  },
+};
+
+export function MailboxFooter({
+  detail,
+  workspaceId,
+}: {
+  detail: InboxItemDetail;
+  workspaceId: string;
+}) {
+  if (detail.status === "resolved" || detail.status === "dismissed") {
+    return (
+      <p className="text-xs text-white/55">
+        {detail.status === "dismissed" ? "Dismissed" : "Resolved"}
+        {detail.resolution ? (
+          <>
+            {" "}
+            ·{" "}
+            <code className="rounded bg-white/[0.06] px-1.5 py-0.5">
+              {detail.resolution}
+            </code>
+          </>
+        ) : null}
+      </p>
+    );
+  }
+
+  const kind = inboxFooterKind(detail.type as InboxType);
+  if (kind === "acknowledge") {
+    return (
+      <PrimaryForm
+        workspaceId={workspaceId}
+        itemId={detail.id}
+        action="resolve"
+        label="Acknowledge"
+      />
+    );
+  }
+  if (kind === "reply") {
+    return (
+      <ReplyForm workspaceId={workspaceId} itemId={detail.id} />
+    );
+  }
+
+  const decision = DECISIONS[detail.type as InboxType];
+  if (!decision) {
+    return (
+      <PrimaryForm
+        workspaceId={workspaceId}
+        itemId={detail.id}
+        action="resolve"
+        label="Resolve"
+      />
+    );
+  }
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <PrimaryForm
+        workspaceId={workspaceId}
+        itemId={detail.id}
+        action={decision.primary.action}
+        label={decision.primary.label}
+      />
+      {decision.secondary.map((spec) => (
+        <SecondaryForm
+          key={spec.action + spec.label}
+          workspaceId={workspaceId}
+          itemId={detail.id}
+          action={spec.action}
+          label={spec.label}
+          style={spec.style}
+        />
+      ))}
+    </div>
+  );
+}
+
+function PrimaryForm({
+  workspaceId,
+  itemId,
+  action,
+  label,
+}: {
+  workspaceId: string;
+  itemId: string;
+  action: ActionVerb;
+  label: string;
+}) {
+  return (
+    <form
+      action={`/api/inbox/${encodeURIComponent(itemId)}/disposition`}
+      method="POST"
+      className="contents"
+    >
+      <input type="hidden" name="ws" value={workspaceId} />
+      <input type="hidden" name="action" value={action} />
+      <input type="hidden" name="return_to" value="/inbox" />
+      <button
+        type="submit"
+        className="inline-flex items-center gap-1.5 rounded-full bg-gradient-to-r from-coral via-lilac to-aqua px-4 py-1.5 text-sm font-bold text-ink shadow-glow transition hover:brightness-110"
+      >
+        {label}
+      </button>
+    </form>
+  );
+}
+
+function SecondaryForm({
+  workspaceId,
+  itemId,
+  action,
+  label,
+  style,
+}: {
+  workspaceId: string;
+  itemId: string;
+  action: ActionVerb;
+  label: string;
+  style: ButtonStyle;
+}) {
+  const tone =
+    style === "danger"
+      ? "border-coral/40 bg-coral/10 text-coral hover:bg-coral/20"
+      : "border-white/15 bg-white/[0.04] text-white/85 hover:bg-white/[0.08]";
+  return (
+    <form
+      action={`/api/inbox/${encodeURIComponent(itemId)}/disposition`}
+      method="POST"
+      className="contents"
+    >
+      <input type="hidden" name="ws" value={workspaceId} />
+      <input type="hidden" name="action" value={action} />
+      <input type="hidden" name="return_to" value="/inbox" />
+      <button
+        type="submit"
+        className={`inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-xs font-semibold transition ${tone}`}
+      >
+        {label}
+      </button>
+    </form>
+  );
+}
+
+function ReplyForm({
+  workspaceId,
+  itemId,
+}: {
+  workspaceId: string;
+  itemId: string;
+}) {
+  return (
+    <form
+      action={`/api/inbox/${encodeURIComponent(itemId)}/disposition`}
+      method="POST"
+      className="space-y-2"
+    >
+      <input type="hidden" name="ws" value={workspaceId} />
+      <input type="hidden" name="action" value="answer" />
+      <input type="hidden" name="return_to" value="/inbox" />
+      <textarea
+        name="answer"
+        rows={3}
+        required
+        placeholder="Reply to the agent…"
+        className="w-full rounded border border-white/10 bg-white/[0.04] px-2 py-1.5 text-sm text-white outline-none focus:border-aqua/40"
+      />
+      <div className="flex items-center gap-2">
+        <button
+          type="submit"
+          className="inline-flex items-center gap-1.5 rounded-full bg-gradient-to-r from-coral via-lilac to-aqua px-4 py-1.5 text-sm font-bold text-ink shadow-glow transition hover:brightness-110"
+        >
+          Send
+        </button>
+        <DismissForm workspaceId={workspaceId} itemId={itemId} />
+      </div>
+    </form>
+  );
+}
+
+function DismissForm({
+  workspaceId,
+  itemId,
+}: {
+  workspaceId: string;
+  itemId: string;
+}) {
+  return (
+    <form
+      action={`/api/inbox/${encodeURIComponent(itemId)}/disposition`}
+      method="POST"
+      className="contents"
+    >
+      <input type="hidden" name="ws" value={workspaceId} />
+      <input type="hidden" name="action" value="dismiss" />
+      <input type="hidden" name="return_to" value="/inbox" />
+      <button
+        type="submit"
+        className="inline-flex items-center gap-1.5 rounded-full border border-white/15 bg-white/[0.04] px-3 py-1.5 text-xs font-semibold text-white/85 transition hover:bg-white/[0.08]"
+      >
+        Dismiss
+      </button>
+    </form>
+  );
+}

--- a/console/src/components/workspace-home.tsx
+++ b/console/src/components/workspace-home.tsx
@@ -725,6 +725,7 @@ const INBOX_SPINE: Record<InboxType, string> = {
   blocker: "bg-coral",
   exception: "bg-coral/60",
   stuck: "bg-white/30",
+  report: "bg-white/15",
 };
 
 
@@ -736,6 +737,7 @@ const INBOX_SPINE_WIDTH: Record<InboxType, string> = {
   blocker: "w-[4px]",
   exception: "w-[2px]",
   stuck: "w-px",
+  report: "w-px",
 };
 
 
@@ -752,6 +754,8 @@ function canonicalActionLabel(type: InboxType): string {
     case "exception":
     case "blocker":
     case "stuck":
+      return "Acknowledge";
+    case "report":
       return "Acknowledge";
   }
 }

--- a/console/src/lib/inbox-types.ts
+++ b/console/src/lib/inbox-types.ts
@@ -20,6 +20,7 @@ export const INBOX_TYPES = [
   "exception",
   "stuck",
   "blocker",
+  "report",
 ] as const;
 export type InboxType = (typeof INBOX_TYPES)[number];
 
@@ -87,7 +88,31 @@ export const INBOX_TYPE_META: Record<
     blurb: "Self-heal could not recover — needs human follow-up.",
     order: 7,
   },
+  report: {
+    label: "Reports",
+    blurb: "Daily / retro / process-review digests — read-only.",
+    order: 8,
+  },
 };
+
+/**
+ * Footer kind drives the mailbox preview-pane footer:
+ *
+ *   - ``acknowledge`` — single "Acknowledge" button. Used for
+ *     ``report`` (read-only digests) — operator marks read and moves
+ *     on, no branching action.
+ *   - ``reply`` — text-area + "Send" submit, plus a Dismiss escape.
+ *     Used for ``clarification`` where the agent needs an answer.
+ *   - ``decision`` — primary + secondary disposition buttons. Used for
+ *     everything that's a yes/no/dismiss decision.
+ */
+export type InboxFooterKind = "acknowledge" | "reply" | "decision";
+
+export function inboxFooterKind(type: InboxType): InboxFooterKind {
+  if (type === "report") return "acknowledge";
+  if (type === "clarification") return "reply";
+  return "decision";
+}
 
 /**
  * One row as it appears in the inbox list. Compact: the detail view
@@ -224,6 +249,7 @@ export function inboxTier(type: InboxType): InboxTier {
       return 2;
     case "improvement":
     case "stuck":
+    case "report":
       return 3;
   }
 }


### PR DESCRIPTION
## Summary

Three-step refactor in response to operator feedback that the
inbox was getting flooded with the wrong shape of work, and that
reviewers had nowhere stable to file findings.

- **PR-A (backend tools)** — adds two universally-useful agent
  tools: ``inbox_create(type, title, body, summary?)`` for
  read-only digest letters (``type=report``), and
  ``find_or_create_project_by_name(name, body)`` for idempotent
  reviewer-style routing into a dedicated Linear project per kind.
- **PR-B (console)** — replaces the tier-sectioned editorial inbox
  with an Outlook-style split pane: list left, preview right,
  type-aware footer at the bottom (acknowledge / quick-reply /
  decision buttons).
- **PR-C (role prompts)** — daily-retro, learning-capture,
  process-reviewer file inbox letters; tech-reviewer / qa-reviewer
  / security-officer file dedup tickets into Tech Debt / QA Debt /
  Security projects respectively. No more ``{{TECH_DEBT_PROJECT_ID}}``
  placeholders. Bundle version bumped 0.22 → 0.23.

## Test plan

- [ ] backend: ``pytest backend/tests/test_agent_tools_inbox_and_routing.py`` (DB required)
- [ ] backend: existing inbox + tracker tests still pass
- [ ] console: ``npx tsc --noEmit`` clean (verified locally)
- [ ] console: ``/inbox`` mailbox renders, row click selects, footer dispatches per-type action
- [ ] e2e: a daily-retro run files a ``type=report`` inbox item and the operator can Acknowledge it
- [ ] e2e: tech-reviewer run creates "Tech Debt" project on first invocation, reuses it on second