### PR TITLE
landing: daily blog cadence + Two readers, two manuals

### DIFF
--- a/landing/content/blog/boring-failures-are-good-failures.md
+++ b/landing/content/blog/boring-failures-are-good-failures.md
@@ -1,7 +1,7 @@
 ---
 title: Boring failures are good failures
 slug: boring-failures-are-good-failures
-date: 2026-05-08
+date: 2026-05-06
 kicker: Best practice
 description: The worst failure mode for an agent isn't a crash — it's silence. The pipeline keeps running, the dashboard stays green, and the work that was supposed to happen quietly didn't. The cure is to make failure modes mundane and named, before the agent ever runs.
 reading_time: 4

--- a/landing/content/blog/champagne-over-teal.md
+++ b/landing/content/blog/champagne-over-teal.md
@@ -1,7 +1,7 @@
 ---
 title: Champagne over teal
 slug: champagne-over-teal
-date: 2026-05-11
+date: 2026-05-07
 kicker: Brand
 description: We swapped the accent colour from teal to muted champagne gold this week. Small change in the diff. Bigger change in how the product reads. Notes on why colour is a positioning lever, not a vibe choice.
 reading_time: 3

--- a/landing/content/blog/clarification-is-not-failure.md
+++ b/landing/content/blog/clarification-is-not-failure.md
@@ -1,7 +1,7 @@
 ---
 title: Clarification is not failure
 slug: clarification-is-not-failure
-date: 2026-05-01
+date: 2026-04-30
 kicker: Best practice
 description: Most agent loops treat "I have a question" as the same outcome as "I crashed." Both stop the pipeline. Both look red on a dashboard. They are completely different things, and conflating them teaches agents to invent rather than ask.
 reading_time: 5

--- a/landing/content/blog/how-we-cut-ship-out-of-elmundi.md
+++ b/landing/content/blog/how-we-cut-ship-out-of-elmundi.md
@@ -1,7 +1,7 @@
 ---
 title: How we cut Ship out of elmundi
 slug: how-we-cut-ship-out-of-elmundi
-date: 2026-04-07
+date: 2026-04-16
 kicker: Origin
 description: Ship did not begin as a greenfield repo. It began as a folder inside a product called elmundi. On Apr 7 we cut it out, and twenty commits later it was a standalone thing with its own CI, its own docs, and its own CLI. This is the prequel to every other post on this blog.
 reading_time: 6

--- a/landing/content/blog/knowledge-buckets-and-the-distiller.md
+++ b/landing/content/blog/knowledge-buckets-and-the-distiller.md
@@ -1,7 +1,7 @@
 ---
 title: Knowledge buckets and the Distiller
 slug: knowledge-buckets-and-the-distiller
-date: 2026-04-21
+date: 2026-04-22
 kicker: Case study
 description: Eight phases in one day — a scope ladder, a dual-written articles table, an LLM-backed ingest classifier, Notion and Linear connectors, and a per-user memory bucket that the agent can actually cite. The knowledge layer Ship needed before it could grow a second brain.
 reading_time: 11

--- a/landing/content/blog/lanes-as-config-or-how-we-killed-workflows.md
+++ b/landing/content/blog/lanes-as-config-or-how-we-killed-workflows.md
@@ -1,7 +1,7 @@
 ---
 title: Lanes as config — or how we killed the workflow artifact
 slug: lanes-as-config-or-how-we-killed-workflows
-date: 2026-04-21
+date: 2026-04-23
 kicker: Architecture
 description: A full RFC, ten commits, one repo — in a single day we retired a first-class artifact kind, introduced lanes-as-config, and made shipctl run the single entry-point for everything a repo schedules. An autopsy of RFC-0007.
 reading_time: 11

--- a/landing/content/blog/po-ideas-belong-in-the-epic.md
+++ b/landing/content/blog/po-ideas-belong-in-the-epic.md
@@ -1,7 +1,7 @@
 ---
 title: PO ideas belong in the epic, not the ticket
 slug: po-ideas-belong-in-the-epic
