### PR TITLE
landing: 9 bootstrap-week posts (Apr 7-15) — full daily coverage

### DIFF
--- a/landing/content/blog/adopt-ship-launcher.md
+++ b/landing/content/blog/adopt-ship-launcher.md
@@ -1,0 +1,55 @@
+---
+title: adopt-ship.sh and the wrong adopters
+slug: adopt-ship-launcher
+date: 2026-04-13
+kicker: Field note
+description: A 60-line shell script meant to make adoption frictionless. The first three people who ran it did the wrong thing in three different ways. What we learned about the gap between "easy to start" and "easy to start correctly."
+reading_time: 4
+author: Denys Kuzin
+tags: [adoption, onboarding, build-in-public, field-note]
+---
+
+`adopt-ship.sh` was a shell script in the repo root. Sixty lines. It cloned the seed bundle into a target repo, copied the agent rule files into `.claude/`, ran `npm install`, and printed a green message.
+
+I'm sharing this because it's a small, perfect example of the gap between *making something easy to start* and *making something easy to start correctly*. The two are different problems and we kept conflating them.
+
+## What the script did right
+
+You ran it from any repo. It did not require you to read the docs. It worked on day-zero macOS and Ubuntu. The success message linked back to the next step. By the standards of "first impression," it was great.
+
+We watched three different people run it in the first week. All three got to the green message. None of them ended up with a working Ship adoption.
+
+## What went wrong
+
+**Adopter #1** ran the script in a fresh repo with no commit history. The seed bundle assumed a git remote was configured; the script didn't check. Their `.claude/` was set up correctly, but their CI couldn't trigger because there was no `origin`. They quietly stopped using it.
+
+**Adopter #2** ran the script in a monorepo with three apps. The script copied agent rule files to the repo root. Two of the three apps couldn't see them because they expected `.claude/` adjacent to their own `package.json`. The agent ran on the wrong codebase for two days before anyone noticed.
+
+**Adopter #3** ran the script and hit a broken `npm install` because their lockfile pinned an incompatible peer dependency. The script reported success because `npm install` had a non-zero exit but the green message printed anyway. Bug on our side, and one we'd never have caught without watching a real adopter.
+
+Three runs. Three different failure modes. None of them were "the script crashed."
+
+## What we changed
+
+We didn't fix the script. We retired it.
+
+The wizard that replaced it (later: Wizard v2) does six things the shell script did not:
+
+- Refuses to run if the target is not a git repo with a remote configured
+- Detects monorepo shape and asks where the agent rule files belong
+- Validates the install actually worked, not just that npm exited
+- Records the user's answers as a manifest that the maintainer can audit
+- Surfaces drift between the seed bundle and the target after install
+- Gates publish on workspace defaults being set
+
+Each of those costs you a hundred lines instead of zero. Each of those was learned from a real adopter doing a real wrong thing.
+
+## The lesson
+
+A "frictionless onboarding" that lets the user complete the happy path while sitting in a broken state is **worse than friction**. It tells them everything's fine when nothing is. Friction in the right place — *we noticed your repo has no remote; here's how to add one* — is the opposite of bad UX. It's the script doing the work the user shouldn't have to know to do.
+
+The metric *did the user get to "done" without crashing* is the wrong metric. The right metric is *did they end up in a configuration that actually works.*
+
+`adopt-ship.sh` got the first metric right. It got the second one wrong, three times in a row.
+
+We don't ship one-shot install scripts anymore.

