### PR TITLE
debug harness: --debug + manual dispatch + console card (PR-6/6)

### DIFF
--- a/.github/workflows/ship-trigger-schedule.yml
+++ b/.github/workflows/ship-trigger-schedule.yml
@@ -82,10 +82,12 @@ jobs:
           set -euo pipefail
           # Manual workflow_dispatch with a routine id bypasses the
           # cron picker — debug harness for "fire this stage now,
-          # detailed log" (PR-6's core surface).
+          # detailed log". ``--debug`` streams a per-step log so the
+          # operator can see every phase interleaved with the agent
+          # CLI's own output.
           if [ -n "$MANUAL_ROUTINE" ]; then
             echo "::group::Ship manual routine ${MANUAL_ROUTINE}${MANUAL_TICKET:+ ticket=$MANUAL_TICKET}"
-            shipctl run --routine "$MANUAL_ROUTINE" --commit-and-pr
+            shipctl run --routine "$MANUAL_ROUTINE" --commit-and-pr --debug
             echo "::endgroup::"
             exit 0
           fi

--- a/backend/app/api/v1/routes/agent_runs.py
+++ b/backend/app/api/v1/routes/agent_runs.py
@@ -2284,3 +2284,116 @@ async def finish_agent_run(
         actions=actions,
         tracker_kind=tracker_kind,
     )
+
+
+# ---------------------------------------------------------------------------
+# Manual routine dispatch (PR-6 of the local-CLI swap — debug harness)
+# ---------------------------------------------------------------------------
+
+
+class RoutineDispatchIn(BaseModel):
+    """Body for ``POST /v1/workspaces/{ws}/agent-runs/dispatch``.
+
+    ``repo_id`` is the WorkspaceRepo whose ``ship-trigger-schedule.yml``
+    we fire. The routine and optional ticket map straight onto the
+    workflow_dispatch ``inputs`` (PR-4 of the local-CLI swap).
+    """
+
+    repo_id: uuid.UUID
+    routine_id: str = Field(min_length=1, max_length=64)
+    ticket_ref: str | None = Field(default=None, max_length=64)
+
+
+class RoutineDispatchOut(BaseModel):
+    accepted: bool
+    repo_full_name: str
+    workflow_file: str
+    routine_id: str
+    ticket_ref: str | None
+
+
+@router.post("/agent-runs/dispatch", response_model=RoutineDispatchOut)
+async def post_dispatch_routine(
+    workspace_id: uuid.UUID,
+    payload: RoutineDispatchIn,
+    auth: AuthContext = Depends(get_current_auth),
+    session: AsyncSession = Depends(get_session),
+    settings: Settings = Depends(get_settings),
+) -> RoutineDispatchOut:
+    """Manually fire ``ship-trigger-schedule.yml`` for one routine.
+
+    Operator-driven debug path. The workflow_dispatch inputs feed
+    straight into ``shipctl run --routine X --commit-and-pr --debug``
+    on the runner so the GHA log shows every step of the pipeline
+    interleaved with the agent CLI's own output.
+
+    Admin-only — manual dispatch consumes Cursor / Codex / Claude
+    quota and opens PRs against the repo, both of which are
+    operator-tier actions.
+    """
+    from backend.app.db.models.integrations import (
+        GitHubInstallation,
+        WorkspaceRepo,
+    )
+    from backend.app.integrations.github.workflows import dispatch_workflow
+
+    await _require_membership(session, workspace_id, auth.user.id, ROLES_ADMIN)
+
+    repo = (
+        await session.execute(
+            sa_select(WorkspaceRepo).where(
+                WorkspaceRepo.id == payload.repo_id,
+                WorkspaceRepo.workspace_id == workspace_id,
+            )
+        )
+    ).scalar_one_or_none()
+    if repo is None:
+        raise HTTPException(status_code=404, detail="repo not in this workspace")
+    if repo.installation_id is None:
+        raise HTTPException(
+            status_code=409,
+            detail="repo has no GitHub App installation; reinstall Ship",
+        )
+    install = await session.get(GitHubInstallation, repo.installation_id)
+    if install is None or install.suspended_at is not None:
+        raise HTTPException(
+            status_code=409,
+            detail="GitHub App installation missing or suspended",
+        )
+
+    inputs: dict[str, str] = {"routine_id": payload.routine_id}
+    if payload.ticket_ref:
+        inputs["ticket_ref"] = payload.ticket_ref
+
+    await dispatch_workflow(
+        repo,
+        install,
+        "ship-trigger-schedule.yml",
+        inputs=inputs,
+        settings=settings,
+    )
+
+    session.add(
+        AuditLog(
+            workspace_id=workspace_id,
+            actor_user_id=auth.user.id,
+            actor_token_id=auth.token.id if auth.token else None,
+            action="agent_run.routine_dispatched",
+            target_kind="workspace_repo",
+            target_id=str(repo.id),
+            payload={
+                "routine_id": payload.routine_id,
+                "ticket_ref": payload.ticket_ref,
+                "workflow_file": "ship-trigger-schedule.yml",
+            },
+        )
+    )
+    await session.flush()
+
+    return RoutineDispatchOut(
+        accepted=True,
+        repo_full_name=repo.full_name,
+        workflow_file="ship-trigger-schedule.yml",
+        routine_id=payload.routine_id,
+        ticket_ref=payload.ticket_ref,
+    )