-date: 2026-05-02
+date: 2026-05-03
 kicker: Best practice
 description: When the agent that writes the ticket and the agent that builds it are different processes, scope and motivation have to live somewhere both of them can read. We tried chat. We tried fat tickets. The thing that actually works is putting it in the project description and keeping the tickets thin.
 reading_time: 6

--- a/landing/content/blog/ship-the-first-two-weeks.md
+++ b/landing/content/blog/ship-the-first-two-weeks.md
@@ -1,7 +1,7 @@
 ---
 title: Ship — the first two weeks
 slug: ship-the-first-two-weeks
-date: 2026-04-22
+date: 2026-04-18
 kicker: Build in public
 description: 189 commits. 16 days. One repo. The story of how Ship, shipctl, and the Ship Console went from an extracted folder to a running cloud platform — read off the actual git log.
 reading_time: 11

--- a/landing/content/blog/the-book-on-sunday.md
+++ b/landing/content/blog/the-book-on-sunday.md
@@ -1,7 +1,7 @@
 ---
 title: The book was written on Sunday
 slug: the-book-on-sunday
-date: 2026-04-19
+date: 2026-04-26
 kicker: Field note
 description: Prologue, manifesto, nine lettered sub-chapters, eight field notes. Every new passage anchored to a specific commit SHA from a real reference org. All of it keyed in between commits to the cloud console, on one Sunday, in a single session that started after midnight.
 reading_time: 5

--- a/landing/content/blog/the-catalog-rename-and-the-matrix-lane.md
+++ b/landing/content/blog/the-catalog-rename-and-the-matrix-lane.md
@@ -1,7 +1,7 @@
 ---
 title: The catalog rename and the matrix lane
 slug: the-catalog-rename-and-the-matrix-lane
-date: 2026-04-22
+date: 2026-04-25
 kicker: Autopsy
 description: 21 patterns renamed across 78 files. A new six-category scheme. Five duplicates deleted. Then a multi-pattern lane with three fan-out modes. RFC-0008, in the order it actually shipped, and why the matrix execution model fell out of the rename.
 reading_time: 11

--- a/landing/content/blog/the-mapping-table-the-runtime-never-read.md
+++ b/landing/content/blog/the-mapping-table-the-runtime-never-read.md
@@ -1,7 +1,7 @@
 ---
 title: The mapping table the runtime never read
 slug: the-mapping-table-the-runtime-never-read
-date: 2026-05-06
+date: 2026-05-05
 kicker: Autopsy
 description: We shipped an editor surface, an LLM resolver, and a PR-write flow for a config field. Twenty-four hours later we walked all of it back. The runtime didn't read the field. The story is about where config belongs.
 reading_time: 5

--- a/landing/content/blog/the-protocol-before-the-product.md
+++ b/landing/content/blog/the-protocol-before-the-product.md
@@ -1,7 +1,7 @@
 ---
 title: The protocol before the product
 slug: the-protocol-before-the-product
-date: 2026-04-18
+date: 2026-04-17
 kicker: Case study
 description: Between the Apr 7 extraction and the Apr 19 cloud console, there is a quiet 11-day stretch that looks like nothing happened. One commit on a Sunday did the whole thing — shipctl v0.9. We wrote the protocol before we wrote the product; here is how and why.
 reading_time: 10

