### PR TITLE
linear: rotate access tokens via scheduled cron, not per-request

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -371,6 +371,18 @@ class Settings(BaseSettings):
         default="read,write,issues:create,comments:create",
         alias="LINEAR_OAUTH_SCOPES",
     )
+    # How often the ``linear_token_refresh_tick`` cron rotates each
+    # workspace's access+refresh pair via Linear's
+    # ``grant_type=refresh_token`` flow. Default 6h is well below
+    # Linear's documented expiry floor for ``actor=user`` apps and
+    # leaves four refresh attempts per day if Linear ever rotates
+    # mid-cadence.
+    linear_token_refresh_hours: int = Field(
+        default=6,
+        ge=1,
+        le=72,
+        alias="LINEAR_TOKEN_REFRESH_HOURS",
+    )
 
     # --- Notion OAuth (pilot Day 2 — tracker WOW flow) ---
     # Public Notion integration credentials from

--- a/backend/app/services/cron.py
+++ b/backend/app/services/cron.py
@@ -89,6 +89,7 @@ class CronLockId(IntEnum):
     KNOWLEDGE_CLAIM_RECONCILE = 1007
     KNOWLEDGE_TOPIC_RENDER = 1008
     KNOWLEDGE_CLAIM_DECAY = 1009
+    LINEAR_TOKEN_REFRESH = 1010
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/services/cron_jobs.py
+++ b/backend/app/services/cron_jobs.py
@@ -481,6 +481,43 @@ async def _knowledge_decay_tick() -> None:
         )
 
 
+@cron_with_lock(
+    lock=CronLockId.LINEAR_TOKEN_REFRESH, name="linear_token_refresh"
+)
+async def _linear_token_refresh_tick() -> None:
+    """Rotate every READY Linear install's access+refresh pair.
+
+    Cadence-based: a credential whose ``last_rotated_at`` is older
+    than ``LINEAR_TOKEN_REFRESH_HOURS`` (default 6h) gets swapped via
+    Linear's ``grant_type=refresh_token`` flow. Operator's "connect
+    Linear once" stays durable — the cron keeps a rolling-fresh access
+    token in the credential row regardless of when the workspace is
+    next hit by an agent run.
+    """
+    from backend.app.core.config import get_settings
+    from backend.app.services.linear_token_refresh import (
+        refresh_all_due_linear_tokens,
+    )
+
+    settings = get_settings()
+    sm = get_sessionmaker()
+    async with sm() as session:
+        try:
+            counts = await refresh_all_due_linear_tokens(
+                session, settings=settings
+            )
+            await session.commit()
+        except Exception:
+            await session.rollback()
+            raise
+
+    if counts.get("rotated") or counts.get("refresh_failed"):
+        log.info(
+            "linear_token_refresh tick: %s",
+            ", ".join(f"{k}={v}" for k, v in counts.items()),
+        )
+
+
 def register_all() -> None:
     """Wire every cron defined in this module into the scheduler.
 
@@ -560,6 +597,17 @@ def register_all() -> None:
         fn=_knowledge_claim_decay_tick,
         cron_expr="30 3 * * *",  # daily at 03:30 UTC
         job_id="knowledge_claim_decay",
+    )
+    # Linear token rotation runs every hour at :05; the per-install
+    # check inside ``refresh_all_due_linear_tokens`` looks at
+    # ``last_rotated_at`` against ``LINEAR_TOKEN_REFRESH_HOURS`` (default
+    # 6h) so most ticks are fast no-ops and only every Nth tick actually
+    # touches Linear. Cron expression at :05 keeps it out of the
+    # knowledge-pipeline pile-ups around :15-:45.
+    register_cron(
+        fn=_linear_token_refresh_tick,
+        cron_expr="5 * * * *",  # hourly at :05 (gated by per-install age)
+        job_id="linear_token_refresh",
     )
 
 

--- a/backend/app/services/linear_token_refresh.py
+++ b/backend/app/services/linear_token_refresh.py
@@ -9,27 +9,20 @@ and the operator had to round-trip a fresh OAuth consent — losing the
 "set it and forget it" property the operator expects from a workspace
 integration.
 
-This service owns two complementary fixes:
+Refresh runs on a fixed cadence rather than per-request: a scheduled
+``linear_token_refresh_tick`` cron iterates every READY install whose
+last rotation is older than ``LINEAR_TOKEN_REFRESH_HOURS`` and swaps
+the pair via Linear's ``grant_type=refresh_token`` flow. The hot path
+(tracker resolver, list_tickets, transition…) reads the credential as
+written and never triggers refresh inline; pre-rotation keeps a rolling
+freshness margin without saddling the picker with a Linear round-trip.
 
-1. *Pre-emptive refresh* — :func:`ensure_fresh_linear_access_token`
-   reads the workspace's Linear credential row, swaps the access token
-   via Linear's ``grant_type=refresh_token`` flow when the stored
-   ``expires_at`` is at or under the safety lead time, and persists the
-   rotated pair (Linear rotates both access AND refresh on each refresh
-   call). The tracker resolver calls this just before constructing the
-   ``LinearTracker`` so every API call sees a fresh token.
-
-2. *Reactive refresh* — :func:`refresh_linear_access_token_now` runs the
-   same refresh path unconditionally, intended as the recovery action
-   when a live API call comes back 401 (Linear's "Authentication
-   required" envelope) and the caller wants one chance to retry rather
-   than fail the whole tick.
+Reactive refresh — :func:`refresh_linear_access_token_now` — stays as
+the recovery hook for callers that observe a 401 from a live API call
+and want one chance to retry rather than fail the whole tick.
 
 Both paths are no-ops when the workspace doesn't have a refresh token
-on file (operator-pasted PATs, legacy installs that never carried one)
-— in those cases the access token is returned as-is and the operator
-will still need to re-authorize on terminal expiry. We log + audit so a
-re-auth banner can pick it up later.
+on file (operator-pasted PATs, legacy installs that never carried one).
 """
 
 from __future__ import annotations
