### PR TITLE
linear: fail-safe on missing stage label + provision bug_triage / qa_automation

### DIFF
--- a/backend/app/integrations/linear/tracker_adapter.py
+++ b/backend/app/integrations/linear/tracker_adapter.py
@@ -470,17 +470,52 @@ class LinearTracker:
 
         parts: list[dict[str, Any]] = []
         target_state_name = self._fsm_to_linear_state.get(stage)
-        if target_state_name and target_state_name in self._state_id_by_name:
-            parts.append(
-                {"state": {"id": {"eq": self._state_id_by_name[target_state_name]}}}
-            )
+        if not target_state_name or target_state_name not in self._state_id_by_name:
+            # Stage not bound to a Linear workflow state — runs out-of-
+            # band (``self_heal`` etc). The caller falls back to a
+            # coarse ``state="open"`` filter for these; return an
+            # empty parts list so we don't accidentally start filtering.
+            return parts
+        parts.append(
+            {"state": {"id": {"eq": self._state_id_by_name[target_state_name]}}}
+        )
 
         # "this role hasn't finished yet" — never re-pick. ``every``
         # matches the empty label collection too, so unlabeled
         # Linear-native tickets at the entry stage still come through.
+        #
+        # Fail-safe: when the workspace's ``label_id_by_stage`` map
+        # doesn't carry an id for this stage (provisioner predates the
+        # stage, FSM extended without re-provisioning, manually
+        # patched integration row, …) the previous behavior silently
+        # dropped this clause and the picker matched *every* ticket in
+        # the target state. Observed in production as one routine
+        # looping on the same ticket every 30 min: the post-finish
+        # transition tries to add the same ``stage:<X>`` breadcrumb,
+        # ``label_id_by_stage.get`` returns ``None``, the mutation
+        # adds no label, the next picker tick sees the same ticket as
+        # eligible — agent re-runs, tokens burn. Surface the gap by
+        # returning a sentinel filter that matches nothing — the cron
+        # tick noops cleanly, the operator sees the missing-provision
+        # gap via the warning log instead of a token bill.
         own_label = self._label_id_by_stage.get(stage)
         if own_label:
             parts.append({"labels": {"every": {"id": {"neq": own_label}}}})
+        else:
+            logger.warning(
+                "linear adapter: stage=%s has no label_id provisioned for "
+                "team=%s; refusing to pick (operator should re-run the "
+                "Linear FSM provisioner)",
+                stage,
+                self._team_id,
+            )
+            # ``some: {id: {eq: <impossible>}}`` matches nothing for any
+            # ticket including unlabeled ones (vacuously false on
+            # empty), so the picker returns zero rows for this stage on
+            # this workspace until provisioning is repaired.
+            parts.append(
+                {"labels": {"some": {"id": {"eq": "00000000-0000-0000-0000-000000000000"}}}}
+            )
 
         # "previous role is done" — for non-entry stages.
         prev = previous_stage(stage)

