### PR TITLE
backend: admin relabel-stages endpoint (escape hatch)

### DIFF
--- a/backend/app/api/v1/routes/agent_runs.py
+++ b/backend/app/api/v1/routes/agent_runs.py
@@ -1498,6 +1498,30 @@ class TicketActionOut(BaseModel):
     note: str | None = None
 
 
+class RelabelStagesIn(BaseModel):
+    """Surgical add/remove of FSM stage labels on a ticket.
+
+    Operator escape hatch for fixing a stuck breadcrumb state when a
+    prior buggy run wrote the wrong stage label (or when the
+    operator wants to fast-forward / rewind a ticket through the
+    chain manually).
+
+    Both lists accept Ship FSM stage names (``task_intake``,
+    ``ba_requirements``, …). The bound tracker resolves them to native
+    label ids; an unknown stage 422s.
+    """
+
+    ticket_ref: str = Field(min_length=1, max_length=128)
+    add: list[str] = Field(default_factory=list)
+    remove: list[str] = Field(default_factory=list)
+
+
+class RelabelStagesOut(BaseModel):
+    ticket_ref: str
+    added: list[str] = Field(default_factory=list)
+    removed: list[str] = Field(default_factory=list)
+
+
 @router.post("/admin/ticket-action", response_model=TicketActionOut)
 async def post_ticket_action(
     workspace_id: uuid.UUID,
@@ -2319,6 +2343,69 @@ class RoutineDispatchOut(BaseModel):
     workflow_file: str
     routine_id: str
     ticket_ref: str | None
+
+
+@router.post("/admin/relabel-stages", response_model=RelabelStagesOut)
+async def post_admin_relabel_stages(
+    workspace_id: uuid.UUID,
+    payload: RelabelStagesIn,
+    auth: AuthContext = Depends(get_current_auth),
+    session: AsyncSession = Depends(get_session),
+    settings: Settings = Depends(get_settings),
+) -> RelabelStagesOut:
+    """Surgically add/remove FSM stage labels on a ticket.
+
+    Admin-only. Calls the bound tracker's ``relabel_stages`` —
+    available on Linear today; other adapters surface a 501 until they
+    implement it.
+    """
+    await _require_membership(session, workspace_id, auth.user.id, ROLES_ADMIN)
+
+    resolved = await resolve_for_workspace(
+        session=session, settings=settings, workspace_id=workspace_id
+    )
+    if resolved is None:
+        raise HTTPException(status_code=422, detail="no_tracker_bound")
+
+    relabel_fn = getattr(resolved.gateway, "relabel_stages", None)
+    if relabel_fn is None:
+        raise HTTPException(
+            status_code=501,
+            detail={
+                "code": "relabel_stages_unsupported",
+                "tracker_kind": resolved.kind,
+            },
+        )
+
+    ref = _ticket_ref_from(resolved.kind, payload.ticket_ref)
+    try:
+        result = await relabel_fn(ref, add=payload.add, remove=payload.remove)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    session.add(
+        AuditLog(
+            workspace_id=workspace_id,
+            actor_user_id=auth.user.id,
+            actor_token_id=auth.token.id if auth.token else None,
+            action="tracker.relabel_stages",
+            target_kind="ticket",
+            target_id=payload.ticket_ref,
+            payload={
+                "add_requested": payload.add,
+                "remove_requested": payload.remove,
+                "added": result.get("added") or [],
+                "removed": result.get("removed") or [],
+            },
+        )
+    )
+    await session.flush()
+
+    return RelabelStagesOut(
+        ticket_ref=payload.ticket_ref,
+        added=result.get("added") or [],
+        removed=result.get("removed") or [],
+    )
 
 
 @router.post("/agent-runs/dispatch", response_model=RoutineDispatchOut)

--- a/backend/app/integrations/linear/tracker_adapter.py
+++ b/backend/app/integrations/linear/tracker_adapter.py
@@ -612,6 +612,91 @@ class LinearTracker:
         """
         await self._gql(mutation, {"id": ticket.id, "stateId": state_id})
 
+    async def relabel_stages(
+        self,
+        ticket: TicketRef,
+        *,
+        add: list[str] | None = None,
+        remove: list[str] | None = None,
+    ) -> dict[str, list[str]]:
+        """Surgically add/remove FSM stage labels on a ticket.
+
+        Operator escape hatch for fixing a stuck label state when the
+        breadcrumb chain got corrupted by a buggy run (e.g. the old
+        ``transition()`` that wrote the wrong stage label). Both args
+        accept Ship FSM stage names (e.g. ``task_intake``,
+        ``ba_requirements``); we resolve them to Linear label ids via
+        ``_label_id_by_stage``.
+
+        Pre-checks the issue's current label set so ``removedLabelIds``
+        only carries labels that are actually present — Linear rejects
+        the whole mutation with ``Label not on issue`` otherwise.
+        Returns ``{"added": [...], "removed": [...]}`` of stage names
+        that actually changed.
+        """
+        if ticket.kind != "linear":
+            raise ValueError(
+                f"LinearTracker can't relabel_stages for kind={ticket.kind}"
+            )
+
+        wanted_add_ids: dict[str, str] = {}
+        for stage in (add or []):
+            lid = self._label_id_by_stage.get(stage)
+            if not lid:
+                raise ValueError(f"unknown stage label {stage!r}")
+            wanted_add_ids[stage] = lid
+        wanted_remove_ids: dict[str, str] = {}
+        for stage in (remove or []):
+            lid = self._label_id_by_stage.get(stage)
+            if not lid:
+                raise ValueError(f"unknown stage label {stage!r}")
+            wanted_remove_ids[stage] = lid
+
+        # Read current labels so we can prune ``remove`` to only what's
+        # actually on the issue.
+        snapshot = await self._gql(
+            """query ShipReadLabels($id: String!) {
+              issue(id: $id) { labels { nodes { id } } }
+            }""",
+            {"id": ticket.id},
+        )
+        present_label_ids = {
+            node.get("id")
+            for node in (
+                ((snapshot.get("issue") or {}).get("labels") or {}).get("nodes")
+                or []
+            )
+            if isinstance(node, dict) and node.get("id")
+        }
+
+        actual_remove_ids = [
+            lid for stage, lid in wanted_remove_ids.items() if lid in present_label_ids
+        ]
+        actual_add_ids = [
+            lid for stage, lid in wanted_add_ids.items() if lid not in present_label_ids
+        ]
+
+        mutation_input: dict[str, Any] = {}
+        if actual_remove_ids:
+            mutation_input["removedLabelIds"] = actual_remove_ids
+        if actual_add_ids:
+            mutation_input["addedLabelIds"] = actual_add_ids
+        if mutation_input:
+            await self._gql(
+                """mutation ShipRelabel($id: String!, $input: IssueUpdateInput!) {
+                  issueUpdate(id: $id, input: $input) { success }
+                }""",
+                {"id": ticket.id, "input": mutation_input},
+            )
+
+        added_stages = [
+            stage for stage, lid in wanted_add_ids.items() if lid in actual_add_ids
+        ]
+        removed_stages = [
+            stage for stage, lid in wanted_remove_ids.items() if lid in actual_remove_ids
+        ]
+        return {"added": added_stages, "removed": removed_stages}
+
     async def set_description(self, ticket: TicketRef, *, body: str) -> None:
         """Replace the issue's description (markdown body).
 


### PR DESCRIPTION
Operator-driven add/remove of FSM stage labels via the bound tracker. Wanted today to recover ELS-62 (has wrong-stage breadcrumb from a test on old buggy transition()). Calls LinearTracker.relabel_stages which pre-checks current labels so removedLabelIds only carries labels actually present (avoids the same Label not on issue 500 we hit before). Audit row tracker.relabel_stages; admin-only.