### PR TITLE
linear: include description in list_tickets (agent prompts were getting empty body)

### DIFF
--- a/backend/app/integrations/linear/tracker_adapter.py
+++ b/backend/app/integrations/linear/tracker_adapter.py
@@ -180,6 +180,7 @@ class LinearTracker:
                   id
                   identifier
                   title
+                  description
                   url
                   state { name type }
                   project { id }
@@ -225,6 +226,13 @@ class LinearTracker:
                 {
                     "id": n.get("identifier") or n.get("id"),
                     "title": n.get("title"),
+                    # Agent prompts render the ticket body as
+                    # ``{{DESCRIPTION}}``; without this the prompt sees
+                    # ``null`` and the intake/BA roles fall back to
+                    # title-only heuristics or ``needs_clarification``
+                    # — even when the operator already wrote a full
+                    # description in Linear.
+                    "body": n.get("description"),
                     "url": n.get("url"),
                     "status": state_name,
                     "updated_at": n.get("updatedAt"),


### PR DESCRIPTION
Critical bug: list_tickets GraphQL query didn't request `description`, so /tracker/next returned `body: null`. Every intake/BA agent saw an empty ticket body even when the operator wrote a full description. Manifested today on ELS-63 (intake → needs_clarification despite 964-char operator body) and ELS-62 (BA had to synthesise the whole Problem/Goal structure from title alone).