### PR TITLE
linear: stop deleting prior stage labels on transition (fix finish 500)

### DIFF
--- a/backend/app/integrations/linear/tracker_adapter.py
+++ b/backend/app/integrations/linear/tracker_adapter.py
@@ -546,64 +546,24 @@ class LinearTracker:
                 raise ValueError(
                     f"Linear state {target_state_name!r} not provisioned for this team"
                 )
-            # Build the new label set: drop all ``stage:*`` labels we
-            # know about, then add the target's. This makes the
-            # transition idempotent on re-runs.
-            other_label_ids = list(
-                set(self._label_id_by_stage.values())
-                - ({target_label_id} if target_label_id else set())
-            )
+            # Stage labels are an *accumulating* breadcrumb trail: each
+            # ``stage:<X>`` is added when role X *finished* its work, so
+            # the picker for the *next* stage can require ``some: {id:
+            # eq <previous_label>}`` (see ``_stage_filter_parts``,
+            # comment block ~line 415). Removing previous stage labels
+            # would break that chain — the next pickup would never
+            # match. We therefore *only* add the target label and move
+            # the workflow state. ``addedLabelIds`` is idempotent on
+            # duplicate add, so re-runs are safe.
+            mutation_input: dict[str, Any] = {"stateId": target_state_id}
+            if target_label_id:
+                mutation_input["addedLabelIds"] = [target_label_id]
             await self._gql(
                 """mutation ShipFsmTransition($id: String!, $input: IssueUpdateInput!) {
                   issueUpdate(id: $id, input: $input) { success }
                 }""",
-                {
-                    "id": ticket.id,
-                    "input": {
-                        "stateId": target_state_id,
-                        **(
-                            {
-                                "labelIds": [target_label_id]
-                                if target_label_id
-                                else []
-                            }
-                            if target_label_id
-                            else {}
-                        ),
-                    },
-                },
+                {"id": ticket.id, "input": mutation_input},
             )
-            # Linear's ``labelIds`` is a SET operation when present —
-            # passing the target replaces all labels with that one set,
-            # which is what we want for stage labels but loses any
-            # other labels (priority, area). Drop the simplification:
-            # use ``addedLabelIds`` + ``removedLabelIds`` if they exist
-            # in the schema. (Linear's ``IssueUpdateInput`` exposes
-            # ``addedLabelIds`` / ``removedLabelIds`` since 2023-Q3.)
-            # We re-issue here with the surgical add/remove so we don't
-            # clobber unrelated labels. The first call already moved
-            # the workflow state; this second call only adjusts labels.
-            mut = await self._gql(
-                """mutation ShipFsmLabels($id: String!, $input: IssueUpdateInput!) {
-                  issueUpdate(id: $id, input: $input) { success }
-                }""",
-                {
-                    "id": ticket.id,
-                    "input": {
-                        **(
-                            {"removedLabelIds": other_label_ids}
-                            if other_label_ids
-                            else {}
-                        ),
-                        **(
-                            {"addedLabelIds": [target_label_id]}
-                            if target_label_id
-                            else {}
-                        ),
-                    },
-                },
-            )
-            del mut
             return
 
         # Legacy path (Linear state name).


### PR DESCRIPTION
## Root cause
Stage labels (``stage:task_intake``, ``stage:ba_requirements``, …) are an **accumulating breadcrumb trail**, not a "current stage" pointer. The picker filter for stage X requires the *previous* stage's label to be present on the ticket (see ``_stage_filter_parts``: ``labels.some.id.eq <previous_label>``).

The original ``transition`` deleted the entire stage-label catalogue via ``removedLabelIds`` — wiping the breadcrumb chain *and* throwing ``Label not on issue`` whenever a label in the list wasn't actually on the ticket (the common case — a ticket usually carries one stage label at a time during a normal walk).

PR #218's global exception handler surfaced the message:
```
"error_class":"RuntimeError","message":"Linear GraphQL error: Label not on issue"
```

Caught the manual intake run on ELS-62: Claude Code drafted the right body + intake comment internally; the tracker write 500'd; audit log saw only ``routine_dispatched``, no transition or comment landed.

## Fix
``transition`` now only ``addedLabelIds`` the target stage label and moves the workflow state. ``addedLabelIds`` is idempotent on duplicate add, so re-runs stay safe. Non-stage labels (priority, area, …) are untouched because the broken first-mutation ``labelIds`` clobber is also gone.

## Test plan
- [ ] After deploy, repeat ``POST /agent-runs/finish`` with ``stage_next=ba_requirements`` against ELS-62 — should 200 with ``actions=[tracker:transition:ba_requirements, tracker:set_description, tracker:comment]``.
- [ ] Linear shows ELS-62 with both ``stage:task_intake`` AND ``stage:ba_requirements`` labels (breadcrumb), state = Todo, description rewritten by Claude.
- [ ] Picker run for ``ba_requirements``: ELS-62 surfaces correctly (it carries ``stage:task_intake`` so the previous-stage filter passes; ``stage:ba_requirements`` is added on completion, so re-runs skip).