--- a/cli/lib/commands/run.mjs
+++ b/cli/lib/commands/run.mjs
@@ -111,6 +111,22 @@ async function _runCommandImpl(ctx, rest) {
     printHelp();
     process.exit(EXIT_OK);
   }
+  // ``--debug`` streams a single-line per-step log so an operator
+  // running ``shipctl run`` from the workflow_dispatch UI can see
+  // every phase of the run interleaved with the agent's own output.
+  // Each step prints a stable prefix so the GHA log is greppable
+  // (``# ship: [t+...] <stage> <status>``). Disabled by default —
+  // production cron ticks stay terse.
+  const stepStart = Date.now();
+  const step = (stage, status, kv = {}) => {
+    if (!args.debug) return;
+    const t = ((Date.now() - stepStart) / 1000).toFixed(1);
+    const pairs = Object.entries(kv)
+      .filter(([, v]) => v !== undefined && v !== null && v !== "")
+      .map(([k, v]) => `${k}=${typeof v === "string" ? v : JSON.stringify(v)}`)
+      .join(" ");
+    process.stderr.write(`# ship: [t+${t}s] ${stage} ${status}${pairs ? " " + pairs : ""}\n`);
+  };
   if (!args.routine && !args.specialist) {
     die(
       EXIT_USAGE,
@@ -179,6 +195,12 @@ async function _runCommandImpl(ctx, rest) {
     );
   }
 
+  step("resolve_args", "ok", {
+    routine: args.routine,
+    specialist: args.specialist,
+    handle: runHandle,
+  });
+
   // 2) Pull the resolved role + the shared system prompt in parallel.
   // ``resolveAgentRole`` returns the workspace override when present,
   // otherwise falls back to the Ship default. ``system`` is fetched
@@ -197,6 +219,12 @@ async function _runCommandImpl(ctx, rest) {
   if (!roleResolved) {
     die(EXIT_USAGE, `unknown agent role '${specialistSlug}' for this workspace`);
   }
+  step("resolve_role", "ok", {
+    specialist: specialistSlug,
+    role_source: roleResolved.source,
+    system_present: Boolean(systemResolved?.prompt),
+    role_len: (roleResolved.prompt || "").length,
+  });
   // Per-routine FSM stage override takes precedence over the role's
   // default. Lets one role (``ba``) drive both ``ba_requirements`` for
   // SDLC and ``wbs`` for decomposition without per-process role clones.
@@ -228,6 +256,7 @@ async function _runCommandImpl(ctx, rest) {
         state: fsmStage,
       });
       if (!task) {
+        step("tracker_next", "noop", { fsm_stage: fsmStage, reason: "no_eligible_ticket" });
         emit(args, {
           status: "noop",
           routine: args.routine,
@@ -238,7 +267,14 @@ async function _runCommandImpl(ctx, rest) {
         });
         process.exit(EXIT_NO_TASK);
       }
+      step("tracker_next", "ok", {
+        fsm_stage: fsmStage,
+        ticket: task.ticket_ref,
+        title_len: (task.title || "").length,
+      });
     }
+  } else {
+    step("tracker_next", "skipped", { reason: "no_fsm_stage" });
   }
 
   // 4) Fetch the workspace policy preamble so the agent prompt
@@ -252,6 +288,9 @@ async function _runCommandImpl(ctx, rest) {
     apiToken,
     workspaceId,
     role: specialistSlug,
+  });
+  step("policies_preamble", policiesPreamble ? "ok" : "empty", {
+    len: policiesPreamble ? policiesPreamble.length : 0,
   });
 
   // 5) Mint a run_id + render prompt with finish-protocol values
@@ -319,6 +358,7 @@ async function _runCommandImpl(ctx, rest) {
     workspaceId,
   });
   const provider = workspaceProvider || DEFAULT_PROVIDER;
