### PR TITLE
backend: agent_provider binding per workspace (PR-1/6)

### DIFF
--- a/backend/app/api/v1/routes/workspaces.py
+++ b/backend/app/api/v1/routes/workspaces.py
@@ -17,6 +17,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.app.api.v1.deps import AuthContext, get_current_auth
 from backend.app.api.v1.schemas import (
+    AgentProviderOut,
+    AgentProviderUpdate,
     WorkspaceCreate,
     WorkspaceDeleteRequest,
     WorkspaceOut,
@@ -348,6 +350,21 @@ async def update_workspace(
             )
         workspace.default_agent_profile = payload.default_agent_profile
         changed["default_agent_profile"] = payload.default_agent_profile
+    if payload.agent_provider is not None:
+        from backend.app.services.agent_provider_resolver import (
+            SUPPORTED_PROVIDERS,
+        )
+
+        if payload.agent_provider not in SUPPORTED_PROVIDERS:
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    "agent_provider must be one of "
+                    f"{sorted(SUPPORTED_PROVIDERS)}"
+                ),
+            )
+        workspace.agent_provider = payload.agent_provider
+        changed["agent_provider"] = payload.agent_provider
 
     if changed:
         session.add(
@@ -363,6 +380,97 @@ async def update_workspace(
         )
     await session.flush()
     return WorkspaceOut.model_validate(workspace)
+
+
+@router.get(
+    "/{workspace_id}/agent-provider",
+    response_model=AgentProviderOut,
+)
+async def get_agent_provider(
+    workspace_id: uuid.UUID,
+    auth: AuthContext = Depends(get_current_auth),
+    session: AsyncSession = Depends(get_session),
+) -> AgentProviderOut:
+    """Read the workspace's bound autonomous-pipeline runtime.
+
+    Mirror of the tracker-binding GET so the wizard / settings page
+    can read this value without parsing the larger ``WorkspaceOut``
+    payload. Membership-gated (read tier).
+    """
+    from backend.app.services.agent_provider_resolver import (
+        SUPPORTED_PROVIDERS,
+        resolve_for_workspace,
+    )
+
+    await _require_membership(session, workspace_id, auth.user.id, ROLES_READ)
+    workspace = await session.get(Workspace, workspace_id)
+    if workspace is None:
+        raise HTTPException(status_code=404, detail="workspace not found")
+    resolved = await resolve_for_workspace(
+        session=session, workspace_id=workspace_id
+    )
+    return AgentProviderOut(
+        workspace_id=workspace_id,
+        kind=resolved.kind,
+        supported=sorted(SUPPORTED_PROVIDERS),
+    )
+
+
+@router.put(
+    "/{workspace_id}/agent-provider",
+    response_model=AgentProviderOut,
+)
+async def set_agent_provider(
+    workspace_id: uuid.UUID,
+    payload: AgentProviderUpdate,
+    auth: AuthContext = Depends(get_current_auth),
+    session: AsyncSession = Depends(get_session),
+) -> AgentProviderOut:
+    """Bind a different agent runtime to the workspace. Admin-only.
+
+    Idempotent: PUT'ing the current value returns 200 without an
+    audit row (no change == no event). The CHECK constraint on the
+    column rejects unknown values defensively even if the resolver's
+    ``SUPPORTED_PROVIDERS`` validation is bypassed.
+    """
+    from backend.app.services.agent_provider_resolver import (
+        SUPPORTED_PROVIDERS,
+    )
+
+    await _require_membership(session, workspace_id, auth.user.id, ROLES_ADMIN)
+    if payload.kind not in SUPPORTED_PROVIDERS:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                "agent_provider must be one of "
+                f"{sorted(SUPPORTED_PROVIDERS)}"
+            ),
+        )
+    workspace = await session.get(Workspace, workspace_id)
+    if workspace is None:
+        raise HTTPException(status_code=404, detail="workspace not found")
+
+    if workspace.agent_provider != payload.kind:
+        previous = workspace.agent_provider
+        workspace.agent_provider = payload.kind
+        session.add(
+            AuditLog(
+                workspace_id=workspace.id,
+                actor_user_id=auth.user.id,
+                actor_token_id=auth.token.id if auth.token else None,
+                action="workspace.agent_provider.set",
+                target_kind="workspace",
+                target_id=str(workspace.id),
+                payload={"from": previous, "to": payload.kind},
+            )
+        )
+        await session.flush()
+
+    return AgentProviderOut(
+        workspace_id=workspace_id,
+        kind=workspace.agent_provider,
+        supported=sorted(SUPPORTED_PROVIDERS),
+    )
 
 
 @router.delete(

--- a/backend/app/api/v1/schemas.py
+++ b/backend/app/api/v1/schemas.py
@@ -53,6 +53,7 @@ class WorkspaceOut(BaseModel):
     name: str
     catalog_sources: dict
     default_agent_profile: str | None = None
+    agent_provider: str
     created_at: datetime
 
 
@@ -130,6 +131,24 @@ class WorkspaceUpdate(BaseModel):
     default_agent_profile: str | None = Field(
         default=None, min_length=1, max_length=64
     )
+    # Bound autonomous-pipeline runtime. Validated against
+    # :data:`backend.app.services.agent_provider_resolver.SUPPORTED_PROVIDERS`
+    # at the route layer.
+    agent_provider: str | None = Field(default=None, min_length=1, max_length=16)
+
+
+class AgentProviderOut(BaseModel):
+    """``GET /v1/workspaces/{ws}/agent-provider`` response."""
+
+    workspace_id: uuid.UUID
+    kind: str
+    supported: list[str]
+
+
+class AgentProviderUpdate(BaseModel):
+    """``PUT /v1/workspaces/{ws}/agent-provider`` body."""
+
+    kind: str = Field(min_length=1, max_length=16)
 
 
 # --- Members ---

--- a/backend/app/db/models/tenancy.py
+++ b/backend/app/db/models/tenancy.py
@@ -168,6 +168,16 @@ class Workspace(Base):
     default_agent_profile: Mapped[str | None] = mapped_column(
         String(64), nullable=True
     )
+    # Bound agent runtime for the workspace's autonomous pipeline. One of
+    # ``cursor`` / ``codex`` / ``claude`` (validated at the DB by a CHECK
+    # constraint mirrored in :func:`agent_provider_resolver.resolve_for_workspace`).
+    # ``shipctl run`` resolves this row to pick which local CLI to invoke
+    # on the GHA runner — the cloud-API path is gone. ``cursor`` stays
+    # the default so existing workspaces keep working without an
+    # explicit operator choice.
+    agent_provider: Mapped[str] = mapped_column(
+        String(16), nullable=False, server_default=text("'cursor'")
+    )
 
     created_at: Mapped[datetime] = _ts_created()
     updated_at: Mapped[datetime] = _ts_updated()

--- a/backend/app/services/agent_provider_resolver.py
+++ b/backend/app/services/agent_provider_resolver.py
@@ -1,0 +1,72 @@
+"""Pick the autonomous-pipeline agent runtime for a workspace.
+
+Mirrors :mod:`backend.app.services.tracker_resolver`: the workspace
+binds to exactly one provider (``cursor`` / ``codex`` / ``claude``)
+and ``shipctl run`` reads the bound row to decide which local CLI to
+invoke on the GHA runner. No peer-ranking, no per-routine fallback at
+the resolver layer — `.ship/config.yml` overrides happen above this
+service if needed.
+
+``cursor`` stays the default for fresh workspaces so the upgrade
+doesn't yank existing pipelines out from under operators who never
+touched the new setting. A typo at either end (DB row or CLI mapping)
+surfaces as a fast 422 against the validated enum below rather than
+an opaque CLI invocation failure on the runner.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from typing import Final, Literal
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.app.db.models.tenancy import Workspace
+
+
+AgentProviderKind = Literal["cursor", "codex", "claude"]
+
+
+SUPPORTED_PROVIDERS: Final[frozenset[str]] = frozenset(
+    {"cursor", "codex", "claude"}
+)
+DEFAULT_PROVIDER: Final[AgentProviderKind] = "cursor"
+
+
+@dataclass(frozen=True)
+class ResolvedAgentProvider:
+    kind: AgentProviderKind
+    # Echo back the workspace id so callers logging the resolution
+    # don't have to thread it through separately.
+    workspace_id: uuid.UUID
+
+
+async def resolve_for_workspace(
+    *,
+    session: AsyncSession,
+    workspace_id: uuid.UUID,
+) -> ResolvedAgentProvider:
+    """Return the workspace's bound agent runtime.
+
+    Falls back to :data:`DEFAULT_PROVIDER` when the row is missing
+    (workspace deleted mid-flight or migration not yet applied) so the
+    runner has *something* to invoke instead of dying with a 500. The
+    falsy path is rare; logged but not raised.
+    """
+
+    row = await session.scalar(
+        select(Workspace.agent_provider).where(Workspace.id == workspace_id)
+    )
+    kind = row if row in SUPPORTED_PROVIDERS else DEFAULT_PROVIDER
+    return ResolvedAgentProvider(kind=kind, workspace_id=workspace_id)
+
+
+__all__ = [
+    "AgentProviderKind",
+    "DEFAULT_PROVIDER",
+    "ResolvedAgentProvider",
+    "SUPPORTED_PROVIDERS",
+    "resolve_for_workspace",
+]

--- a/backend/migrations/versions/0063_workspace_agent_provider.py
+++ b/backend/migrations/versions/0063_workspace_agent_provider.py
@@ -1,0 +1,57 @@
+"""workspaces.agent_provider — bound agent runtime per workspace
+
+Adds a ``Workspace.agent_provider`` column (``cursor`` / ``codex`` /
+``claude``) so the autonomous pipeline picks which local CLI to run on
+the GHA runner the same way it picks a tracker. Default is ``cursor``
+to keep existing workspaces working without an explicit operator
+choice.
+
+A CHECK constraint pins the accepted enum at the DB layer; the resolver
+in :mod:`backend.app.services.agent_provider_resolver` mirrors the same
+set so a typo on either side surfaces as a 422 / IntegrityError instead
+of an opaque CLI invocation failure.
+
+Revision ID: 0063_agent_provider
+Revises: 0062_priority_default_planning
+Create Date: 2026-05-07
+"""
+
+from __future__ import annotations
+
+from typing import Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "0063_agent_provider"
+down_revision: Union[str, None] = "0062_priority_default_planning"
+branch_labels: Union[str, tuple[str, ...], None] = None
+depends_on: Union[str, tuple[str, ...], None] = None
+
+
+_TABLE = "workspaces"
+_COLUMN = "agent_provider"
+_CHECK = "ck_workspaces_agent_provider_enum"
+
+
+def upgrade() -> None:
+    op.add_column(
+        _TABLE,
+        sa.Column(
+            _COLUMN,
+            sa.String(length=16),
+            nullable=False,
+            server_default=sa.text("'cursor'"),
+        ),
+    )
+    op.create_check_constraint(
+        _CHECK,
+        _TABLE,
+        f"{_COLUMN} IN ('cursor', 'codex', 'claude')",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(_CHECK, _TABLE, type_="check")
+    op.drop_column(_TABLE, _COLUMN)

--- a/backend/tests/test_v1_agent_provider.py
+++ b/backend/tests/test_v1_agent_provider.py
@@ -1,0 +1,154 @@
+"""Workspace agent_provider binding (PR-1).
+
+Covers the resolver default, the GET/PUT routes, the audit row, and
+the validation guard rails (CHECK constraint + 422 on unsupported
+kind).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_resolver_returns_default_for_fresh_workspace(
+    db_session, seed_workspace
+) -> None:
+    from backend.app.services.agent_provider_resolver import (
+        DEFAULT_PROVIDER,
+        resolve_for_workspace,
+    )
+
+    _, _, workspace = seed_workspace
+    resolved = await resolve_for_workspace(
+        session=db_session, workspace_id=workspace.id
+    )
+    assert resolved.kind == DEFAULT_PROVIDER
+    assert resolved.workspace_id == workspace.id
+
+
+@pytest.mark.asyncio
+async def test_resolver_reads_bound_kind(
+    db_session, seed_workspace
+) -> None:
+    from backend.app.services.agent_provider_resolver import (
+        resolve_for_workspace,
+    )
+
+    _, _, workspace = seed_workspace
+    workspace.agent_provider = "claude"
+    await db_session.flush()
+
+    resolved = await resolve_for_workspace(
+        session=db_session, workspace_id=workspace.id
+    )
+    assert resolved.kind == "claude"
+
+
+@pytest.mark.asyncio
+async def test_get_agent_provider_returns_default_and_supported(
+    v1_client, seed_workspace
+) -> None:
+    _, raw, workspace = seed_workspace
+    resp = await v1_client.get(
+        f"/v1/workspaces/{workspace.id}/agent-provider",
+        headers={"Authorization": f"Bearer {raw}"},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["workspace_id"] == str(workspace.id)
+    assert body["kind"] == "cursor"
+    assert body["supported"] == ["claude", "codex", "cursor"]
+
+
+@pytest.mark.asyncio
+async def test_put_agent_provider_changes_kind_and_audits(
+    db_session, v1_client, seed_workspace
+) -> None:
+    from sqlalchemy import select
+
+    from backend.app.db.models.tenancy import AuditLog, Workspace
+
+    _, raw, workspace = seed_workspace
+    resp = await v1_client.put(
+        f"/v1/workspaces/{workspace.id}/agent-provider",
+        json={"kind": "codex"},
+        headers={"Authorization": f"Bearer {raw}"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["kind"] == "codex"
+
+    refreshed = await db_session.get(Workspace, workspace.id)
+    assert refreshed.agent_provider == "codex"
+
+    rows = (
+        await db_session.execute(
+            select(AuditLog).where(
+                AuditLog.workspace_id == workspace.id,
+                AuditLog.action == "workspace.agent_provider.set",
+            )
+        )
+    ).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].payload == {"from": "cursor", "to": "codex"}
+
+
+@pytest.mark.asyncio
+async def test_put_agent_provider_idempotent_no_audit(
+    db_session, v1_client, seed_workspace
+) -> None:
+    from sqlalchemy import select
+
+    from backend.app.db.models.tenancy import AuditLog
+
+    _, raw, workspace = seed_workspace
+    # Workspace defaults to cursor; PUT'ing the same value is a no-op.
+    resp = await v1_client.put(
+        f"/v1/workspaces/{workspace.id}/agent-provider",
+        json={"kind": "cursor"},
+        headers={"Authorization": f"Bearer {raw}"},
+    )
+    assert resp.status_code == 200, resp.text
+
+    rows = (
+        await db_session.execute(
+            select(AuditLog).where(
+                AuditLog.workspace_id == workspace.id,
+                AuditLog.action == "workspace.agent_provider.set",
+            )
+        )
+    ).scalars().all()
+    assert rows == []
+
+
+@pytest.mark.asyncio
+async def test_put_agent_provider_rejects_unknown(
+    v1_client, seed_workspace
+) -> None:
+    _, raw, workspace = seed_workspace
+    resp = await v1_client.put(
+        f"/v1/workspaces/{workspace.id}/agent-provider",
+        json={"kind": "copilot"},
+        headers={"Authorization": f"Bearer {raw}"},
+    )
+    assert resp.status_code == 422, resp.text
+    assert "agent_provider must be one of" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_patch_workspace_can_set_agent_provider(
+    db_session, v1_client, seed_workspace
+) -> None:
+    from backend.app.db.models.tenancy import Workspace
+
+    _, raw, workspace = seed_workspace
+    resp = await v1_client.patch(
+        f"/v1/workspaces/{workspace.id}",
+        json={"agent_provider": "claude"},
+        headers={"Authorization": f"Bearer {raw}"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["agent_provider"] == "claude"
+
+    refreshed = await db_session.get(Workspace, workspace.id)
+    assert refreshed.agent_provider == "claude"


### PR DESCRIPTION
## Summary
- New ``Workspace.agent_provider`` column (cursor / codex / claude, default cursor) plus 0063 migration with CHECK constraint.
- ``backend/app/services/agent_provider_resolver.resolve_for_workspace`` mirroring the tracker resolver — single source of truth that ``shipctl run`` will read in PR-3 to choose which local CLI to invoke on the GHA runner.
- ``GET/PUT /v1/workspaces/{ws}/agent-provider`` endpoints (admin-only PUT) plus ``agent_provider`` field on the existing ``WorkspaceUpdate`` PATCH so the settings page can drive it.
- Audit row ``workspace.agent_provider.set`` on every change; idempotent PUTs don't audit.
- Tests for resolver default + bound read, GET supported list, PUT audit + idempotency, 422 on unsupported, PATCH path.

This PR is the foundation; PR-2 wires the console UI, PR-3 swaps the CLI to read this and execute the bound CLI locally on the runner, PR-4 updates the workflow, PR-5 deletes the Cursor cloud poll path.

## Test plan
- [ ] ``python -m pytest backend/tests/test_v1_agent_provider.py`` (DB required).
- [ ] ``alembic upgrade head`` applies cleanly on a fresh DB.
- [ ] ``GET /v1/workspaces/{ws}/agent-provider`` returns ``{kind: cursor, supported: [claude, codex, cursor]}`` for fresh workspaces.
- [ ] ``PUT /v1/workspaces/{ws}/agent-provider {"kind": "claude"}`` flips the row and writes the audit event; PUT'ing the same kind again is a 200 no-op.