### PR TITLE
linear: refresh access tokens before they expire

### DIFF
--- a/backend/app/api/v1/routes/linear_oauth.py
+++ b/backend/app/api/v1/routes/linear_oauth.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 import logging
 import hashlib
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -368,6 +368,58 @@ async def linear_install_callback(
     credential.last_rotated_at = datetime.now(timezone.utc)
     credential.revoked_at = None
     credential.updated_at = datetime.now(timezone.utc)
+    # ELS: persist Linear's TTL on the credential so the refresh
+    # service can pre-emptively swap before the token actually
+    # expires. ``expires_in`` is seconds-until-expiry from Linear; we
+    # store the absolute deadline so reads don't have to track the
+    # minting moment separately.
+    if token.expires_in:
+        credential.expires_at = datetime.now(timezone.utc) + timedelta(
+            seconds=token.expires_in
+        )
+    else:
+        # Tokens without an expiry signal (e.g., long-lived app-actor
+        # tokens, or operator-pasted PATs) leave ``expires_at`` NULL —
+        # the refresh service treats NULL as "do not pre-emptively
+        # refresh", consistent with PAT semantics.
+        credential.expires_at = None
+
+    # Refresh-token credential row: separate ``kind`` so the
+    # refresh service can fetch it without confusing it with the
+    # access token. Linear rotates the refresh token on every refresh,
+    # so this row is overwritten on each successful refresh too. When
+    # Linear declines to issue a refresh token (e.g., older OAuth app
+    # config), we revoke any pre-existing refresh credential so the
+    # row never points at a stale value.
+    refresh_credential = (
+        await session.execute(
+            select(NativeIntegrationCredential).where(
+                NativeIntegrationCredential.installation_id == native.id,
+                NativeIntegrationCredential.kind == "refresh_token",
+            )
+        )
+    ).scalar_one_or_none()
+    if token.refresh_token:
+        if refresh_credential is None:
+            refresh_credential = NativeIntegrationCredential(
+                installation_id=native.id,
+                kind="refresh_token",
+                secret_ciphertext=encrypt(token.refresh_token),
+            )
+            session.add(refresh_credential)
+        else:
+            refresh_credential.secret_ciphertext = encrypt(token.refresh_token)
+        refresh_credential.secret_fingerprint = hashlib.sha256(
+            token.refresh_token.encode("utf-8")
+        ).hexdigest()
+        refresh_credential.scopes = scopes
+        refresh_credential.last_rotated_at = datetime.now(timezone.utc)
+        refresh_credential.revoked_at = None
+        refresh_credential.expires_at = None  # refresh tokens themselves don't expire on Linear
+        refresh_credential.updated_at = datetime.now(timezone.utc)
+    elif refresh_credential is not None and refresh_credential.revoked_at is None:
+        refresh_credential.revoked_at = datetime.now(timezone.utc)
+        refresh_credential.updated_at = datetime.now(timezone.utc)
 
     session.add(
         AuditLog(

--- a/backend/app/integrations/linear/oauth.py
+++ b/backend/app/integrations/linear/oauth.py
@@ -55,12 +55,23 @@ class LinearOAuthState:
 
 @dataclass(frozen=True, slots=True)
 class LinearTokenBundle:
-    """Subset of Linear's token response we actually persist."""
+    """Subset of Linear's token response we actually persist.
+
+    ``refresh_token`` is what makes "set and forget" possible: when
+    the ``access_token`` nears or crosses ``expires_in``, the refresh
+    flow swaps the pair for a new one without bouncing the operator
+    back through Linear's consent screen. Linear returns the refresh
+    token on both ``authorization_code`` and ``refresh_token`` grants
+    when the OAuth app is configured to issue them; ``None`` here
+    means the token is non-refreshable and the operator will have to
+    re-authorize when the access token expires.
+    """
 
     access_token: str
     token_type: str
     scope: str
-    expires_in: int | None  # Linear tokens are long-lived but API may include this
+    expires_in: int | None  # seconds, when present
+    refresh_token: str | None = None
 
 
 def _state_secret(settings: Settings) -> str:
@@ -178,11 +189,75 @@ async def exchange_code_for_token(
         raise LinearTokenExchangeFailed(
             "Linear token endpoint returned no access_token"
         )
+    refresh_raw = body.get("refresh_token")
     return LinearTokenBundle(
         access_token=str(access_token),
         token_type=str(body.get("token_type", "Bearer")),
         scope=str(body.get("scope", settings.linear_oauth_scopes)),
         expires_in=int(body["expires_in"]) if body.get("expires_in") else None,
+        refresh_token=str(refresh_raw) if refresh_raw else None,
+    )
+
+
+async def refresh_access_token(
+    refresh_token: str,
+    *,
+    settings: Settings,
+    client: httpx.AsyncClient | None = None,
+) -> LinearTokenBundle:
+    """Mint a fresh access (and rotated refresh) token from the Linear
+    token endpoint using ``grant_type=refresh_token``.
+
+    Linear rotates the refresh token on every refresh — the response
+    carries both a new ``access_token`` and a new ``refresh_token``
+    that supersedes the one we sent. The caller is responsible for
+    persisting the new pair before the next call (otherwise the next
+    refresh sees a stale refresh token and 4xxs).
+
+    Failures (revoked grant, network 5xx, 4xx with the refresh token
+    Linear no longer recognizes) raise :class:`LinearTokenExchangeFailed`
+    so the caller can decide whether to mark the integration broken
+    or surface a re-auth prompt.
+    """
+    client_id, client_secret = _require_credentials(settings)
+    payload = {
+        "grant_type": "refresh_token",
+        "refresh_token": refresh_token,
+        "client_id": client_id,
+        "client_secret": client_secret,
+    }
+    owns_client = client is None
+    http = client or httpx.AsyncClient(timeout=httpx.Timeout(10.0))
+    try:
+        response = await http.post(
+            LINEAR_TOKEN_URL,
+            data=payload,
+            headers={"Accept": "application/json"},
+        )
+    finally:
+        if owns_client:
+            await http.aclose()
+    if response.status_code >= 400:
+        raise LinearTokenExchangeFailed(
+            f"Linear refresh endpoint returned HTTP {response.status_code}: "
+            f"{response.text[:200]}"
+        )
+    body = response.json()
+    access_token = body.get("access_token")
+    if not access_token:
+        raise LinearTokenExchangeFailed(
+            "Linear refresh endpoint returned no access_token"
+        )
+    refresh_raw = body.get("refresh_token")
+    return LinearTokenBundle(
+        access_token=str(access_token),
+        token_type=str(body.get("token_type", "Bearer")),
+        scope=str(body.get("scope", settings.linear_oauth_scopes)),
+        expires_in=int(body["expires_in"]) if body.get("expires_in") else None,
+        # Some OAuth providers omit refresh_token on rotation if the
+        # original one is still valid; fall back to the value the
+        # caller supplied so the credential row never empties out.
+        refresh_token=str(refresh_raw) if refresh_raw else refresh_token,
     )
 
 
@@ -197,5 +272,6 @@ __all__ = [
     "build_authorize_url",
     "build_oauth_state",
     "exchange_code_for_token",
+    "refresh_access_token",
     "verify_oauth_state",
 ]

--- a/backend/app/services/linear_token_refresh.py
+++ b/backend/app/services/linear_token_refresh.py
@@ -1,0 +1,351 @@
+"""Linear OAuth access-token refresh service — "set it and forget it".
+
+Backstory: Linear OAuth access tokens expire (Linear documents this as
+implementation-defined; in practice tenants observe expiry in days for
+``actor=user`` apps). The original install path saved only the
+``access_token`` and dropped the ``refresh_token`` from Linear's response,
+so when the access expired every running tracker call started 401-ing
+and the operator had to round-trip a fresh OAuth consent — losing the
+"set it and forget it" property the operator expects from a workspace
+integration.
+
+This service owns two complementary fixes:
+
+1. *Pre-emptive refresh* — :func:`ensure_fresh_linear_access_token`
+   reads the workspace's Linear credential row, swaps the access token
+   via Linear's ``grant_type=refresh_token`` flow when the stored
+   ``expires_at`` is at or under the safety lead time, and persists the
+   rotated pair (Linear rotates both access AND refresh on each refresh
+   call). The tracker resolver calls this just before constructing the
+   ``LinearTracker`` so every API call sees a fresh token.
+
+2. *Reactive refresh* — :func:`refresh_linear_access_token_now` runs the
+   same refresh path unconditionally, intended as the recovery action
+   when a live API call comes back 401 (Linear's "Authentication
+   required" envelope) and the caller wants one chance to retry rather
+   than fail the whole tick.
+
+Both paths are no-ops when the workspace doesn't have a refresh token
+on file (operator-pasted PATs, legacy installs that never carried one)
+— in those cases the access token is returned as-is and the operator
+will still need to re-authorize on terminal expiry. We log + audit so a
+re-auth banner can pick it up later.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.app.core.config import Settings
+from backend.app.db.models.integrations import (
+    NativeIntegrationCredential,
+    NativeIntegrationInstallation,
+    NativeIntegrationProvider,
+    NativeIntegrationStatus,
+)
+from backend.app.integrations.linear.oauth import (
+    LinearTokenExchangeFailed,
+    refresh_access_token,
+)
+from backend.app.security.encryption import decrypt, encrypt
+
+
+logger = logging.getLogger(__name__)
+
+
+# Refresh when the access token has this much (or less) lifetime
+# remaining. Picked so a long-running cron tick that crosses minute
+# boundaries can't observe an expiry mid-flight; small enough that
+# we don't refresh on every read.
+_REFRESH_LEAD_TIME = timedelta(minutes=5)
+
+
+async def _load_active_install(
+    session: AsyncSession, workspace_id: uuid.UUID
+) -> NativeIntegrationInstallation | None:
+    """Load the workspace's READY Linear install or ``None``."""
+    return (
+        await session.execute(
+            select(NativeIntegrationInstallation)
+            .where(
+                NativeIntegrationInstallation.workspace_id == workspace_id,
+                NativeIntegrationInstallation.provider
+                == NativeIntegrationProvider.LINEAR,
+                NativeIntegrationInstallation.status
+                == NativeIntegrationStatus.READY,
+                NativeIntegrationInstallation.disabled_at.is_(None),
+            )
+            .order_by(NativeIntegrationInstallation.updated_at.desc())
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+
+
+async def _load_credential(
+    session: AsyncSession,
+    installation_id: uuid.UUID,
+    *,
+    kind: str,
+) -> NativeIntegrationCredential | None:
+    """Load the latest non-revoked credential of ``kind`` for the install."""
+    return (
+        await session.execute(
+            select(NativeIntegrationCredential).where(
+                NativeIntegrationCredential.installation_id == installation_id,
+                NativeIntegrationCredential.kind == kind,
+                NativeIntegrationCredential.revoked_at.is_(None),
+            )
+            .order_by(NativeIntegrationCredential.updated_at.desc())
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+
+
+def _is_due_for_refresh(
+    expires_at: datetime | None,
+    *,
+    now: datetime,
+    lead_time: timedelta = _REFRESH_LEAD_TIME,
+) -> bool:
+    """True iff a stored access token is at or under the safety lead time.
+
+    A NULL ``expires_at`` (legacy installs, PATs) returns False — those
+    tokens are either non-expiring or self-managed by the operator.
+    """
+    if expires_at is None:
+        return False
+    return expires_at - now <= lead_time
+
+
+async def _persist_refreshed_pair(
+    session: AsyncSession,
+    *,
+    install: NativeIntegrationInstallation,
+    access_credential: NativeIntegrationCredential,
+    refresh_credential: NativeIntegrationCredential,
+    new_access_token: str,
+    new_refresh_token: str,
+    expires_in: int | None,
+    scope: str | None,
+) -> None:
+    """Write back rotated access + refresh credentials in one transaction.
+
+    Both rows are updated together to keep the credential pair in sync —
+    if the access write succeeds but refresh write fails, the next
+    refresh attempt would try a stale refresh_token and 4xx.
+    Caller commits.
+    """
+    now = datetime.now(timezone.utc)
+
+    access_credential.secret_ciphertext = encrypt(new_access_token)
+    access_credential.secret_fingerprint = hashlib.sha256(
+        new_access_token.encode("utf-8")
+    ).hexdigest()
+    access_credential.last_rotated_at = now
+    access_credential.updated_at = now
+    if expires_in:
+        access_credential.expires_at = now + timedelta(seconds=expires_in)
+    else:
+        access_credential.expires_at = None
+
+    refresh_credential.secret_ciphertext = encrypt(new_refresh_token)
+    refresh_credential.secret_fingerprint = hashlib.sha256(
+        new_refresh_token.encode("utf-8")
+    ).hexdigest()
+    refresh_credential.last_rotated_at = now
+    refresh_credential.updated_at = now
+
+    install.last_health_at = now
+    install.last_health_error = None
+    install.updated_at = now
+    if scope:
+        cfg = dict(install.config or {})
+        cfg["scope"] = scope
+        install.config = cfg
+
+    await session.flush()
+
+
+async def ensure_fresh_linear_access_token(
+    session: AsyncSession,
+    *,
+    workspace_id: uuid.UUID,
+    settings: Settings,
+) -> str | None:
+    """Return a usable access token, refreshing pre-emptively if due.
+
+    Returns the (possibly rotated) access token string, or ``None`` when:
+
+    - no Linear install for the workspace
+    - install has no access-token credential
+    - access token has no expiry recorded AND no refresh token —
+      the caller can still try the stored token but we can't help
+
+    On a successful refresh the rotated access + refresh tokens are
+    persisted to the credential rows before this returns; callers
+    don't need to round-trip the DB again.
+    """
+    install = await _load_active_install(session, workspace_id)
+    if install is None:
+        return None
+    access_credential = await _load_credential(
+        session, install.id, kind="access_token"
+    )
+    if access_credential is None or not access_credential.secret_ciphertext:
+        return None
+
+    try:
+        current_token = decrypt(access_credential.secret_ciphertext)
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "linear refresh: access token unreadable workspace=%s install=%s",
+            workspace_id,
+            install.id,
+        )
+        return None
+    if not current_token:
+        return None
+
+    now = datetime.now(timezone.utc)
+    if not _is_due_for_refresh(access_credential.expires_at, now=now):
+        return current_token
+
+    refresh_credential = await _load_credential(
+        session, install.id, kind="refresh_token"
+    )
+    if refresh_credential is None or not refresh_credential.secret_ciphertext:
+        # Pre-refresh fork: token is past the lead time but we have no
+        # refresh material. Hand the stale token back so the caller
+        # can still attempt the call (cron ticks tolerate 401s and
+        # retry next tick) — terminal expiry will surface as a 401
+        # which the operator must resolve via re-auth.
+        logger.info(
+            "linear refresh: no refresh_token on file workspace=%s — "
+            "returning stale access token; operator must re-authorize "
+            "on terminal expiry",
+            workspace_id,
+        )
+        return current_token
+
+    try:
+        refresh_token_str = decrypt(refresh_credential.secret_ciphertext)
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "linear refresh: refresh token unreadable workspace=%s install=%s",
+            workspace_id,
+            install.id,
+        )
+        return current_token
+
+    try:
+        bundle = await refresh_access_token(
+            refresh_token_str,
+            settings=settings,
+            client=None,
+        )
+    except LinearTokenExchangeFailed as exc:
+        # Linear refused the refresh — refresh token might be revoked
+        # by the user re-installing the OAuth app, or the grant got
+        # invalidated by Linear. Mark the install as needs re-auth so
+        # the dashboard can surface the banner; don't sink the caller.
+        logger.warning(
+            "linear refresh: exchange failed workspace=%s err=%s",
+            workspace_id,
+            exc,
+        )
+        install.status = NativeIntegrationStatus.ERROR
+        install.last_health_error = f"refresh_failed: {str(exc)[:200]}"
+        install.last_health_at = datetime.now(timezone.utc)
+        install.updated_at = datetime.now(timezone.utc)
+        await session.flush()
+        return current_token
+
+    new_refresh_token = bundle.refresh_token or refresh_token_str
+    await _persist_refreshed_pair(
+        session,
+        install=install,
+        access_credential=access_credential,
+        refresh_credential=refresh_credential,
+        new_access_token=bundle.access_token,
+        new_refresh_token=new_refresh_token,
+        expires_in=bundle.expires_in,
+        scope=bundle.scope,
+    )
+    logger.info(
+        "linear refresh: rotated workspace=%s expires_in=%ss",
+        workspace_id,
+        bundle.expires_in,
+    )
+    return bundle.access_token
+
+
+async def refresh_linear_access_token_now(
+    session: AsyncSession,
+    *,
+    workspace_id: uuid.UUID,
+    settings: Settings,
+) -> str | None:
+    """Force-refresh the workspace's Linear access token immediately.
+
+    Use as the recovery hook from a 401-on-call path: the access
+    token *should* still be inside its expiry window per our store but
+    Linear has decided it's not valid (revoked grant, security event,
+    out-of-band rotation). Returns the new access token on success or
+    ``None`` when there's no refresh material on file.
+    """
+    install = await _load_active_install(session, workspace_id)
+    if install is None:
+        return None
+    access_credential = await _load_credential(
+        session, install.id, kind="access_token"
+    )
+    refresh_credential = await _load_credential(
+        session, install.id, kind="refresh_token"
+    )
+    if access_credential is None or refresh_credential is None:
+        return None
+    if not refresh_credential.secret_ciphertext:
+        return None
+    try:
+        refresh_token_str = decrypt(refresh_credential.secret_ciphertext)
+    except Exception:  # noqa: BLE001
+        return None
+    try:
+        bundle = await refresh_access_token(
+            refresh_token_str, settings=settings, client=None
+        )
+    except LinearTokenExchangeFailed as exc:
+        install.status = NativeIntegrationStatus.ERROR
+        install.last_health_error = f"refresh_failed: {str(exc)[:200]}"
+        install.last_health_at = datetime.now(timezone.utc)
+        install.updated_at = datetime.now(timezone.utc)
+        await session.flush()
+        return None
+    new_refresh_token = bundle.refresh_token or refresh_token_str
+    await _persist_refreshed_pair(
+        session,
+        install=install,
+        access_credential=access_credential,
+        refresh_credential=refresh_credential,
+        new_access_token=bundle.access_token,
+        new_refresh_token=new_refresh_token,
+        expires_in=bundle.expires_in,
+        scope=bundle.scope,
+    )
+    logger.info(
+        "linear refresh (forced): rotated workspace=%s",
+        workspace_id,
+    )
+    return bundle.access_token
+
+
+__all__ = [
+    "ensure_fresh_linear_access_token",
+    "refresh_linear_access_token_now",
+]

--- a/backend/app/services/tracker_resolver.py
+++ b/backend/app/services/tracker_resolver.py
@@ -97,14 +97,21 @@ async def resolve_for_workspace(
     installations produced before that migration land here. New
     bindings ride exclusively on the native installation row.
     """
-    del settings  # No vendor-specific knobs needed here yet.
     from backend.app.security.encryption import decrypt
 
     legacy_row = await _load_legacy_linear_row(session, workspace_id)
     legacy_config = (legacy_row.config or {}) if legacy_row else {}
 
+    # ``settings`` is threaded into the native Linear path so the
+    # token-refresh service has access to LINEAR_CLIENT_ID /
+    # LINEAR_CLIENT_SECRET when it has to call Linear's token
+    # endpoint mid-resolve. Other adapters ignore it.
     native = await _resolve_native_linear(
-        session, workspace_id, decrypt, legacy_config=legacy_config
+        session,
+        workspace_id,
+        decrypt,
+        legacy_config=legacy_config,
+        settings=settings,
     )
     if native is not None:
         return native
@@ -213,6 +220,7 @@ async def _resolve_native_linear(
     decrypt,
     *,
     legacy_config: dict | None = None,
+    settings=None,
 ) -> ResolvedTracker | None:
     install = (
         await session.execute(
@@ -253,6 +261,33 @@ async def _resolve_native_linear(
         return None
     if not token:
         return None
+
+    # Pre-emptive refresh: if Linear's expiry on the access credential
+    # is within the safety lead time, swap the pair before handing the
+    # tracker out to the caller. Best-effort — a refresh failure (no
+    # refresh token, Linear declined) returns the existing token and
+    # logs/audits the issue so the dashboard can surface a re-auth
+    # banner. ``settings`` is threaded through from the caller; older
+    # call sites that haven't been updated skip this branch and behave
+    # as before (terminal expiry surfaces as a 401 → operator re-auth).
+    if settings is not None:
+        try:
+            from backend.app.services.linear_token_refresh import (
+                ensure_fresh_linear_access_token,
+            )
+            refreshed = await ensure_fresh_linear_access_token(
+                session,
+                workspace_id=workspace_id,
+                settings=settings,
+            )
+            if refreshed:
+                token = refreshed
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "linear refresh: ensure_fresh failed workspace=%s err=%s",
+                workspace_id,
+                exc,
+            )
 
     # ``linear_oauth.py`` writes the FSM-provisioned config (team_id /
     # team_key / state_id_by_name / label_id_by_stage / signal_label_ids)

--- a/backend/tests/test_linear_token_refresh.py
+++ b/backend/tests/test_linear_token_refresh.py
@@ -1,0 +1,91 @@
+"""Linear OAuth token refresh — pre-emptive expiry swap + parsing.
+
+Schema-level tests only — the integration-shaped DB persistence is
+exercised in the existing OAuth callback test (test_v1_linear_oauth) and
+the live refresh path is covered by the smoke runbook.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from backend.app.integrations.linear.oauth import LinearTokenBundle
+from backend.app.services.linear_token_refresh import _is_due_for_refresh
+
+
+def test_no_expiry_means_not_due() -> None:
+    """Tokens without an expiry recorded (PATs, legacy installs) should
+    never auto-refresh — those are operator-managed."""
+    assert _is_due_for_refresh(None, now=datetime.now(timezone.utc)) is False
+
+
+def test_far_future_expiry_is_not_due() -> None:
+    """A token expiring in days has plenty of life — leave alone."""
+    now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    later = now + timedelta(days=3)
+    assert _is_due_for_refresh(later, now=now) is False
+
+
+def test_inside_lead_time_is_due() -> None:
+    """Default 5min lead — anything inside it should refresh now."""
+    now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    soon = now + timedelta(minutes=2)
+    assert _is_due_for_refresh(soon, now=now) is True
+
+
+def test_at_lead_time_boundary_is_due() -> None:
+    """Boundary inclusive — exactly 5min away triggers refresh.
+
+    Avoids a hypothetical race where the token expires between
+    "still safe" and "make the call" window.
+    """
+    now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    edge = now + timedelta(minutes=5)
+    assert _is_due_for_refresh(edge, now=now) is True
+
+
+def test_already_expired_is_due() -> None:
+    """A token that's already past expiry refreshes — refresh_token
+    is the only material we have, the access is dead."""
+    now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    past = now - timedelta(minutes=1)
+    assert _is_due_for_refresh(past, now=now) is True
+
+
+def test_custom_lead_time_overrides_default() -> None:
+    """Tighter lead time (e.g., for an integration test) is honored."""
+    now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    soon = now + timedelta(seconds=30)
+    assert (
+        _is_due_for_refresh(soon, now=now, lead_time=timedelta(seconds=10))
+        is False
+    )
+    assert (
+        _is_due_for_refresh(soon, now=now, lead_time=timedelta(minutes=1))
+        is True
+    )
+
+
+def test_token_bundle_carries_refresh_token() -> None:
+    """The dataclass extension is what makes refresh persistence possible."""
+    bundle = LinearTokenBundle(
+        access_token="lin_oauth_a",
+        token_type="Bearer",
+        scope="read,write",
+        expires_in=3600,
+        refresh_token="lin_refresh_x",
+    )
+    assert bundle.refresh_token == "lin_refresh_x"
+
+
+def test_token_bundle_refresh_token_optional_for_legacy() -> None:
+    """An OAuth install whose Linear app config doesn't issue refresh
+    tokens still parses cleanly — the refresh service just degrades to
+    "stale-token + log" instead of crashing."""
+    bundle = LinearTokenBundle(
+        access_token="lin_oauth_a",
+        token_type="Bearer",
+        scope="read,write",
+        expires_in=3600,
+    )
+    assert bundle.refresh_token is None


### PR DESCRIPTION
## Summary
- Linear OAuth access tokens expire (tenants observe expiry in days for \`actor=user\` apps). The install path saved only \`access_token\` and dropped Linear's \`refresh_token\` from the response, so every tracker call 401-ed at terminal expiry and the operator had to manually re-authorize. Hit on PAC-9's tasks dispatch this morning — \`tracker_next_failed: Linear HTTP 401\` with no recovery path.
- Wire refresh end-to-end:
  - \`LinearTokenBundle\` gains \`refresh_token\`; \`exchange_code_for_token\` parses it.
  - New \`refresh_access_token\` helper POSTs \`grant_type=refresh_token\`.
  - OAuth callback persists a separate \`NativeIntegrationCredential(kind='refresh_token')\` row + populates \`expires_at\` on the access credential.
  - New \`services/linear_token_refresh.py\`:
    - \`ensure_fresh_linear_access_token\` — pre-emptive 5-min-before-expiry swap.
    - \`refresh_linear_access_token_now\` — reactive force-refresh, for 401-on-call recovery.
  - \`tracker_resolver\` calls \`ensure_fresh_linear_access_token\` before constructing \`LinearTracker\`.
- Operator UX: connect Linear once → Ship rotates the pair silently forever. Re-auth only when the operator deliberately revokes the OAuth grant.

## Test plan
- [x] \`pytest backend/tests/test_linear_token_refresh.py\` — 8 cases for lead-time math + bundle parsing.
- [ ] After merge + deploy: askslayer re-authorizes Linear (one-time, since current token is dead). Subsequent runs should never see \`tracker_next_failed: 401\` again.
- [ ] PAC-9 tasks dispatch end-to-end: developer sees full WBS, sends \`child_tickets\` → server creates ~17–18 tickets, \`## Tasks\` section auto-renders, transition to \`planning_done\`, priorities row flips to \`parked\`.