@@ -59,11 +52,12 @@ from backend.app.security.encryption import decrypt, encrypt
 logger = logging.getLogger(__name__)
 
 
-# Refresh when the access token has this much (or less) lifetime
-# remaining. Picked so a long-running cron tick that crosses minute
-# boundaries can't observe an expiry mid-flight; small enough that
-# we don't refresh on every read.
-_REFRESH_LEAD_TIME = timedelta(minutes=5)
+# How stale the credential must be before the scheduled tick rotates
+# it. Used as the floor on ``last_rotated_at`` — anything older than
+# (now - this) gets refreshed. ``LINEAR_TOKEN_REFRESH_HOURS`` from
+# settings is the canonical knob; this default keeps the helper
+# usable from tests without standing up a Settings.
+_DEFAULT_REFRESH_AGE = timedelta(hours=6)
 
 
 async def _load_active_install(
@@ -108,19 +102,22 @@ async def _load_credential(
 
 
 def _is_due_for_refresh(
-    expires_at: datetime | None,
+    last_rotated_at: datetime | None,
     *,
     now: datetime,
-    lead_time: timedelta = _REFRESH_LEAD_TIME,
+    max_age: timedelta = _DEFAULT_REFRESH_AGE,
 ) -> bool:
-    """True iff a stored access token is at or under the safety lead time.
+    """True iff a stored access token's last rotation is older than ``max_age``.
 
-    A NULL ``expires_at`` (legacy installs, PATs) returns False — those
-    tokens are either non-expiring or self-managed by the operator.
+    Cadence-based refresh, not expiry-based: the scheduled tick rotates
+    every credential whose age crosses the threshold regardless of
+    Linear's stated ``expires_in``. NULL ``last_rotated_at`` (just-installed,
+    never rotated) is treated as eligible so a fresh install starts the
+    rotation cycle on the next tick.
     """
-    if expires_at is None:
-        return False
-    return expires_at - now <= lead_time
+    if last_rotated_at is None:
+        return True
+    return (now - last_rotated_at) >= max_age
 
 
 async def _persist_refreshed_pair(
@@ -172,91 +169,50 @@ async def _persist_refreshed_pair(
     await session.flush()
 
 
-async def ensure_fresh_linear_access_token(
+async def _refresh_install(
     session: AsyncSession,
+    install: NativeIntegrationInstallation,
     *,
-    workspace_id: uuid.UUID,
     settings: Settings,
-) -> str | None:
-    """Return a usable access token, refreshing pre-emptively if due.
+) -> bool:
+    """Rotate one workspace's Linear access+refresh pair.
 
-    Returns the (possibly rotated) access token string, or ``None`` when:
-
-    - no Linear install for the workspace
-    - install has no access-token credential
-    - access token has no expiry recorded AND no refresh token —
-      the caller can still try the stored token but we can't help
-
-    On a successful refresh the rotated access + refresh tokens are
-    persisted to the credential rows before this returns; callers
-    don't need to round-trip the DB again.
+    Returns True when Linear accepted the refresh and we persisted the
+    rotated pair, False when the install is unrotatable (no refresh
+    token / unreadable / Linear declined). On Linear refusal the install
+    is marked ERROR with ``last_health_error='refresh_failed: ...'`` so
+    the console can surface a re-auth banner; the existing access token
+    stays in the row so the next tick still has *something* to use.
     """
