### PR TITLE
cli: 3 local agent CLI adapters (PR-3/6)

### DIFF
--- a/cli/lib/agents/claude.mjs
+++ b/cli/lib/agents/claude.mjs
@@ -1,0 +1,78 @@
+/**
+ * Anthropic Claude Code CLI local adapter.
+ *
+ * Runs the ``claude`` binary (from ``@anthropic-ai/claude-code``) on
+ * the GHA runner. Mirrors the Cursor / Codex shape: the runner has
+ * already prepared the branch in ``workdir``; the adapter just
+ * invokes the CLI in non-interactive mode and returns once it
+ * terminates.
+ *
+ * Headless flags ('claude --help'):
+ *   -p / --print                                 non-interactive, print + exit
+ *   --output-format text|json|stream-json
+ *   --dangerously-skip-permissions               required on a fresh runner
+ *                                                without prior workspace trust
+ *                                                history (CI sandbox)
+ *   --add-dir <dirs...>                          extra dirs the agent may
+ *                                                touch — we add the workspace
+ *                                                explicitly even though it's
+ *                                                cwd, so symlink-style repos
+ *                                                still resolve
+ *
+ * Auth: ``ANTHROPIC_API_KEY`` env var. Claude Code also reads a
+ * keychain entry on macOS but CI runners don't have it.
+ */
+
+import { spawn } from "node:child_process";
+
+
+/**
+ * @param {object} opts
+ * @param {string} opts.workdir      repo checkout dir; defaults to process.cwd()
+ * @param {string} opts.branchName   branch the agent commits onto (already checked out)
+ * @param {string} opts.prompt       full prompt body
+ * @param {Record<string,string>} [opts.env]  extra env vars merged onto process.env
+ * @param {(line: string) => void} [opts.onLog] streaming log hook
+ * @returns {Promise<{ agentId: string, branchName: string, status: string, exitCode: number }>}
+ */
+export async function runClaudeAgent({
+  workdir = process.cwd(),
+  branchName,
+  prompt,
+  env = {},
+  onLog = (l) => process.stderr.write(`[claude] ${l}\n`),
+} = {}) {
+  if (!branchName) throw new Error("runClaudeAgent: branchName required");
+  if (!prompt || typeof prompt !== "string") {
+    throw new Error("runClaudeAgent: prompt required");
+  }
+  if (!(process.env.ANTHROPIC_API_KEY || env.ANTHROPIC_API_KEY)) {
+    throw new Error("ANTHROPIC_API_KEY is not set");
+  }
+
+  const args = [
+    "--print",
+    "--dangerously-skip-permissions",
+    "--add-dir",
+    workdir,
+    "--output-format",
+    "text",
+    prompt,
+  ];
+
+  onLog(`launch claude branch=${branchName} cwd=${workdir} prompt=${prompt.length}b`);
+  const child = spawn("claude", args, {
+    cwd: workdir,
+    env: { ...process.env, ...env },
+    stdio: ["ignore", "inherit", "inherit"],
+  });
+
+  const exitCode = await new Promise((resolve, reject) => {
+    child.on("error", reject);
+    child.on("exit", (code) => resolve(code ?? 1));
+  });
+
+  const status = exitCode === 0 ? "FINISHED" : "ERRORED";
+  onLog(`claude terminal: status=${status} exit=${exitCode}`);
+  return { agentId: `claude-${branchName}`, branchName, status, exitCode };
+}

