### PR TITLE
linear: include description in the filtered list_tickets projection

### DIFF
--- a/backend/app/integrations/linear/tracker_adapter.py
+++ b/backend/app/integrations/linear/tracker_adapter.py
@@ -193,6 +193,15 @@ class LinearTracker:
             data = await self._gql(gql, {"first": first})
             nodes = (data.get("issues") or {}).get("nodes") or []
         else:
+            # ``description`` MUST stay in the projection. The picker
+            # always reaches this filtered branch in production (team_id
+            # gate alone makes ``issue_filter`` non-empty), and a
+            # missing ``description`` field here means every SDLC
+            # agent receives ``body=None`` in its prompt — observed as
+            # intake / BA opening ``needs_clarification`` saying "the
+            # ticket body is empty" on tickets that actually had a
+            # populated description in Linear. The unfiltered branch
+            # above carries it; if you edit one projection, edit both.
             gql = """
             query ShipListIssues($first: Int!, $filter: IssueFilter) {
               issues(first: $first, orderBy: updatedAt, filter: $filter) {
@@ -200,6 +209,7 @@ class LinearTracker:
                   id
                   identifier
                   title
+                  description
                   url
                   state { name type }
                   project { id }


### PR DESCRIPTION
## Summary
The filtered branch of \`LinearTracker.list_tickets\` was missing \`description\` from its GraphQL projection. The picker always hits the filtered branch in production (team_id gate alone is enough), so every SDLC agent received \`body=None\` despite the row mapping reading \`n.get("description")\`. Operator complaint: agents finishing with \`needs_clarification\` saying "the ticket body is empty" on populated tickets.

One-line fix: add \`description\` to the filtered query (the unfiltered one had it). Comment added so the projections stay in sync.

## Test plan
- [x] Existing list_tickets / fsm_filter tests still green.
- [ ] After deploy: file a fresh feature ticket with body. \`shipctl trigger\` picks intake, agent's prompt should now carry the body. No \`needs_clarification\` for "empty body" on populated tickets.