### PR TITLE
console: agent provider picker on workspace settings (PR-2/6)

### DIFF
--- a/console/src/app/(authed)/settings/_shell/settings-shell.tsx
+++ b/console/src/app/(authed)/settings/_shell/settings-shell.tsx
@@ -362,6 +362,7 @@ export async function SettingsShell({
                 </div>
               </Card>
               <DefaultAgentCard workspace={workspace} />
+              <AgentProviderCard workspace={workspace} />
             </div>
           )}
 
@@ -912,6 +913,68 @@ function DefaultAgentCard({ workspace }: { workspace: ApiWorkspace }) {
           className="h-10 whitespace-nowrap rounded-full border border-aqua/30 bg-aqua/10 px-4 text-xs font-bold text-aqua transition hover:bg-aqua/15"
         >
           Save default
+        </button>
+      </form>
+    </Card>
+  );
+}
+
+// Mirror of backend ``SUPPORTED_PROVIDERS``. Each option is one of the
+// three local-CLI runtimes shipctl can dispatch on the GHA runner.
+const AGENT_PROVIDER_OPTIONS: { value: "cursor" | "codex" | "claude"; label: string; hint: string }[] = [
+  {
+    value: "cursor",
+    label: "Cursor Agent",
+    hint: "Local cursor-agent CLI on the runner",
+  },
+  {
+    value: "codex",
+    label: "OpenAI Codex",
+    hint: "Local @openai/codex CLI on the runner",
+  },
+  {
+    value: "claude",
+    label: "Claude Code",
+    hint: "Local @anthropic-ai/claude-code CLI on the runner",
+  },
+];
+
+function AgentProviderCard({ workspace }: { workspace: ApiWorkspace }) {
+  const current = workspace.agent_provider ?? "cursor";
+  return (
+    <Card>
+      <CardHeader
+        title="Autonomous pipeline runtime"
+        subtitle="Which local CLI runs on the GitHub Actions runner when shipctl dispatches a routine. Switching takes effect from the next cron tick — in-flight runs finish under the previous binding."
+      />
+      <form
+        action="/api/settings/agent-provider"
+        method="POST"
+        className="flex flex-col gap-3 sm:flex-row sm:items-end"
+      >
+        <input type="hidden" name="ws" value={workspace.id} suppressHydrationWarning />
+        <label className="flex-1">
+          <span className="mb-1 block text-[10px] font-bold uppercase tracking-widest text-white/55">
+            Provider
+          </span>
+          <select
+            name="provider"
+            defaultValue={current}
+            required
+            className="w-full rounded border border-white/10 bg-white/[0.04] px-2 py-2 text-sm text-white outline-none focus:border-aqua/40"
+          >
+            {AGENT_PROVIDER_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label} — {opt.hint}
+              </option>
+            ))}
+          </select>
+        </label>
+        <button
+          type="submit"
+          className="h-10 whitespace-nowrap rounded-full border border-aqua/30 bg-aqua/10 px-4 text-xs font-bold text-aqua transition hover:bg-aqua/15"
+        >
+          Save provider
         </button>
       </form>
     </Card>

--- a/console/src/app/api/settings/agent-provider/route.ts
+++ b/console/src/app/api/settings/agent-provider/route.ts
@@ -1,0 +1,65 @@
+/**
+ * POST /api/settings/agent-provider — set the workspace-bound agent
+ * runtime (cursor / codex / claude).
+ *
+ * Server-action endpoint for the General settings card. Forwards to
+ * PUT /v1/workspaces/{id}/agent-provider so the audit trail captures
+ * the change with the dedicated ``workspace.agent_provider.set`` row
+ * instead of a generic ``workspace.update``. The bound kind is what
+ * shipctl run resolves on the GHA runner to pick which local CLI
+ * (cursor-agent / codex / claude) to invoke.
+ */
+
+import { NextResponse } from "next/server";
+
+import {
+  ApiHttpError,
+  ApiUnavailableError,
+  isApiConfigured,
+  setAgentProvider,
+} from "@/lib/api/client";
+import { resolveOrigin } from "@/lib/api/origin";
+
+// Mirror of backend ``SUPPORTED_PROVIDERS``. Kept in sync by hand —
+// the picker UI and this guard read the same set.
+const VALID_PROVIDERS = new Set(["cursor", "codex", "claude"] as const);
+
+type ProviderKind = "cursor" | "codex" | "claude";
+
+export async function POST(request: Request) {
+  const origin = resolveOrigin(request);
+  const form = await request.formData();
+  const wsId = (form.get("ws") ?? "").toString();
+  const provider = (form.get("provider") ?? "").toString();
+
+  if (!wsId || !VALID_PROVIDERS.has(provider as ProviderKind)) {
+    return back(origin, "bad_input");
+  }
+  if (!isApiConfigured()) {
+    return back(origin, "api_unavailable");
+  }
+
+  try {
+    await setAgentProvider(wsId, provider as ProviderKind);
+  } catch (err) {
+    if (err instanceof ApiUnavailableError) return back(origin, "api_unavailable");
+    if (err instanceof ApiHttpError) {
+      if (err.status === 401)
+        return NextResponse.redirect(
+          new URL("/login?error=session_expired", origin),
+          303,
+        );
+      if (err.status === 403) return back(origin, "forbidden");
+      return back(origin, `http_${err.status}`);
+    }
+    return back(origin, "unknown");
+  }
+
+  return NextResponse.redirect(new URL("/settings/general", origin), 303);
+}
+
+function back(origin: string, code: string) {
+  const url = new URL("/settings/general", origin);
+  url.searchParams.set("error", code);
+  return NextResponse.redirect(url, 303);
+}

