### PR TITLE
cli: drop legacy config.yml agent.* + cloud plumbing (PR-5/6)

### DIFF
--- a/cli/lib/agents/index.mjs
+++ b/cli/lib/agents/index.mjs
@@ -3,16 +3,15 @@
  *
  * The workspace binds to one of the three local CLIs via
  * ``Workspace.agent_provider`` (cursor / codex / claude); ``shipctl
- * run`` resolves that binding before invoking ``runAgent`` so the
- * runner installs and executes only the right CLI on each tick. Per-
- * routine override is still honoured via ``.ship/config.yml``
- * ``agent.overrides.<routine>.provider`` for debug runs.
+ * run`` resolves that binding through ``GET /v1/workspaces/{ws}/agent-provider``
+ * before invoking ``runAgent`` so the runner installs and executes
+ * only the right CLI on each tick.
  *
  * Each adapter expects the runner to have already checked out the
  * target branch in ``workdir`` and configured git committer identity.
  * After the adapter returns, the runner pushes the branch and opens
  * a PR via ``gh``. There is no remote service in the loop anymore —
- * the cloud-poll path was removed in PR-5 once Cursor's GitHub App
+ * the cloud-poll path was removed once Cursor's GitHub App
  * dependency proved fragile (organisation-level App removal silently
  * killed every cron tick).
  */
@@ -28,21 +27,7 @@ const RUNTIMES = {
   claude: runClaudeAgent,
 };
 
-const DEFAULT_PROVIDER = "cursor";
-
-
-export function resolveProvider(config, routineId) {
-  // Per-routine override on the customer's .ship/config.yml — used
-  // for debug pinning ("force this one routine to claude") without
-  // touching the workspace binding. The workspace-level default
-  // arrives via the API resolver path inside `shipctl run`; this
-  // function only handles the config.yml branches.
-  const override = config?.agent?.overrides?.[routineId]?.provider;
-  if (override) return String(override).toLowerCase();
-  const def = config?.agent?.default?.provider;
-  if (def) return String(def).toLowerCase();
-  return DEFAULT_PROVIDER;
-}
+export const DEFAULT_PROVIDER = "cursor";
 
 
 /**

--- a/cli/lib/commands/preflight.mjs
+++ b/cli/lib/commands/preflight.mjs
@@ -29,8 +29,14 @@
 import path from "node:path";
 
 import { findShipRoot, readConfig } from "../config/io.mjs";
-import { resolveProvider } from "../agents/index.mjs";
+import { DEFAULT_PROVIDER, SUPPORTED_PROVIDERS } from "../agents/index.mjs";
 import { fetchWithRetry } from "../retry.mjs";
+
+const PROVIDER_SECRET_ENV = {
+  cursor: "CURSOR_API_KEY",
+  codex: "OPENAI_API_KEY",
+  claude: "ANTHROPIC_API_KEY",
+};
 
 const EXIT_OK = 0;
 const EXIT_USAGE = 2;
@@ -55,15 +61,16 @@ export async function preflightCommand(ctx, rest) {
   if (!env.workspaceId) missingSecrets.push("SHIP_WORKSPACE_ID");
   if (!env.apiBase) missingSecrets.push("SHIP_API_BASE");
 
-  // Provider-specific secrets only when we know which provider the
-  // workflow will resolve to. ``args.routine`` / ``args.specialist``
-  // is optional — when absent we report the workspace-default
-  // provider (typically ``cursor``).
-  const provider = config
-    ? resolveProvider(config, args.routine || args.specialist)
-    : "cursor";
-  if (provider === "cursor" && !env.cursorKey) {
-    missingSecrets.push("CURSOR_API_KEY");
+  // Provider resolution moved to the workspace binding row in PR-1
+  // of the local-CLI swap. Read it from the API when we have enough
+  // env to query; degrade to ``DEFAULT_PROVIDER`` so preflight stays
+  // useful for the ``ready=false`` path even when the API is
+  // unreachable. ``provider`` always has a value so the secret check
+  // below is unconditional.
+  const provider = await resolveBoundProvider(env);
+  const providerSecret = PROVIDER_SECRET_ENV[provider];
+  if (providerSecret && !process.env[providerSecret]) {
+    missingSecrets.push(providerSecret);
   }
 
   // Role-side denial surfacing. We don't *enforce* the deny list
@@ -174,8 +181,39 @@ function readEnv() {
     ),
     apiToken: process.env.SHIP_API_TOKEN || "",
     workspaceId: process.env.SHIP_WORKSPACE_ID || "",
-    cursorKey: process.env.CURSOR_API_KEY || "",
   };
+}
+
+
+/**
+ * Resolve the workspace-bound runtime via
+ * ``GET /v1/workspaces/{ws}/agent-provider``. Returns
+ * ``DEFAULT_PROVIDER`` when env doesn't carry enough to query, or
+ * when the API call fails — preflight stays useful in the unreachable
+ * case rather than hard-failing.
+ */
+async function resolveBoundProvider({ apiBase, apiToken, workspaceId }) {
+  if (!apiBase || !apiToken || !workspaceId) return DEFAULT_PROVIDER;
+  try {
+    const res = await fetchWithRetry(
+      () =>
+        fetch(
+          `${apiBase}/v1/workspaces/${encodeURIComponent(workspaceId)}/agent-provider`,
+          {
+            headers: {
+              Accept: "application/json",
+              Authorization: `Bearer ${apiToken}`,
+            },
+          },
+        ),
+      { description: "agent-provider" },
+    );
+    if (!res.ok) return DEFAULT_PROVIDER;
+    const body = await res.json();
+    return SUPPORTED_PROVIDERS.includes(body.kind) ? body.kind : DEFAULT_PROVIDER;
+  } catch {
+    return DEFAULT_PROVIDER;
+  }
 }
 
 