-    install = await _load_active_install(session, workspace_id)
-    if install is None:
-        return None
     access_credential = await _load_credential(
         session, install.id, kind="access_token"
     )
-    if access_credential is None or not access_credential.secret_ciphertext:
-        return None
-
-    try:
-        current_token = decrypt(access_credential.secret_ciphertext)
-    except Exception:  # noqa: BLE001
-        logger.warning(
-            "linear refresh: access token unreadable workspace=%s install=%s",
-            workspace_id,
-            install.id,
-        )
-        return None
-    if not current_token:
-        return None
-
-    now = datetime.now(timezone.utc)
-    if not _is_due_for_refresh(access_credential.expires_at, now=now):
-        return current_token
-
     refresh_credential = await _load_credential(
         session, install.id, kind="refresh_token"
     )
-    if refresh_credential is None or not refresh_credential.secret_ciphertext:
-        # Pre-refresh fork: token is past the lead time but we have no
-        # refresh material. Hand the stale token back so the caller
-        # can still attempt the call (cron ticks tolerate 401s and
-        # retry next tick) — terminal expiry will surface as a 401
-        # which the operator must resolve via re-auth.
-        logger.info(
-            "linear refresh: no refresh_token on file workspace=%s — "
-            "returning stale access token; operator must re-authorize "
-            "on terminal expiry",
-            workspace_id,
-        )
-        return current_token
-
+    if access_credential is None or refresh_credential is None:
+        return False
+    if not refresh_credential.secret_ciphertext:
+        return False
     try:
         refresh_token_str = decrypt(refresh_credential.secret_ciphertext)
     except Exception:  # noqa: BLE001
         logger.warning(
-            "linear refresh: refresh token unreadable workspace=%s install=%s",
-            workspace_id,
+            "linear refresh: refresh-token unreadable workspace=%s install=%s",
+            install.workspace_id,
             install.id,
         )
-        return current_token
-
+        return False
+    if not refresh_token_str:
+        return False
     try:
         bundle = await refresh_access_token(
-            refresh_token_str,
-            settings=settings,
-            client=None,
+            refresh_token_str, settings=settings, client=None
         )
     except LinearTokenExchangeFailed as exc:
-        # Linear refused the refresh — refresh token might be revoked
-        # by the user re-installing the OAuth app, or the grant got
-        # invalidated by Linear. Mark the install as needs re-auth so
-        # the dashboard can surface the banner; don't sink the caller.
         logger.warning(
             "linear refresh: exchange failed workspace=%s err=%s",
-            workspace_id,
+            install.workspace_id,
             exc,
         )
         install.status = NativeIntegrationStatus.ERROR