--- a/cli/lib/agents/codex.mjs
+++ b/cli/lib/agents/codex.mjs
@@ -1,0 +1,70 @@
+/**
+ * OpenAI Codex CLI local adapter.
+ *
+ * Runs the official ``codex`` binary (from ``@openai/codex``) on the
+ * GHA runner. Mirrors the Cursor / Claude shape: the runner has
+ * already prepared the branch in ``workdir``; the adapter just
+ * invokes the CLI in non-interactive mode and returns once it
+ * terminates.
+ *
+ * Headless mode is ``codex exec`` per
+ * https://developers.openai.com/codex/noninteractive .  ``--full-auto``
+ * suppresses the permission prompts, ``--skip-git-repo-check`` lets
+ * us run inside a freshly checked-out repo without git-state
+ * heuristics intercepting.  Prompt is passed as the trailing
+ * positional arg.
+ *
+ * Auth: ``OPENAI_API_KEY`` env var (Codex also accepts a ChatGPT
+ * sign-in but that's interactive; CI uses the API-key path).
+ */
+
+import { spawn } from "node:child_process";
+
+
+/**
+ * @param {object} opts
+ * @param {string} opts.workdir      repo checkout dir; defaults to process.cwd()
+ * @param {string} opts.branchName   branch the agent commits onto (already checked out)
+ * @param {string} opts.prompt       full prompt body
+ * @param {Record<string,string>} [opts.env]  extra env vars merged onto process.env
+ * @param {(line: string) => void} [opts.onLog] streaming log hook
+ * @returns {Promise<{ agentId: string, branchName: string, status: string, exitCode: number }>}
+ */
+export async function runCodexAgent({
+  workdir = process.cwd(),
+  branchName,
+  prompt,
+  env = {},
+  onLog = (l) => process.stderr.write(`[codex] ${l}\n`),
+} = {}) {
+  if (!branchName) throw new Error("runCodexAgent: branchName required");
+  if (!prompt || typeof prompt !== "string") {
+    throw new Error("runCodexAgent: prompt required");
+  }
+  if (!(process.env.OPENAI_API_KEY || env.OPENAI_API_KEY)) {
+    throw new Error("OPENAI_API_KEY is not set");
+  }
+
+  const args = [
+    "exec",
+    "--full-auto",
+    "--skip-git-repo-check",
+    prompt,
+  ];
+
+  onLog(`launch codex exec branch=${branchName} cwd=${workdir} prompt=${prompt.length}b`);
+  const child = spawn("codex", args, {
+    cwd: workdir,
+    env: { ...process.env, ...env },
+    stdio: ["ignore", "inherit", "inherit"],
+  });
+
+  const exitCode = await new Promise((resolve, reject) => {
+    child.on("error", reject);
+    child.on("exit", (code) => resolve(code ?? 1));
+  });
+
+  const status = exitCode === 0 ? "FINISHED" : "ERRORED";
+  onLog(`codex terminal: status=${status} exit=${exitCode}`);
+  return { agentId: `codex-${branchName}`, branchName, status, exitCode };
+}

--- a/cli/lib/agents/cursor.mjs
+++ b/cli/lib/agents/cursor.mjs
@@ -1,143 +1,78 @@
 /**
- * Cursor Cloud Agent runtime adapter.
+ * Cursor Agent local-CLI adapter.
  *
- * Wraps the public ``POST https://api.cursor.com/v0/agents`` API the
- * ElMundi sibling repo uses (``tools/linear-agent/scripts/cloud-agent-launch.mjs``).
- * The shape Ship needs:
+ * Runs the official ``cursor-agent`` binary on the GHA runner. The
+ * runner prepares the working tree and switches to the target branch
+ * *before* this adapter is invoked; we just execute the CLI in
+ * ``workdir`` and let it make commits in place. Push + PR creation
+ * happen in the workflow step after the adapter returns.
  *
- *   1. Launch an agent against ``repo`` at ``ref`` with ``prompt``.
- *   2. Poll until the agent's status is one of the terminal values
- *      (``FINISHED`` / ``ERRORED`` / ``CANCELLED``).
- *   3. Return the branch name + final status to ``shipctl run``. Side
- *      effects (tracker writes / inbox rows) happen via the agent's
- *      own ``POST /agent-runs/finish`` call from inside Cursor — the
- *      CLI no longer reads a state file off the branch.
+ * Headless flags ('cursor-agent --help'):
+ *   -p / --print              non-interactive mode (no TTY)
+ *   --output-format text|stream-json
+ *   --force / --yolo          allow write/shell tools without prompts
+ *   --trust                   skip workspace-trust dialog
+ *   --workspace <path>        cwd override (we set it explicitly)
  *
- * Auth: ``CURSOR_API_KEY`` env var, sent as Basic ``<key>:`` per Cursor's
- * docs.
+ * Auth: ``CURSOR_API_KEY`` env var (same key used by the cloud API).
  */
 