--- a/landing/content/blog/bunny-three-weeks-of-fights.md
+++ b/landing/content/blog/bunny-three-weeks-of-fights.md
@@ -1,0 +1,47 @@
+---
+title: Bunny Magic Containers, three weeks of fights
+slug: bunny-three-weeks-of-fights
+date: 2026-04-08
+kicker: Field note
+description: Sixteen consecutive `fix(bunny)` commits. The Magic Containers API was new, the docs were thin, and our deploy pipeline learned each lesson the same way every team learns it. Here's the shape of the fight, told off the actual commit log.
+reading_time: 4
+author: Denys Kuzin
+tags: [infra, bunny, build-in-public, field-note]
+---
+
+If you grep the early git log for `fix(bunny):` you get sixteen commits in two weeks. None of them are interesting on their own. Together they tell a familiar story about deploying to a brand-new platform: the docs are thin, the API surface keeps almost matching what you'd expect from another vendor, and every "almost" costs a day.
+
+This is a short note, not a guide. Bunny Magic Containers is a fine product; it was just very new in April, and the rough edges came in a particular order.
+
+## The shape of the fight
+
+The same loop, sixteen times:
+
+1. Read the Bunny docs.
+2. Mirror what we'd done with the previous host (App Platform, Fly, ECS — pick yours).
+3. POST to MC fails with a 500 or a vague 4xx.
+4. Read the *response body* — not the status code — and discover the API rejects a field the docs implied was optional.
+5. Strip the field, retry, ship.
+6. Find the next field in step 3 next deploy.
+
+Concretely: the create payload at one point had `name`, `region`, three probe configs, and a sticky-cleanup flag. By Week 2 the payload had `name` and `regions`. The docs hadn't lied; the API had just gotten stricter about *what they actually meant.*
+
+## Three lessons that compounded
+
+**Read the response body.** A 500 with no body is a wall. A 500 with `"field 'foo' not allowed"` is a clue. We added a logging step early because the GitHub Action originally swallowed the body on non-2xx; that one change cut the loop time in half.
+
+**Image digest, not tag.** The first deploy worked. The second deploy fetched a stale image because the Magic Containers fetched by tag and the registry had cached. We switched to PATCHing the digest after a Docker Hub round-trip, with `imagePullPolicy: always`. Two commits to land, hours of debugging to discover.
+
+**Honor the env var first, lookup second.** Bunny's MC creates apps by name; if the name lookup fails, you can pass `BUNNY_APP_ID` directly. We had to learn this twice, because the lookup-then-create flow swallows the case where the name is taken by an app you don't own.
+
+## Why the post
+
+The lesson is not "Bunny is hard." The lesson is: **when you adopt a new infra vendor, your CI is the most expensive learning environment you have.** Each commit in our `fix(bunny):` chain was a real outage of internal velocity — half a day where the team couldn't see their changes deployed.
+
+If you're picking a new infra layer in 2026 — DOKS, Fly, Railway, Bunny, Render, App Platform — budget for *three weeks of CI fights* and treat that as the cost of entry. Not because any of those products are bad. Because every API surface has its lessons, and the docs only cover the ones somebody else has already taken.
+
+## Postscript
+
+The Magic Containers product matured significantly while we were fighting with it. Half the issues above are no longer issues. We use Bunny for landing now (it's good at static + edge), and migrated the live backend off it because of cold-start behaviour, not because of the deploy pipeline.
+
+The CI script — `scripts/bunny-deploy-platform.mjs` — is in the repo. If you're an early-MC adopter, it'll save you a day.

--- a/landing/content/blog/cloud-prompts-in-english.md
+++ b/landing/content/blog/cloud-prompts-in-english.md
@@ -1,0 +1,41 @@
+---
+title: Translating cloud-prompts to English
+slug: cloud-prompts-in-english
+date: 2026-04-09
+kicker: Field note
+description: The prompts that came over from elmundi were partly Ukrainian. We sat one afternoon and translated them. Three things changed; one of them was unexpected.
+reading_time: 3
+author: Denys Kuzin
+tags: [prompts, agents, build-in-public, field-note]
+---
+
+The prompts that landed in the first commit were bilingual. The role descriptions were English; the in-context examples were Ukrainian. Inside elmundi this had been fine — the team was Ukrainian, the customer was Ukrainian, the LLM happily switched.
+
+For Ship to be a public project, the prompts had to switch too. We sat one afternoon and translated them. The commit body says *chore(prompts): translate cloud-prompts and related templates to English*. It was not a chore.
+
+## What got translated
+
+About forty prompt templates. Role definitions, exit-contract prose, error messages the agent would write back at the user. Plus the `_base` template that everything inherits from.
+
+The translation was straightforward in the literal sense — DeepL and a careful re-read. The hard part was something else.
+
+## Three things changed
+
+**1. The voice settled.** Bilingual prompts had a small voice drift between the English parts and the Ukrainian parts. After translation, every role's prose came out in one consistent register. The agent's outputs got more uniform within hours of merging. We had assumed the bilingual mix was neutral; it wasn't.
+
+**2. The model preferred the new prose.** Output quality on the same tickets noticeably improved — fewer hallucinations on names, fewer mixed-language responses, more confident citations. We were not running an A/B; this was just on-the-day-after observation, but several team members flagged it independently. Plausible mechanism: pretraining data is overwhelmingly English, and a fully-English prompt nudges the model into its "best" distribution.
+
+**3. We discovered which lines we never actually needed.** Six templates had bilingual sections that were copy-pasted between roles for safety. When we translated and consolidated, three of those got deleted entirely — they hadn't been adding signal, just length. Translating forced a re-read; re-reading found the dead weight.
+
+## What we kept bilingual
+
+Two surfaces stayed bilingual on purpose:
+
+- **User-facing chat in the console.** If the user writes in Ukrainian, the agent answers in Ukrainian. The prompt asks for *the user's language*, not English. (RFC-0006 added explicit-shift detection later, but the language pivot was already there.)
+- **The book.** `landing/content/book.md` still has a Ukrainian Part II — the methodology section that originated in Ukrainian and was specifically requested by the original audience. We added it back as `docs(uk): add Ukrainian Part II — Prompts & workflows` two days later.
+
+So: **English for the agent's instructions, the user's language for the agent's output.** Two different surfaces, two different policies.
+
+## The lesson
+
+Mixed-language prompts aren't neutral. They drift the voice, they leave dead lines, they nudge the model out of its strongest distribution. If your team works in language X but your prompts are read by a model trained on language Y — translate. The cost is one afternoon. The payoff is in every reply the agent gives, forever.

--- a/landing/content/blog/extracted-from-elmundi.md
+++ b/landing/content/blog/extracted-from-elmundi.md
@@ -1,0 +1,47 @@
+---
+title: What "extracted from elmundi" actually carried
+slug: extracted-from-elmundi
+date: 2026-04-07
+kicker: Origin
+description: One commit, six months of methodology, and the LICENSE file that did more work than any line of code. A look at what was actually inside the first import.
+reading_time: 4
+author: Denys Kuzin
+tags: [origin, build-in-public, autopsy]
+---
+
+The first commit on the new repo says *Initial import: Ship framework (extracted from elmundi)*. One commit. One day. Twenty thousand lines touching every directory the new project would have for its first month.
+
+It is not what I would have guessed was inside, if you'd asked me on April 8.
+
+## What got carried over
+
+The methodology files — the markdown that describes what an agent does at each lifecycle stage — moved verbatim. The prompts that shipped with each role moved verbatim. The Node runtime that orchestrated the lanes moved verbatim. The MkDocs site that served as both operator manual and agent reading list — also verbatim.
+
+This was the boring stuff. We thought it would be the hard stuff.
+
+## What got rewritten
+
+Three things got rewritten on the first day, and they were the things that decided whether the extraction was real:
+
+**Paths.** Every reference in the methodology that pointed to `tools/linear-agent/` got rewritten to `cli/` paths under the new layout. Every example that used `elmundi/some-pattern` became a generic. The commit body specifically calls out *ElMundi-specific examples gone*.
+
+**The LICENSE.** There hadn't been one before. There was now. Apache-2.0. This is the change that actually made Ship a separate thing from elmundi. The methodology had been "elmundi's habit" for six months; the LICENSE made it "a project that anyone can use." Without it, the rest of the diff would have been moving files into a folder no one was allowed to read.
+
+**The `mkdocs.yml`.** A single line was different: the GitHub link. Pointing at the new repo. Same content, same render, different ownership. That line is the one I keep going back to. It's tiny. It carries everything.
+
+## What was missing
+
+The first commit did *not* include:
+
+- A way to actually run anything outside the elmundi codebase. The runtime worked because it had been tuned against one specific repo. The wider claim — that the methodology travels — was unproven.
+- A CLI in any meaningful sense. There were Node scripts. There was no `shipctl`.
+- A landing site. There was an MkDocs render of the manual. That was it.
+- A backend. The cloud-product angle would not appear until twelve days later.
+
+## The lesson
+
+A methodology you can run inside the repo it grew in is **a habit**. The first commit did not turn it into a product; it turned it into a project. Those are different things, and most of April was spent on the difference.
+
+What the commit actually did was set the boundary: from now on, anything that worked because of *elmundi-specific assumptions* would have to be made explicit and parameterized, or removed. That single move — *we cannot rely on the host anymore* — is what made every later commit possible.
+
+A LICENSE file is a tiny artifact. On April 7, it was the most consequential one in the diff.

--- a/landing/content/blog/killed-mkdocs-kept-the-urls.md
+++ b/landing/content/blog/killed-mkdocs-kept-the-urls.md
@@ -1,0 +1,53 @@
+---
+title: Killed MkDocs, kept the URLs
+slug: killed-mkdocs-kept-the-urls
+date: 2026-04-10
+kicker: Architecture
+description: We replaced the docs runtime in one commit. Same content, same URL paths, different stack. The constraint that did most of the work was "no broken links."
+reading_time: 4
+author: Denys Kuzin
+tags: [architecture, docs, build-in-public]
+---
+
+On April 10 the docs runtime changed. MkDocs out, Next.js in. Same Markdown source files, same URL paths, different rendering. The commit is one line in the git log: *feat: landing app, ship CLI, backend API; retire MkDocs runtime.*
+
+The interesting part was the constraint. "No broken links" forced every other decision.
+
+## Why retire MkDocs
+
+MkDocs was fine. It still is fine. We retired it for two reasons that had nothing to do with MkDocs itself:
+
+**One render target, multiple audiences.** The same site needed to host the docs (`/docs`), the marketing pages (`/`, `/use-cases`, `/process`), the book (`/book`), and the catalog pages (`/patterns`, `/tools`, `/collections`). MkDocs is excellent at the first one, awkward at the others. Running two stacks side by side — MkDocs at `/docs` and Next at the rest — was a deploy story we didn't want to maintain.
+
+**Real interactivity for the marketing surfaces.** The hero needs to render a process mock with live ticket-card animations. The roadmap teaser needs to pull from the live `/v1/roadmap` endpoint at build time. None of that fits MkDocs without bolt-ons.
+
+## The constraint
+
+Here's what made the migration tractable: **every existing `/docs/...` URL had to keep working**.
+
+Inside elmundi, the docs URL had been linked from chat messages, from PR descriptions, from agent outputs that other agents had cited. Breaking those would have created a tail of broken citations across the methodology system itself. So the rule was simple: same path on the new site, same content, same anchor IDs.
+
+That constraint did most of the work. It meant we couldn't reorganize the docs hierarchy "while we were in there"; the migration had to be **render-only**, not structure. Which meant the migration could land in one commit instead of fifteen.
+
+## What changed
+
+- Markdown source files moved from the MkDocs working tree to `documentation/` at the repo root.
+- The Next.js `landing` app added a dynamic route `/docs/[...slug]` that reads `documentation/**.md`.
+- The MkDocs `mkdocs.yml` got deleted in the same commit. No "deprecated, will remove next month" period — the new render shipped, the old one was gone.
+- A second commit later in the day fixed `Docker build for MkDocs snippets` (we still bundled MkDocs *content* into the Docker image for one more day, until the consumers got pointed at the new render).
+
+## What didn't change
+
+Anchor IDs. Each H2 in the source had a slug that MkDocs auto-generated; we matched it in the new render. Bookmarks didn't break.
+
+URL trailing slashes. MkDocs served `/docs/foo/`; Next.js redirected `/docs/foo/` → `/docs/foo`. We added the redirect explicitly so old links worked.
+
+Markdown extensions. The source uses MkDocs admonition syntax (`!!! note`); the new render preserves it via a remark plugin.
+
+## The lesson
+
+When you replace a runtime, the URLs are the contract. The content is *implementation*; the URLs are *interface*. We migrated the runtime in a day because we held the interface constant.
+
+The reverse — keeping the runtime, changing the URLs — would have been catastrophic, because every external citation would need rewriting, and we control none of those.
+
+The shape of the migration generalizes: **whatever the smallest stable contract is, hold it constant**, and everything inside can change in a single commit.

--- a/landing/content/blog/methodology-api-one-endpoint.md
+++ b/landing/content/blog/methodology-api-one-endpoint.md
@@ -1,0 +1,65 @@
+---
+title: The methodology API — one endpoint, two consumers
+slug: methodology-api-one-endpoint
+date: 2026-04-15
+kicker: Architecture
+description: shipctl reads from it. Every agent reads from it. The customer's repo never sees the source files. One HTTP API, deliberately small, cleanly versioned. The shape that made the rest of April land smoothly.
+reading_time: 4
+author: Denys Kuzin
+tags: [architecture, api, build-in-public]
+---
+
+By April 15 the repo had a refactor (`documentation/`, `prompts/`, `runtime/`), an Apache-2.0 license, a CLI scaffold, a deploy pipeline, and several adapters. What it didn't have was an *API*. The methodology was still being read off disk by everything that needed it.
+
+The commit that fixed this was `Unify methodology API for catalogs and add npm publish workflow`. One endpoint shape. Two consumers: `shipctl` and the in-process agent runtime. The customer's repo never reads the source files directly.
+
+This is a short note about *why* one endpoint and *why* two consumers, in a stack where it would have been easy to skip the API and have everything read the filesystem.
+
+## What the API does
+
+Three resource families, two verbs each:
+
+- `GET /patterns`, `GET /patterns/:id`
+- `GET /tools`, `GET /tools/:id`
+- `GET /collections`, `GET /collections/:id`
+
+Plus a fetch endpoint:
+
+- `POST /fetch` with `{kind, id, version}` returns the body
+
+That's the whole shape. No mutations. No filtering language. No GraphQL. The endpoints are not even particularly RESTful — they're a thin shell over a deterministic catalog.
+
+The catalog itself is built from the on-disk source files (`prompts/`, later `artifacts/`) at server start, with a checksum so we know when it's stale. A pattern at v0.4.2 returns the same body forever; a new body means a new version.
+
+## Why one endpoint
+
+I argued for a richer API at first. *Surely the agent will want filters? Surely the CLI will want pagination?* No, and no.
+
+`shipctl` lists everything once and caches locally. The agent fetches one artifact at a time, by ID + version. Neither consumer needed filters. Neither consumer needed pagination. We were planning around imagined needs.
+
+When we wrote the actual consumer code, the API stayed small. **The smallness is the feature.** A small API is one we can keep stable for the lifetime of the project. A clever API is one we'd have to deprecate in three months.
+
+## Why two consumers, both via HTTP
+
+`shipctl` is a separate process running on the customer's machine. Of course it goes through HTTP. That's not the interesting part.
+
+The interesting part is that the *in-process agent* — code running in the same Python process as the catalog server — also goes through HTTP. It would be technically faster to read from disk directly. We chose not to.
+
+The reason is simple: **the in-process agent is the canonical consumer**. If we let it read from disk, we'd be telling everyone else (`shipctl`, future external integrators, the customer's own scripts) that they're a second-class citizen. They'd hit edge cases the in-process code never hit. Bugs would split between paths.
+
+By forcing the in-process agent through HTTP, we guarantee that *what shipctl sees is what the agent sees*. There's exactly one read path. If it has a bug, both consumers find it on the same day.
+
+## What this enabled
+
+A bunch of things, in order of how often they came up:
+
+- Versioning. Bumping a pattern from v0.4.2 to v0.4.3 means the API returns the new version next time someone asks for `latest`, but agents already in flight still get v0.4.2 by ID. No coordination needed.
+- Cacheability. `shipctl` caches by ID+version. The cache is correct because versions never change. We can be aggressive about cache duration.
+- Auditability. Every agent run records which artifact ID+version it read. The methodology API is the source of truth for "what did the agent know."
+- The MCP-server experiment didn't ship. The decision to stick with this API instead of running an MCP server in parallel was clean precisely because the API was already working.
+
+## The lesson
+
+A small API is a stable API. Two consumers on the same HTTP path is one fewer surprise per week. The temptation to make the in-process consumer "fast" by giving it filesystem access is the temptation that produces split codepaths and inconsistent bugs.
+
+We made the in-process consumer go over HTTP and we never looked back. Every other piece of architecture in April landed smoothly because of it.

