### PR TITLE
console: /analytics page (DORA + live system + recent merges)

### DIFF
--- a/console/package-lock.json
+++ b/console/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ship-console",
-  "version": "0.14.2",
+  "version": "0.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ship-console",
-      "version": "0.14.2",
+      "version": "0.16.0",
       "dependencies": {
         "@auth0/nextjs-auth0": "^4.18.0",
         "@sentry/nextjs": "^10.49.0",
@@ -16,6 +16,7 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-markdown": "^10.1.0",
+        "recharts": "^3.8.1",
         "remark-gfm": "^4.0.1"
       },
       "devDependencies": {
@@ -1945,6 +1946,42 @@
         "module-details-from-path": "^1.0.4"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.7",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.7.tgz",
+      "integrity": "sha512-LFVFtAROHcDy1er5UI6nodRFnZ2SgdCXhfNSI+DpObO8N7Pur/muBGsjzH5wpnFHCYhYVQxZskCkV4koQ//3/Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rollup/plugin-commonjs": {
       "version": "28.0.1",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-28.0.1.tgz",
@@ -2815,6 +2852,18 @@
         "webpack": ">=5.0.0"
       }
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -2843,6 +2892,69 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
     },
     "node_modules/@types/debug": {
       "version": "4.1.13",
@@ -3004,6 +3116,12 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -4487,6 +4605,15 @@
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -4586,6 +4713,127 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -4663,6 +4911,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
       "version": "1.3.0",
@@ -5016,6 +5270,16 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.46.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.1.tgz",
+      "integrity": "sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -5459,6 +5723,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/events": {
       "version": "3.3.0",
@@ -6091,6 +6361,16 @@
       "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
       "license": "MIT"
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -6158,6 +6438,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-alphabetical": {
@@ -8857,7 +9146,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-markdown": {
@@ -8885,6 +9173,29 @@
       "peerDependencies": {
         "@types/react": ">=18",
         "react": ">=18"
+      }
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
       }
     },
     "node_modules/read-cache": {
@@ -8929,6 +9240,51 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/recharts": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -9063,6 +9419,12 @@
       "engines": {
         "node": ">=9.3.0 || >=8.10.0 <9.0.0"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "2.0.0-next.6",
@@ -10045,6 +10407,12 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -10513,6 +10881,28 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/watchpack": {

--- a/console/package.json
+++ b/console/package.json
@@ -19,6 +19,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-markdown": "^10.1.0",
+    "recharts": "^3.8.1",
     "remark-gfm": "^4.0.1"
   },
   "devDependencies": {

--- a/console/src/app/(authed)/analytics/page.tsx
+++ b/console/src/app/(authed)/analytics/page.tsx
@@ -1,0 +1,413 @@
+/**
+ * Analytics — DORA + live system telemetry surface.
+ *
+ * Server component that fetches the four DORA metrics over a rolling
+ * window (30 / 90 days, switched via ``?days=…``) and the live-system
+ * aggregator (relocated from the home page in PR-D1). Charts render
+ * client-side via ``recharts`` in :module:`./_components/charts`.
+ *
+ * Layout: a 4-up grid of DORA cards (Deployment Frequency, Lead Time,
+ * Change Failure Rate, MTTR) on top — each card carries a headline
+ * number, a DORA performance band label, and a tiny chart. Below the
+ * grid, a ``Live system`` block (Knowledge / Routines / Daily /
+ * Specialists) for ambient health, and a ``Recent`` activity list.
+ */
+
+import Link from "next/link";
+import { redirect } from "next/navigation";
+
+import { ApiUnavailable } from "@/components/api-unavailable";
+import { PageBody, PageHeader } from "@/components/app-shell";
+import { DashboardLiveSystem } from "@/components/dashboard/live-system";
+import {
+  CfrChart,
+  DfChart,
+  LtChart,
+  MttrSparkline,
+} from "@/components/analytics/charts";
+import { cn } from "@/lib/cn";
+import {
+  ApiHttpError,
+  getDoraAnalytics,
+  getLiveSystem,
+  getOpsDashboard,
+  type ApiDoraResponse,
+  type ApiLiveSystem,
+  type ApiOpsDashboard,
+} from "@/lib/api/client";
+import {
+  getCachedSessionToken,
+  getCachedWorkspaces,
+} from "@/lib/api/session-cache.server";
+import { getResolvedWorkspaceId } from "@/lib/workspace-resolve.server";
+import { pickWorkspace } from "@/lib/workspace-scope";
+
+export const dynamic = "force-dynamic";
+
+const ALLOWED_WINDOWS = [30, 90, 180] as const;
+type WindowDays = (typeof ALLOWED_WINDOWS)[number];
+
+type Mode =
+  | {
+      source: "live";
+      workspaceId: string;
+      multiWs: boolean;
+      windowDays: WindowDays;
+      dora: ApiDoraResponse;
+      liveSystem: ApiLiveSystem | null;
+      summary: ApiOpsDashboard | null;
+    }
+  | { source: "down"; reason: string };
+
+function parseWindow(raw: string | string[] | undefined): WindowDays {
+  const v = typeof raw === "string" ? Number.parseInt(raw, 10) : NaN;
+  return ALLOWED_WINDOWS.includes(v as WindowDays) ? (v as WindowDays) : 30;
+}
+
+async function load(
+  windowDays: WindowDays,
+  searchParams: Record<string, string | string[] | undefined>,
+): Promise<Mode> {
+  const token = await getCachedSessionToken();
+  if (!token) {
+    redirect("/login?next=%2Fanalytics&reason=session_expired");
+  }
+
+  const ws = await getCachedWorkspaces();
+  const resolved = await getResolvedWorkspaceId(searchParams, ws);
+  const workspace = pickWorkspace(ws, resolved);
+
+  let dora: ApiDoraResponse;
+  try {
+    dora = await getDoraAnalytics(workspace.id, windowDays, token);
+  } catch (err) {
+    if (err instanceof ApiHttpError && err.status === 401) {
+      redirect("/login?next=%2Fanalytics&reason=session_expired");
+    }
+    return {
+      source: "down",
+      reason:
+        err instanceof Error
+          ? err.message
+          : "Could not load DORA analytics.",
+    };
+  }
+
+  // Live system + ops summary are best-effort — a missing block
+  // shouldn't block the DORA grid which is the headline content.
+  const [liveSystem, summary] = await Promise.all([
+    getLiveSystem(workspace.id, token).catch(() => null),
+    getOpsDashboard(workspace.id, token).catch(() => null),
+  ]);
+
+  return {
+    source: "live",
+    workspaceId: workspace.id,
+    multiWs: ws.length > 1,
+    windowDays,
+    dora,
+    liveSystem,
+    summary,
+  };
+}
+
+export default async function AnalyticsPage({
+  searchParams,
+}: {
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const params = ((await (searchParams ?? Promise.resolve({}))) ?? {}) as Record<
+    string,
+    string | string[] | undefined
+  >;
+  const windowDays = parseWindow(params.days);
+  const data = await load(windowDays, params);
+
+  if (data.source === "down") {
+    return (
+      <>
+        <PageHeader kicker="data" title="Analytics" />
+        <PageBody>
+          <ApiUnavailable scope="analytics" details={data.reason} />
+        </PageBody>
+      </>
+    );
+  }
+
+  const { workspaceId, multiWs, dora, liveSystem, summary } = data;
+  const wsScope = multiWs ? `?ws=${encodeURIComponent(workspaceId)}` : "";
+
+  return (
+    <>
+      <PageHeader
+        kicker="data"
+        title="Analytics"
+        actions={<WindowPicker current={windowDays} workspaceScope={wsScope} />}
+      />
+      <PageBody>
+        <div className="mx-auto max-w-6xl space-y-12">
+          <DoraGrid dora={dora} />
+
+          {liveSystem !== null && (
+            <section className="space-y-4">
+              <header className="flex items-baseline justify-between">
+                <h2 className="text-[10px] font-bold uppercase tracking-[0.22em] text-white/45">
+                  Live system
+                </h2>
+                <p className="text-[11px] text-white/40">
+                  Ambient health · refreshed on each render
+                </p>
+              </header>
+              <DashboardLiveSystem data={liveSystem} />
+            </section>
+          )}
+
+          {summary !== null && summary.shipped.items.length > 0 && (
+            <RecentMerges summary={summary} />
+          )}
+        </div>
+      </PageBody>
+    </>
+  );
+}
+
+
+// ---------------------------------------------------------------------------
+// DORA grid — four cards, headline + band label + chart
+// ---------------------------------------------------------------------------
+
+
+function DoraGrid({ dora }: { dora: ApiDoraResponse }) {
+  return (
+    <section className="space-y-4">
+      <header className="flex items-baseline justify-between">
+        <h2 className="text-[10px] font-bold uppercase tracking-[0.22em] text-white/45">
+          DORA · last {dora.window_days} days
+        </h2>
+        <p className="text-[11px] text-white/40">
+          Computed{" "}
+          {new Date(dora.computed_at).toLocaleString(undefined, {
+            dateStyle: "medium",
+            timeStyle: "short",
+          })}
+        </p>
+      </header>
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+        <DoraCard
+          title="Deployment frequency"
+          headline={formatPerDay(dora.deployment_frequency.per_day_median)}
+          sub={`${dora.deployment_frequency.total_deploys} deploys total · p90 ${formatPerDay(dora.deployment_frequency.per_day_p90)}`}
+          band={dora.deployment_frequency.label}
+        >
+          <DfChart data={dora.deployment_frequency.time_series} />
+        </DoraCard>
+        <DoraCard
+          title="Lead time for changes"
+          headline={formatHours(dora.lead_time.median_hours)}
+          sub={`${dora.lead_time.sample_size} merged PRs · p90 ${formatHours(dora.lead_time.p90_hours)}`}
+          band={dora.lead_time.label}
+        >
+          <LtChart data={dora.lead_time.time_series} />
+        </DoraCard>
+        <DoraCard
+          title="Change failure rate"
+          headline={formatRate(dora.change_failure_rate.rate)}
+          sub={`${dora.change_failure_rate.failed_deploys} failed deploys · ${dora.change_failure_rate.hotfix_prs} hotfix PRs · ${dora.change_failure_rate.total_deploys} total`}
+          band={dora.change_failure_rate.label}
+        >
+          <CfrChart data={dora.change_failure_rate.time_series} />
+        </DoraCard>
+        <DoraCard
+          title="Mean time to recovery"
+          headline={formatHours(dora.mttr.median_hours)}
+          sub={
+            dora.mttr.incidents.length === 0
+              ? "no incidents in window"
+              : `${dora.mttr.incidents.filter((i) => i.recovered_at).length} recovered · ${dora.mttr.incidents.filter((i) => i.recovered_at === null).length} open · p90 ${formatHours(dora.mttr.p90_hours)}`
+          }
+          band={dora.mttr.label}
+        >
+          <MttrSparkline incidents={dora.mttr.incidents} />
+        </DoraCard>
+      </div>
+    </section>
+  );
+}
+
+
+function DoraCard({
+  title,
+  headline,
+  sub,
+  band,
+  children,
+}: {
+  title: string;
+  headline: string;
+  sub: string;
+  band: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <article className="space-y-4 rounded-xl border border-white/[0.08] bg-white/[0.02] p-5">
+      <header className="space-y-1">
+        <p className="text-[10px] font-bold uppercase tracking-[0.18em] text-white/45">
+          {title}
+        </p>
+        <p className="font-display text-3xl font-bold text-white">
+          {headline}
+        </p>
+        <p className="text-[11px] text-white/55">{sub}</p>
+        <p
+          className={cn(
+            "text-[11px] font-semibold",
+            band.startsWith("Elite")
+              ? "text-aqua/90"
+              : band.startsWith("High")
+                ? "text-aqua/70"
+                : band.startsWith("Medium")
+                  ? "text-sun/80"
+                  : band.startsWith("Low")
+                    ? "text-coral"
+                    : "text-white/40",
+          )}
+        >
+          {band}
+        </p>
+      </header>
+      <div className="h-32">{children}</div>
+    </article>
+  );
+}
+
+
+// ---------------------------------------------------------------------------
+// Window picker — 30 / 90 / 180 days
+// ---------------------------------------------------------------------------
+
+
+function WindowPicker({
+  current,
+  workspaceScope,
+}: {
+  current: WindowDays;
+  workspaceScope: string;
+}) {
+  return (
+    <nav className="flex items-baseline gap-3 text-xs">
+      {ALLOWED_WINDOWS.map((d, idx) => {
+        const active = d === current;
+        const sep = workspaceScope ? "&" : "?";
+        const href = `/analytics${workspaceScope}${sep}days=${d}`;
+        return (
+          <span key={d} className="flex items-baseline">
+            <Link
+              href={href}
+              aria-current={active ? "page" : undefined}
+              className={cn(
+                "transition",
+                active
+                  ? "font-semibold text-white"
+                  : "text-white/45 hover:text-white",
+              )}
+            >
+              {d}d
+            </Link>
+            {idx < ALLOWED_WINDOWS.length - 1 && (
+              <span className="ml-3 text-white/15">·</span>
+            )}
+          </span>
+        );
+      })}
+    </nav>
+  );
+}
+
+
+// ---------------------------------------------------------------------------
+// Recent merges — relocated from the old home right-rail
+// ---------------------------------------------------------------------------
+
+
+function RecentMerges({ summary }: { summary: ApiOpsDashboard }) {
+  const items = summary.shipped.items.slice(0, 12);
+  return (
+    <section className="space-y-3">
+      <header className="flex items-baseline justify-between">
+        <h2 className="text-[10px] font-bold uppercase tracking-[0.22em] text-white/45">
+          Recent · last 24h
+        </h2>
+        <p className="text-[11px] text-white/40">
+          {summary.shipped.features_shipped_count} features ·{" "}
+          {summary.shipped.fixes_count} fixes ·{" "}
+          {summary.shipped.rollbacks_count} rollbacks
+        </p>
+      </header>
+      <ul className="divide-y divide-white/[0.06]">
+        {items.map((item, idx) => (
+          <li
+            key={`${idx}-${item.name}`}
+            className="flex items-baseline justify-between gap-4 py-3"
+          >
+            <div className="min-w-0">
+              <p className="text-[10px] font-bold uppercase tracking-[0.18em] text-white/45">
+                {item.type}
+                {item.repo && (
+                  <>
+                    <span className="mx-2 text-white/15">·</span>
+                    <span className="font-normal normal-case tracking-normal">
+                      {item.repo}
+                    </span>
+                  </>
+                )}
+              </p>
+              <p className="mt-1 truncate text-sm text-white">{item.name}</p>
+            </div>
+            {item.href && (
+              <a
+                href={item.href}
+                target="_blank"
+                rel="noreferrer"
+                className="shrink-0 text-[11px] font-semibold text-white/55 hover:text-white"
+              >
+                Open →
+              </a>
+            )}
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+
+// ---------------------------------------------------------------------------
+// Formatters
+// ---------------------------------------------------------------------------
+
+
+function formatPerDay(n: number): string {
+  if (n >= 1) return `${n.toFixed(n >= 10 ? 0 : 1)}/day`;
+  if (n === 0) return "—";
+  // < 1 / day → flip to the canonical DORA cadence labels.
+  const perWeek = n * 7;
+  if (perWeek >= 1) return `${perWeek.toFixed(1)}/week`;
+  const perMonth = n * 30;
+  return `${perMonth.toFixed(1)}/month`;
+}
+
+function formatHours(n: number | null): string {
+  if (n === null || Number.isNaN(n)) return "—";
+  if (n < 1) return `${Math.round(n * 60)}m`;
+  if (n < 24) return `${n.toFixed(1)}h`;
+  const days = n / 24;
+  if (days < 7) return `${days.toFixed(1)}d`;
+  const weeks = days / 7;
+  if (weeks < 4) return `${weeks.toFixed(1)}w`;
+  const months = days / 30;
+  return `${months.toFixed(1)}mo`;
+}
+
+function formatRate(n: number): string {
+  return `${Math.round(n * 100)}%`;
+}

--- a/console/src/components/analytics/charts.tsx
+++ b/console/src/components/analytics/charts.tsx
@@ -1,0 +1,231 @@
+"use client";
+
+/**
+ * Recharts-backed sparklines for the DORA cards on /analytics.
+ *
+ * Kept terse: these are auxiliary renderings — the headline number on
+ * the card is the actual story. Charts give the operator a quick
+ * "trend up / trend down / lumpy" read without forcing them to scan
+ * a table.
+ */
+
+import {
+  Area,
+  AreaChart,
+  Bar,
+  BarChart,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+import type {
+  ApiDoraCfrPoint,
+  ApiDoraDfPoint,
+  ApiDoraIncident,
+  ApiDoraLtPoint,
+} from "@/lib/api/client";
+
+
+const TOOLTIP_STYLE: React.CSSProperties = {
+  background: "rgba(10, 10, 14, 0.95)",
+  border: "1px solid rgba(255,255,255,0.08)",
+  borderRadius: 6,
+  padding: "6px 10px",
+  fontSize: 11,
+  color: "rgba(255,255,255,0.85)",
+};
+
+
+export function DfChart({ data }: { data: ApiDoraDfPoint[] }) {
+  return (
+    <ResponsiveContainer width="100%" height="100%">
+      <BarChart data={data} margin={{ top: 4, right: 4, bottom: 0, left: 0 }}>
+        <XAxis
+          dataKey="date"
+          tick={{ fontSize: 9, fill: "rgba(255,255,255,0.4)" }}
+          interval="preserveStartEnd"
+          minTickGap={32}
+          tickFormatter={shortDate}
+        />
+        <YAxis hide allowDecimals={false} />
+        <Tooltip
+          contentStyle={TOOLTIP_STYLE}
+          formatter={(value) => {
+            const n = typeof value === "number" ? value : Number(value);
+            return [`${n} deploy${n === 1 ? "" : "s"}`, "count"];
+          }}
+          labelFormatter={(label) => fullDate(String(label))}
+        />
+        <Bar dataKey="count" fill="#5eead4" radius={[2, 2, 0, 0]} />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}
+
+
+export function LtChart({ data }: { data: ApiDoraLtPoint[] }) {
+  // Drop weeks with no samples so the line doesn't dive to 0 and look
+  // like a regression. The chart's job is to show trend, not zero-fill.
+  const filtered = data.filter((d) => d.median_hours !== null);
+  return (
+    <ResponsiveContainer width="100%" height="100%">
+      <LineChart
+        data={filtered}
+        margin={{ top: 4, right: 4, bottom: 0, left: 0 }}
+      >
+        <XAxis
+          dataKey="week_start"
+          tick={{ fontSize: 9, fill: "rgba(255,255,255,0.4)" }}
+          interval="preserveStartEnd"
+          minTickGap={32}
+          tickFormatter={shortDate}
+        />
+        <YAxis hide />
+        <Tooltip
+          contentStyle={TOOLTIP_STYLE}
+          formatter={(value) => {
+            const n = typeof value === "number" ? value : Number(value);
+            return [`${n.toFixed(1)} h`, "median"];
+          }}
+          labelFormatter={(label) => `Week of ${shortDate(String(label))}`}
+        />
+        <Line
+          type="monotone"
+          dataKey="median_hours"
+          stroke="#a78bfa"
+          strokeWidth={2}
+          dot={{ r: 2, fill: "#a78bfa" }}
+          activeDot={{ r: 4 }}
+          isAnimationActive={false}
+        />
+      </LineChart>
+    </ResponsiveContainer>
+  );
+}
+
+
+export function CfrChart({ data }: { data: ApiDoraCfrPoint[] }) {
+  // Stack failed bars on top of total to read failures as a portion
+  // of activity rather than an absolute. Keep colours editorial — sun
+  // for total volume, coral for failures so a bad day jumps out.
+  const merged = data.map((p) => ({
+    date: p.date,
+    success: Math.max(p.total - p.failed, 0),
+    failed: p.failed,
+  }));
+  return (
+    <ResponsiveContainer width="100%" height="100%">
+      <BarChart
+        data={merged}
+        margin={{ top: 4, right: 4, bottom: 0, left: 0 }}
+      >
+        <XAxis
+          dataKey="date"
+          tick={{ fontSize: 9, fill: "rgba(255,255,255,0.4)" }}
+          interval="preserveStartEnd"
+          minTickGap={32}
+          tickFormatter={shortDate}
+        />
+        <YAxis hide allowDecimals={false} />
+        <Tooltip
+          contentStyle={TOOLTIP_STYLE}
+          labelFormatter={(label) => fullDate(String(label))}
+          formatter={(value, name) => [
+            `${value}`,
+            String(name) === "success" ? "succeeded" : "failed",
+          ]}
+        />
+        <Bar
+          dataKey="success"
+          stackId="a"
+          fill="#5eead4"
+          radius={[0, 0, 0, 0]}
+        />
+        <Bar
+          dataKey="failed"
+          stackId="a"
+          fill="#f87171"
+          radius={[2, 2, 0, 0]}
+        />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}
+
+
+export function MttrSparkline({ incidents }: { incidents: ApiDoraIncident[] }) {
+  const series = incidents
+    .filter((i) => i.hours !== null)
+    .map((i, idx) => ({
+      idx,
+      hours: i.hours ?? 0,
+      label: i.workflow_name ?? "deploy",
+    }));
+  if (series.length === 0) {
+    return (
+      <p className="flex h-full items-center justify-center text-[11px] italic text-white/30">
+        {incidents.length === 0
+          ? "No incidents in window."
+          : `${incidents.length} open · no recoveries yet.`}
+      </p>
+    );
+  }
+  return (
+    <ResponsiveContainer width="100%" height="100%">
+      <AreaChart
+        data={series}
+        margin={{ top: 4, right: 4, bottom: 0, left: 0 }}
+      >
+        <XAxis hide dataKey="idx" />
+        <YAxis hide />
+        <Tooltip
+          contentStyle={TOOLTIP_STYLE}
+          formatter={(value) => {
+            const n = typeof value === "number" ? value : Number(value);
+            return [`${n.toFixed(2)} h`, "recovery"];
+          }}
+          labelFormatter={(_, payload) => {
+            if (payload && payload.length > 0) {
+              const item = payload[0]?.payload as { label?: string } | undefined;
+              return item?.label ?? "incident";
+            }
+            return "incident";
+          }}
+        />
+        <Area
+          type="monotone"
+          dataKey="hours"
+          stroke="#f87171"
+          fill="#f87171"
+          fillOpacity={0.2}
+          strokeWidth={2}
+          isAnimationActive={false}
+        />
+      </AreaChart>
+    </ResponsiveContainer>
+  );
+}
+
+
+function shortDate(value: string): string {
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return value;
+  return d.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function fullDate(value: string): string {
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return value;
+  return d.toLocaleDateString(undefined, {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+  });
+}

--- a/console/src/components/app-shell.tsx
+++ b/console/src/components/app-shell.tsx
@@ -65,6 +65,7 @@ function buildWorkspaceNav(): NavGroup[] {
       items: [
         { href: "/", label: "Dashboard", icon: <DotIcon /> },
         { href: "/inbox", label: "Inbox", icon: <DotIcon /> },
+        { href: "/analytics", label: "Analytics", icon: <DotIcon /> },
         { href: "/process", label: "Process", icon: <DotIcon /> },
         { href: "/knowledge", label: "Knowledge", icon: <DotIcon /> },
         { href: "/settings/policy", label: "Policies", icon: <DotIcon /> },

--- a/console/src/lib/api/client.ts
+++ b/console/src/lib/api/client.ts
@@ -2647,6 +2647,75 @@ export function getLiveSystem(
   );
 }
 
+// ---------------------------------------------------------------------------
+// Analytics — DORA metrics over a rolling window
+// ---------------------------------------------------------------------------
+
+export interface ApiDoraDfPoint {
+  date: string;
+  count: number;
+}
+export interface ApiDoraLtPoint {
+  week_start: string;
+  median_hours: number | null;
+  sample: number;
+}
+export interface ApiDoraCfrPoint {
+  date: string;
+  total: number;
+  failed: number;
+}
+export interface ApiDoraIncident {
+  failed_at: string;
+  recovered_at: string | null;
+  hours: number | null;
+  workflow_name: string | null;
+}
+export interface ApiDoraResponse {
+  window_days: number;
+  computed_at: string;
+  deployment_frequency: {
+    total_deploys: number;
+    per_day_median: number;
+    per_day_p90: number;
+    label: string;
+    time_series: ApiDoraDfPoint[];
+  };
+  lead_time: {
+    median_hours: number | null;
+    p90_hours: number | null;
+    label: string;
+    sample_size: number;
+    time_series: ApiDoraLtPoint[];
+  };
+  change_failure_rate: {
+    rate: number;
+    label: string;
+    total_deploys: number;
+    failed_deploys: number;
+    hotfix_prs: number;
+    time_series: ApiDoraCfrPoint[];
+  };
+  mttr: {
+    median_hours: number | null;
+    p90_hours: number | null;
+    label: string;
+    incidents: ApiDoraIncident[];
+  };
+}
+
+export function getDoraAnalytics(
+  workspaceId: string,
+  days: number,
+  token?: string,
+): Promise<ApiDoraResponse> {
+  const qs = `?days=${encodeURIComponent(String(days))}`;
+  return apiFetch<ApiDoraResponse>(
+    `/v1/workspaces/${encodeURIComponent(workspaceId)}/analytics/dora${qs}`,
+    { token },
+  );
+}
+
 export function dismissNotification(
   workspaceId: string,
   notificationId: string,


### PR DESCRIPTION
## Summary

PR-D3 of the dashboard refactor — the receiving end of PR-D1. Telemetry
that lived on the home page now has a real home with charts you can
actually analyse against.

- New ``/analytics`` route in the sidebar.
- 4-up DORA card grid (deployment frequency / lead time / CFR / MTTR)
  with recharts sparklines and DORA performance band labels.
- Window picker (30 / 90 / 180 days) via ``?days=…``.
- ``DashboardLiveSystem`` relocated here from the home right rail.
- ``Recent · last 24h`` merge list at the bottom.
- ``getDoraAnalytics`` API client wired against the PR-D2 backend.

Adds ``recharts`` (^3.8.1) to the console.

## Test plan

- [x] ``npx tsc --noEmit`` clean
- [x] ``npx eslint`` clean on touched files
- [ ] Manual: ``/analytics`` renders 4 cards + live-system + recent list
- [ ] Manual: window picker switches between 30/90/180 day data
- [ ] Manual: empty workspace → "No data" labels, "no incidents" sparkline