--- a/backend/app/services/linear_provisioner.py
+++ b/backend/app/services/linear_provisioner.py
@@ -49,11 +49,23 @@ logger = logging.getLogger(__name__)
 SHIP_FSM_STAGES: tuple[str, ...] = (
     # Per-ticket SDLC (the "development" process)
     "task_intake",
+    # Parallel intake — operator labels a ticket ``stage:bug_triage``
+    # to route through bug intake. Without a provisioned label, the
+    # Linear adapter's ``_fsm_filter`` silently drops its own-stage
+    # exclusion clause; the bug_triage picker then matches every Todo
+    # ticket regardless and the routine loops on the same ticket
+    # forever. Mint the label up front so the filter is exact.
+    "bug_triage",
     "ba_requirements",
     "tech_arch_plan",
     "qa_arch_plan",
     "dev_implementation",
     "qa_manual",
+    # Parallel quality lane to qa_manual — same loop hazard if the
+    # label isn't provisioned; pickers for both fan in on the same
+    # In Progress state so the missing-own-label fallback would mis-
+    # route every ticket post-dev_implementation.
+    "qa_automation",
     "pr_review",
     "self_heal",
     # Per-project decomposition (the "decomposition" process — runs on
@@ -121,11 +133,22 @@ def previous_stage(stage: str) -> str | None:
 # the label carrying the SDLC stage.
 FSM_TO_LINEAR_STATE: dict[str, str] = {
     "task_intake": "Todo",
+    # Parallel intake to task_intake — same Linear state (Todo), the
+    # bug_triage label distinguishes them. Operator labels a ticket
+    # ``stage:bug_triage`` manually to route through bug intake;
+    # without this entry the picker for bug_triage has nowhere to
+    # match and the filter degrades to "any Todo ticket".
+    "bug_triage": "Todo",
     "ba_requirements": "Todo",
     "tech_arch_plan": "Todo",
     "qa_arch_plan": "Todo",
     "dev_implementation": "In Progress",
     "qa_manual": "In Progress",
+    # Parallel quality lane to qa_manual — both pick from In Progress;
+    # the stage label is the only thing that distinguishes the two
+    # routines, so the label MUST be provisioned for the filter to
+    # work.
+    "qa_automation": "In Progress",
     # Review is human-only — agents transition INTO it but never pick
     # FROM it.
     "pr_review": "Review",

--- a/backend/tests/test_linear_tracker_fsm_filter.py
+++ b/backend/tests/test_linear_tracker_fsm_filter.py
@@ -170,3 +170,76 @@ def test_self_heal_falls_back_to_coarse_open_filter() -> None:
     # No ``state`` clause and no own-label since FSM_TO_LINEAR_STATE
     # doesn't include self_heal in the test fixture's mapping.
     assert all("state" not in p for p in parts)
+
+
+def test_missing_own_label_returns_impossible_sentinel() -> None:
+    """When the workspace's provisioner didn't mint a label for a
+    stage that IS bound to a Linear workflow state, the picker must
+    fail-safe to "match nothing" instead of "match every ticket".
+
+    Reproduction of the production loop: bug_triage's stage label is
+    not in ``label_id_by_stage``, but bug_triage IS mapped to ``Todo``
+    in ``fsm_to_linear_state``. The previous filter shape silently
+    dropped the own-label exclusion → picker matched every Todo
+    ticket → routine ran every cron tick, burning agent tokens for
+    no progress. The new shape adds an impossible-id ``some.id.eq``
+    sentinel so the picker returns zero rows until provisioning is
+    repaired.
+    """
+    # Tracker fixture WITHOUT bug_triage in label_id_by_stage but WITH
+    # the state mapping (mirrors a workspace where the provisioner
+    # ran before bug_triage was added to SHIP_FSM_STAGES).
+    tracker = _make_tracker(
+        stage_labels={
+            # Mirror a pre-fix workspace where bug_triage / qa_automation
+            # / code_review were never minted as labels.
+            "task_intake": "lbl_intake",
+            "ba_requirements": "lbl_ba",
+            "tech_arch_plan": "lbl_tech_arch",
+            "dev_implementation": "lbl_dev",
+            "qa_manual": "lbl_qa_manual",
+            "pr_review": "lbl_pr_review",
+        }
+    )
+    parts = tracker._fsm_filter("bug_triage")
+
+    # The state clause still lands.
+    state_clauses = [p for p in parts if "state" in p]
+    assert len(state_clauses) == 1
+    assert (
+        state_clauses[0]["state"]["id"]["eq"] == "todo_state_id"
+    )
+
+    # The impossible-id sentinel matches nothing — no real label
+    # carries this id.
+    sentinel_clauses = [
+        p
+        for p in parts
+        if "labels" in p
+        and "some" in p["labels"]
+        and p["labels"]["some"].get("id", {}).get("eq")
+        == "00000000-0000-0000-0000-000000000000"
+    ]
+    assert len(sentinel_clauses) == 1, (
+        "missing-own-label stage must inject an impossible-id sentinel "
+        "so the picker matches zero tickets"
+    )
+
+    # And crucially, no plain ``every.id.neq`` own-label exclusion —
+    # that's what would silently let every ticket through if the
+    # provisioner gap was tolerated.
+    every_neq_clauses = [
+        p
+        for p in parts
+        if "labels" in p
+        and "every" in p["labels"]
+        and "neq" in p["labels"]["every"].get("id", {})
+    ]
+    # ``needs:clarification`` exclusion is one ``every / neq`` clause;
+    # the bug_triage own-label is the second that would exist in the
+    # healthy case. Here we want exactly one (the clarification one),
+    # not two.
+    assert len(every_neq_clauses) == 1, (
+        "missing-own-label stage must not emit an own-label exclusion "
+        "clause; only the needs:clarification one is expected"
+    )


### PR DESCRIPTION
## Summary
Production observed a routine looping on the same ticket every cron tick for 24h, burning ~\$200 in agent tokens without progress (ELS-98..103 in Denys's workspace, bug_triage routine repeatedly picking ELS-99).

**Root cause** (two layers):
1. The Linear FSM provisioner's \`SHIP_FSM_STAGES\` list never included \`bug_triage\` or \`qa_automation\` (\`code_review\` is aliased via \`pr_review\`). So those stages had no row in \`label_id_by_stage\`.
2. \`LinearTracker._fsm_filter\` silently dropped the own-stage exclusion clause when \`label_id_by_stage.get(stage)\` returned None. With bug_triage mapped to \`Todo\` in \`FSM_TO_LINEAR_STATE\`, the picker for bug_triage matched **every** Todo ticket. The agent ran, called \`finish\`, the server tried to add \`stage:bug_triage\` as a breadcrumb — same \`get\` returned None, no label added — and the next cron tick took the same ticket again. Forever loop.

**Fixes**:
- \`SHIP_FSM_STAGES\` adds \`bug_triage\` + \`qa_automation\`; \`FSM_TO_LINEAR_STATE\` maps both. Fresh workspaces get the labels minted automatically.
- \`_fsm_filter\` fail-safe: when a stage has a Linear state mapping but no own-label id, return an impossible-id \`some.id.eq\` sentinel that matches zero tickets, plus a warning log. Cron tick noops cleanly instead of looping.
- \`self_heal\` out-of-band path preserved (no state mapping → empty filter → caller falls back to \`state="open"\`).

## Test plan
- [x] \`pytest backend/tests/test_linear_tracker_fsm_filter.py\` — 7 cases including new \`test_missing_own_label_returns_impossible_sentinel\`.
- [ ] After deploy: bug_triage routine should stop picking ELS-99..103 (already manually tagged with stage:bug_triage); ba_requirements gets its turn on the next cron tick.
- [ ] Existing workspaces with missing bug_triage label provision will see \`warning: stage=bug_triage has no label_id provisioned\` in logs but no agent runs spawned.