--- a/console/src/lib/api/client.ts
+++ b/console/src/lib/api/client.ts
@@ -179,6 +179,7 @@ export function updateWorkspace(
     name?: string;
     catalog_sources?: Record<string, boolean>;
     default_agent_profile?: string;
+    agent_provider?: "cursor" | "codex" | "claude";
   },
   token?: string,
 ): Promise<ApiWorkspace> {
@@ -187,6 +188,40 @@ export function updateWorkspace(
     body: input,
     token,
   });
+}
+
+/**
+ * GET ``/v1/workspaces/{ws}/agent-provider`` — the dedicated read for
+ * the bound autonomous-pipeline runtime. Returns the canonical kind
+ * the resolver would produce plus the supported list (so the FE
+ * doesn't have to keep its own enum in sync with the backend's
+ * ``SUPPORTED_PROVIDERS``).
+ */
+export interface ApiAgentProvider {
+  workspace_id: string;
+  kind: "cursor" | "codex" | "claude";
+  supported: ("cursor" | "codex" | "claude")[];
+}
+
+export function getAgentProvider(
+  workspaceId: string,
+  token?: string,
+): Promise<ApiAgentProvider> {
+  return apiFetch<ApiAgentProvider>(
+    `/v1/workspaces/${workspaceId}/agent-provider`,
+    { token },
+  );
+}
+
+export function setAgentProvider(
+  workspaceId: string,
+  kind: "cursor" | "codex" | "claude",
+  token?: string,
+): Promise<ApiAgentProvider> {
+  return apiFetch<ApiAgentProvider>(
+    `/v1/workspaces/${workspaceId}/agent-provider`,
+    { method: "PUT", body: { kind }, token },
+  );
 }
 
 // --- Integrations ----------------------------------------------------------

--- a/console/src/lib/api/types.ts
+++ b/console/src/lib/api/types.ts
@@ -68,6 +68,13 @@ export type ApiWorkspace = {
    * gates all edits until this is set.
    */
   default_agent_profile: string | null;
+  /**
+   * Bound autonomous-pipeline runtime. ``shipctl run`` reads this to
+   * pick which local CLI to invoke on the GHA runner. One of
+   * ``cursor`` / ``codex`` / ``claude``; defaults to ``cursor`` for
+   * fresh workspaces.
+   */
+  agent_provider: "cursor" | "codex" | "claude";
   created_at: string;
 };
 


### PR DESCRIPTION
## Summary
- Surface the new ``Workspace.agent_provider`` binding on ``/settings/general``: a select with cursor / codex / claude options, mirroring the existing ``DefaultAgentCard`` shape.
- ``ApiWorkspace.agent_provider`` field added to the type; ``updateWorkspace()`` accepts it for partial updates.
- New dedicated ``getAgentProvider`` / ``setAgentProvider`` client helpers wrapping the new ``/v1/workspaces/{ws}/agent-provider`` endpoints from PR #212.
- ``/api/settings/agent-provider`` Next route mirrors the bad_input / api_unavailable / forbidden / 401-redirect handling from ``default-agent``.

## Test plan
- [ ] ``cd console && npx tsc --noEmit`` exits 0.
- [ ] Open ``/settings/general``: the new "Autonomous pipeline runtime" card renders below "Default agent profile" with the workspace's bound kind preselected.
- [ ] Submit the form with each option; refresh — the new value sticks and ``GET /v1/workspaces/{ws}/agent-provider`` returns the same kind.
- [ ] Submitting an unknown value returns a 422 from the backend; the route surfaces ``?error=http_422``.

## Stacks on top of
#212 — agent_provider DB column + API binding (PR-1).