--- a/landing/content/blog/two-readers-two-manuals.md
+++ b/landing/content/blog/two-readers-two-manuals.md
@@ -1,0 +1,112 @@
+---
+title: Two readers, two manuals
+slug: two-readers-two-manuals
+date: 2026-05-08
+kicker: Best practice
+description: Documentation written for a human and documentation written for an agent are different artifacts. We learned that the hard way and split them. Here is what changed when we did.
+reading_time: 7
+author: Denys Kuzin
+tags: [docs, agents, methodology, build-in-public]
+---
+
+Ship has two folders that look like documentation. They are not the same kind of thing.
+
+`documentation/` is for humans. Its render is `/docs/` on the live site. Prose, examples, diagrams, the reasoning behind a decision, and the occasional self-deprecating aside. A senior engineer reading it should be able to put a workspace together in an afternoon.
+
+`artifacts/` is for agents. Its render is not a website at all — it is a JSON catalog served from `/patterns`, `/tools`, `/collections`, fetched by `shipctl` and by every role agent that runs inside Ship. There is no narrative. There is frontmatter, IDs, paths, schemas, and a body that has been peer-reviewed by a different set of eyes — *another agent*.
+
+For three weeks we tried to keep both readerships happy with one set of files. It cost us every week.
+
+## The mistake
+
+When you ship code that runs inside an LLM-driven agent loop, your first instinct is "the agent should just read our docs." Of course. Docs are written. Markdown is structured-ish. The agent has retrieval. We're done.
+
+Except the agent isn't reading docs. The agent is *acting on* them.
+
+A human reading "we usually use Postgres" thinks, *OK, you usually use Postgres*. An agent reading the same line thinks *the contract says Postgres* and rejects a config that uses MySQL — even though the doc says "usually," not "must." The hedge that signals nuance to a human is invisible to a model with high confidence and no eyebrow.
+
+This is the central asymmetry. **Prose hedges are a feature in human-readable text and a bug in agent-readable text.** A model trained to be helpful will treat your aside notes as instructions. It does not know they are asides.
+
+Going the other way is worse. A human opening a stripped-down YAML schema with no examples, no reasoning, no aside notes — bounces in thirty seconds. They don't know what to do with `transition.trigger_actor: user | agent | either`. They want a paragraph that says *what* the field is for and *why* the three values, please.
+
+So: one folder where prose is the feature. Another folder where prose is the bug. Same word "documentation" — completely different artifacts.
+
+## What we changed
+
+Three structural moves, none of them subtle.
+
+**Split the folders.** `documentation/` is human. `artifacts/` is agent. Different schemas, different review cycles, different render targets. RFC-0005 collapsed each artifact into a single file with strict frontmatter and a body the agent retrieves; nothing else lives there. The story of that collapse is a separate post — *[Artifacts are frontmatter now](/blog/artifacts-are-frontmatter-now)* — but the *why* is here: an artifact body cannot afford prose that drifts from the schema, so it does not get prose at all.
+
+**Different review eyes.** A pattern's body in `artifacts/` is reviewed by another agent before merge. We literally have a routine that runs the artifact through a "would another role agent operate from this body in production" check. If the body reads like a blog post, the check fails. If the frontmatter is missing fields, the check fails. The reviewer is not a human; the reviewer is an LLM being asked to operate from this exact body, on a real ticket, with the same workspace tools the production agent has.
+
+**Catalog API as the moat.** Agents do not read `artifacts/` from the filesystem. They read it through `GET /patterns`, `/tools`, `/collections` — versioned, immutable per version, addressable by ID. If we change a pattern body without bumping the version, an agent in flight cannot accidentally pick up half-old, half-new content. Humans can edit the manual and ship the next render in five minutes. Agents see exactly the version they were given when their run started, for the lifetime of that run.
+
+These three things — folders, reviewers, API — turned "documentation" from one process into two. Both more demanding than what existed before. Both *much* clearer about who they are for.
+
+## What humans get
+
+Walk into `documentation/`, or its render `/docs/`:
+
+- **Narrative.** *The Inbox is not a backlog* opens with a one-sentence promise and unwraps it for two paragraphs before the schema appears. That isn't slow; it's loading the human's working memory with a frame.
+- **Examples.** Every concept has at least one worked example. A senior engineer reading should be able to ctrl-F for their case.
+- **Reasoning.** Why we chose a seven-state canonical lifecycle, not four or twelve. Why `awaiting_input` is *not* `blocked`. The reasoning is on the page; the consequence is the schema.
+- **Diagrams.** Most pages have one. The SVG generator is in the repo, but the diagrams exist for the human eye. If you remove them, the page still parses; it just costs the reader an extra minute.
+- **Reading time labels.** Three minutes vs eleven minutes. We tell you upfront; we don't pretend everything is a thirty-second skim.
+- **The occasional joke.** Not many. But Ship has a voice; the docs carry it. *You can't `git push --force` reality.*
+
+What humans do NOT get from `documentation/`:
+
+- Strict schemas as the primary content
+- Field-by-field tables that would be unreadable in prose
+- Agent-addressable IDs with no other context
+
+For those, the docs link out to the catalog endpoints — which exist precisely because they are not in this folder.
+
+## What agents get
+
+Walk into `artifacts/`, or its render via `/patterns/{id}`:
+
+- **Frontmatter as contract.** Every field is required, validated, versioned. Missing field = build fails, not "renders weird."
+- **Stable IDs.** `pattern.intake-clarification` does not become `pattern.intake-clarify-questions` next month. If we want to rename, we deprecate first; the old ID resolves to the new for one minor version.
+- **Strict schemas.** `transition.trigger_actor: user | agent | either`. No fourth option. No "we sometimes do X." The schema is the answer.
+- **Versioning.** A pattern at v0.4.2 stays at v0.4.2 forever. New body? New version. The agent that reads v0.4.2 today gets the same thing tomorrow, and in production six months from now.
+- **No prose.** The body of an artifact is steps, not story. If you find yourself writing "for example…" in a pattern body, that line is in the wrong file. It belongs in `documentation/`.
+- **Citation paths.** Every claim an agent makes traces back to an artifact ID + version. *I picked the QA-architect role because `pattern.test-architecture` v0.7.1 says…* This is the audit trail; this is what makes the difference between "an agent did something" and "evidence beats opinion."
+
+What agents do NOT get from `artifacts/`:
+
+- Long-form reasoning ("we chose this because…")
+- Examples written for humans to learn from
+- Hedges, asides, jokes
+
+If a pattern body needs to express a fallback, it gets a *new field* — `alternatives`, `escape_hatches` — not a paragraph of prose. The schema absorbs the nuance the prose used to carry. That is harder than writing the paragraph. It is also why the agent can be trusted to follow it.
+
+## The cost of mixing
+
+Before the split, we had one set of pattern files and we tried to write them so both readers could use them. Three failure modes, in order of how often they bit us:
+
+**The agent over-trusted prose.** A pattern said *we usually do X but if Y, do Z*. The agent ran the pattern, hit case Y, and proceeded with X anyway because the example showed X. The hedge was invisible. We caught this in production once. Once was enough.
+
+**The human couldn't find the contract.** Engineering onboarding: "what does this pattern actually require?" The answer was buried in a paragraph that started with *this is generally about…* Three quarters of an hour to find the schema, and a senior engineer who left the page muttering.
+
+**The two writers fought.** When the same file is being optimized for both readers, every PR has a fight: more prose for the human (the agent will mishandle hedges) or more schema for the agent (the human will bounce on the wall of YAML). Compromise documentation is bad documentation, in both directions.
+
+After the split, each PR optimizes for one reader. The pattern PR strips fluff. The doc PR adds it back. Both files improve. The two readers stop competing.
+
+## A note on the third reader
+
+Ship actually has a third documentation surface: `landing/content/book.md`. That one is written for a different human — not the engineer onboarding, but the person deciding whether to *adopt* this whole way of working. It is more philosophy than schema. Different folder, different render, different reader.
+
+The principle is the same. **Pick the reader before you pick the words.** Books are not docs are not artifacts. Trying to make any one of those three carry the weight of the other two is the same category error every time.
+
+## The lesson
+
+If you are building a product where AI agents act on your codebase, you have at least two reader bases. They want different things. They cannot share a manual.
+
+**Humans want narrative. Agents want contracts. One cannot be the other.**
+
+The temptation to use one source — *DRY, single source of truth, write once* — is the strongest mistake you can make in this stack. It is a category error: you are treating *documentation* as a single artifact when it is two artifacts that live in two folders, get reviewed by two different reviewers, render to two different surfaces, and get versioned on two different cadences.
+
+Ship's `documentation/` and `artifacts/` are not "old docs and new docs" or "the wiki and the API reference." They are **the two manuals every AI-native codebase needs**.
+
+Pick which file you are writing. Then write it for that reader. The other file is somebody else's problem.

