### PR TITLE
finish: persist decomposition sections into the project body

### DIFF
--- a/backend/app/api/v1/routes/agent_runs.py
+++ b/backend/app/api/v1/routes/agent_runs.py
@@ -177,6 +177,27 @@ class WriteOut(BaseModel):
     note: str | None = None
 
 
+class ProjectSectionPatch(BaseModel):
+    """One section the decomposition agent owns and is patching this run.
+
+    Each role in the decomposition chain owns exactly one section of
+    the project body (BA → ``WBS``, tech-arch → ``Architecture``,
+    qa-arch → ``Test architecture``, qa-eng → ``QA scenarios``,
+    developer → ``Tasks``). The role prompts told agents to "patch via
+    ``upsert_project_section(...)``" — but that was a fictional tool;
+    the server now reads this list from ``FinishIn`` and applies each
+    patch via ``LinearTracker.upsert_project_section`` (existing
+    adapter method that replace-or-appends a ``## <section>`` block).
+
+    ``project_id`` is derived server-side from the anchor ticket the
+    run was working against — agents only need to declare what
+    section + body they produced, not where to write it.
+    """
+
+    section: str = Field(min_length=1, max_length=64)
+    body: str = Field(max_length=50_000)
+
+
 class FinishIn(BaseModel):
     """Payload the Cursor agent posts to ``/agent-runs/finish`` from
     inside its runtime once it's done with the work.
@@ -208,6 +229,11 @@ class FinishIn(BaseModel):
     # Risks / etc.). Linear keeps prior bodies in the issue activity
     # feed so the operator can always see what changed.
     description: str | None = Field(default=None, max_length=20_000)
+    # Decomposition stage artefacts: the role's section of the project
+    # body. Persisted via the tracker's ``upsert_project_section``
+    # adapter (replace-or-append the ``## <section>`` block). Empty
+    # for SDLC / non-decomposition runs.
+    project_sections: list[ProjectSectionPatch] = Field(default_factory=list)
     # Which process the run executed under. Defaults to the per-ticket
     # SDLC (``development``); ``decomposition`` (ELS-75) is the
     # project-anchor pipeline. The finish hook reads this to know
@@ -2233,6 +2259,77 @@ async def finish_agent_run(
             if payload.comment:
                 await resolved.gateway.comment(ref, body=payload.comment)
                 actions.append("tracker:comment")
+            # Decomposition body sections (ELS-75 write path). Each role
+            # in the decomposition chain owns one ``## <section>`` of the
+            # project body and emits its artefact here; the adapter's
+            # ``upsert_project_section`` replace-or-appends the named
+            # block, so re-running a stage cleanly overwrites just its
+            # own section. We resolve the project_id from the anchor
+            # ticket via the snapshot helper rather than trusting the
+            # agent to pass it — the anchor already carries
+            # ``project.id`` and that's the canonical source.
+            #
+            # Ordering note: sections land before ``transition`` so a
+            # downstream stage that immediately picks up this anchor
+            # already sees the section it should read; otherwise the
+            # next picker tick could race ahead of the body write.
+            #
+            # Best-effort: a ``NotImplementedError`` (adapter doesn't
+            # model projects), missing project on the anchor, or a
+            # transient Linear 5xx fails the section but doesn't sink
+            # the rest of the finish — the audit trail surfaces the
+            # specific section so the operator can re-run.
+            if payload.project_sections:
+                snapshot = await _try_ticket_snapshot(resolved.gateway, ref)
+                project_id = (snapshot or {}).get("project_id")
+                upsert = getattr(
+                    resolved.gateway, "upsert_project_section", None
+                )
+                if project_id and upsert is not None:
+                    for patch in payload.project_sections:
+                        try:
+                            await upsert(
+                                str(project_id),
+                                section=patch.section,
+                                body=patch.body,
+                            )
+                            actions.append(
+                                f"tracker:project_section:{patch.section}"
+                            )
+                        except NotImplementedError:
+                            logger.warning(
+                                "agent_run.finish: tracker_kind=%s does not "
+                                "implement upsert_project_section; "
+                                "section=%s skipped",
+                                resolved.kind,
+                                patch.section,
+                            )
+                        except Exception as exc:  # noqa: BLE001 — logged below
+                            logger.warning(
+                                "agent_run.finish: project section write "
+                                "failed ws=%s ticket=%s section=%s err=%s",
+                                workspace_id,
+                                payload.ticket_ref,
+                                patch.section,
+                                exc,
+                            )
+                            actions.append(
+                                f"tracker:project_section_failed:{patch.section}"
+                            )
+                elif not project_id:
+                    logger.warning(
+                        "agent_run.finish: anchor ticket=%s has no project; "
+                        "%d project_sections skipped",
+                        payload.ticket_ref,
+                        len(payload.project_sections),
+                    )
+                elif upsert is None:
+                    logger.warning(
+                        "agent_run.finish: tracker_kind=%s has no "
+                        "upsert_project_section adapter; %d sections skipped",
+                        resolved.kind,
+                        len(payload.project_sections),
+                    )
             # Pass ``from_state`` so the adapter adds the breadcrumb
             # label for the role that *just finished* (``fsm_stage``),
             # not the next role's. The picker for ``stage_next`` reads

--- a/backend/app/resources/agent_roles/ba.md
+++ b/backend/app/resources/agent_roles/ba.md
@@ -38,7 +38,7 @@ When the run context flags `process=decomposition` (project-first delivery, ELS-
 - The "ticket" the runtime hands you is the **planning anchor** (`planning:anchor` label). Do NOT rewrite the anchor's description; the project body — not the anchor — carries decomposition artefacts.
 - Read the project's `## Brief` (the PO drafted it in Navigator). Emit a coarse **work breakdown structure** — a list of child-ticket stubs.
 - Each WBS line is **name + 2-3 lines of scope**. NOT detailed acceptance criteria. SDLC's BA writes those when each child enters `task_intake`; pre-writing them here is wasted work.
-- Patch ONLY the `## WBS` section via `upsert_project_section(project_id=<from anchor's project>, section="WBS", body=<your WBS>)`. NEVER touch `## Brief`, `## Architecture`, `## Test architecture`, or `## Tasks` — those are owned by other stages.
+- Emit your WBS body on the finish payload as `project_sections: [{ "section": "WBS", "body": <your WBS markdown> }]`. The server resolves the anchor's project and upserts the `## WBS` block (replacing any prior WBS, leaving other sections alone). NEVER touch `## Brief`, `## Architecture`, `## Test architecture`, or `## Tasks` — those are owned by other stages.
 - Do NOT create child tickets yourself. The `tasks` stage at the end of the decomposition chain creates them from the WBS you produce.
 - Finish with `outcome=ready_next_step`, `stage_next=architecture`, `process=decomposition`.
 - End your audit `comment` with: `[Ship decomposition:role-ba]`

--- a/backend/app/resources/agent_roles/developer.md
+++ b/backend/app/resources/agent_roles/developer.md
@@ -27,7 +27,7 @@ When the run context flags `process=decomposition` (project-first delivery, ELS-
 - For each line in `## WBS`, create exactly **one child ticket** via the `create_ticket` tool, with `project_id` set to the anchor's project. Each child:
   - **Title**: the WBS line's name, verbatim.
   - **Body**: 3-5 lines pulling Goal + Scope from the WBS line + 1-2 architecture pointers from `## Architecture`. Do NOT write detailed acceptance criteria, test plans, or implementation notes — SDLC's BA, tech architect, and QA architect refine those when the child enters `task_intake`.
-- After all child tickets exist, patch `## Tasks` via `upsert_project_section(project_id=<from anchor's project>, section="Tasks", body=<list of identifiers + names>)` — one bullet per child ticket created.
+- After all child tickets exist, emit the index on the finish payload as `project_sections: [{ "section": "Tasks", "body": <list of identifiers + names> }]` — one bullet per child ticket created. The server upserts only the `## Tasks` block.
 - NEVER touch `## Brief`, `## WBS`, `## Architecture`, or `## Test architecture`. Those are owned by upstream stages.
 - Finish with `outcome=ready_next_step`, `stage_next=planning_done`, `process=decomposition`. The server's completion hook then flips the project's dashboard row from Drafts → Parked so the project sits ready for the PO to promote (Parked → Active) when they decide it's worth the capacity. Agents do not auto-pick from Parked.
 - End your audit `comment` with: `[Ship decomposition:role-developer]`

--- a/backend/app/resources/agent_roles/qa-architect.md
+++ b/backend/app/resources/agent_roles/qa-architect.md
@@ -36,6 +36,6 @@ When the run context flags `process=decomposition` (project-first delivery, ELS-
 
 - The "ticket" handed to you is the **planning anchor** (`planning:anchor` label). Read the project's `## Brief`, `## WBS`, and `## Architecture` — the PO drafted the brief, BA emitted the WBS, the tech architect designed the system.
 - Test architecture is at **project scale**: unit / integration / e2e split for the feature as a whole, fixtures the team needs to stand up once, risk-based focus across the WBS. Per-child-ticket test cases come later (SDLC's QA architect handles those when each child reaches `qa_arch_plan`).
-- Patch ONLY the `## Test architecture` section via `upsert_project_section(project_id=<from anchor's project>, section="Test architecture", body=<your strategy>)`. Never touch `## Brief`, `## WBS`, `## Architecture`, or `## Tasks`.
+- Emit your strategy on the finish payload as `project_sections: [{ "section": "Test architecture", "body": <your strategy markdown> }]`. The server upserts only the `## Test architecture` block; never touch `## Brief`, `## WBS`, `## Architecture`, or `## Tasks`.
 - Finish with `outcome=ready_next_step`, `stage_next=tasks`, `process=decomposition`.
 - End your audit `comment` with: `[Ship decomposition:role-qa-architect]`

--- a/backend/app/resources/agent_roles/qa-engineer.md
+++ b/backend/app/resources/agent_roles/qa-engineer.md
@@ -34,4 +34,4 @@ End your single ticket comment with: `[Ship SDLC:role-qa-engineer]`
 
 When the run context flags `process=decomposition` (project-first delivery, ELS-75): the current `tasks` stage is **developer-only** — see `developer.md`'s decomposition section. QA-engineer is not invoked in today's decomposition chain.
 
-If a future stage routes you here under `process=decomposition`, your owned section in the project body is `## QA scenarios`. Output 1-2 happy-path scenarios per WBS line — coarse, project-level. Per-ticket QA work is the SDLC `qa_manual` stage's job; do NOT pre-walk every edge case here. Patch ONLY `## QA scenarios` via `upsert_project_section`. Never edit other sections.
+If a future stage routes you here under `process=decomposition`, your owned section in the project body is `## QA scenarios`. Output 1-2 happy-path scenarios per WBS line — coarse, project-level. Per-ticket QA work is the SDLC `qa_manual` stage's job; do NOT pre-walk every edge case here. Emit your scenarios on the finish payload as `project_sections: [{ "section": "QA scenarios", "body": <your scenarios markdown> }]`; the server upserts only that block, never edit other sections.

--- a/backend/app/resources/agent_roles/tech-architect.md
+++ b/backend/app/resources/agent_roles/tech-architect.md
@@ -36,7 +36,7 @@ When the run context flags `process=decomposition` (project-first delivery, ELS-
 
 - The "ticket" handed to you is the **planning anchor** (`planning:anchor` label). Read the project's `## Brief` and `## WBS` — the PO drafted the brief in Navigator and BA emitted the WBS upstream.
 - Architecture is at **project scale**: components touched, contracts, risk + rollback for the feature as a whole — not per-ticket. Each WBS line will spawn its own child ticket whose own architect-stage refines into a per-ticket plan; pre-writing per-ticket designs here is wasted work.
-- Patch ONLY the `## Architecture` section via `upsert_project_section(project_id=<from anchor's project>, section="Architecture", body=<your design>)`. Never touch `## Brief`, `## WBS`, `## Test architecture`, or `## Tasks`.
+- Emit your design on the finish payload as `project_sections: [{ "section": "Architecture", "body": <your design markdown> }]`. The server upserts only the `## Architecture` block; never touch `## Brief`, `## WBS`, `## Test architecture`, or `## Tasks`.
 - Open questions belong in your section under an explicit `### Open questions` subheading; do NOT escalate via `needs_clarification` from decomposition unless the gap is fatal — the WBS already carries the human's brief, and child tickets surface their own clarifications when they hit SDLC.
 - Finish with `outcome=ready_next_step`, `stage_next=test_architecture`, `process=decomposition`.
 - End your audit `comment` with: `[Ship decomposition:role-tech-architect]`

--- a/backend/tests/test_finish_project_sections_schema.py
+++ b/backend/tests/test_finish_project_sections_schema.py
@@ -1,0 +1,107 @@
+"""Schema for the decomposition write path on ``/agent-runs/finish``.
+
+The decomposition agents (BA, tech-architect, qa-architect, qa-engineer,
+developer) emit their stage's section of the project body via
+``FinishIn.project_sections``. The server then routes each entry into
+``LinearTracker.upsert_project_section``. The unit tests here exercise
+just the Pydantic shape — the handler-side wiring is exercised
+end-to-end in the agent run integration tests / live smoke (this file
+exists to fail loudly on accidental field rename or validation drop).
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from backend.app.api.v1.routes.agent_runs import FinishIn, ProjectSectionPatch
+
+
+def test_project_sections_default_is_empty_list() -> None:
+    """SDLC runs (no decomposition) finish without sections — must default to [].
+
+    Concretely: an SDLC ``code_review`` run never sets
+    ``project_sections`` and the handler must still accept the
+    payload. A required-field default mistake here would make every
+    SDLC tick 422.
+    """
+    finish = FinishIn(
+        run_id="r1",
+        outcome="ready_next_step",
+        ticket_ref="ENG-1",
+        stage_next="qa_manual",
+    )
+    assert finish.project_sections == []
+
+
+def test_project_sections_accepts_dicts() -> None:
+    """Agents post JSON; FastAPI coerces dicts → ProjectSectionPatch.
+
+    Pin the coercion shape so a future Pydantic upgrade or BaseModel
+    rewrite can't silently drop list-of-dict ingestion.
+    """
+    finish = FinishIn(
+        run_id="r1",
+        outcome="ready_next_step",
+        ticket_ref="ENG-1",
+        stage_next="architecture",
+        process="decomposition",
+        project_sections=[
+            {"section": "WBS", "body": "- thing one\n- thing two"},
+        ],
+    )
+    assert len(finish.project_sections) == 1
+    assert finish.project_sections[0].section == "WBS"
+    assert finish.project_sections[0].body.startswith("- thing one")
+
+
+def test_project_sections_accepts_multiple_entries() -> None:
+    """A single role only owns one section, but the schema permits a
+    list because the developer stage may patch ``Tasks`` while a
+    legacy run-replay re-emits an upstream section in the same call —
+    and forcing exactly-one would force agents to chain 2 finish
+    calls. We let the role prompt enforce single-section intent.
+    """
+    finish = FinishIn(
+        run_id="r1",
+        outcome="ready_next_step",
+        ticket_ref="ENG-1",
+        stage_next="planning_done",
+        process="decomposition",
+        project_sections=[
+            {"section": "Tasks", "body": "- ENG-101 thing\n- ENG-102 thing"},
+            {"section": "WBS", "body": "(unchanged)"},
+        ],
+    )
+    assert [p.section for p in finish.project_sections] == ["Tasks", "WBS"]
+
+
+def test_section_must_be_non_empty() -> None:
+    with pytest.raises(ValidationError):
+        ProjectSectionPatch(section="", body="…")
+
+
+def test_section_capped_at_64_chars() -> None:
+    """Linear's section heading goes into a markdown line; an
+    operator who pastes a 4kB heading by accident shouldn't blow up
+    the project body parser."""
+    with pytest.raises(ValidationError):
+        ProjectSectionPatch(section="x" * 65, body="…")
+
+
+def test_body_capped_at_50k() -> None:
+    """Project bodies are bounded; reject before the Linear API
+    rejects at its own (lower) limit so the audit row carries the
+    intent rather than an opaque 4xx."""
+    with pytest.raises(ValidationError):
+        ProjectSectionPatch(section="WBS", body="x" * 50_001)
+
+
+def test_body_zero_length_is_allowed() -> None:
+    """An agent may need to *clear* a section it previously owned —
+    e.g. re-running a stage that decided the prior content was wrong.
+    Empty body is the explicit "wipe my section" signal; the
+    upsert_project_section adapter handles the empty-block case.
+    """
+    patch = ProjectSectionPatch(section="WBS", body="")
+    assert patch.body == ""


