### PR TITLE
workflow: bump trigger timeout 30→60 min

### DIFF
--- a/.github/workflows/ship-trigger-schedule.yml
+++ b/.github/workflows/ship-trigger-schedule.yml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   trigger:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - name: Checkout (full history for agent introspection + branch push)
         uses: actions/checkout@v4


### PR DESCRIPTION
QA-arch hit 30-min wall on ELS-62 (19K body). Bump to 60.