--- a/landing/content/blog/we-deleted-the-worker.md
+++ b/landing/content/blog/we-deleted-the-worker.md
@@ -1,7 +1,7 @@
 ---
 title: We deleted the worker. The system got simpler.
 slug: we-deleted-the-worker
-date: 2026-04-20
+date: 2026-04-21
 kicker: Architecture
 description: Five moving parts in the morning, two by the end of the day. A worker, a Redis queue, a repo cache, and a git-sync loop — and why deleting them made the Ship Console cheaper, faster, and easier to reason about.
 reading_time: 7

--- a/landing/content/blog/wizard-v2-the-art-of-saying-no.md
+++ b/landing/content/blog/wizard-v2-the-art-of-saying-no.md
@@ -1,7 +1,7 @@
 ---
 title: Wizard v2 — the art of saying no
 slug: wizard-v2-the-art-of-saying-no
-date: 2026-04-21
+date: 2026-04-24
 kicker: Case study
 description: Ten steps became three, then stayed three across seven backend rewrites in one day. A case study in keeping a flow honest while the mechanism under it moves.
 reading_time: 8


### PR DESCRIPTION
## Summary

Two changes in one PR.

**1. Daily cadence on /blog.** Spread the 22 existing posts across consecutive dates — Apr 16 → May 8, 2026, one post per day, no gaps, no same-day duplicates. Narrative arc preserved (origin → methodology → manifestos). Body text untouched; only `date:` frontmatter was rewritten. Event dates inside posts are unchanged; publication date is now the slot on the calendar.

