### PR TITLE
HOTFIX: Linear removed labels.none — switch FSM filter to every/neq

### DIFF
--- a/backend/app/integrations/linear/tracker_adapter.py
+++ b/backend/app/integrations/linear/tracker_adapter.py
@@ -437,15 +437,22 @@ class LinearTracker:
         ticket ``stage:bug_triage`` themselves to route it through bug
         intake; the standard idempotency rule applies.
 
-        Empty-collection trap (also ELS-90): Linear's
+        Empty-collection trap (ELS-90): Linear's
         ``IssueLabelCollectionFilter`` interprets a bare
         ``{"labels": {"id": {"nin": [...]}}}`` as ``some`` semantics —
         a label exists whose id is not in the list. On a ticket with
         **no labels at all**, that's vacuously false, so the
-        unlabeled ticket is excluded. We use the explicit ``none``
-        operator (``"labels": {"none": {"id": {"eq": id}}}``) so an
-        empty label collection is vacuously a match for "doesn't
-        have this label" — which is the obvious intent.
+        unlabeled ticket is excluded.
+
+        We previously used the ``none`` operator to encode "doesn't
+        have this label", but Linear removed ``none`` from
+        ``IssueLabelCollectionFilter`` (the API now rejects it as an
+        invalid field with "Did you mean 'name' or 'some'?"). The
+        equivalent shape is ``every: {id: {neq: X}}`` — *every*
+        label's id differs from X, which is vacuously true on an empty
+        collection (every element of {} satisfies any predicate). So
+        the unlabeled ticket still matches, and the labelled-with-X
+        ticket is correctly excluded.
 
         ``self_heal`` is intentionally not in ``FSM_STAGE_ORDER``; it
         runs out-of-band against any open ticket and falls back to the
@@ -460,10 +467,12 @@ class LinearTracker:
                 {"state": {"id": {"eq": self._state_id_by_name[target_state_name]}}}
             )
 
-        # "this role hasn't finished yet" — never re-pick.
+        # "this role hasn't finished yet" — never re-pick. ``every``
+        # matches the empty label collection too, so unlabeled
+        # Linear-native tickets at the entry stage still come through.
         own_label = self._label_id_by_stage.get(stage)
         if own_label:
-            parts.append({"labels": {"none": {"id": {"eq": own_label}}}})
+            parts.append({"labels": {"every": {"id": {"neq": own_label}}}})
 
         # "previous role is done" — for non-entry stages.
         prev = previous_stage(stage)
@@ -478,11 +487,11 @@ class LinearTracker:
         # question for a human. Skip these tickets at every stage so we
         # don't repeatedly comment on a ticket that's waiting on a human
         # answer. The label gets cleared by the human (Linear UI) when
-        # they reply. ``none`` (not bare ``nin``) for the same
-        # empty-collection reason as the own-label check above.
+        # they reply. Same ``every / neq`` shape as the own-label check
+        # above so unlabeled tickets aren't accidentally filtered out.
         clar = self._signal_label_ids.get("needs_clarification")
         if clar:
-            parts.append({"labels": {"none": {"id": {"eq": clar}}}})
+            parts.append({"labels": {"every": {"id": {"neq": clar}}}})
         return parts
 
     async def add_signal_label(self, ticket: TicketRef, *, key: str) -> None:

--- a/backend/tests/test_linear_tracker_fsm_filter.py
+++ b/backend/tests/test_linear_tracker_fsm_filter.py
@@ -21,8 +21,12 @@ filter ``{"labels": {"id": {"nin": [intake_label]}}}`` does NOT
 match because the ticket has zero labels — Linear's GraphQL
 interprets it as "some label exists with id not in [intake_label]",
 and "some" of an empty collection is false. The fix uses