@@ -264,8 +220,7 @@ async def ensure_fresh_linear_access_token(
         install.last_health_at = datetime.now(timezone.utc)
         install.updated_at = datetime.now(timezone.utc)
         await session.flush()
-        return current_token
-
+        return False
     new_refresh_token = bundle.refresh_token or refresh_token_str
     await _persist_refreshed_pair(
         session,
@@ -279,10 +234,72 @@ async def ensure_fresh_linear_access_token(
     )
     logger.info(
         "linear refresh: rotated workspace=%s expires_in=%ss",
-        workspace_id,
+        install.workspace_id,
         bundle.expires_in,
     )
-    return bundle.access_token
+    return True
+
+
+async def refresh_all_due_linear_tokens(
+    session: AsyncSession,
+    *,
+    settings: Settings,
+    max_age: timedelta | None = None,
+) -> dict[str, int]:
+    """Iterate every READY Linear install and rotate the credential
+    pair when the last rotation is older than ``max_age``.
+
+    Used by the scheduled ``linear_token_refresh_tick`` cron — runs
+    every ``LINEAR_TOKEN_REFRESH_HOURS``. Returns a counter dict for
+    log + audit visibility; the caller commits.
+    """
+    if max_age is None:
+        max_age = timedelta(hours=settings.linear_token_refresh_hours)
+    now = datetime.now(timezone.utc)
+
+    installs = (
+        await session.execute(
+            select(NativeIntegrationInstallation)
+            .where(
+                NativeIntegrationInstallation.provider
+                == NativeIntegrationProvider.LINEAR,
+                NativeIntegrationInstallation.status
+                == NativeIntegrationStatus.READY,
+                NativeIntegrationInstallation.disabled_at.is_(None),
+            )
+        )
+    ).scalars().all()
+
+    seen = 0
+    rotated = 0
+    skipped_unrotatable = 0
+    skipped_fresh = 0
+    failed = 0
+    for install in installs:
+        seen += 1
+        access_credential = await _load_credential(
+            session, install.id, kind="access_token"
+        )
+        if access_credential is None:
+            skipped_unrotatable += 1
+            continue
+        if not _is_due_for_refresh(
+            access_credential.last_rotated_at, now=now, max_age=max_age
+        ):
+            skipped_fresh += 1
+            continue
+        ok = await _refresh_install(session, install, settings=settings)
+        if ok:
+            rotated += 1
+        else:
+            failed += 1
+    return {
+        "installs_seen": seen,
+        "rotated": rotated,
+        "skipped_fresh": skipped_fresh,
+        "skipped_unrotatable": skipped_unrotatable,
+        "refresh_failed": failed,
+    }
 
 
 async def refresh_linear_access_token_now(
@@ -291,61 +308,31 @@ async def refresh_linear_access_token_now(
     workspace_id: uuid.UUID,
     settings: Settings,
 ) -> str | None:
-    """Force-refresh the workspace's Linear access token immediately.
+    """Force-refresh one workspace's Linear access token immediately.
 
-    Use as the recovery hook from a 401-on-call path: the access
-    token *should* still be inside its expiry window per our store but
-    Linear has decided it's not valid (revoked grant, security event,
-    out-of-band rotation). Returns the new access token on success or
-    ``None`` when there's no refresh material on file.
+    Recovery hook for callers that observe a 401 from a live API call —
+    rotates regardless of ``last_rotated_at`` age. Returns the new
+    access token on success, ``None`` when the install has no refresh
+    material on file or Linear declined the refresh.
     """
     install = await _load_active_install(session, workspace_id)
     if install is None:
         return None
+    ok = await _refresh_install(session, install, settings=settings)
+    if not ok:
+        return None
     access_credential = await _load_credential(
         session, install.id, kind="access_token"
     )
-    refresh_credential = await _load_credential(
-        session, install.id, kind="refresh_token"
-    )
-    if access_credential is None or refresh_credential is None:
-        return None
-    if not refresh_credential.secret_ciphertext:
+    if access_credential is None or not access_credential.secret_ciphertext:
         return None
     try:
-        refresh_token_str = decrypt(refresh_credential.secret_ciphertext)
+        return decrypt(access_credential.secret_ciphertext)
     except Exception:  # noqa: BLE001
         return None
-    try:
-        bundle = await refresh_access_token(
-            refresh_token_str, settings=settings, client=None
-        )
-    except LinearTokenExchangeFailed as exc:
-        install.status = NativeIntegrationStatus.ERROR
-        install.last_health_error = f"refresh_failed: {str(exc)[:200]}"
-        install.last_health_at = datetime.now(timezone.utc)
-        install.updated_at = datetime.now(timezone.utc)
-        await session.flush()
-        return None
-    new_refresh_token = bundle.refresh_token or refresh_token_str
-    await _persist_refreshed_pair(
-        session,
-        install=install,
-        access_credential=access_credential,
-        refresh_credential=refresh_credential,
-        new_access_token=bundle.access_token,
-        new_refresh_token=new_refresh_token,
-        expires_in=bundle.expires_in,
-        scope=bundle.scope,
-    )
-    logger.info(
-        "linear refresh (forced): rotated workspace=%s",
-        workspace_id,
-    )
-    return bundle.access_token
 
 
 __all__ = [
-    "ensure_fresh_linear_access_token",
+    "refresh_all_due_linear_tokens",
     "refresh_linear_access_token_now",
 ]

--- a/backend/app/services/tracker_resolver.py
+++ b/backend/app/services/tracker_resolver.py
@@ -262,32 +262,16 @@ async def _resolve_native_linear(
     if not token:
         return None
 
-    # Pre-emptive refresh: if Linear's expiry on the access credential
-    # is within the safety lead time, swap the pair before handing the
-    # tracker out to the caller. Best-effort — a refresh failure (no
-    # refresh token, Linear declined) returns the existing token and
-    # logs/audits the issue so the dashboard can surface a re-auth
-    # banner. ``settings`` is threaded through from the caller; older
-    # call sites that haven't been updated skip this branch and behave
-    # as before (terminal expiry surfaces as a 401 → operator re-auth).
-    if settings is not None:
-        try:
-            from backend.app.services.linear_token_refresh import (
-                ensure_fresh_linear_access_token,
-            )
-            refreshed = await ensure_fresh_linear_access_token(
-                session,
-                workspace_id=workspace_id,
-                settings=settings,
-            )
-            if refreshed:
-                token = refreshed
-        except Exception as exc:  # noqa: BLE001
-            logger.warning(
-                "linear refresh: ensure_fresh failed workspace=%s err=%s",
-                workspace_id,
-                exc,
-            )
+    # Token freshness is owned by the scheduled
+    # ``linear_token_refresh_tick`` cron (every
+    # ``LINEAR_TOKEN_REFRESH_HOURS`` hours), not by this hot path.
+    # Resolving in-line per-request would add a second-long Linear
+    # round-trip to the picker; doing it on a fixed cadence keeps a
+    # rolling-fresh access token in the credential row regardless of
+    # how often the workspace is hit. ``settings`` stays in the
+    # signature for any future inline knobs but is intentionally
+    # unused here.
+    del settings
 
     # ``linear_oauth.py`` writes the FSM-provisioned config (team_id /
     # team_key / state_id_by_name / label_id_by_stage / signal_label_ids)

--- a/backend/tests/test_linear_token_refresh.py
+++ b/backend/tests/test_linear_token_refresh.py
@@ -1,8 +1,9 @@
-"""Linear OAuth token refresh — pre-emptive expiry swap + parsing.
+"""Linear OAuth token refresh — cadence math + bundle parsing.
 
-Schema-level tests only — the integration-shaped DB persistence is
-exercised in the existing OAuth callback test (test_v1_linear_oauth) and
-the live refresh path is covered by the smoke runbook.
+Schema-level coverage only. The DB-persistence + Linear API roundtrip
+paths are exercised by the existing OAuth callback test
+(test_v1_linear_oauth) and the live ``linear_token_refresh_tick`` cron
+in production.
 """
 
 from __future__ import annotations
@@ -13,55 +14,47 @@ from backend.app.integrations.linear.oauth import LinearTokenBundle
 from backend.app.services.linear_token_refresh import _is_due_for_refresh
 
 
-def test_no_expiry_means_not_due() -> None:
-    """Tokens without an expiry recorded (PATs, legacy installs) should
-    never auto-refresh — those are operator-managed."""
-    assert _is_due_for_refresh(None, now=datetime.now(timezone.utc)) is False
+def test_null_last_rotated_is_due() -> None:
+    """A just-installed credential (never rotated) starts the cycle on
+    the next tick. Treated as eligible so a brand-new install isn't
+    silently skipped because ``last_rotated_at`` was NULL."""
+    assert _is_due_for_refresh(None, now=datetime.now(timezone.utc)) is True
 
 
-def test_far_future_expiry_is_not_due() -> None:
-    """A token expiring in days has plenty of life — leave alone."""
-    now = datetime(2026, 1, 1, tzinfo=timezone.utc)
-    later = now + timedelta(days=3)
-    assert _is_due_for_refresh(later, now=now) is False
+def test_recently_rotated_is_not_due() -> None:
+    """A token rotated 5 minutes ago is far from the 6h threshold —
+    leave it alone."""
+    now = datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc)
+    fresh = now - timedelta(minutes=5)
+    assert _is_due_for_refresh(fresh, now=now) is False
 
 
-def test_inside_lead_time_is_due() -> None:
-    """Default 5min lead — anything inside it should refresh now."""
-    now = datetime(2026, 1, 1, tzinfo=timezone.utc)
-    soon = now + timedelta(minutes=2)
-    assert _is_due_for_refresh(soon, now=now) is True
+def test_past_threshold_is_due() -> None:
+    """Default 6h max age — anything rotated longer ago refreshes."""
+    now = datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc)
+    stale = now - timedelta(hours=7)
+    assert _is_due_for_refresh(stale, now=now) is True
 
 
-def test_at_lead_time_boundary_is_due() -> None:
-    """Boundary inclusive — exactly 5min away triggers refresh.
-
-    Avoids a hypothetical race where the token expires between
-    "still safe" and "make the call" window.
-    """
-    now = datetime(2026, 1, 1, tzinfo=timezone.utc)
-    edge = now + timedelta(minutes=5)
+def test_at_threshold_is_due() -> None:
+    """Boundary inclusive — exactly 6h since last rotation triggers
+    refresh; avoids a tick-aligned race where the next tick lands a
+    second after the boundary and we'd skip another whole period."""
+    now = datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc)
+    edge = now - timedelta(hours=6)
     assert _is_due_for_refresh(edge, now=now) is True
 
 
