### PR TITLE
HOTFIX: tracker/next defensive degradation + DORA band off mean

### DIFF
--- a/backend/app/api/v1/routes/agent_runs.py
+++ b/backend/app/api/v1/routes/agent_runs.py
@@ -360,7 +360,48 @@ async def get_next_task(
     # Pull extra rows so a head-of-list orphan / parked-project row
     # doesn't starve the picker — we drop the skips and pick the first
     # eligible row that remains.
-    rows = await resolved.gateway.list_tickets(state=state, limit=10)
+    #
+    # Defensive degradation: a Linear hiccup (rotated state ID, deleted
+    # label, transient API 5xx) raises RuntimeError out of the
+    # GraphQL helper. The cron tick must NOT fail the workflow over
+    # that — the next tick will retry. Surface the error in the audit
+    # log so an operator can debug, then return ``ticket=None`` so the
+    # cron noops cleanly.
+    try:
+        rows = await resolved.gateway.list_tickets(state=state, limit=10)
+    except RuntimeError as exc:
+        logger.exception(
+            "tracker/next: list_tickets failed ws=%s state=%s err=%s",
+            workspace_id,
+            state,
+            exc,
+        )
+        try:
+            session.add(
+                AuditLog(
+                    workspace_id=workspace_id,
+                    actor_user_id=auth.user.id,
+                    actor_token_id=auth.token.id if auth.token else None,
+                    action="agent_run.tracker_next_failed",
+                    target_kind="fsm_stage",
+                    target_id=state,
+                    payload={
+                        "tracker_kind": resolved.kind,
+                        "fsm_stage": state,
+                        "error": str(exc)[:500],
+                    },
+                )
+            )
+            await session.flush()
+        except Exception as audit_exc:  # noqa: BLE001 — audit failure must not sink the response
+            logger.warning(
+                "tracker/next: audit write failed ws=%s err=%s",
+                workspace_id,
+                audit_exc,
+            )
+        return TaskResponseOut(
+            ticket=None, fsm_stage=state, tracker_kind=resolved.kind
+        )
     if not rows:
         return TaskResponseOut(
             ticket=None, fsm_stage=state, tracker_kind=resolved.kind

--- a/backend/app/api/v1/routes/analytics_dora.py
+++ b/backend/app/api/v1/routes/analytics_dora.py
@@ -105,9 +105,10 @@ class DfPoint(BaseModel):
 
 class DeploymentFrequency(BaseModel):
     total_deploys: int
+    per_day_average: float
     per_day_median: float
     per_day_p90: float
-    label: str  # DORA performance band
+    label: str  # DORA performance band (computed off the average)
     time_series: list[DfPoint]
 
 
@@ -168,12 +169,20 @@ class DoraOut(BaseModel):
 # ---------------------------------------------------------------------------
 
 
-def _label_deployment_frequency(per_day_median: float) -> str:
-    if per_day_median >= 1.0:
+def _label_deployment_frequency(per_day_average: float) -> str:
+    """DORA band off the average deploy-per-day rate.
+
+    We classify off the mean rather than the per-day median because a
+    healthy trunk-based workflow batches deploys into a few high-traffic
+    days per week — the median is then 0 even though the team ships
+    daily on aggregate. Mean tracks the cadence the operator
+    actually feels.
+    """
+    if per_day_average >= 1.0:
         return "Elite — daily or better"
-    if per_day_median >= 1 / 7:
+    if per_day_average >= 1 / 7:
         return "High — between weekly and daily"
-    if per_day_median >= 1 / 30:
+    if per_day_average >= 1 / 30:
         return "Medium — between monthly and weekly"
     return "Low — less than monthly"
 
@@ -266,13 +275,15 @@ def _compute_deployment_frequency(
         if d in counts_by_day:
             counts_by_day[d] += 1
     counts = list(counts_by_day.values())
+    average = (sum(counts) / len(counts)) if counts else 0.0
     median = float(statistics.median(counts)) if counts else 0.0
     p90 = float(_percentile([float(c) for c in counts], 90) or 0.0)
     return DeploymentFrequency(
         total_deploys=len(successful),
+        per_day_average=average,
         per_day_median=median,
         per_day_p90=p90,
-        label=_label_deployment_frequency(median),
+        label=_label_deployment_frequency(average),
         time_series=[
             DfPoint(date=d, count=c) for d, c in counts_by_day.items()
         ],

--- a/backend/tests/test_v1_analytics_dora.py
+++ b/backend/tests/test_v1_analytics_dora.py
@@ -38,6 +38,7 @@ async def test_empty_workspace_returns_zero_shape(
     assert body["window_days"] == 30
     df = body["deployment_frequency"]
     assert df["total_deploys"] == 0
+    assert df["per_day_average"] == 0.0
     assert df["per_day_median"] == 0.0
     assert len(df["time_series"]) >= 30
 

--- a/console/src/app/(authed)/analytics/page.tsx
+++ b/console/src/app/(authed)/analytics/page.tsx
@@ -195,8 +195,8 @@ function DoraGrid({ dora }: { dora: ApiDoraResponse }) {
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
         <DoraCard
           title="Deployment frequency"
-          headline={formatPerDay(dora.deployment_frequency.per_day_median)}
-          sub={`${dora.deployment_frequency.total_deploys} deploys total · p90 ${formatPerDay(dora.deployment_frequency.per_day_p90)}`}
+          headline={formatPerDay(dora.deployment_frequency.per_day_average)}
+          sub={`${dora.deployment_frequency.total_deploys} deploys total · median ${formatPerDay(dora.deployment_frequency.per_day_median)} · p90 ${formatPerDay(dora.deployment_frequency.per_day_p90)}`}
           band={dora.deployment_frequency.label}
         >
           <DfChart data={dora.deployment_frequency.time_series} />

--- a/console/src/lib/api/client.ts
+++ b/console/src/lib/api/client.ts
@@ -2676,6 +2676,7 @@ export interface ApiDoraResponse {
   computed_at: string;
   deployment_frequency: {
     total_deploys: number;
+    per_day_average: number;
     per_day_median: number;
     per_day_p90: number;
     label: string;


### PR DESCRIPTION
## Summary

Two production issues found on morning sweep:

1. **Schedule trigger 500 loop.** ``/tracker/next?state=<fsm>`` was 500ing
   for FSM-mapped stages — Linear adapter's ``_gql`` raised
   ``RuntimeError`` which propagated past FastAPI. Cron kept failing
   every 30 min, agents not picked up.
2. **DORA DF band misclassified.** 144 deploys/30 days = 4.8/day → Elite,
   but the band was computed off median (which is 0 for batched
   releases) and read "Low — less than monthly".

Fixes:

1. Catch ``RuntimeError`` in ``get_next_task``, log + audit, return
   ``ticket=None`` so cron noops cleanly.
2. Classify DF band off mean (``total/days``), surface median + p90
   as secondary stats.

## Test plan

- [x] tsc clean
- [x] backend imports clean, label band unit checks pass
- [ ] Manual: ``curl /tracker/next?state=task_intake`` returns 200 ticket=null after deploy
- [ ] Manual: schedule trigger run after deploy → success
- [ ] Manual: /analytics DF card shows correct headline + Elite band