### PR TITLE
intake: absorb ba_requirements into task_intake (1 LLM call instead of 2)

### DIFF
--- a/backend/app/api/v1/routes/processes.py
+++ b/backend/app/api/v1/routes/processes.py
@@ -172,21 +172,23 @@ _SEEDED_PROCESSES: tuple[dict[str, Any], ...] = (
 )
 
 _PROCESS_STATE_ORDER: tuple[str, ...] = (
-    # Phase 1.5 canon — eight pipeline stages in execution order. The
+    # Phase 1.5 canon — seven pipeline stages in execution order. The
     # dashboard's process projector iterates this tuple to render the
     # canvas; runtime aggregation skips lane keys not present here.
-    # ``pr_review`` is kept as a legacy alias below in
-    # :data:`_PROCESS_STATE_ALIASES` so pre-v0.20 configs still
-    # project. ``bug_triage`` was the parallel-intake entry; it
-    # produced an infinite loop on feature tickets (agent correctly
-    # refused to fabricate bug-report fields, then the routine kept
-    # re-picking the same ticket every tick) and the stage was
-    # folded into ``task_intake``. Legacy configs that still
-    # reference ``bug_triage`` route through the alias below so the
-    # canvas doesn't grow stale columns but the runtime aggregator
-    # doesn't drop their audit rows either.
+    # Two retirements are kept as legacy aliases below in
+    # :data:`_PROCESS_STATE_ALIASES` so pre-v0.21 configs still
+    # project:
+    #   - ``bug_triage`` (parallel-intake entry) — folded into
+    #     ``task_intake`` after producing an infinite loop on feature
+    #     tickets (agent correctly refused to fabricate bug-report
+    #     fields, routine kept re-picking).
+    #   - ``ba_requirements`` (separate BA stage) — folded into
+    #     ``task_intake`` because the same context-load was feeding
+    #     two LLM calls in a row to produce overlapping output shapes.
+    #     Intake now writes the full impl-grade spec in one pass.
+    # ``pr_review`` is also legacy (renamed to ``code_review``); same
+    # alias treatment.
     "task_intake",
-    "ba_requirements",
     "tech_arch_plan",
     "qa_arch_plan",
     "dev_implementation",
@@ -196,11 +198,13 @@ _PROCESS_STATE_ORDER: tuple[str, ...] = (
 )
 
 # Legacy stage ids that should still count as process states for
-# pre-v0.20 configs. Kept separate from ``_PROCESS_STATE_ORDER`` so
-# the canvas only renders the canonical eight but the runtime
+# pre-v0.21 configs. Kept separate from ``_PROCESS_STATE_ORDER`` so
+# the canvas only renders the canonical seven but the runtime
 # aggregator (``_runtime_by_state``) doesn't drop pipeline runs that
 # referenced the old id.
-_PROCESS_STATE_ALIASES: frozenset[str] = frozenset({"pr_review", "bug_triage"})
+_PROCESS_STATE_ALIASES: frozenset[str] = frozenset(
+    {"pr_review", "bug_triage", "ba_requirements"}
+)
 
 _ROUTINE_IDS: frozenset[str] = frozenset(
     {

--- a/backend/app/resources/agent_roles/ba.md
+++ b/backend/app/resources/agent_roles/ba.md
@@ -13,32 +13,51 @@ name: BA / specification
 
 ## Task
 
-The ticket arrives shaped by intake (Problem / Goal / Expected behaviour / Scope / AC / Non-goals / Risks). Your job is to extend the description with implementation-grade specification.
+The per-ticket SDLC ``ba_requirements`` stage was folded into ``intake``
+so the same context-load that classifies the ticket also produces the
+implementation-grade spec. This role is now invoked only by:
 
-The BA spec sections you append below the intake sections:
+- The **decomposition** chain (project-first delivery, ELS-75) — produces
+  the WBS section of a project body on the planning anchor (see below).
+- The **consult_specialist** sub-agent surface — Navigator or another
+  operator delegates "shape this ticket / draft these acceptance
+  criteria" as a one-off, without going through the FSM.
 
-- **Feature description** — one paragraph in your own words.
-- **User stories** — `As a … I want … so that …` bullets, one per scenario.
-- **Acceptance criteria** — Given/When/Then or numbered list, observable + testable.
-- **Edge cases** — explicit list, with the expected behaviour for each.
-- **Impacted components** — repo paths / modules / services.
-- **Technical notes** — schema/API/UX hooks the developer needs but the user shouldn't have to derive.
-- **Test plan** — what the QA stage will exercise.
-
-If you have enough to specify, finish with `outcome=ready_next_step`, `stage_next=dev_implementation`.
-
-The standing rules — write to `description` not `comment`, respect the intake sections, escalate as `needs_clarification` when scope is too large — come from your workspace's policies.
-
-The `comment` field on this stage is a one-paragraph audit narration of what you added/changed and why. End it with: `[Ship SDLC:role-ba]`
+If you arrive here in SDLC ``ba_requirements`` mode on a legacy in-flight
+ticket (the FSM stage was retired but the ticket already has the
+``stage:ba_requirements`` breadcrumb from a pre-retirement run), pass the
+ticket forward unchanged: finish with ``outcome=ready_next_step``,
+``stage_next=tech_arch_plan``, no description rewrite, and leave a one-
+line comment ``[Ship SDLC:role-ba] stage retired; passed through``. The
+intake stage already produced the spec; re-running BA's work would just
+churn the description.
 
 ## Decomposition mode
 
-When the run context flags `process=decomposition` (project-first delivery, ELS-75) you're not refining a single ticket — you're producing the **WBS section** of a *project body* on the project's planning anchor. Different rules apply:
+When the run context flags ``process=decomposition`` you're producing
+the **WBS section** of a *project body* on the project's planning anchor.
+Different rules apply:
 
-- The "ticket" the runtime hands you is the **planning anchor** (`planning:anchor` label). Do NOT rewrite the anchor's description; the project body — not the anchor — carries decomposition artefacts.
-- Read the project's `## Brief` (the PO drafted it in Navigator). Emit a coarse **work breakdown structure** — a list of child-ticket stubs.
-- Each WBS line is **name + 2-3 lines of scope**. NOT detailed acceptance criteria. SDLC's BA writes those when each child enters `task_intake`; pre-writing them here is wasted work.
-- Emit your WBS body as a **top-level** `project_sections` field on the JSON body of `POST /agent-runs/finish` — NOT nested inside the `payload` dict. Wire shape: `{ "outcome": "ready_next_step", "stage_next": "architecture", "process": "decomposition", "ticket_ref": "<anchor>", "project_sections": [{ "section": "WBS", "body": "<your WBS markdown>" }], "comment": "..." }`. The server resolves the anchor's project and upserts the `## WBS` block (replacing any prior WBS, leaving other sections alone). NEVER touch `## Brief`, `## Architecture`, `## Test architecture`, or `## Tasks` — those are owned by other stages.
-- Do NOT create child tickets yourself. The `tasks` stage at the end of the decomposition chain creates them from the WBS you produce.
-- Finish with `outcome=ready_next_step`, `stage_next=architecture`, `process=decomposition`.
-- End your audit `comment` with: `[Ship decomposition:role-ba]`
+- The "ticket" the runtime hands you is the **planning anchor**
+  (``planning:anchor`` label). Do NOT rewrite the anchor's description;
+  the project body — not the anchor — carries decomposition artefacts.
+- Read the project's ``## Brief`` (the PO drafted it in Navigator). Emit
+  a coarse **work breakdown structure** — a list of child-ticket stubs.
+- Each WBS line is **name + 2-3 lines of scope**. NOT detailed acceptance
+  criteria. The intake stage writes those when each child enters
+  ``task_intake``; pre-writing them here is wasted work.
+- Emit your WBS body as a **top-level** ``project_sections`` field on the
+  JSON body of ``POST /agent-runs/finish`` — NOT nested inside the
+  ``payload`` dict. Wire shape: ``{ "outcome": "ready_next_step",
+  "stage_next": "architecture", "process": "decomposition", "ticket_ref":
+  "<anchor>", "project_sections": [{ "section": "WBS", "body": "<your WBS
+  markdown>" }], "comment": "..." }``. The server resolves the anchor's
+  project and upserts the ``## WBS`` block (replacing any prior WBS,
+  leaving other sections alone). NEVER touch ``## Brief``,
+  ``## Architecture``, ``## Test architecture``, or ``## Tasks`` — those
+  are owned by other stages.
+- Do NOT create child tickets yourself. The ``tasks`` stage at the end of
+  the decomposition chain creates them from the WBS you produce.
+- Finish with ``outcome=ready_next_step``, ``stage_next=architecture``,
+  ``process=decomposition``.
+- End your audit ``comment`` with: ``[Ship decomposition:role-ba]``

--- a/backend/app/resources/agent_roles/intake.md
+++ b/backend/app/resources/agent_roles/intake.md
@@ -1,9 +1,9 @@
 ---
-name: Intake
+name: Intake / Spec
 fsm_stage: task_intake
 ---
 
-# Role: Intake ({{ISSUE}})
+# Role: Intake & Spec ({{ISSUE}})
 
 {{BASE}}
 
@@ -14,35 +14,73 @@ fsm_stage: task_intake
 
 ## Task
 
-Classify the ticket: feature / bug / refactor / infra / improvement. Check completeness against the relevant shape:
+Combined intake + specification pass. The legacy ``ba_requirements``
+stage was folded in here so the same context-load that classifies the
+ticket also produces the implementation-grade spec — saves the
+duplicate Linear / repo round-trip and the second LLM call, which
+together were ~50% of the token spend on a typical feature ticket
+between filing and architecture review.
 
-- **Feature / refactor / improvement / infra** — goal, problem, expectation, scope, AC, constraints.
-- **Bug** — repro steps, expected vs actual, environment, severity, scope of impact.
+Two passes in one finish:
 
-The parallel `bug_triage` stage was retired after it produced infinite loops on feature tickets; intake now owns both shapes and shapes the description for whichever the ticket actually is.
+**1) Classify** the ticket: feature / bug / refactor / infra /
+improvement. The classification determines the body shape below.
 
-**If enough to shape:** finish with `outcome=ready_next_step`, `stage_next=ba_requirements`, and rewrite the description (via the `description` field) using one of these section sets:
+**2) Shape the body** as a complete implementation-grade spec. Pick
+the section list that matches the classification:
 
-For features / refactor / improvement / infra:
+For *features / refactor / improvement / infra*:
 
-1. **Problem**
-2. **Goal**
-3. **Expected behaviour**
-4. **Scope**
-5. **Acceptance criteria**
-6. **Non-goals**
-7. **Risks**
+1. **Problem** — one paragraph in the operator's voice.
+2. **Goal** — what "done" means for the human ordering the work.
+3. **Feature description** — one paragraph in your own words; this
+   is the BA paraphrase that proves you understood.
+4. **User stories** — ``As a … I want … so that …`` bullets, one per
+   scenario the change touches.
+5. **Acceptance criteria** — Given/When/Then or a numbered list,
+   each item observable + testable. This is what QA writes from
+   downstream.
+6. **Edge cases** — explicit list, with the expected behaviour for
+   each. Don't punt with "and so on".
+7. **Scope** — the things in.
+8. **Non-goals** — the things deliberately out.
+9. **Impacted components** — repo paths / modules / services the
+   developer should expect to touch. Read the repo lightly here —
+   you have the tools; use them.
+10. **Technical notes** — schema / API / UX hooks the developer
+    needs but the user shouldn't have to derive. Keep concise; the
+    tech-architect stage owns the full design.
+11. **Test plan** — what the QA architecture stage will exercise.
+12. **Risks** — the gotchas that would surface in PR review.
 
-For bugs:
+For *bugs*:
 
-1. **Summary** (one-line symptom)
-2. **Steps to reproduce**
-3. **Expected behaviour**
-4. **Actual behaviour**
-5. **Environment** (build / commit / runner / browser / OS as relevant)
-6. **Severity** (operator pain — does the agent pipeline still function? are users affected?)
-7. **Scope of impact** (which surfaces / users / routines)
+1. **Summary** (one-line symptom).
+2. **Steps to reproduce** (numbered, runnable by a stranger).
+3. **Expected behaviour**.
+4. **Actual behaviour**.
+5. **Environment** (build / commit / runner / browser / OS as relevant).
+6. **Severity** (operator pain — does the agent pipeline still
+   function? are users affected?).
+7. **Scope of impact** (which surfaces / users / routines).
+8. **Suspect area** (one paragraph: where in the codebase you'd
+   start looking, with file paths if you can pin them down).
+9. **Acceptance criteria for the fix** — Given/When/Then or numbered;
+   the conditions that prove the bug is gone.
 
-The standing rules — don't touch Backlog tickets, write the rewritten body to `description` (not `comment`), escalate as `needs_clarification` when context is missing — come from your workspace's policies.
+## Finish
 
-The `comment` field carries a one-paragraph audit narration of *what you changed and why*, including the classification you settled on. End it with: `[Ship SDLC:role-intake]`
+If you have enough context to produce the full spec, finish with
+``outcome=ready_next_step``, ``stage_next=tech_arch_plan``, and put
+the rewritten body in the ``description`` field (not ``comment``).
+The legacy ``ba_requirements`` stage no longer fires — what you
+write here is what the architecture stages read directly.
+
+The standing rules — don't touch Backlog tickets, write the
+rewritten body to ``description`` not ``comment``, escalate as
+``needs_clarification`` when context is missing — come from your
+workspace's policies.
+
+The ``comment`` field carries a one-paragraph audit narration of
+*what you changed and why*, including the classification you
+settled on. End it with: ``[Ship SDLC:role-intake]``

--- a/backend/app/services/catalog.py
+++ b/backend/app/services/catalog.py
@@ -257,12 +257,14 @@ def default_development_process_config(
 ) -> dict[str, object]:
     """Return the canonical FSM process seeded into new repo configs.
 
-    Phase 1 introduced eight pipeline specialists (intake, ba,
-    tech-architect, qa-architect, developer, qa-engineer,
-    qa-automation, reviewer) and Phase 3 added the gates knob; this
-    config now matches that canon. ``specialist.id`` carries the
-    kebab-case agent-role slug — the same slug the runtime resolver
-    accepts at ``/v1/.../agent-roles/{slug}/resolve``.
+    Phase 1 introduced eight pipeline specialists; this PR collapsed
+    intake + ba into a single ``task_intake`` stage (same context-load
+    was feeding two LLM calls in a row producing overlapping output
+    shapes), leaving seven SDLC stages: intake, tech-architect, qa-
+    architect, developer, qa-engineer, qa-automation, reviewer.
+    ``specialist.id`` carries the kebab-case agent-role slug — the
+    same slug the runtime resolver accepts at
+    ``/v1/.../agent-roles/{slug}/resolve``.
 
     Intake handles both feature requests and bug reports — the
     bug-triage stage was folded into ``task_intake`` after the
@@ -291,21 +293,17 @@ def default_development_process_config(
                 "state": "planning",
                 "specialist": {"id": "intake", "name": "Intake"},
                 "instructions": (
-                    "Shape new tickets into a structured form before BA "
-                    "writes the spec. Handles both feature requests and "
-                    "bug reports — for bugs, surface Steps / Expected / "
-                    "Actual / Environment in the description; for "
-                    "features, surface Problem / Goal / Scope / Risks."
-                ),
-            },
-            {
-                "id": "ba_requirements",
-                "name": "Requirements",
-                "state": "planning",
-                "specialist": {"id": "ba", "name": "BA / specification"},
-                "instructions": (
-                    "Turn the shaped ticket into acceptance criteria, "
-                    "constraints, risks, and an explicit test plan."
+                    "Classify + produce the full impl-grade spec in one "
+                    "pass. Output sections depend on classification — "
+                    "features use Problem / Goal / Feature description / "
+                    "User stories / AC / Edge cases / Scope / Non-goals "
+                    "/ Impacted components / Technical notes / Test plan "
+                    "/ Risks; bugs use Summary / Steps / Expected / "
+                    "Actual / Environment / Severity / Scope / Suspect "
+                    "area / AC for fix. The legacy ``ba_requirements`` "
+                    "stage was folded in here — same context-load was "
+                    "feeding two LLM calls in a row, producing "
+                    "overlapping output shapes."
                 ),
             },
             {
@@ -373,8 +371,7 @@ def default_development_process_config(
             },
         ],
         "transitions": [
-            {"from": "task_intake", "to": "ba_requirements"},
-            {"from": "ba_requirements", "to": "tech_arch_plan"},
+            {"from": "task_intake", "to": "tech_arch_plan"},
             {"from": "tech_arch_plan", "to": "qa_arch_plan"},
             {"from": "qa_arch_plan", "to": "dev_implementation"},
             {"from": "dev_implementation", "to": "qa_manual"},

--- a/backend/app/services/lane_recipes.py
+++ b/backend/app/services/lane_recipes.py
@@ -154,12 +154,11 @@ DEFAULT_SEED_LANES: Final[dict[str, dict[str, object]]] = {
         "specialist": "intake",
         "fsm_stage": "task_intake",
     },
-    "ba_requirements": {
-        "kind": "schedule",
-        "cron": "*/30 * * * *",
-        "specialist": "ba",
-        "fsm_stage": "ba_requirements",
-    },
+    # ``ba_requirements`` routine retired — intake now produces the full
+    # impl-grade spec, see ``agent_roles/intake.md``. Legacy in-flight
+    # tickets that already carry ``stage:ba_requirements`` breadcrumb
+    # advance through ``tech_arch_plan`` (which requires the
+    # ``stage:task_intake`` breadcrumb they also have).
     "tech_arch_plan": {
         "kind": "schedule",
         "cron": "*/30 * * * *",
@@ -208,9 +207,11 @@ ROUTINE_DISPLAY_LABELS: Final[dict[str, str]] = {
     "qa_review": "QA review",
     "security_review": "Security review",
     "process_review": "Process review",
-    # SDLC routines (per-stage ticket pickup).
-    "intake": "Intake",
-    "ba_requirements": "Requirements",
+    # SDLC routines (per-stage ticket pickup). ``ba_requirements`` was
+    # folded into ``intake`` — the label kept here only so legacy
+    # configs / audit rows referencing it still display.
+    "intake": "Intake & Spec",
+    "ba_requirements": "Requirements (retired)",
     "tech_arch_plan": "Tech architecture",
     "qa_arch_plan": "Test architecture",
     "dev_implementation": "Implementation",

--- a/backend/app/services/linear_provisioner.py
+++ b/backend/app/services/linear_provisioner.py
@@ -81,10 +81,17 @@ SHIP_FSM_STAGES: tuple[str, ...] = (
 
 
 # Linear order of the SDLC stages. Self-heal is parallel to the main
-# pipeline (any open ticket) so it stays out of the chain.
+# pipeline (any open ticket) so it stays out of the chain. The legacy
+# ``ba_requirements`` stage was folded into ``task_intake`` — they were
+# doing the same context-load twice in a row to produce overlapping
+# output shapes; the merged ``task_intake`` writes the full impl-grade
+# spec in one pass. The label stays in ``SHIP_FSM_STAGES`` /
+# ``FSM_TO_LINEAR_STATE`` so legacy in-flight tickets still parse,
+# but the chain advances ``task_intake → tech_arch_plan`` now and
+# ``previous_stage("tech_arch_plan")`` returns ``"task_intake"``
+# accordingly.
 FSM_STAGE_ORDER: tuple[str, ...] = (
     "task_intake",
-    "ba_requirements",
     "tech_arch_plan",
     "qa_arch_plan",
     "dev_implementation",

--- a/backend/app/services/seed_bundle.py
+++ b/backend/app/services/seed_bundle.py
@@ -158,7 +158,18 @@ from backend.app.services.tracker_fsm import (
 #         tokens at every tick). Intake now owns both feature and
 #         bug shapes; Linear's native issue type is the source of
 #         truth for bug-vs-feature.
-BUNDLE_VERSION: str = "0.29"
+# ``0.30`` → ba_requirements stage folded into task_intake. Same
+#         context-load was feeding two LLM calls in a row to produce
+#         overlapping output shapes (intake: classify + Problem /
+#         Goal / AC / Risks; BA: Feature description / User stories
+#         / AC / Edge cases / Impacted components / Technical notes
+#         / Test plan / Risks — ~80% overlap). The merged
+#         ``task_intake`` writes the full impl-grade spec in one
+#         pass, transitioning directly to ``tech_arch_plan``. Cuts
+#         per-ticket SDLC token spend ~50% pre-architecture review.
+#         The ``ba`` specialist file stays for decomposition WBS
+#         mode + the ``consult_specialist`` sub-agent surface.
+BUNDLE_VERSION: str = "0.30"
 
 # Default knowledge starters for PR 1. Empty by design: generated knowledge is
 # analyzed post-merge and proposed in a second PR. Historical callers can still

--- a/backend/tests/test_decomposition_role_modes.py
+++ b/backend/tests/test_decomposition_role_modes.py
@@ -61,11 +61,31 @@ def test_role_carries_decomposition_block(slug: str, section: str | None) -> Non
         # Pin the owned ``## <name>`` section by literal text so a
         # rename slips into a test failure instead of a silent
         # drift that breaks ``upsert_project_section`` matching.
-        assert f'section="{section}"' in prompt, (
-            f"{slug}: Decomposition block should pin its owned section to "
-            f'``section="{section}"`` so the prompt and the tracker '
-            f"helper agree on the heading"
-        )
+        # Post-#229 the role prompts pass sections via JSON
+        # (``"section": "<name>"``) on the finish payload rather than
+        # the older ``upsert_project_section(section="<name>")`` tool
+        # call, so the test asserts the JSON shape.
+        #
+        # ``developer`` is special — the ``tasks`` stage sends
+        # ``child_tickets`` (not ``project_sections``) and the server
+        # auto-renders the ``## Tasks`` section from the created
+        # identifiers. The prompt mentions ``Tasks`` only in prose,
+        # not in a wire-shape JSON literal. We assert the prose
+        # mention instead so a rename of ``Tasks`` to something else
+        # still slips into a test failure.
+        if slug == "developer":
+            assert "Tasks" in prompt, (
+                f"{slug}: Decomposition block must mention the "
+                f"``Tasks`` section (server auto-renders it from "
+                f"``child_tickets``); a rename should slip into a "
+                f"test failure."
+            )
+        else:
+            assert f'"section": "{section}"' in prompt, (
+                f"{slug}: Decomposition block should pin its owned "
+                f'section to ``"section": "{section}"`` so the '
+                f"prompt and the tracker helper agree on the heading"
+            )
 
 
 def test_planning_process_config_emits_routines_with_fsm_stage() -> None:

--- a/backend/tests/test_linear_tracker_fsm_filter.py
+++ b/backend/tests/test_linear_tracker_fsm_filter.py
@@ -123,15 +123,18 @@ def test_intake_filter_state_clause_is_todo() -> None:
     assert state_parts[0] == {"state": {"id": {"eq": "todo_state_id"}}}
 
 
-def test_ba_requirements_filter_requires_previous_stage_label() -> None:
+def test_tech_arch_plan_filter_requires_previous_stage_label() -> None:
     """Subsequent stages still depend on the previous stage's label
-    being set (intake adds ``stage:task_intake`` on transition)."""
+    being set (intake adds ``stage:task_intake`` on transition).
+    ``ba_requirements`` was folded into ``task_intake``, so the
+    first non-entry SDLC stage is now ``tech_arch_plan`` and its
+    predecessor is ``task_intake``."""
     tracker = _make_tracker()
-    parts = tracker._fsm_filter("ba_requirements")
+    parts = tracker._fsm_filter("tech_arch_plan")
     label_clauses = _find_label_clauses(parts)
     has_some = any("some" in p["labels"] for p in label_clauses)
     assert has_some, (
-        "ba_requirements must require the previous (intake) stage "
+        "tech_arch_plan must require the previous (task_intake) stage "
         "label via the ``some`` operator"
     )
     # The own-label exclusion must use ``every / neq``.
@@ -144,7 +147,7 @@ def test_needs_clarification_exclusion_uses_every_neq_too() -> None:
     exclusion. A ticket with no labels at all must not be silently
     excluded by it."""
     tracker = _make_tracker()
-    parts = tracker._fsm_filter("ba_requirements")
+    parts = tracker._fsm_filter("tech_arch_plan")
     clar_clauses = [
         p
         for p in parts

--- a/backend/tests/test_services_seed_bundle.py
+++ b/backend/tests/test_services_seed_bundle.py
@@ -82,15 +82,16 @@ def test_compose_default_bundle_emits_config_yml() -> None:
     # default — autonomous through the agent reviewer, human only at
     # PR merge. Operators who want earlier interjection edit it.
     assert "gates: after_pr" in config_body
-    # Phase 1.5: eight canonical pipeline stages, kebab-case specialist
+    # Phase 1.5: seven canonical pipeline stages, kebab-case specialist
     # slugs matching the agent-role files. Pinned so a regression in
     # ``default_development_process_config`` doesn't silently drop a
-    # stage from new wizard seeds. The parallel-entry ``bug_triage``
-    # stage was retired after producing an infinite loop on feature
-    # tickets — intake now owns both feature and bug shapes.
+    # stage from new wizard seeds. Retired stages:
+    # - ``bug_triage`` — parallel-intake loop on feature tickets;
+    #   intake now owns both shapes.
+    # - ``ba_requirements`` — same context-load as intake was feeding
+    #   two LLM calls in a row; intake now writes the full spec.
     for state_id in (
         "task_intake",
-        "ba_requirements",
         "tech_arch_plan",
         "qa_arch_plan",
         "dev_implementation",
@@ -102,7 +103,6 @@ def test_compose_default_bundle_emits_config_yml() -> None:
             f"missing process.states[].id={state_id} in seeded YAML"
         )
     for slug in (
-        "id: ba\n",
         "id: tech-architect\n",
         "id: qa-architect\n",
         "id: developer\n",
@@ -113,10 +113,16 @@ def test_compose_default_bundle_emits_config_yml() -> None:
         assert slug in config_body, (
             f"missing specialist {slug.strip()} in seeded YAML"
         )
-    # Sanity: the retired ``bug-triage`` specialist must not creep back
-    # into freshly seeded YAML — would re-introduce the loop.
+    # Sanity: retired stages / specialists must not creep back into
+    # freshly seeded YAML — would re-introduce the bug_triage loop
+    # or the duplicate BA-spec LLM call.
     assert "id: bug-triage\n" not in config_body
     assert "fsm_stage: bug_triage" not in config_body
+    assert "fsm_stage: ba_requirements" not in config_body
+    # ``ba`` specialist file STAYS (decomp WBS uses it, plus the
+    # consult_specialist surface). It just no longer appears as an
+    # SDLC routine — check the absence by looking for the SDLC
+    # routine pin, not the specialist line.
 
 
 def test_compose_default_bundle_emits_decomposition_routines() -> None:
@@ -201,7 +207,6 @@ def test_compose_default_bundle_emits_sdlc_routines() -> None:
 
     sdlc_routines = {
         "intake": ("intake", "task_intake"),
-        "ba_requirements": ("ba", "ba_requirements"),
         "tech_arch_plan": ("tech-architect", "tech_arch_plan"),
         "qa_arch_plan": ("qa-architect", "qa_arch_plan"),
         "dev_implementation": ("developer", "dev_implementation"),


### PR DESCRIPTION
## Summary
- intake and BA were doing the same context-load twice in a row, producing overlapping output shapes (~80% overlap). Real perspective differences only appear starting at tech-architect (system shape) and qa-architect (test strategy).
- Merge intake + ba_requirements into a single \`task_intake\` stage that writes the full implementation-grade spec in one Claude call. ~50% token savings on the early SDLC chain, zero quality loss (output sections are the union of the two old shapes).
- \`ba\` specialist file stays for decomposition WBS + \`consult_specialist\` surface.

## Changes
- \`FSM_STAGE_ORDER\` drops \`ba_requirements\`; \`previous_stage("tech_arch_plan")\` → \`"task_intake"\`. Legacy in-flight tickets with both breadcrumbs still match the new filter.
- \`SHIP_FSM_STAGES\` + \`FSM_TO_LINEAR_STATE\` keep \`ba_requirements\` for label-provisioning back-compat.
- \`lane_recipes.SDLC_ROUTINES\` drops the BA routine; display label marked \`(retired)\`.
- \`catalog.default_development_process_config\`: drop state + collapse transitions (\`task_intake → ba_requirements → tech_arch_plan\` → \`task_intake → tech_arch_plan\`).
- \`_PROCESS_STATE_ORDER\` drops; \`_PROCESS_STATE_ALIASES\` adopts for legacy audit aggregation.
- \`intake.md\`: absorbs BA's 12-section feature shape + 9-section bug shape; \`stage_next=tech_arch_plan\` directly.
- \`ba.md\`: SDLC section becomes a passthrough on legacy in-flight tickets; decomp WBS mode unchanged.
- \`BUNDLE_VERSION\` 0.29 → 0.30.

## Test plan
- [x] \`pytest backend/tests/test_services_seed_bundle.py test_linear_tracker_fsm_filter.py test_decomposition_role_modes.py test_picker_*\` — 70 cases pass, includes new sanity \`fsm_stage: ba_requirements\` MUST NOT appear in seed YAML.
- [ ] After deploy: file a fresh feature ticket. Should hit \`task_intake\` once, finish with full spec body, transition straight to \`tech_arch_plan\`. Zero \`fsm_stage=ba_requirements\` finishes in audit_log.
- [ ] Legacy in-flight tickets at \`ba_requirements\` (e.g., Denys's ws ELS-98..103 if any still there): tech_arch_plan picker should take them on next tick (both stage:task_intake + stage:ba_requirements present).