### PR TITLE
fix: process editor opens correct process; knowledge sync hourly

### DIFF
--- a/backend/app/api/v1/routes/knowledge_import_sources.py
+++ b/backend/app/api/v1/routes/knowledge_import_sources.py
@@ -56,7 +56,15 @@ class ImportSourceCreateIn(BaseModel):
     config: dict[str, Any] = Field(default_factory=dict)
     integration_id: uuid.UUID | None = None
     repo_id: uuid.UUID | None = None
-    sync_interval_minutes: int | None = Field(default=24 * 60, ge=15)
+    # 60 min is the operator-friendly default — once an hour the
+    # knowledge cache catches up with the doc-repo / Notion / Confluence
+    # source. The previous 24-hour default left the operator's freshly
+    # pushed docs invisible to agents until the next morning, which
+    # surfaced as "the source says ready · 24h ago, why isn't it
+    # syncing?". The cron sweep runs every 15 min, so 60 min is the
+    # smallest sensible cadence below which the cron would skip the
+    # row half its passes anyway.
+    sync_interval_minutes: int | None = Field(default=60, ge=15)
 
     @field_validator("kind")
     @classmethod

--- a/backend/app/services/knowledge_ingestion.py
+++ b/backend/app/services/knowledge_ingestion.py
@@ -159,7 +159,7 @@ async def create_import_source(
     integration_id: uuid.UUID | None = None,
     repo_id: uuid.UUID | None = None,
     actor_user_id: uuid.UUID | None = None,
-    sync_interval_minutes: int | None = 24 * 60,
+    sync_interval_minutes: int | None = 60,
 ) -> KnowledgeImportSource:
     if kind not in KnowledgeImportSourceKind.ALL:
         raise KnowledgeIngestionError(f"unsupported source kind: {kind}")

--- a/console/src/app/(authed)/process/process-config.ts
+++ b/console/src/app/(authed)/process/process-config.ts
@@ -69,6 +69,17 @@ export function processFromRepoConfig(
   const rawProcess = asRecord(config?.parsed?.process);
   if (!rawProcess) return null;
 
+  // Repo configs serialise a single process today (the SDLC, id
+  // "development"). When the operator opens a different process — e.g.
+  // ``/process/decomposition`` for the project-anchor pipeline — the
+  // YAML overlay would otherwise replace the API's correct projection
+  // with the SDLC and the editor reads as if every process is the
+  // SDLC. Skip the YAML merge unless its id matches the process the
+  // operator actually navigated to. The API projection is canonical
+  // for processes the YAML doesn't model.
+  const yamlId = stringValue(rawProcess.id) ?? null;
+  if (yamlId && yamlId !== fallback.id) return null;
+
   const rawStates = Array.isArray(rawProcess.states) ? rawProcess.states : null;
   if (!rawStates || rawStates.length === 0) return null;
 


### PR DESCRIPTION
## Summary

Two morning-sweep bugs:

1. **Process editor /process/decomposition opens SDLC.**
   ``processFromRepoConfig`` was overlaying the YAML's
   single-process definition onto every requested process, so
   non-SDLC processes (like Decomposition) inherited the SDLC
   states from .ship/config.yml. Skip the overlay when YAML id
   doesn't match the requested process id.

2. **Knowledge sources default to 24h cadence.**
   "ready · 24h ago" — operator pushed docs, expected fresh sync,
   waited a full day. Default was 1440 min. Drop to 60 min so
   the cron sweep (every 15 min) can pick it up within an hour.

## Test plan

- [x] tsc clean, backend imports clean
- [ ] /process/decomposition shows Decomposition states (not SDLC)
- [ ] New docs_repo source created → ``sync_interval_minutes: 60``
- [ ] Existing source needs one-shot ``POST .../sync`` to refresh now