--- a/landing/content/blog/multi-tracker-adapters-no-customers.md
+++ b/landing/content/blog/multi-tracker-adapters-no-customers.md
@@ -1,0 +1,52 @@
+---
+title: Multi-tracker adapters before there were customers
+slug: multi-tracker-adapters-no-customers
+date: 2026-04-14
+kicker: Architecture
+description: We shipped Linear, GitHub Issues, Notion, Jira, and Asana adapters before any of them had a real user. It is the exception to the "build for one before many" rule. Here is why we did it anyway and what kept the cost down.
+reading_time: 4
+author: Denys Kuzin
+tags: [architecture, integrations, build-in-public]
+---
+
+The default rule for a pre-revenue startup is *build for one before many*. Pick one customer, one platform, one shape, and saturate it before generalizing. Generalization is expensive and most of the variation will be wrong.
+
+We violated this rule on April 14. The commit body says *feat(cli): ship-agent multi-tracker adapters and docs*. Five tracker integrations in one commit, none of them with a paying user. Here is why, and the small structural choice that kept the cost manageable.
+
+## Why we did it
+
+The methodology *only works* if Ship is the layer above the tracker, not glued to it. Our positioning was always "vendors are plugs rather than the story" — the line is in the README — and that positioning is meaningless if the only plug is Linear.
+
+If we shipped a closed beta with Linear-only, every conversation with a buyer would start with: *but we use Jira.* The methodology would have to defend itself as a *Linear add-on*, not as a delivery system. We'd have already lost the framing.
+
+So adapters first, customers second, even though customers second is the harder problem.
+
+## How we kept the cost down
+
+Two structural moves.
+
+**One canonical state model, seven slots.** Every adapter resolves its native states (Linear's `In Progress`, Jira's `In Development`, Asana's `Doing`) into the same seven canonical buckets — Backlog, Planning, Executing, Reviewing, Awaiting Input, Blocked, Closed. The methodology operates on canonical states; the adapter does the round-trip. This means the methodology doesn't grow per-tracker code paths. Adding a sixth tracker is a translation table, not an algorithm change.
+
+**Adapter as a thin trait, not a deep abstraction.** The adapter interface has six methods: `fetch_issues`, `fetch_workflow_states`, `update_state`, `add_comment`, `find_by_label`, `health_check`. That's it. Anything trickier — webhooks, custom fields, ACLs — is per-adapter, lives in the adapter file, and doesn't leak into the rest of the codebase. The methodology doesn't know which tracker is connected; it asks the adapter and trusts the answer.
+
+These two together meant adding an adapter was about 200 lines plus a config schema. Five adapters fit in one PR.
+
+## What we got wrong
+
+We thought the adapters would all be roughly equivalent in usefulness. They were not. Three months in:
+
+- **Linear**: dominant, validated end-to-end, the reference implementation
+- **GitHub Issues**: validated, second most-used in pilots
+- **Notion**: validated, surprising adoption from PM-heavy teams
+- **Jira**: behind a feature flag, still works, but the workflow customization landscape is so wide that "validated end-to-end" requires per-instance testing
+- **Asana**: planned, kept the adapter dormant; not enough demand to invest in QA-ing it
+
+We've kept the dormant ones in `code` because the cost of keeping them is one CI run and the *negotiating* value of having them is real. Buyers see "five trackers" on the matrix, even if four are partial.
+
+## The lesson
+
+The "build for one" rule is right most of the time. The exception is when **the *plurality* itself is the value proposition**. If your positioning is "we sit above any tracker," shipping with one tracker is shipping a different positioning by accident.
+
+Two structural choices kept the cost low: a canonical state model the methodology operates on, and a thin adapter interface so per-tracker complexity doesn't leak. If your positioning needs plurality, those are the two moves to make first.
+
+If your positioning doesn't need plurality, just go build for one. The rule's right.

--- a/landing/content/blog/the-docs-mcp-experiment.md
+++ b/landing/content/blog/the-docs-mcp-experiment.md
@@ -1,0 +1,51 @@
+---
+title: The docs-mcp-server experiment we deleted
+slug: the-docs-mcp-experiment
+date: 2026-04-12
+kicker: Autopsy
+description: We built a Model Context Protocol server to expose the docs to agents. It worked. Then we deleted it. Why building the right thing the wrong way is sometimes worse than not building it.
+reading_time: 4
+author: Denys Kuzin
+tags: [autopsy, mcp, agents, build-in-public]
+---
+
+Two commits, three days apart:
+
+- `feat: add initial implementation of docs-mcp-server with Docker support`
+- `chore(repo): remove unused docs-mcp-server experiment from /tools/`
+
+In between: about forty hours of work and a lesson we hadn't expected.
+
+## What it was
+
+The pitch was clean. Anthropic's Model Context Protocol gives agents a uniform way to call into external tooling. We have docs the agent needs to read. Therefore: an MCP server that wraps `documentation/` and exposes it as searchable tools.
+
+We built it. It started, accepted MCP requests, and returned doc passages. The Docker image was 80 MB. The protocol round-trips were single-digit milliseconds. The whole thing felt clean.
+
+## Why we deleted it
+
+Three reasons, in order of how loudly they argued.
+
+**The agent didn't need MCP — it needed the catalog API.** When an agent asks "what's the role definition for QA-architect," it doesn't want to retrieve a markdown passage and parse it. It wants the *structured artifact*: ID, version, body, schemas. We were already building that as the methodology API (`/patterns`, `/tools`, `/collections`). MCP gave us a protocol; what the agent needed was a *contract*. Different things.
+
+**Two read paths is one too many.** With both MCP and the methodology API live, the agent had to decide: which one for which question? That decision is exactly the kind of thing LLMs get wrong. We didn't want to spend any optimization budget teaching the agent to pick its read path; we wanted a single read path that always worked.
+
+**The MCP server's killer feature was the wrong feature for our case.** MCP shines when many independent agents need to call into many independent tools. We have one workspace, one agent ecosystem, one source of docs. The polyglot interop that MCP buys you is a payment for a problem we don't have.
+
+## What we learned
+
+- **MCP is great for the right shape of problem.** If you're building a tool that *external agents* will integrate with — give them an MCP surface. They'll thank you.
+- **MCP is the wrong shape for "my agents read my docs."** That's a methodology API. Versioned, typed, single-source.
+- **The cost of an extra read path is hidden.** It looked like the MCP server cost us forty hours up front. The real cost was the *steady-state* cognitive overhead of two ways to ask the same question. We caught it on day three and walked it back.
+
+## The deletion commit
+
+The body of the deletion commit is one line: *no users, no consumers, no follow-up planned*. We deleted the Docker config in the same commit. Removed the `tools/docs-mcp-server/` folder, removed the workflow that built it, removed the README that explained it. Net diff: -1,247 lines.
+
+I keep that commit on a sticky note. It was a real piece of work, well-built, and walking it back was the right move. We were not "wrong to try." We were right to *stop*.
+
+## The lesson
+
+Building the right thing the wrong way is sometimes worse than not building it. Two read paths is one too many. The agent did not need MCP; it needed contracts.
+
+We deleted forty hours of work and shipped faster afterwards because of it. That arithmetic is not intuitive. It's correct.

--- a/landing/content/blog/the-shape-refactor.md
+++ b/landing/content/blog/the-shape-refactor.md
@@ -1,0 +1,59 @@
+---
+title: The repo refactor that gave shape to everything else
+slug: the-shape-refactor
+date: 2026-04-11
+kicker: Architecture
+description: Three top-level folders — documentation, prompts, runtime. Each one had a different reader. Renaming and moving files for half a day made the next four weeks possible.
+reading_time: 4
+author: Denys Kuzin
+tags: [architecture, refactor, build-in-public]
+---
+
+Day five, after the extraction had shipped and the deploy pipeline had stopped catching fire, we did a refactor that doesn't sound like much. The commit body says *refactor: repo layout (documentation, prompts, runtime) + agent adoption*. Half a day of moving files around. No new behaviour.
+
+It is the single most important commit of April for what came later.
+
+## The shape before
+
+Inside elmundi, the methodology had grown organically. There was a `docs/` folder for the manual, a `tools/linear-agent/` folder that contained both prompts and runtime code, a `prompts/` folder that contained *some* prompts, and a few scattered markdown files at the root that nobody could justify but nobody wanted to delete.
+
+This was fine when one team owned the whole repo. It became indefensible the moment the methodology had to be a *product*, with different people maintaining different layers.
+
+## The shape after
+
+Three top-level folders. Each one has one reader.
+
+**`documentation/`** is for humans. The manual. Rendered to `/docs/`. Prose, examples, diagrams. Reviewed for clarity.
+
+**`prompts/`** is for agents. Role definitions, exit contracts, in-context examples. Rendered through the methodology API. Reviewed for *operational correctness* — does another agent execute this prompt sensibly?
+
+**`runtime/`** is the code that runs. Reviewed for correctness. (Later renamed to `cli/` and `backend/` as those split, but on April 11 they were one folder.)
+
+Plus two adjuncts:
+
+- `landing/` — the Next.js app rendering the manual + the marketing site
+- `artifacts/` — pattern/tool/collection definitions (this folder didn't fully separate from `prompts/` until RFC-0005, eight days later)
+
+## Why it mattered
+
+Three things became possible the next day that hadn't been possible the previous day.
+
+**A pull request could declare its target reader.** Before the refactor, a PR could touch a prompt that was also a doc that was also a runtime config. Reviewers had to context-switch through all three readerships. After the refactor, a PR was either a docs change or a prompt change or a runtime change, and reviewers could optimize for one reader.
+
+**The `methodology API` became sketchable.** With prompts in their own folder, the obvious move was a single endpoint that read from that folder and served them as a catalog. The `Unify methodology API for catalogs` commit came four days later and was a small change because the foundation was already laid.
+
+**The agent-adoption rule shipped.** The same commit added the rule "agents must read from `prompts/` *via the API*, never from disk." That rule survives today and is what eventually became RFC-0005's hard separation between filesystem and runtime.
+
+## What didn't change
+
+The methodology. Not one prompt got rewritten. Not one rule got loosened. Everything that worked before kept working. This was *just* a refactor — same behaviour, different shape.
+
+That's how I know it was the right refactor: behaviour identical, but four weeks of subsequent work all referenced "now that things live in folder X."
+
+## The lesson
+
+Naming folders is naming readers. If your folders don't correspond to who reads them, every PR has a renaming fight, every doc has the wrong audience, and every product decision flattens into a pile of "yes-but-also" arguments.
+
+When the readers are clear, the schemas follow. When the schemas follow, the contracts get tight. When the contracts get tight, the product can ship.
+
+Three folders. Half a day. Everything later.


### PR DESCRIPTION
## Summary

Adds 9 short posts covering Apr 7–15, the bootstrap stretch before the methodology started shipping under PR-flow. Each post is grounded in actual git commits from that day; voice matches the existing Ship-Log register (terse, opinionated, field-note flavoured).

After this merges, `/blog` has **32 consecutive days** of content, Apr 7 → May 8 (today). One post per day. No gaps.

## What's new

| Date | Slug | Reading time | Topic |
|------|------|--------------|-------|
| Apr 7 | extracted-from-elmundi | 4 min | What was actually inside the initial-import commit; the LICENSE as the most consequential line. |
| Apr 8 | bunny-three-weeks-of-fights | 4 min | Sixteen `fix(bunny):` commits in the early CI. Read the body, not the status. |
| Apr 9 | cloud-prompts-in-english | 3 min | Translating the bilingual prompts. Voice settled, model preferred it, three templates fell out. |
| Apr 10 | killed-mkdocs-kept-the-urls | 4 min | Replacing the docs runtime in one commit under a "no broken links" constraint. |
| Apr 11 | the-shape-refactor | 4 min | `documentation/`, `prompts/`, `runtime/` — naming folders is naming readers. |
| Apr 12 | the-docs-mcp-experiment | 4 min | Built the right thing the wrong way; deleted 1,247 lines two days later. |
| Apr 13 | adopt-ship-launcher | 4 min | adopt-ship.sh and three adopters who got to green with broken setups. |
| Apr 14 | multi-tracker-adapters-no-customers | 4 min | Five adapters before any paying user; the plurality-as-positioning argument. |
| Apr 15 | methodology-api-one-endpoint | 4 min | Small API, two consumers, both via HTTP — the stability that made the rest of April land. |

## Test plan

- [x] Each post has full frontmatter (title, slug, date, kicker, description, reading_time, author, tags)
- [x] No same-day duplicates with existing posts
- [x] Total 32 posts on Apr 7 → May 8 = 32 consecutive days, one per day
- [ ] `npm run landing:build` passes
- [ ] /blog index orders newest-first; bootstrap posts appear at the bottom
- [ ] Sitemap includes all 32 entries

## Related

Builds on #232 (daily cadence + `Two readers, two manuals`).