--- a/cli/lib/commands/run.mjs
+++ b/cli/lib/commands/run.mjs
@@ -34,9 +34,11 @@
  *   - SHIP_API_BASE         — Ship server, e.g. https://api.ship.elmundi.com
  *   - SHIP_API_TOKEN        — workspace API token (admin scope; rendered
  *                             into the agent's prompt so it can call
- *                             /agent-runs/finish from inside Cursor)
+ *                             /agent-runs/finish from inside the agent)
  *   - SHIP_WORKSPACE_ID     — UUID of the workspace this run belongs to
- *   - CURSOR_API_KEY        — Cursor Cloud agent API key (when provider=cursor)
+ *   - CURSOR_API_KEY        — Cursor agent CLI auth (when provider=cursor)
+ *   - ANTHROPIC_API_KEY     — Claude Code CLI auth (when provider=claude)
+ *   - OPENAI_API_KEY        — OpenAI Codex CLI auth (when provider=codex)
  *   - GITHUB_REPOSITORY     — owner/repo (the repo the agent will check out)
  *
  * Note: there is **no SHIP_REPO_ID** — a workspace is the project, so
@@ -51,7 +53,7 @@ import path from "node:path";
 
 import { readConfig, findShipRoot } from "../config/io.mjs";
 import { resolveExecutable } from "../runtime/routines.mjs";
-import { resolveProvider, runAgent } from "../agents/index.mjs";
+import { DEFAULT_PROVIDER, runAgent } from "../agents/index.mjs";
 import { fetchWithRetry } from "../retry.mjs";
 
 const SYSTEM_ROLE_SLUG = "system";
@@ -304,19 +306,19 @@ async function _runCommandImpl(ctx, rest) {
     process.exit(EXIT_OK);
   }
 
-  // 4) Resolve the agent runtime. Workspace binding (PR-1) wins; we
-  // fall back to ``.ship/config.yml`` ``agent.default.provider`` /
-  // ``agent.overrides.<routine>.provider`` only when the workspace
-  // call fails (offline dev / unreachable API). The local-only model
-  // means the runner has already prepared the branch in ``$PWD`` —
-  // adapters just exec the bound CLI and let it commit in place.
+  // 4) Resolve the agent runtime. The workspace's bound provider
+  // (``GET /v1/workspaces/{ws}/agent-provider``) is the single source
+  // of truth — when it fails we fall straight back to the resolver's
+  // built-in ``DEFAULT_PROVIDER`` (cursor) so an unreachable API
+  // doesn't strand the runner. The legacy ``.ship/config.yml``
+  // ``agent.default.provider`` / ``agent.overrides`` block was
+  // dropped in PR-5 of the local-CLI swap.
   const workspaceProvider = await fetchWorkspaceAgentProvider({
     apiBase,
     apiToken,
     workspaceId,
   });
