### PR TITLE
picker: exempt planning anchors from project-priority gate

### DIFF
--- a/backend/app/api/v1/routes/agent_runs.py
+++ b/backend/app/api/v1/routes/agent_runs.py
@@ -81,6 +81,17 @@ router = APIRouter(
 logger = logging.getLogger(__name__)
 
 
+# Planning-anchor identification. Set by the tracker adapter when the
+# anchor is minted (Linear: ``LinearTracker.PLANNING_ANCHOR_LABEL``).
+# The picker uses it to bypass the project-priority gate for anchors
+# whose project is still in Drafts (``state='planning'``) — without
+# this exempt the decomposition routines (wbs / architecture /
+# qa_plan / planning_done) can never run, because their anchor lives
+# in a Drafts project by definition and ``planning_done`` is what
+# graduates Drafts → Parked.
+_PLANNING_ANCHOR_LABEL: str = "planning:anchor"
+
+
 # ---------------------------------------------------------------------------
 # Schemas
 # ---------------------------------------------------------------------------
@@ -330,6 +341,13 @@ async def get_next_task(
       audit row but no inbox spam (operator's choice to hold them).
       Projects with no priority row are treated as not-yet-onboarded
       and skipped too.
+    * **Planning-anchor exempt.** Tickets carrying the
+      ``planning:anchor`` label bypass the priority gate. Anchors
+      live in Drafts projects (``state='planning'``) by design, and
+      the decomposition routines (wbs / architecture / qa_plan /
+      planning_done) running against them are what *graduates* the
+      project to Parked. Without the exempt, decomposition would
+      deadlock on its own gate.
     """
     await _require_membership(session, workspace_id, auth.user.id, ROLES_ADMIN)
 
@@ -430,6 +448,15 @@ async def get_next_task(
         if matched_overlays:
             skipped_overlay.append((row, matched_overlays))
             continue
+        # Planning-anchor exempt: anchors live in Drafts projects
+        # (``state='planning'``) by construction. The decomposition
+        # FSM (wbs / architecture / qa_plan / planning_done) is what
+        # *moves* a project out of Drafts (``planning_done`` flips
+        # it to Parked); gating those routines on
+        # ``priority_state='active'`` would deadlock the funnel.
+        # Auto-onboard + the priority gate below still apply to
+        # regular tickets.
+        is_anchor = _is_planning_anchor(row.get("labels") or [])
         # ELS-80: WorkspaceProjectPriority gate — only ``active``
         # projects feed the picker.
         # ELS-92: when a ticket has a ``project_id`` but no priorities
@@ -444,7 +471,7 @@ async def get_next_task(
         # ``_tool_create_project`` writes the row explicitly with
         # ``state='planning'``, so this auto-onboard never overrides
         # an in-progress draft.
-        if project_id is not None:
+        if project_id is not None and not is_anchor:
             priority_state = await _project_priority_state(
                 session, workspace_id=workspace_id, project_id=str(project_id)
             )
@@ -526,6 +553,21 @@ async def get_next_task(
             fsm_stage=state,
             project_context=project_context,
         ),
+    )
+
+
+def _is_planning_anchor(labels: list[Any]) -> bool:
+    """Return True if ``labels`` contains the planning-anchor marker.
+
+    Match is exact + case-sensitive — Linear adapter mints the label
+    as the literal string :data:`_PLANNING_ANCHOR_LABEL`, and any
+    other casing or near-match is the operator's hand-edit, not the
+    minted anchor. Non-string entries skip silently so tracker rows
+    with weird label shapes never crash the picker.
+    """
+    return any(
+        isinstance(lbl, str) and lbl == _PLANNING_ANCHOR_LABEL
+        for lbl in labels
     )
 
 

--- a/backend/tests/test_agent_runs_anchor_exempt.py
+++ b/backend/tests/test_agent_runs_anchor_exempt.py
@@ -1,0 +1,64 @@
+"""Picker planning-anchor exempt.
+
+Planning anchors live in Drafts projects (``priority.state='planning'``)
+by construction — the decomposition FSM (wbs / architecture / qa_plan /
+planning_done) is what graduates Drafts → Parked. The picker therefore
+bypasses the project-priority gate for any row carrying the
+``planning:anchor`` label; without the exempt the decomposition routines
+would deadlock on their own gate.
+
+The matcher is intentionally exact + case-sensitive — the Linear adapter
+mints the literal label string, and any near-match is operator drift
+the picker should treat as a regular ticket.
+"""
+
+from __future__ import annotations
+
+from backend.app.api.v1.routes.agent_runs import _is_planning_anchor
+
+
+def test_anchor_label_present_returns_true() -> None:
+    assert _is_planning_anchor(["planning:anchor"]) is True
+
+
+def test_anchor_label_alongside_stage_labels_returns_true() -> None:
+    """Stage labels travel with the anchor through FSM transitions."""
+    assert (
+        _is_planning_anchor(["stage:wbs", "planning:anchor", "p1"]) is True
+    )
+
+
+def test_no_anchor_label_returns_false() -> None:
+    assert _is_planning_anchor(["stage:wbs", "p1", "frontend"]) is False
+
+
+def test_empty_labels_returns_false() -> None:
+    assert _is_planning_anchor([]) is False
+
+
+def test_case_variant_does_not_match() -> None:
+    """Adapter mints the literal — operator-renamed labels are not anchors."""
+    assert _is_planning_anchor(["Planning:Anchor"]) is False
+    assert _is_planning_anchor(["PLANNING:ANCHOR"]) is False
+
+
+def test_near_miss_strings_do_not_match() -> None:
+    """Suffix / prefix variants are unrelated free-form labels."""
+    assert _is_planning_anchor(["planning:anchor-v2"]) is False
+    assert _is_planning_anchor(["x-planning:anchor"]) is False
+
+
+def test_non_string_entries_skip_silently() -> None:
+    """Garbage in the labels array doesn't crash the matcher."""
+    assert (
+        _is_planning_anchor(  # type: ignore[list-item]
+            [None, 42, "", "planning:anchor"]
+        )
+        is True
+    )
+    assert (
+        _is_planning_anchor(  # type: ignore[list-item]
+            [None, 42, ""]
+        )
+        is False
+    )


### PR DESCRIPTION
## Summary
- Decomposition routines (wbs / architecture / qa_plan / planning_done) run against the planning anchor of a Drafts project. The picker's project-priority gate only admits `state='active'` projects — but Drafts is `'planning'` by design, and `planning_done` is the stage that graduates Drafts → Parked. Without an exempt, decomposition deadlocks on its own gate.
- `tracker/next` now bypasses the priority check when the row carries the literal `planning:anchor` label that the Linear adapter mints. Orphan and overlay-freeze gates still apply; non-anchor tickets in Drafts still get skipped via the existing `priority_skipped` audit row.
- Repro from today: askslayer's PAC-9 anchor sat in `stage:wbs` after Hand off, but every wbs tick returned `noop reason=no_eligible_ticket` because his project was in Drafts.

## Test plan
- [x] `_is_planning_anchor` unit tests cover present / absent / mixed-with-stage / case-variant / near-miss / non-string-entries.
- [ ] Re-dispatch `ship-trigger-schedule.yml` on `askslayer/visitor-back@alexey_38` with `routine_id=wbs`, `ticket_ref=PAC-9` after the Render deploy lands; expect BA agent to actually pick the anchor.