### PR DESCRIPTION
## Summary
- Five decomposition role prompts (ba, tech-architect, qa-architect, qa-engineer, developer) all told agents to "patch via \`upsert_project_section(...)\`". The adapter method exists on \`LinearTracker\`, but \`FinishIn\` had no field for it and \`finish_agent_run\` had no handler — the agent's "tool call" was symbolic, the artefact was never persisted. Today's first PAC-9 BA run lost a 26-stub WBS this way.
- Adds \`FinishIn.project_sections: list[ProjectSectionPatch]\` (default \`[]\` for SDLC runs). On \`ready_next_step\`, handler resolves the anchor's \`project_id\` via \`get_ticket_snapshot\` and routes each entry through \`LinearTracker.upsert_project_section\`. Sections land before the FSM transition so the next stage's picker can't race ahead of the body write.
- Updates the five role prompts to declare \`project_sections\` as a finish-payload field, not a separate tool call.
- Best-effort failure path: a \`NotImplementedError\` (non-Linear adapter) or transient Linear 5xx fails just the section, leaves \`comment\` + \`transition\` alone, and emits a \`tracker:project_section_failed:<section>\` action so the operator can re-run.

## Test plan
- [x] \`pytest backend/tests/test_finish_project_sections_schema.py\` — 7 schema cases (empty default, dict coercion, multiple entries, section min/max length, body cap, zero-length body for explicit clear).
- [ ] After merge + Render rollout: reset PAC-9 to wbs (Linear state move + strip stage:wbs label), re-dispatch routine_id=wbs ticket_ref=PAC-9, verify project body picks up \`## WBS\` section with the BA's full output (not just the audit comment summary).