-``{"labels": {"none": {"id": {"eq": intake_label}}}}``: "no label
-exists with id == intake_label", which is vacuously true on empty.
+``{"labels": {"every": {"id": {"neq": intake_label}}}}``: every
+label's id differs from intake_label, which is vacuously true on
+the empty label collection. (Linear removed the ``none`` operator
+from ``IssueLabelCollectionFilter`` after this fix shipped, so the
+implementation switched to the ``every / neq`` shape; the semantic
+intent — "ticket lacks this label" — is unchanged.)
 """
 
 from __future__ import annotations
@@ -75,10 +79,12 @@ def _find_label_clauses(parts: list[dict[str, Any]]) -> list[dict[str, Any]]:
     return [p for p in parts if "labels" in p]
 
 
-def test_intake_filter_uses_none_operator_for_own_label_exclusion() -> None:
-    """The own-label exclusion must use ``none`` (not bare ``nin``)
-    so a ticket with zero labels passes the filter — that's the
-    common shape for a freshly-filed Linear-native ticket."""
+def test_intake_filter_excludes_own_label_via_every_neq() -> None:
+    """The own-label exclusion must encode "ticket lacks this label"
+    in a way that matches the empty label collection too — that's
+    the common shape for a freshly-filed Linear-native ticket. We
+    use ``every / neq`` because Linear removed the ``none`` operator
+    from ``IssueLabelCollectionFilter``."""
     tracker = _make_tracker()
     parts = tracker._fsm_filter("task_intake")  # noqa: SLF001 - shape test
 
@@ -87,12 +93,10 @@ def test_intake_filter_uses_none_operator_for_own_label_exclusion() -> None:
     assert len(label_clauses) == 2
 
     own = label_clauses[0]
-    # ELS-90: bare ``nin`` is the bug being fixed. ``none`` is the
-    # vacuous-truth-on-empty-collection form.
-    assert "none" in own["labels"], (
-        f"intake's own-label exclusion must use ``none`` operator (got {own!r})"
+    assert "every" in own["labels"], (
+        f"intake's own-label exclusion must use ``every`` operator (got {own!r})"
     )
-    assert own["labels"]["none"] == {"id": {"eq": "lbl_intake"}}
+    assert own["labels"]["every"] == {"id": {"neq": "lbl_intake"}}
 
 
 def test_intake_filter_has_no_previous_stage_clause() -> None:
@@ -130,12 +134,12 @@ def test_ba_requirements_filter_requires_previous_stage_label() -> None:
         "ba_requirements must require the previous (intake) stage "
         "label via the ``some`` operator"
     )
-    # The own-label exclusion must still use ``none``.
-    has_none = any("none" in p["labels"] for p in label_clauses)
-    assert has_none
+    # The own-label exclusion must use ``every / neq``.
+    has_every = any("every" in p["labels"] for p in label_clauses)
+    assert has_every
 
 
-def test_needs_clarification_exclusion_uses_none_too() -> None:
+def test_needs_clarification_exclusion_uses_every_neq_too() -> None:
     """Same empty-collection issue applies to the ``needs:clarification``
     exclusion. A ticket with no labels at all must not be silently
     excluded by it."""
@@ -145,11 +149,11 @@ def test_needs_clarification_exclusion_uses_none_too() -> None:
         p
         for p in parts
         if "labels" in p
-        and "none" in p["labels"]
-        and p["labels"]["none"].get("id", {}).get("eq") == "lbl_clar"
+        and "every" in p["labels"]
+        and p["labels"]["every"].get("id", {}).get("neq") == "lbl_clar"
     ]
     assert len(clar_clauses) == 1, (
-        "``needs:clarification`` exclusion should be a single ``none.id.eq`` clause"
+        "``needs:clarification`` exclusion should be a single ``every.id.neq`` clause"
     )
 
 


### PR DESCRIPTION
## Summary

Tickets weren't moving through the SDLC pipeline. Audit log shows
Linear's GraphQL rejecting our filter with:

> Field "none" is not defined by type "IssueLabelCollectionFilter".
> Did you mean "name" or "some"?

Linear silently deprecated the ``none`` operator on
``IssueLabelCollectionFilter``. Every FSM-mapped state's pickup
500'd, defensive try/except returned ``ticket=null``, cron silently
no-op'd. Switched to ``every: {id: {neq: X}}`` — equivalent shape
that's vacuously true on the empty label collection (still matches
unlabeled Linear-native tickets).

Tests updated. Defensive try/except retained — kept the cron green
while we figured this out and is correct behaviour for any future
Linear schema drift.

## Test plan

- [x] ``_fsm_filter`` returns ``every / neq`` shape for all stages
- [ ] After deploy: ``GET /tracker/next?state=task_intake`` returns a real ticket
- [ ] Schedule trigger picks up + dispatches an SDLC agent