### PR TITLE
feat: drain-first picker via routine pipeline_priority

### DIFF
--- a/backend/app/services/catalog.py
+++ b/backend/app/services/catalog.py
@@ -246,6 +246,15 @@ def bundle_routine_entries(
         # ``ba_requirements`` for SDLC and ``wbs`` for decomposition).
         if isinstance(lane.get("fsm_stage"), str):
             routine["fsm_stage"] = str(lane["fsm_stage"])
+        # ``pipeline_priority`` drives the CLI's drain-first picker
+        # (``cli/lib/runtime/routines.mjs`` sorts due routines by this
+        # field DESC so later-stage tickets fire before early-stage
+        # ones in the same tick). Lanes without an explicit priority
+        # — daily / retro / sweeps — fall through and the CLI treats
+        # them as ``0``.
+        raw_priority = lane.get("pipeline_priority")
+        if isinstance(raw_priority, int) and not isinstance(raw_priority, bool):
+            routine["pipeline_priority"] = raw_priority
         if isinstance(lane.get("description"), str):
             routine["description"] = str(lane["description"])
         routines[str(routine_id)] = routine
@@ -510,12 +519,19 @@ def default_planning_process_config() -> dict[str, object]:
         # ``planning_done`` is terminal — no routine — and the finish
         # hook on the ``tasks`` stage flips the dashboard row Drafts →
         # Parked.
+        # ``pipeline_priority`` drives drain-first ordering when
+        # multiple decomposition stages are cron-due simultaneously
+        # (the common case — they all run at ``*/30 * * * *``). The
+        # CLI sorts due routines DESC and picks the LATER stage so
+        # an anchor closest to ``planning_done`` clears before a new
+        # WBS starts. See ``cli/lib/runtime/routines.mjs::dueRoutines``.
         "routines": {
             "wbs": {
                 "name": "Decomposition WBS",
                 "enabled": True,
                 "specialist": "ba",
                 "fsm_stage": "wbs",
+                "pipeline_priority": 10,
                 "trigger": {
                     "type": "schedule",
                     "cron": "*/30 * * * *",
@@ -532,6 +548,7 @@ def default_planning_process_config() -> dict[str, object]:
                 "enabled": True,
                 "specialist": "tech-architect",
                 "fsm_stage": "architecture",
+                "pipeline_priority": 20,
                 "trigger": {
                     "type": "schedule",
                     "cron": "*/30 * * * *",
@@ -548,6 +565,7 @@ def default_planning_process_config() -> dict[str, object]:
                 "enabled": True,
                 "specialist": "qa-architect",
                 "fsm_stage": "test_architecture",
+                "pipeline_priority": 30,
                 "trigger": {
                     "type": "schedule",
                     "cron": "*/30 * * * *",
@@ -564,6 +582,7 @@ def default_planning_process_config() -> dict[str, object]:
                 "enabled": True,
                 "specialist": "developer",
                 "fsm_stage": "tasks",
+                "pipeline_priority": 40,
                 "trigger": {
                     "type": "schedule",
                     "cron": "*/30 * * * *",

--- a/backend/app/services/lane_recipes.py
+++ b/backend/app/services/lane_recipes.py
@@ -145,14 +145,25 @@ DEFAULT_SEED_LANES: Final[dict[str, dict[str, object]]] = {
     #
     # 30-min cadence is the safe free-tier default (matches the
     # trigger workflow's own */30 cron). The trigger workflow
-    # picks at most ONE due routine per tick, so adding 9 stages
-    # doesn't multiply the budget — picker scans them in order
-    # and dispatches the first eligible one.
+    # picks at most ONE due routine per tick.
+    #
+    # ``pipeline_priority`` drives drain-first scheduling: when
+    # multiple SDLC routines are cron-due in the same tick (the
+    # common case, since they all share ``*/30 * * * *``), the
+    # picker sorts by priority DESC and runs the LATER pipeline
+    # stage first. Reasoning: minimize WIP, prefer flushing tickets
+    # toward Done over feeding new ones into the head of the queue.
+    # A code-review-eligible ticket waits less than an intake ticket
+    # because it's closer to delivering value. Supporting routines
+    # above carry no ``pipeline_priority`` and fall back to ``0``;
+    # daily / retro / sweeps cron once per day, so they almost never
+    # contend with the SDLC chain anyway.
     "intake": {
         "kind": "schedule",
         "cron": "*/30 * * * *",
         "specialist": "intake",
         "fsm_stage": "task_intake",
+        "pipeline_priority": 10,
     },
     # ``ba_requirements`` routine retired — intake now produces the full
     # impl-grade spec, see ``agent_roles/intake.md``. Legacy in-flight
@@ -164,36 +175,42 @@ DEFAULT_SEED_LANES: Final[dict[str, dict[str, object]]] = {
         "cron": "*/30 * * * *",
         "specialist": "tech-architect",
         "fsm_stage": "tech_arch_plan",
+        "pipeline_priority": 20,
     },
     "qa_arch_plan": {
         "kind": "schedule",
         "cron": "*/30 * * * *",
         "specialist": "qa-architect",
         "fsm_stage": "qa_arch_plan",
+        "pipeline_priority": 30,
     },
     "dev_implementation": {
         "kind": "schedule",
         "cron": "*/30 * * * *",
         "specialist": "developer",
         "fsm_stage": "dev_implementation",
+        "pipeline_priority": 40,
     },
     "qa_manual": {
         "kind": "schedule",
         "cron": "*/30 * * * *",
         "specialist": "qa-engineer",
         "fsm_stage": "qa_manual",
+        "pipeline_priority": 50,
     },
     "qa_automation": {
         "kind": "schedule",
         "cron": "*/30 * * * *",
         "specialist": "qa-automation",
         "fsm_stage": "qa_automation",
+        "pipeline_priority": 60,
     },
     "code_review": {
         "kind": "schedule",
         "cron": "*/30 * * * *",
         "specialist": "reviewer",
         "fsm_stage": "code_review",
+        "pipeline_priority": 70,
     },
 }
 

--- a/backend/app/services/seed_bundle.py
+++ b/backend/app/services/seed_bundle.py
@@ -169,7 +169,17 @@ from backend.app.services.tracker_fsm import (
 #         per-ticket SDLC token spend ~50% pre-architecture review.
 #         The ``ba`` specialist file stays for decomposition WBS
 #         mode + the ``consult_specialist`` sub-agent surface.
-BUNDLE_VERSION: str = "0.30"
+# ``0.31`` → Drain-first scheduling: every SDLC + decomposition
+#         routine carries a ``pipeline_priority`` (intake=10 … code
+#         review=70; wbs=10 … tasks=40). The CLI's ``dueRoutines``
+#         sorts by this field DESC so when multiple stages are cron-
+#         due in the same window (the common case — all SDLC routines
+#         share ``*/30 * * * *``), the LATER pipeline stage runs first.
+#         Operator-facing motivation: Lean-WIP — a code-review-eligible
+#         ticket is closer to value than an intake one, so flush the
+#         tail before feeding the head. Was: YAML iteration order →
+#         ``intake`` always won → tail of the pipeline starved.
+BUNDLE_VERSION: str = "0.31"
 
 # Default knowledge starters for PR 1. Empty by design: generated knowledge is
 # analyzed post-merge and proposed in a second PR. Historical callers can still

--- a/backend/tests/test_services_seed_bundle.py
+++ b/backend/tests/test_services_seed_bundle.py
@@ -175,6 +175,23 @@ def test_compose_default_bundle_emits_decomposition_routines() -> None:
     assert "specialist: qa-architect" in config_body
     assert "specialist: developer" in config_body
 
+    # ``pipeline_priority`` drives the CLI's drain-first picker: the
+    # later decomposition stage (``tasks`` = 40) outranks the earlier
+    # (``wbs`` = 10) so an anchor close to ``planning_done`` clears
+    # before a new WBS starts. We pin the exact numbers because the
+    # ordering is a load-bearing operator-facing contract — bumping
+    # the constants should slip into the test, not deploy silently.
+    for routine_id, priority in (
+        ("wbs", 10),
+        ("architecture", 20),
+        ("test_architecture", 30),
+        ("tasks", 40),
+    ):
+        assert f"pipeline_priority: {priority}" in config_body, (
+            f"missing pipeline_priority: {priority} on decomposition "
+            f"routine {routine_id}"
+        )
+
 
 def test_compose_default_bundle_emits_sdlc_routines() -> None:
     """SDLC routines land in ``process.routines`` so customer cron has
@@ -206,15 +223,15 @@ def test_compose_default_bundle_emits_sdlc_routines() -> None:
     config_body = next(c for p, c in bundle.files if p == CONFIG_PATH)
 
     sdlc_routines = {
-        "intake": ("intake", "task_intake"),
-        "tech_arch_plan": ("tech-architect", "tech_arch_plan"),
-        "qa_arch_plan": ("qa-architect", "qa_arch_plan"),
-        "dev_implementation": ("developer", "dev_implementation"),
-        "qa_manual": ("qa-engineer", "qa_manual"),
-        "qa_automation": ("qa-automation", "qa_automation"),
-        "code_review": ("reviewer", "code_review"),
+        "intake": ("intake", "task_intake", 10),
+        "tech_arch_plan": ("tech-architect", "tech_arch_plan", 20),
+        "qa_arch_plan": ("qa-architect", "qa_arch_plan", 30),
+        "dev_implementation": ("developer", "dev_implementation", 40),
+        "qa_manual": ("qa-engineer", "qa_manual", 50),
+        "qa_automation": ("qa-automation", "qa_automation", 60),
+        "code_review": ("reviewer", "code_review", 70),
     }
-    for routine_id, (specialist, fsm_stage) in sdlc_routines.items():
+    for routine_id, (specialist, fsm_stage, priority) in sdlc_routines.items():
         assert f"    {routine_id}:" in config_body, (
             f"missing SDLC routine {routine_id} in seeded YAML"
         )
@@ -226,6 +243,15 @@ def test_compose_default_bundle_emits_sdlc_routines() -> None:
         # decomposition); just assert presence.
         assert f"specialist: {specialist}" in config_body, (
             f"missing specialist {specialist} on SDLC routine {routine_id}"
+        )
+        # Drain-first ordering — the CLI sorts due routines by this
+        # field DESC, so ``code_review`` (70) outranks ``intake`` (10)
+        # when both are cron-due in the same window. Pin the exact
+        # numbers so a bump shows up as a test diff rather than a
+        # silent change in production scheduling behavior.
+        assert f"pipeline_priority: {priority}" in config_body, (
+            f"missing pipeline_priority: {priority} on SDLC routine "
+            f"{routine_id}"
         )
 
 

--- a/cli/lib/runtime/routines.mjs
+++ b/cli/lib/runtime/routines.mjs
@@ -69,6 +69,15 @@ export function routineToExecutable(id, routine) {
     // single role (e.g. ``ba``) serves both SDLC (``ba_requirements``)
     // and decomposition (``wbs``) without per-process role clones.
     fsm_stage: stringOrNull(routine.fsm_stage),
+    // Drain-first scheduling: when multiple routines are cron-due in
+    // the same tick (the common case for SDLC + decomposition because
+    // every stage shares ``*/30 * * * *``), ``dueRoutines`` sorts by
+    // this DESC so the LATER pipeline stage runs first. Reasoning is
+    // Lean-WIP: a code-review-eligible ticket is closer to delivering
+    // value than an intake one, so flushing the tail of the pipeline
+    // outranks feeding the head. Routines without a priority — daily
+    // / retro / sweeps — fall through to ``0`` (effectively last).
+    pipeline_priority: numberOrZero(routine.pipeline_priority),
   };
 }
 
@@ -156,6 +165,7 @@ export function dueRoutines(config, { event, now = new Date() }) {
         window_start: slot.toISOString(),
         window_end: windowEnd.toISOString(),
         window_key: `schedule:${routineId}:${formatWindowKey(slot)}`,
+        pipeline_priority: executable.pipeline_priority,
       });
       continue;
     }
@@ -167,8 +177,20 @@ export function dueRoutines(config, { event, now = new Date() }) {
       window_start: started.toISOString(),
       window_end: started.toISOString(),
       window_key: `${event}:${routineId}:${formatWindowKey(started)}`,
+      pipeline_priority: executable.pipeline_priority,
     });
   }
+  // Drain-first ordering: highest ``pipeline_priority`` runs first
+  // when multiple routines are due in the same tick. Ties break on
+  // ``routine_id`` ascending for deterministic test output and a
+  // stable claim sequence (so two runners with clock drift don't
+  // claim the routines in different orders on the same window).
+  due.sort((a, b) => {
+    const pa = numberOrZero(a.pipeline_priority);
+    const pb = numberOrZero(b.pipeline_priority);
+    if (pa !== pb) return pb - pa;
+    return a.routine_id < b.routine_id ? -1 : a.routine_id > b.routine_id ? 1 : 0;
+  });
   return { due, skipped };
 }
 
@@ -300,4 +322,13 @@ function formatWindowKey(date) {
 
 function stringOrNull(value) {
   return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function numberOrZero(value) {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim()) {
+    const parsed = Number.parseFloat(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return 0;
 }

--- a/cli/tests/routines-due.test.mjs
+++ b/cli/tests/routines-due.test.mjs
@@ -1,0 +1,154 @@
+// Drain-first scheduler — ``dueRoutines`` sorts the cron-due
+// candidates by ``pipeline_priority`` DESC so the LATER SDLC stage
+// runs first.
+//
+// The operator's bug, restated: when N stages are cron-due in the
+// same window (the common case because every SDLC routine ships
+// with the canonical half-hourly cron), the old code returned them
+// in YAML iteration order, ``intake`` always won, the tail of the
+// pipeline (code review, qa automation) starved, and tickets piled
+// up at the planning gate. Drain-first flips that: empty the tail
+// first, minimize WIP, prefer flushing tickets toward Done over
+// starting new ones.
+//
+// Test surface is the local computation only — we don't exercise
+// the ``/routine-runs/claim`` HTTP path here; that's covered by
+// ``trigger.mjs``'s integration footprint elsewhere. The single
+// invariant this file pins is "due array exits ``dueRoutines``
+// already sorted by drain-first priority."
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  dueRoutines,
+  routineToExecutable,
+} from "../lib/runtime/routines.mjs";
+
+/** Build a single schedule-trigger routine spec. */
+function _scheduleRoutine(priority, extras = {}) {
+  return {
+    enabled: true,
+    trigger: { type: "schedule", cron: "*/30 * * * *", window: "30m" },
+    specialist: "developer",
+    pipeline_priority: priority,
+    ...extras,
+  };
+}
+
+// A timestamp that lands on a half-hour boundary so every routine
+// with the canonical SDLC cron is due.
+const ON_THE_HALF = new Date("2026-05-11T15:00:00.000Z");
+
+test("dueRoutines: SDLC chain returns drain-first order (code_review first)", () => {
+  const config = {
+    process: {
+      routines: {
+        intake: _scheduleRoutine(10),
+        tech_arch_plan: _scheduleRoutine(20),
+        qa_arch_plan: _scheduleRoutine(30),
+        dev_implementation: _scheduleRoutine(40),
+        qa_manual: _scheduleRoutine(50),
+        qa_automation: _scheduleRoutine(60),
+        code_review: _scheduleRoutine(70),
+      },
+    },
+  };
+  const { due } = dueRoutines(config, { event: "schedule", now: ON_THE_HALF });
+  assert.deepEqual(
+    due.map((r) => r.routine_id),
+    [
+      "code_review",
+      "qa_automation",
+      "qa_manual",
+      "dev_implementation",
+      "qa_arch_plan",
+      "tech_arch_plan",
+      "intake",
+    ],
+    "due list must come out highest-priority first (code_review > intake)",
+  );
+});
+
+test("dueRoutines: missing pipeline_priority defaults to 0 (lowest)", () => {
+  // Daily / retro / sweeps don't carry a priority. They must sort
+  // BELOW any priority-bearing SDLC routine when they happen to
+  // share a tick (rare but possible — e.g., 09:00 UTC where the
+  // daily ``0 9 * * *`` cron AND the SDLC ``*/30 * * * *`` cron
+  // both fire).
+  const config = {
+    process: {
+      routines: {
+        intake: _scheduleRoutine(10),
+        // No ``pipeline_priority`` — supporting routine shape.
+        daily: {
+          enabled: true,
+          trigger: { type: "schedule", cron: "*/30 * * * *", window: "30m" },
+          specialist: "daily-retro",
+        },
+      },
+    },
+  };
+  const { due } = dueRoutines(config, { event: "schedule", now: ON_THE_HALF });
+  assert.deepEqual(
+    due.map((r) => r.routine_id),
+    ["intake", "daily"],
+    "intake (priority 10) must rank above daily (default 0)",
+  );
+});
+
+test("dueRoutines: equal priorities break ties on routine_id ASC", () => {
+  // Determinism matters: two GitHub-Actions runners triggering at
+  // the same window must claim routines in identical order so
+  // window contention is reproducible. Same priority → lexicographic
+  // routine_id, ascending.
+  const config = {
+    process: {
+      routines: {
+        zebra: _scheduleRoutine(50),
+        alpha: _scheduleRoutine(50),
+        mike: _scheduleRoutine(50),
+      },
+    },
+  };
+  const { due } = dueRoutines(config, { event: "schedule", now: ON_THE_HALF });
+  assert.deepEqual(
+    due.map((r) => r.routine_id),
+    ["alpha", "mike", "zebra"],
+    "ties must break ASC by routine_id so runners agree on order",
+  );
+});
+
+test("dueRoutines: each due row carries its pipeline_priority", () => {
+  // Trigger.mjs and downstream consumers (audit logs, future
+  // server-side probe) read ``pipeline_priority`` off the due rows;
+  // pin that it survives the projection.
+  const config = {
+    process: {
+      routines: {
+        code_review: _scheduleRoutine(70),
+        intake: _scheduleRoutine(10),
+      },
+    },
+  };
+  const { due } = dueRoutines(config, { event: "schedule", now: ON_THE_HALF });
+  const byId = Object.fromEntries(due.map((r) => [r.routine_id, r]));
+  assert.equal(byId.code_review.pipeline_priority, 70);
+  assert.equal(byId.intake.pipeline_priority, 10);
+});
+
+test("routineToExecutable: numeric pipeline_priority surfaces; missing → 0", () => {
+  const ex = routineToExecutable("intake", { pipeline_priority: 10 });
+  assert.equal(ex.pipeline_priority, 10);
+
+  const ex0 = routineToExecutable("daily", {});
+  assert.equal(
+    ex0.pipeline_priority,
+    0,
+    "routines without an explicit priority must surface 0 (sort last)",
+  );
+
+  // Non-numeric garbage shouldn't make the picker blow up.
+  const exJunk = routineToExecutable("junk", { pipeline_priority: "abc" });
+  assert.equal(exJunk.pipeline_priority, 0);
+});


### PR DESCRIPTION
## Summary

Picker now empties the **tail** of the pipeline before feeding the head — Lean-WIP scheduling. When multiple SDLC routines are cron-due in the same window (the common case, since every stage ships with the canonical half-hourly cron), the LATER pipeline stage runs first.

Was: ``intake`` always won by YAML iteration order, tail stages (code_review, qa_automation) starved, tickets piled up at the planning gate.

Now:
- SDLC: intake=10 → tech_arch_plan=20 → qa_arch_plan=30 → dev_implementation=40 → qa_manual=50 → qa_automation=60 → **code_review=70**
- Decomposition: wbs=10 → architecture=20 → test_architecture=30 → **tasks=40**

``cli/lib/runtime/routines.mjs::dueRoutines`` sorts due routines DESC by ``pipeline_priority`` with a routine_id ASC tiebreaker. Supporting routines (daily / retro / sweeps) carry no priority → default 0 → sort last.

Server-side **empty-queue probe** is deliberately out of scope here. If a high-priority stage gets picked but its tracker queue is empty, ``shipctl run`` exits no-op and we wait 30 min for the next tick. Acceptable for closed beta — we can add the probe in a follow-up if real starvation shows up.

Bundle version: 0.30 → 0.31.

## Test plan

- [x] ``cli/tests/routines-due.test.mjs`` — 5 new tests (drain-first order, missing priority defaults to 0, tiebreak, priority survives projection, ``routineToExecutable`` parsing)
- [x] ``backend/tests/test_services_seed_bundle.py`` — extended SDLC + decomposition routine tests to pin the priority numbers in seeded YAML
- [x] ``test_decomposition_role_modes.py`` still green
- [ ] Manual after merge: re-seed one workspace, watch one cron tick where ≥2 stages are due — confirm the higher-priority one fires