**2. New post (May 8): *Two readers, two manuals*.** A best-practice piece arguing that human-targeted documentation and agent-targeted documentation are different artifacts. Built on Ship's actual structural decisions — `documentation/` vs `artifacts/`, RFC-0005's single-file shape, the `/patterns` / `/tools` / `/collections` catalog API, agent-as-reviewer routine, version-pinned reads. Reading time: 7 min.

## New schedule

| Date | Post |
|------|------|
| 2026-04-16 | how-we-cut-ship-out-of-elmundi |
| 2026-04-17 | the-protocol-before-the-product |
| 2026-04-18 | ship-the-first-two-weeks |
| 2026-04-19 | artifacts-are-frontmatter-now |
| 2026-04-20 | from-chat-to-navigator |
| 2026-04-21 | we-deleted-the-worker |
| 2026-04-22 | knowledge-buckets-and-the-distiller |
| 2026-04-23 | lanes-as-config-or-how-we-killed-workflows |
| 2026-04-24 | wizard-v2-the-art-of-saying-no |
| 2026-04-25 | the-catalog-rename-and-the-matrix-lane |
| 2026-04-26 | the-book-on-sunday |
| 2026-04-27 | the-inbox-is-not-a-backlog |
| 2026-04-28 | policies-before-prompts |
| 2026-04-29 | we-moved-the-front-door |
| 2026-04-30 | clarification-is-not-failure |
| 2026-05-01 | the-agent-that-finished-without-committing |
| 2026-05-02 | cheap-classifier-first |
| 2026-05-03 | po-ideas-belong-in-the-epic |
| 2026-05-04 | the-dark-factory-is-closed |
| 2026-05-05 | the-mapping-table-the-runtime-never-read |
| 2026-05-06 | boring-failures-are-good-failures |
| 2026-05-07 | champagne-over-teal |
| 2026-05-08 | **two-readers-two-manuals** ← new |

## Test plan

- [x] All 23 posts on consecutive days, no dupes
- [x] New post parses + has all required frontmatter fields
- [ ] `npm run landing:build` passes
- [ ] `/blog` index orders posts newest-first; new post appears at the top
- [ ] `/blog/two-readers-two-manuals` renders with kicker, title, description, tags, body
- [ ] /sitemap.xml includes all 23 entries

## What's next

Coverage starts on Apr 16; project actually started Apr 7. If we want strict daily back to Apr 7, that's 9 more posts to fill Apr 7-15 — happy to draft a follow-up batch from the early bootstrap commits (RFC-0005 wave 1, MkDocs retirement, Bunny CI fights, book-on-Sunday lead-up, etc.).