-def test_already_expired_is_due() -> None:
-    """A token that's already past expiry refreshes — refresh_token
-    is the only material we have, the access is dead."""
-    now = datetime(2026, 1, 1, tzinfo=timezone.utc)
-    past = now - timedelta(minutes=1)
-    assert _is_due_for_refresh(past, now=now) is True
-
-
-def test_custom_lead_time_overrides_default() -> None:
-    """Tighter lead time (e.g., for an integration test) is honored."""
-    now = datetime(2026, 1, 1, tzinfo=timezone.utc)
-    soon = now + timedelta(seconds=30)
+def test_custom_max_age_overrides_default() -> None:
+    """Tighter cadence (e.g., for an integration test) is honored."""
+    now = datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc)
+    forty_min = now - timedelta(minutes=40)
     assert (
-        _is_due_for_refresh(soon, now=now, lead_time=timedelta(seconds=10))
+        _is_due_for_refresh(forty_min, now=now, max_age=timedelta(hours=1))
         is False
     )
     assert (
-        _is_due_for_refresh(soon, now=now, lead_time=timedelta(minutes=1))
+        _is_due_for_refresh(forty_min, now=now, max_age=timedelta(minutes=30))
         is True
     )
 
@@ -80,8 +73,8 @@ def test_token_bundle_carries_refresh_token() -> None:
 
 def test_token_bundle_refresh_token_optional_for_legacy() -> None:
     """An OAuth install whose Linear app config doesn't issue refresh
-    tokens still parses cleanly — the refresh service just degrades to
-    "stale-token + log" instead of crashing."""
+    tokens still parses cleanly — the cron sweep skips that install
+    instead of crashing."""
     bundle = LinearTokenBundle(
         access_token="lin_oauth_a",
         token_type="Bearer",


### PR DESCRIPTION
## Summary
- #240 wired Linear refresh-token storage and a per-request \`ensure_fresh_linear_access_token\` that ran a Linear round-trip when the access expiry was within 5 minutes. Hot-path implementation works but adds a Linear API call to every picker tick when cadence math goes hot — overkill for a token rotated a few times a day.
- Switch to cadence-based rotation:
  - Drop the per-request refresh from \`tracker_resolver._resolve_native_linear\`. Resolver reads the credential as written.
  - New scheduled cron \`linear_token_refresh_tick\` (CronLockId 1010, hourly at :05) iterates every READY Linear install and rotates the pair when \`last_rotated_at\` is older than \`LINEAR_TOKEN_REFRESH_HOURS\` (default 6h, env-tunable).
  - \`refresh_all_due_linear_tokens\` returns a counter dict so the tick logs \`rotated\`/\`skipped_fresh\`/\`refresh_failed\` in one structured line.
  - \`refresh_linear_access_token_now\` (the reactive 401-recovery hook) refactored onto the same \`_refresh_install\` helper so scheduled and forced paths can't drift.

## Test plan
- [x] \`pytest backend/tests/test_linear_token_refresh.py\` — 7 cadence cases (null/fresh/at-threshold/past-threshold/custom-age) + bundle parsing.
- [ ] After merge + Render rollout: askslayer re-authorizes Linear once. Within 6h, the cron should rotate the pair and write a fresh \`last_rotated_at\`. Operator never sees expiry again.