### PR TITLE
project_context: lift caps for planning-anchor reads

### DIFF
--- a/backend/app/api/v1/routes/agent_runs.py
+++ b/backend/app/api/v1/routes/agent_runs.py
@@ -561,9 +561,21 @@ async def get_next_task(
     # per-task brief. We pass ``project_id`` directly from the
     # ``list_tickets`` row (ELS-83 already projected it) so we don't
     # round-trip Linear a second time per pick.
+    #
+    # Decomposition exception: when the picked ticket IS the planning
+    # anchor itself, the role's *job* is to read upstream sections in
+    # full and produce the next one — a child-ticket-style 2KB-per-
+    # section cap starves the developer stage in particular (it has
+    # to enumerate every WBS slice into one child ticket per slice).
+    # An anchor read returns the full canonical excerpt without per-
+    # section caps; the overall body is bounded by Linear's project
+    # body size in practice, and clipping that mid-WBS is exactly the
+    # blocker we just observed.
+    is_anchor_pick = _is_planning_anchor(pick.get("labels") or [])
     project_context = await _build_project_context_for_ticket(
         resolved=resolved,
         project_id=pick.get("project_id"),
+        full=is_anchor_pick,
     )
     return TaskResponseOut(
         fsm_stage=state,
@@ -1056,6 +1068,7 @@ async def _build_project_context_for_ticket(
     resolved,  # ResolvedTracker — avoid circular import
     project_id: str | None,
     overall_cap_bytes: int = _PROJECT_CONTEXT_CAP_BYTES,
+    full: bool = False,
 ) -> str | None:
     """Fetch the project body and return its canonical-section excerpt.
 
@@ -1065,6 +1078,14 @@ async def _build_project_context_for_ticket(
     architect's blocker on the original ELS-86 design. ``None``
     here (orphan ticket / non-Linear adapter that doesn't surface
     project_id) skips the lookup cleanly.
+
+    ``full=True`` is the anchor read path: caps are lifted both per-
+    section and overall, so the role that owns slicing the WBS into
+    children sees every slice rather than the first ~5 (the tasks
+    routine's developer was hitting that exact cliff). For SDLC
+    child-ticket picks ``full=False`` is the safe default — the
+    section caps preserve sibling-Tasks visibility against a runaway
+    upstream section.
 
     All steps are best-effort: any failure (tracker that can't model
     projects, unauthenticated, network 5xx, project deleted) returns
@@ -1102,6 +1123,20 @@ async def _build_project_context_for_ticket(
     content = project.get("content") if isinstance(project, dict) else None
     if not isinstance(content, str):
         return None
+    if full:
+        # Anchor read: skip the per-section caps. Pass an open-ended
+        # overall cap (max signed int range from the validator's view
+        # is more than enough) and per-section caps that all clear the
+        # body's actual length so ``_truncate_section`` becomes a
+        # no-op. The canonical extraction still happens — heading
+        # ordering + non-canonical-section drop — so the agent doesn't
+        # have to scan a 50KB body to find ``## WBS``.
+        big_caps = {s: 1 << 20 for s in _PROJECT_CONTEXT_SECTIONS}
+        return _extract_project_sections(
+            content,
+            section_caps=big_caps,
+            overall_cap_bytes=1 << 20,
+        )
     return _extract_project_sections(
         content, overall_cap_bytes=overall_cap_bytes
     )

--- a/backend/tests/test_agent_runs_project_context.py
+++ b/backend/tests/test_agent_runs_project_context.py
@@ -187,7 +187,38 @@ def test_undersized_body_is_returned_verbatim_no_marker() -> None:
     assert out is not None
     assert "…(truncated)" not in out
     assert "Short." in out
-    assert "one item" in out
+
+
+def test_anchor_full_extract_skips_per_section_cap() -> None:
+    """Anchor reads ask for the full body — every WBS line lands so a
+    decomposition role (developer's tasks stage in particular) can
+    enumerate all slices into child tickets. The default ``2KB``
+    per-section cap clipped the WBS at ~5 slices on real projects.
+    """
+    huge_wbs = "\n".join(
+        [f"- WBS line {i:04d}: detail detail detail" for i in range(300)]
+    )
+    body = (
+        "## Brief\n\nShort.\n\n"
+        f"## WBS\n\n{huge_wbs}\n\n"
+        "## Architecture\n\nA.\n"
+    )
+    big_caps = {
+        s: 1 << 20
+        for s in (
+            "Brief",
+            "WBS",
+            "Architecture",
+            "Test architecture",
+            "Tasks",
+        )
+    }
+    out = _extract_project_sections(
+        body, section_caps=big_caps, overall_cap_bytes=1 << 20
+    )
+    assert out is not None
+    assert "WBS line 0299" in out  # last slice survives
+    assert "…(truncated)" not in out
 
 
 def test_preserves_section_order_even_when_body_is_out_of_order() -> None:


### PR DESCRIPTION
## Summary
- Picker's project-context excerpt is sized for SDLC child-ticket runs (2KB per canonical section, 10KB overall). For decomposition runs picked off the planning anchor, the role's job is to read upstream sections in full and produce the next one — that cap starved today's PAC-9 \`tasks\`-routine developer at slice 5 of an 18-slice WBS, which correctly returned \`outcome=blocked\` with an inbox row asking for the full body.
- Detect anchor pickups via \`planning:anchor\` label and pass \`full=True\` to \`_build_project_context_for_ticket\`. The full path uses effectively-unbounded caps (1MB) and still routes through \`_extract_project_sections\` so the canonical Brief→WBS→Architecture→Test architecture→Tasks ordering survives.
- SDLC child-ticket picks behave exactly as before; the existing sibling-Tasks-visibility test still passes.

## Test plan
- [x] \`pytest backend/tests/test_agent_runs_project_context.py\` — added \`test_anchor_full_extract_skips_per_section_cap\` (300-line WBS lands all 300 lines), all prior tests still green.
- [ ] After deploy: re-dispatch \`routine_id=tasks ticket_ref=PAC-9\` on askslayer/visitor-back. Developer should see all 18 WBS slices in its prompt, create 18 child tickets, persist \`## Tasks\` section, transition to \`planning_done\` (which flips Drafts → Parked).