-  const provider =
-    workspaceProvider || resolveProvider(config, args.routine || specialistSlug);
+  const provider = workspaceProvider || DEFAULT_PROVIDER;
   const branchName = makeBranchName(runHandle, task?.ticket_ref);
   const baseBranch = (env.githubRef || "main").trim() || "main";
 
@@ -722,10 +724,10 @@ async function getNextTask({ apiBase, apiToken, workspaceId, state }) {
 
 
 /**
- * Read the workspace's bound agent provider (PR-1's
- * ``GET /v1/workspaces/{ws}/agent-provider``). Falls back to
- * ``null`` on a fetch failure so the caller can degrade to the
- * ``.ship/config.yml`` ``resolveProvider`` chain.
+ * Read the workspace's bound agent provider via
+ * ``GET /v1/workspaces/{ws}/agent-provider``. Returns ``null`` on
+ * any failure so the caller can degrade to ``DEFAULT_PROVIDER``
+ * rather than stranding the runner.
  */
 async function fetchWorkspaceAgentProvider({ apiBase, apiToken, workspaceId }) {
   if (!apiBase || !apiToken || !workspaceId) return null;
@@ -1025,10 +1027,16 @@ ENV
                        so the agent can call /agent-runs/finish itself
   SHIP_WORKSPACE_ID    UUID of the workspace (a workspace is one project)
   GITHUB_REPOSITORY    owner/repo (which checkout the agent gets)
-  CURSOR_API_KEY       Cursor Cloud API key (when agent.default.provider=cursor)
+  CURSOR_API_KEY       Cursor agent CLI auth   (when bound provider=cursor)
+  ANTHROPIC_API_KEY    Claude Code CLI auth     (when bound provider=claude)
+  OPENAI_API_KEY       OpenAI Codex CLI auth    (when bound provider=codex)
+
+  Provider is read from GET /v1/workspaces/{ws}/agent-provider.
+  Falls back to 'cursor' if the API call fails so an unreachable
+  Ship server doesn't strand the runner.
 
 EXIT
-  0  agent runtime reached a terminal state (FINISHED/CANCELLED/ERRORED).
+  0  agent runtime reached a terminal state (FINISHED/ERRORED).
      Whether the agent actually called /agent-runs/finish is observable
      in the audit log — this CLI no longer waits on that signal.
   1  usage / config error

--- a/cli/lib/config/io.mjs
+++ b/cli/lib/config/io.mjs
@@ -38,7 +38,6 @@ const KEY_ORDER = {
     "shipctl_min",
     "api",
     "stack",
-    "agent",
     "lanes",
     "artifacts",
     "cache",
@@ -47,8 +46,6 @@ const KEY_ORDER = {
   api: ["base_url", "channel", "ttl_hours", "offline_ok"],
   stack: ["tracker", "ci", "agents", "agent", "language", "preset"],
   "stack.agent": ["provider"],
-  agent: ["default", "overrides"],
-  "agent.default": ["provider"],
   /* lanes.* is handled by LANE_KEY_ORDER below — each lane follows the
    * same ordering regardless of its id. */
   artifacts: ["pins", "auto_update"],
@@ -81,7 +78,7 @@ function orderForPath(pathKey) {
   return KEY_ORDER[pathKey] || [];
 }
 
-const USER_KEYED_LEAF_MAPS = new Set(["artifacts.pins", "agent.overrides"]);
+const USER_KEYED_LEAF_MAPS = new Set(["artifacts.pins"]);
 const USER_KEYED_STRUCT_MAPS = new Set(["lanes"]);
 
 function orderedCopy(obj, pathKey) {

--- a/cli/lib/config/schema.mjs
+++ b/cli/lib/config/schema.mjs
@@ -186,10 +186,6 @@ export function DEFAULT_CONFIG_V2() {
     shipctl_min: "0.12.0",
     api: v1.api,
     stack: v1.stack,
-    agent: {
-      default: { provider: null },
-      overrides: {},
-    },
     process: DEFAULT_PROCESS_CONFIG(),
     lanes: {},
     artifacts: v1.artifacts,
@@ -246,7 +242,6 @@ const KNOWN_TOP_LEVEL_V2 = new Set([
   "shipctl_min",
   "api",
   "stack",
-  "agent",
   "process",
   "lanes",
   "artifacts",
@@ -657,47 +652,12 @@ function requireOptionalString(value, prefix, errors, { required }) {
 }
 
 function validateV2Lanes(obj, errors, warnings) {
-  const agent = obj.agent;
-  if (agent !== undefined) {
-    if (!isPlainObject(agent)) {
-      errors.push("agent: must be an object");
-    } else {
-      pushUnknownKeyWarnings(agent, new Set(["default", "overrides"]), "agent", warnings);
-      if (agent.default !== undefined) {
-        if (!isPlainObject(agent.default)) {
-          errors.push("agent.default: must be an object");
-        } else {
-          pushUnknownKeyWarnings(agent.default, new Set(["provider"]), "agent.default", warnings);
-          const p = agent.default.provider;
-          if (p !== undefined && p !== null) {
-            if (typeof p !== "string" || p.length < 1 || p.length > 64) {
-              errors.push("agent.default.provider: must be a non-empty string (≤64 chars)");
-            }
-          }
-        }
-      }
-      if (agent.overrides !== undefined) {
-        if (!isPlainObject(agent.overrides)) {
-          errors.push("agent.overrides: must be a map");
-        } else {
-          for (const [laneId, override] of Object.entries(agent.overrides)) {
-            if (!LANE_ID_REGEX.test(laneId)) {
-              errors.push(`agent.overrides[${JSON.stringify(laneId)}]: invalid lane id`);
-              continue;
-            }
-            if (!isPlainObject(override)) {
-              errors.push(`agent.overrides.${laneId}: must be an object`);
-              continue;
-            }
-            const p = override.provider;
-            if (p !== undefined && p !== null && (typeof p !== "string" || p.length < 1 || p.length > 64)) {
-              errors.push(`agent.overrides.${laneId}.provider: must be a non-empty string (≤64 chars)`);
-            }
-          }
-        }
-      }
-    }
-  }
+  // Note: the legacy ``agent.default.provider`` / ``agent.overrides`` block
+  // is no longer recognised — workspace-level binding via the
+  // ``Workspace.agent_provider`` row + ``GET /v1/workspaces/{ws}/agent-provider``
+  // is the single source of truth (PR-1/PR-3 of the local-CLI swap).
+  // Repos that still carry an ``agent:`` key in .ship/config.yml see
+  // it surface as an "unknown key" warning via the top-level scan.
 
   const lanes = obj.lanes;
   if (lanes === undefined) {

--- a/cli/tests/config.test.mjs
+++ b/cli/tests/config.test.mjs
@@ -322,9 +322,6 @@ stack:
   ci: gh-actions
   agents: []
   language: multi
-agent:
-  default: {}
-  overrides: {}
 lanes:
   pr_review:
     kind: event


### PR DESCRIPTION
## Summary
- Drop the ``.ship/config.yml`` ``agent.default.provider`` / ``agent.overrides`` knobs — workspace ``agent_provider`` binding (PR-1) is the single source of truth.
- ``run.mjs`` reads the bound provider from the API; falls back to ``DEFAULT_PROVIDER`` (cursor) on API failure rather than consulting ``.ship/config.yml``.
- ``preflight.mjs`` queries the same endpoint and picks the matching env key (``CURSOR_API_KEY`` / ``ANTHROPIC_API_KEY`` / ``OPENAI_API_KEY``) for the missing-secret check.
- ``agents/index.mjs`` no longer exports ``resolveProvider``; just ``runAgent`` + ``DEFAULT_PROVIDER`` + ``SUPPORTED_PROVIDERS``.
- ``DEFAULT_CONFIG_V2`` and ``KNOWN_TOP_LEVEL_V2`` lose the ``agent`` key; repos still carrying it get a "unknown key" warning.
- ``validateV2Lanes`` drops the ``agent.*`` validation arm; ``io.mjs`` drops the matching key-order + USER_KEYED_LEAF_MAPS entries.

The Cursor cloud poll loop was removed in PR-3 (cursor.mjs rewrite). This PR removes the remaining config.yml escape hatch.

## Test plan
- [ ] ``cd cli && npm test`` — 91/91 pass.
- [ ] ``shipctl run --help`` exits 0 and lists the three runtime env vars.
- [ ] ``shipctl preflight --json`` against an offline workspace returns ``provider: cursor`` (default fallback) and lists ``CURSOR_API_KEY`` as missing iff that env isn't set.

## Stacks on top of
#212 (PR-1), #213 (PR-2), #214 (PR-3), #215 (PR-4). PR-6 adds the debug harness (verbose logs + console "Run this routine" button).