+  step("resolve_provider", workspaceProvider ? "ok" : "default", { provider });
   const branchName = makeBranchName(runHandle, task?.ticket_ref);
   const baseBranch = (env.githubRef || "main").trim() || "main";
 
@@ -330,6 +370,7 @@ async function _runCommandImpl(ctx, rest) {
   if (args.commitAndPr) {
     try {
       prepareGitBranch({ branchName, baseBranch });
+      step("prepare_branch", "ok", { branch: branchName, base: baseBranch });
     } catch (err) {
       emit(args, {
         status: "error",
@@ -347,6 +388,11 @@ async function _runCommandImpl(ctx, rest) {
   }
 
   let runtime;
+  step("launch_agent", "starting", {
+    provider,
+    branch: branchName,
+    prompt_len: prompt.length,
+  });
   try {
     runtime = await runAgent(provider, {
       workdir: process.cwd(),
@@ -391,7 +437,13 @@ async function _runCommandImpl(ctx, rest) {
       });
       process.exit(EXIT_AGENT_FAIL);
     }
+    step("agent_done", "ok", {
+      provider,
+      runtime_status: runtime.status,
+      exit_code: runtime.exitCode,
+    });
     if (!hasNewCommits(baseBranch)) {
+      step("post_run", "noop", { reason: "no_commits" });
       emit(args, {
         status: "noop_no_commits",
         routine: args.routine,
@@ -407,6 +459,7 @@ async function _runCommandImpl(ctx, rest) {
     }
     try {
       pushed = pushBranch({ branchName });
+      step("push_branch", "ok", { branch: branchName });
       prUrl = openPullRequest({
         branchName,
         baseBranch,
@@ -419,6 +472,7 @@ async function _runCommandImpl(ctx, rest) {
           runHandle,
         }),
       });
+      step("open_pr", prUrl ? "ok" : "skipped_gh_unavailable", { pr: prUrl || null });
     } catch (err) {
       emit(args, {
         status: "error",
@@ -988,6 +1042,7 @@ function parseArgs(rest) {
     help: false,
     dryRun: false,
     commitAndPr: false,
+    debug: false,
   };
   const copy = [...rest];
   while (copy.length) {
@@ -996,6 +1051,7 @@ function parseArgs(rest) {
     if (a === "--json") { out.json = true; copy.shift(); continue; }
     if (a === "--dry-run") { out.dryRun = true; copy.shift(); continue; }
     if (a === "--commit-and-pr") { out.commitAndPr = true; copy.shift(); continue; }
+    if (a === "--debug") { out.debug = true; copy.shift(); continue; }
     if (a === "--routine" && copy[1] !== undefined) { out.routine = copy[1]; copy.splice(0, 2); continue; }
     if (a === "--specialist" && copy[1] !== undefined) { out.specialist = copy[1]; copy.splice(0, 2); continue; }
     if (a === "--cwd" && copy[1] !== undefined) { out.cwd = path.resolve(copy[1]); copy.splice(0, 2); continue; }
@@ -1020,6 +1076,14 @@ Run
 
   --routine     id from process.routines in .ship/config.yml (cron-driven)
   --specialist  agent-role slug from the Ship registry (pipeline-pick fallback)
+
+DEBUG
+  --debug       stream a single-line per-step log to stderr (resolve_role,
+                tracker_next, policies_preamble, resolve_provider,
+                prepare_branch, launch_agent, push_branch, open_pr).
+                Useful for workflow_dispatch debug runs — the GHA log
+                shows every phase of the pipeline interleaved with the
+                agent CLI's own output.
 
 ENV
   SHIP_API_BASE        Ship server base URL (e.g. https://api.ship.elmundi.com)

--- a/console/src/app/(authed)/settings/_shell/settings-shell.tsx
+++ b/console/src/app/(authed)/settings/_shell/settings-shell.tsx
@@ -363,6 +363,10 @@ export async function SettingsShell({
               </Card>
               <DefaultAgentCard workspace={workspace} />
               <AgentProviderCard workspace={workspace} />
+              <DispatchRoutineCard
+                workspace={workspace}
+                repos={activatedRepos}
+              />
             </div>
           )}
 
@@ -975,6 +979,89 @@ function AgentProviderCard({ workspace }: { workspace: ApiWorkspace }) {
           className="h-10 whitespace-nowrap rounded-full border border-aqua/30 bg-aqua/10 px-4 text-xs font-bold text-aqua transition hover:bg-aqua/15"
         >
           Save provider
+        </button>
+      </form>
+    </Card>
+  );
+}
+
+function DispatchRoutineCard({
+  workspace,
+  repos,
+}: {
+  workspace: ApiWorkspace;
+  repos: ApiActivatedRepo[];
+}) {
+  const hasRepo = repos.length > 0;
+  const defaultRepoId = repos[0]?.id ?? "";
+  return (
+    <Card>
+      <CardHeader
+        title="Dispatch routine (debug)"
+        subtitle="Fire any FSM routine manually against the bound provider — the GHA workflow_dispatch runs shipctl run --routine X --debug, which streams a step-by-step log into the runner output. Admin-only; consumes agent quota."
+      />
+      {!hasRepo && (
+        <div className="mb-4 rounded-xl border border-sun/30 bg-sun/[0.06] px-3 py-2 text-xs text-sun/95">
+          No activated repos yet. Activate one before dispatching.
+        </div>
+      )}
+      <form
+        action="/api/settings/dispatch-routine"
+        method="POST"
+        className="grid gap-3 sm:grid-cols-[1fr,1fr,1fr,auto]"
+      >
+        <input type="hidden" name="ws" value={workspace.id} suppressHydrationWarning />
+        <label className="flex flex-col gap-1">
+          <span className="text-[10px] font-bold uppercase tracking-widest text-white/55">
+            Repo
+          </span>
+          <select
+            name="repo"
+            defaultValue={defaultRepoId}
+            required
+            disabled={!hasRepo}
+            className="rounded border border-white/10 bg-white/[0.04] px-2 py-2 text-sm text-white outline-none focus:border-aqua/40 disabled:opacity-50"
+          >
+            {repos.map((r) => (
+              <option key={r.id} value={r.id}>
+                {r.full_name}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-[10px] font-bold uppercase tracking-widest text-white/55">
+            Routine id
+          </span>
+          <input
+            name="routine"
+            type="text"
+            placeholder="intake / dev_implementation / qa_manual …"
+            required
+            pattern="[A-Za-z0-9_-]{1,64}"
+            disabled={!hasRepo}
+            className="rounded border border-white/10 bg-white/[0.04] px-2 py-2 font-mono text-sm text-white outline-none focus:border-aqua/40 disabled:opacity-50"
+          />
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-[10px] font-bold uppercase tracking-widest text-white/55">
+            Pin ticket (optional)
+          </span>
+          <input
+            name="ticket"
+            type="text"
+            placeholder="ELS-15"
+            pattern="[A-Z0-9-]{1,32}"
+            disabled={!hasRepo}
+            className="rounded border border-white/10 bg-white/[0.04] px-2 py-2 font-mono text-sm text-white outline-none focus:border-aqua/40 disabled:opacity-50"
+          />
+        </label>
+        <button
+          type="submit"
+          disabled={!hasRepo}
+          className="h-10 self-end whitespace-nowrap rounded-full border border-aqua/30 bg-aqua/10 px-4 text-xs font-bold text-aqua transition hover:bg-aqua/15 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          Dispatch
         </button>
       </form>
     </Card>

--- a/console/src/app/api/settings/dispatch-routine/route.ts
+++ b/console/src/app/api/settings/dispatch-routine/route.ts
@@ -1,0 +1,73 @@
+/**
+ * POST /api/settings/dispatch-routine — manually fire a Ship routine
+ * against the workspace's selected repo. Forwards to
+ * ``POST /v1/workspaces/{ws}/agent-runs/dispatch`` (PR-6 of the
+ * local-CLI swap), which dispatches ``ship-trigger-schedule.yml``
+ * with the routine + optional ticket inputs.
+ *
+ * Server-action endpoint for the General settings "Dispatch routine"
+ * card. Form fields: ``ws``, ``repo``, ``routine``, optional ``ticket``.
+ */
+
+import { NextResponse } from "next/server";
+
+import {
+  ApiHttpError,
+  ApiUnavailableError,
+  dispatchRoutine,
+  isApiConfigured,
+} from "@/lib/api/client";
+import { resolveOrigin } from "@/lib/api/origin";
+
+const ROUTINE_RE = /^[a-z0-9_-]{1,64}$/i;
+const TICKET_RE = /^[A-Z0-9-]{1,32}$/;
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export async function POST(request: Request) {
+  const origin = resolveOrigin(request);
+  const form = await request.formData();
+  const wsId = (form.get("ws") ?? "").toString();
+  const repoId = (form.get("repo") ?? "").toString();
+  const routine = (form.get("routine") ?? "").toString().trim();
+  const ticket = (form.get("ticket") ?? "").toString().trim();
+
+  if (!UUID_RE.test(wsId) || !UUID_RE.test(repoId) || !ROUTINE_RE.test(routine)) {
+    return back(origin, "bad_input");
+  }
+  if (ticket && !TICKET_RE.test(ticket)) {
+    return back(origin, "bad_ticket");
+  }
+  if (!isApiConfigured()) {
+    return back(origin, "api_unavailable");
+  }
+
+  try {
+    await dispatchRoutine(wsId, {
+      repo_id: repoId,
+      routine_id: routine,
+      ticket_ref: ticket || null,
+    });
+  } catch (err) {
+    if (err instanceof ApiUnavailableError) return back(origin, "api_unavailable");
+    if (err instanceof ApiHttpError) {
+      if (err.status === 401)
+        return NextResponse.redirect(
+          new URL("/login?error=session_expired", origin),
+          303,
+        );
+      if (err.status === 403) return back(origin, "forbidden");
+      return back(origin, `http_${err.status}`);
+    }
+    return back(origin, "unknown");
+  }
+
+  const url = new URL("/settings/general", origin);
+  url.searchParams.set("dispatched", routine);
+  return NextResponse.redirect(url, 303);
+}
+
+function back(origin: string, code: string) {
+  const url = new URL("/settings/general", origin);
+  url.searchParams.set("error", code);
+  return NextResponse.redirect(url, 303);
+}

--- a/console/src/lib/api/client.ts
+++ b/console/src/lib/api/client.ts
@@ -224,6 +224,32 @@ export function setAgentProvider(
   );
 }
 
+/**
+ * POST ``/v1/workspaces/{ws}/agent-runs/dispatch`` — manually fire a
+ * routine against the workspace's bound repo. Workflow_dispatch
+ * inputs feed straight into ``shipctl run --routine X --debug`` on
+ * the runner so the GHA log shows every pipeline phase interleaved
+ * with the agent CLI's own output.
+ */
+export interface ApiDispatchRoutineOut {
+  accepted: boolean;
+  repo_full_name: string;
+  workflow_file: string;
+  routine_id: string;
+  ticket_ref: string | null;
+}
+
+export function dispatchRoutine(
+  workspaceId: string,
+  body: { repo_id: string; routine_id: string; ticket_ref?: string | null },
+  token?: string,
+): Promise<ApiDispatchRoutineOut> {
+  return apiFetch<ApiDispatchRoutineOut>(
+    `/v1/workspaces/${workspaceId}/agent-runs/dispatch`,
+    { method: "POST", body, token },
+  );
+}
+
 // --- Integrations ----------------------------------------------------------
 
 export function listIntegrations(


### PR DESCRIPTION
## Summary
Three surfaces that close the loop on manually firing FSM stages with detailed logs.

**``shipctl run --debug``** — single-line per-step log to stderr so the GHA ``workflow_dispatch`` UI shows every phase interleaved with the agent CLI output. Steps emitted: ``resolve_args`` / ``resolve_role`` / ``tracker_next`` / ``policies_preamble`` / ``resolve_provider`` / ``prepare_branch`` / ``launch_agent`` / ``agent_done`` / ``push_branch`` / ``open_pr``.

**``POST /v1/workspaces/{ws}/agent-runs/dispatch``** — admin-only endpoint that fires ``ship-trigger-schedule.yml`` against a bound repo with ``{routine_id, ticket_ref?}`` workflow_dispatch inputs (the PR-4 surface). Audit row ``agent_run.routine_dispatched``.

**Console "Dispatch routine (debug)" card** on ``/settings/general`` — repo picker, routine id field, optional ticket pin, submit. Forwards through ``/api/settings/dispatch-routine`` to the new endpoint.

The workflow passes ``--debug`` on the manual path so dispatched runs always carry the verbose log; cron ticks stay terse.

## Test plan
- [ ] ``shipctl run --routine intake --debug --dry-run`` — emits the full step trace.
- [ ] ``cd cli && npm test`` — 91/91 pass.
- [ ] ``POST /v1/workspaces/{ws}/agent-runs/dispatch`` returns 200 + audit row when called as admin; 403 as non-admin; 404 if repo isn't in the workspace.
- [ ] Console "Dispatch routine" card on ``/settings/general``: pick a repo, type a routine id, hit submit — workflow_dispatch fires on the runner, GHA log shows the ``[t+...]`` step trace.

## Stacks on top of
#212 (PR-1), #213 (PR-2), #214 (PR-3), #215 (PR-4), #216 (PR-5). Final PR in the local-CLI swap stack.