-import { Buffer } from "node:buffer";
-
-const BASE = "https://api.cursor.com";
-const TERMINAL_STATUSES = new Set(["FINISHED", "ERRORED", "CANCELLED"]);
-
-
-function authHeader() {
-  const key = (process.env.CURSOR_API_KEY || "").trim();
-  if (!key) {
-    throw new Error("CURSOR_API_KEY is not set");
-  }
-  return "Basic " + Buffer.from(`${key}:`).toString("base64");
-}
-
-
-async function postJson(path, body) {
-  const res = await fetch(`${BASE}${path}`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: authHeader(),
-    },
-    body: JSON.stringify(body),
-  });
-  const text = await res.text();
-  if (!res.ok) {
-    throw new Error(`Cursor API ${path} ${res.status}: ${text.slice(0, 500)}`);
-  }
-  return text ? JSON.parse(text) : {};
-}
-
-
-async function getJson(path) {
-  const res = await fetch(`${BASE}${path}`, {
-    headers: { Authorization: authHeader() },
-  });
-  const text = await res.text();
-  if (!res.ok) {
-    throw new Error(`Cursor API ${path} ${res.status}: ${text.slice(0, 500)}`);
-  }
-  return text ? JSON.parse(text) : {};
-}
+import { spawn } from "node:child_process";
 
 
 /**
- * Launch a single Cursor agent and poll until it terminates.
- *
  * @param {object} opts
- * @param {string} opts.repoUrl       e.g. ``https://github.com/owner/repo``
- * @param {string} opts.ref           branch the agent checks out (default ``main``)
- * @param {string} opts.branchName    branch the agent commits onto
+ * @param {string} opts.workdir       repo checkout dir; defaults to process.cwd()
+ * @param {string} opts.branchName    branch the agent commits onto (already checked out)
  * @param {string} opts.prompt        full prompt body
- * @param {boolean} [opts.autoCreatePr] open a PR when done (default false)
- * @param {number} [opts.pollIntervalMs]   poll cadence (default 15s)
- * @param {number} [opts.timeoutMs]   total deadline (default 30 min)
+ * @param {Record<string,string>} [opts.env]  extra env vars merged onto process.env
  * @param {(line: string) => void} [opts.onLog] streaming log hook
- * @returns {Promise<{ agentId: string, branchName: string, status: string, raw: object }>}
+ * @returns {Promise<{ agentId: string, branchName: string, status: string, exitCode: number }>}
  */
 export async function runCursorAgent({
-  repoUrl,
-  ref = "main",
+  workdir = process.cwd(),
   branchName,
   prompt,
-  autoCreatePr = false,
-  pollIntervalMs = 15_000,
-  timeoutMs = 30 * 60 * 1000,
-  onLog = (l) => console.error(`[cursor] ${l}`),
+  env = {},
+  onLog = (l) => process.stderr.write(`[cursor] ${l}\n`),
 } = {}) {
-  if (!repoUrl) throw new Error("runCursorAgent: repoUrl required");
   if (!branchName) throw new Error("runCursorAgent: branchName required");
   if (!prompt || typeof prompt !== "string") {
     throw new Error("runCursorAgent: prompt required");
   }
+  if (!(process.env.CURSOR_API_KEY || env.CURSOR_API_KEY)) {
+    throw new Error("CURSOR_API_KEY is not set");
+  }
 
-  const launch = await postJson("/v0/agents", {
-    prompt: { text: prompt },
-    source: { repository: repoUrl, ref },
-    target: {
-      branchName,
-      autoCreatePr,
-      openAsCursorGithubApp: false,
-    },
+  // ``--print`` keeps stdout clean enough to surface in the workflow
+  // log, ``--force`` + ``--trust`` are required for non-interactive
+  // write/shell operations on a fresh runner without prior workspace
+  // trust history. ``--workspace`` pins cwd explicitly so the agent
+  // doesn't drift when the parent shell's cwd is mutated.
+  const args = [
+    "--print",
+    "--force",
+    "--trust",
+    "--workspace",
+    workdir,
+    "--output-format",
+    "text",
+    prompt,
+  ];
+
+  onLog(`launch cursor-agent branch=${branchName} cwd=${workdir} prompt=${prompt.length}b`);
+  const child = spawn("cursor-agent", args, {
+    cwd: workdir,
+    env: { ...process.env, ...env },
+    stdio: ["ignore", "inherit", "inherit"],
   });
-  const agentId = launch.id || launch.agentId || launch.agent_id;
-  if (!agentId) {
-    throw new Error(`Cursor launch returned no agent id: ${JSON.stringify(launch).slice(0, 300)}`);
-  }
-  onLog(`launched agent=${agentId} branch=${branchName} ref=${ref}`);
 
-  const deadline = Date.now() + timeoutMs;
-  let lastStatus = launch.status || "CREATING";
-  while (Date.now() < deadline) {
-    if (TERMINAL_STATUSES.has(String(lastStatus).toUpperCase())) {
-      onLog(`agent terminal: status=${lastStatus}`);
-      return { agentId, branchName, status: lastStatus, raw: launch };
-    }
-    await sleep(pollIntervalMs);
-    let snapshot;
-    try {
-      snapshot = await getJson(`/v0/agents/${encodeURIComponent(agentId)}`);
-    } catch (err) {
-      onLog(`poll error (continuing): ${err.message}`);
-      continue;
-    }
-    const next = (snapshot.status || "").toString();
-    if (next && next !== lastStatus) {
-      onLog(`status: ${lastStatus} → ${next}`);
-      lastStatus = next;
-    }
-    if (TERMINAL_STATUSES.has(next.toUpperCase())) {
-      return { agentId, branchName, status: next, raw: snapshot };
-    }
-  }
-  throw new Error(
-    `Cursor agent ${agentId} did not reach a terminal state within ${Math.round(
-      timeoutMs / 1000,
-    )}s (last status: ${lastStatus})`,
-  );
-}
+  const exitCode = await new Promise((resolve, reject) => {
+    child.on("error", reject);
+    child.on("exit", (code) => resolve(code ?? 1));
+  });
 
-
-function sleep(ms) {
-  return new Promise((r) => setTimeout(r, ms));
+  const status = exitCode === 0 ? "FINISHED" : "ERRORED";
+  onLog(`cursor-agent terminal: status=${status} exit=${exitCode}`);
+  return { agentId: `cursor-agent-${branchName}`, branchName, status, exitCode };
 }

--- a/cli/lib/agents/index.mjs
+++ b/cli/lib/agents/index.mjs
@@ -1,26 +1,42 @@
 /**
  * Agent runtime dispatcher.
  *
- * E14 picks the runtime per ``.ship/config.yml`` ``agent.default.provider``
- * (and per-routine override under ``agent.overrides.<routine>``). Today
- * Cursor Cloud is the only one wired in; ``claude`` / ``codex`` slots
- * exist so adding them later is a single new file plus an entry in
- * ``RUNTIMES`` here.
+ * The workspace binds to one of the three local CLIs via
+ * ``Workspace.agent_provider`` (cursor / codex / claude); ``shipctl
+ * run`` resolves that binding before invoking ``runAgent`` so the
+ * runner installs and executes only the right CLI on each tick. Per-
+ * routine override is still honoured via ``.ship/config.yml``
+ * ``agent.overrides.<routine>.provider`` for debug runs.
+ *
+ * Each adapter expects the runner to have already checked out the
+ * target branch in ``workdir`` and configured git committer identity.
+ * After the adapter returns, the runner pushes the branch and opens
+ * a PR via ``gh``. There is no remote service in the loop anymore —
+ * the cloud-poll path was removed in PR-5 once Cursor's GitHub App
+ * dependency proved fragile (organisation-level App removal silently
+ * killed every cron tick).
  */
 
+import { runClaudeAgent } from "./claude.mjs";
+import { runCodexAgent } from "./codex.mjs";
 import { runCursorAgent } from "./cursor.mjs";
 
 
 const RUNTIMES = {
   cursor: runCursorAgent,
-  // claude: runClaudeCodeAgent,   // TODO when we add it
-  // codex:  runCodexAgent,        // TODO when we add it
+  codex: runCodexAgent,
+  claude: runClaudeAgent,
 };
 
 const DEFAULT_PROVIDER = "cursor";
 
 
 export function resolveProvider(config, routineId) {
+  // Per-routine override on the customer's .ship/config.yml — used
+  // for debug pinning ("force this one routine to claude") without
+  // touching the workspace binding. The workspace-level default
+  // arrives via the API resolver path inside `shipctl run`; this
+  // function only handles the config.yml branches.
   const override = config?.agent?.overrides?.[routineId]?.provider;
   if (override) return String(override).toLowerCase();
   const def = config?.agent?.default?.provider;
@@ -34,7 +50,7 @@ export function resolveProvider(config, routineId) {
  *
  * @param {string} provider — one of ``RUNTIMES``' keys.
  * @param {object} opts — passed straight through to the runtime.
- * @returns {Promise<{ agentId: string, branchName: string, status: string, raw: object }>}
+ * @returns {Promise<{ agentId: string, branchName: string, status: string, exitCode: number }>}
  */
 export async function runAgent(provider, opts) {
   const fn = RUNTIMES[provider];

--- a/cli/lib/commands/run.mjs
+++ b/cli/lib/commands/run.mjs
@@ -303,20 +303,27 @@ async function _runCommandImpl(ctx, rest) {
     process.exit(EXIT_OK);
   }
 
-  // 4) Launch agent runtime
-  const provider = resolveProvider(config, args.routine || specialistSlug);
+  // 4) Resolve the agent runtime. Workspace binding (PR-1) wins; we
+  // fall back to ``.ship/config.yml`` ``agent.default.provider`` /
+  // ``agent.overrides.<routine>.provider`` only when the workspace
+  // call fails (offline dev / unreachable API). The local-only model
+  // means the runner has already prepared the branch in ``$PWD`` —
+  // adapters just exec the bound CLI and let it commit in place.
+  const workspaceProvider = await fetchWorkspaceAgentProvider({
+    apiBase,
+    apiToken,
+    workspaceId,
+  });
+  const provider =
+    workspaceProvider || resolveProvider(config, args.routine || specialistSlug);
   const branchName = makeBranchName(runHandle, task?.ticket_ref);
-  const repoUrl = githubRepo ? `https://github.com/${githubRepo}` : null;
-  if (!repoUrl) die(EXIT_USAGE, "GITHUB_REPOSITORY env var is required to launch agent");
 
   let runtime;
   try {
     runtime = await runAgent(provider, {
-      repoUrl,
-      ref: env.githubRef || "main",
+      workdir: process.cwd(),
       branchName,
       prompt,
-      autoCreatePr: false,
     });
   } catch (err) {
     emit(args, {
@@ -326,16 +333,14 @@ async function _runCommandImpl(ctx, rest) {
       run_id: runId,
       run_handle: runHandle,
       stage: "launch_agent",
+      provider,
       error: err instanceof Error ? err.message : String(err),
     });
     process.exit(EXIT_AGENT_FAIL);
   }
 
-  // The agent calls POST /agent-runs/finish from inside Cursor with
-  // its outcome. The CLI's job ends here — Cursor's terminal status
-  // tells us the runtime didn't crash; whether the agent actually
-  // called /finish (and what outcome it reported) is observable in
-  // the audit log + the resulting tracker state.
+  // Push + PR creation happen in the workflow step after this exits;
+  // the agent has finished committing on ``branchName`` by now.
   emit(args, {
     status: "completed",
     routine: args.routine,
@@ -344,7 +349,9 @@ async function _runCommandImpl(ctx, rest) {
     ticket_ref: task?.ticket_ref || null,
     agent_id: runtime.agentId,
     branch: runtime.branchName,
-    cursor_status: runtime.status,
+    provider,
+    runtime_status: runtime.status,
+    exit_code: runtime.exitCode,
     run_id: runId,
     run_handle: runHandle,
   });
@@ -502,6 +509,40 @@ async function getNextTask({ apiBase, apiToken, workspaceId, state }) {
   }
   const body = await res.json();
   return body.ticket || null;
+}
+
+
+/**
+ * Read the workspace's bound agent provider (PR-1's
+ * ``GET /v1/workspaces/{ws}/agent-provider``). Falls back to
+ * ``null`` on a fetch failure so the caller can degrade to the
+ * ``.ship/config.yml`` ``resolveProvider`` chain.
+ */
+async function fetchWorkspaceAgentProvider({ apiBase, apiToken, workspaceId }) {
+  if (!apiBase || !apiToken || !workspaceId) return null;
+  const url = `${apiBase}/v1/workspaces/${encodeURIComponent(workspaceId)}/agent-provider`;
+  let res;
+  try {
+    res = await fetchWithRetry(
+      () =>
+        fetch(url, {
+          headers: {
+            Accept: "application/json",
+            Authorization: `Bearer ${apiToken}`,
+          },
+        }),
+      { description: "agent-provider" },
+    );
+  } catch {
+    return null;
+  }
+  if (!res.ok) return null;
+  try {
+    const body = await res.json();
+    return body.kind || null;
+  } catch {
+    return null;
+  }
 }
 
 


### PR DESCRIPTION
## Summary
- ``cli/lib/agents/cursor.mjs`` rewritten to spawn the local ``cursor-agent`` binary instead of polling ``api.cursor.com/v0/agents``.
- New ``codex.mjs`` (``codex exec --full-auto``) and ``claude.mjs`` (``claude --print --dangerously-skip-permissions``).
- ``shipctl run`` now reads the workspace's bound provider from ``GET /v1/workspaces/{ws}/agent-provider`` (PR-1). Falls back to ``.ship/config.yml`` ``agent.default.provider`` only when the API call fails.
- Adapters expect the runner to have prepared the branch in ``$PWD``; they exec the CLI in cwd, let it commit in place, and return ``{status: 'FINISHED'|'ERRORED', exitCode}``. Push + PR creation move to the workflow step (PR-4).

This removes the Cursor cloud dependency on the org's GitHub App — the cause of today's 13 failed cron runs.

## Test plan
- [ ] ``cd cli && npm test`` — 91 tests pass.
- [ ] Adapter signatures: each requires its own API key env var; missing key surfaces as a clear ``Error`` before spawn.
- [ ] Resolver order: ``GET /v1/workspaces/{ws}/agent-provider`` wins; offline fallback to ``.ship/config.yml`` works.

## Stacks on top of
#212 (PR-1), #213 (PR-2). PR-4 wires the workflow.