### PR TITLE
feat: multi-action-per-tick in cron trigger (drain 5 routines per tick)

### DIFF
--- a/.github/workflows/ship-trigger-schedule.yml
+++ b/.github/workflows/ship-trigger-schedule.yml
@@ -91,27 +91,65 @@ jobs:
             echo "::endgroup::"
             exit 0
           fi
-          # Normal cron path: trigger picks the next routine, run executes it.
+          # Normal cron path. ``shipctl trigger`` returns *all* due
+          # routines sorted drain-first (later SDLC stage outranks
+          # earlier — see ``pipeline_priority``).
+          #
+          # We iterate the due list and run up to
+          # ``SHIP_MAX_ACTIONS_PER_TICK`` (default 5) routines that
+          # land work, NOT just the first. Two reasons:
+          #
+          #   1. GitHub throttles ``schedule:`` workflows during peak
+          #      load — observed gaps of 4-8 hours between ticks in
+          #      production. The old one-action-per-tick rule
+          #      multiplied that latency by the number of stages
+          #      remaining on the pipeline (an 8-hour cron gap × 5
+          #      stages = 40 hours per ticket).
+          #   2. A single tick that drains 4-5 actions fits in the
+          #      runner's 30-min budget (≈4 min per agent invocation)
+          #      and keeps the pipeline moving when cron itself is
+          #      unreliable.
+          #
+          # ``noop`` rows are skipped fast (the routine has nothing
+          # eligible). Each ``ok`` row counts toward the cap. A
+          # genuine non-zero exit from ``shipctl run`` bubbles up
+          # via ``set -e`` and stops the tick.
+          MAX_ACTIONS_PER_TICK=${SHIP_MAX_ACTIONS_PER_TICK:-5}
           shipctl trigger --event schedule --repo "$SHIP_REPO" --pipeline-fallback --json > /tmp/ship-action.json
-          ACTION=$(jq -r '.next_action.kind // "noop"' /tmp/ship-action.json)
-          case "$ACTION" in
-            routine)
-              ROUTINE=$(jq -r '.next_action.routine_id' /tmp/ship-action.json)
+          jq '.due_routines[].routine_id' /tmp/ship-action.json | tr -d '"' > /tmp/ship-due-routines.txt || true
+          ACTIONS_DONE=0
+          if [ -s /tmp/ship-due-routines.txt ]; then
+            while IFS= read -r ROUTINE; do
+              [ -z "$ROUTINE" ] && continue
+              if [ "$ACTIONS_DONE" -ge "$MAX_ACTIONS_PER_TICK" ]; then
+                echo "Ship: hit MAX_ACTIONS_PER_TICK=$MAX_ACTIONS_PER_TICK; remaining routines wait for next cron."
+                break
+              fi
               echo "::group::Ship routine ${ROUTINE}"
-              SHIP_REPO="" shipctl run --routine "$ROUTINE" --trigger schedule --commit-and-pr
+              STATUS_FILE="/tmp/ship-status-${ROUTINE//\//_}.json"
+              rm -f "$STATUS_FILE"
+              SHIP_REPO="" shipctl run --routine "$ROUTINE" --trigger schedule --commit-and-pr --status-file "$STATUS_FILE"
               echo "::endgroup::"
-              ;;
-            pipeline_pick)
+              STATUS=$(jq -r '.status // "ok"' "$STATUS_FILE" 2>/dev/null || echo "ok")
+              REASON=$(jq -r '.reason // ""' "$STATUS_FILE" 2>/dev/null || echo "")
+              if [ "$STATUS" = "noop" ]; then
+                echo "Ship: routine ${ROUTINE} noop (reason=${REASON}); trying next."
+                continue
+              fi
+              echo "Ship: routine ${ROUTINE} did work (status=${STATUS}); continuing through due list."
+              ACTIONS_DONE=$((ACTIONS_DONE + 1))
+            done < /tmp/ship-due-routines.txt
+          fi
+          if [ "$ACTIONS_DONE" = "0" ]; then
+            ACTION=$(jq -r '.next_action.kind // "noop"' /tmp/ship-action.json)
+            if [ "$ACTION" = "pipeline_pick" ]; then
               SPECIALIST=$(jq -r '.next_action.specialist' /tmp/ship-action.json)
               echo "::group::Ship pipeline pick — ${SPECIALIST}"
               SHIP_REPO="" shipctl run --specialist "$SPECIALIST" --trigger pipeline_pick --commit-and-pr
               echo "::endgroup::"
-              ;;
-            noop)
-              echo "Ship: nothing to do this tick."
-              ;;
-            *)
-              echo "Ship: unrecognised next_action.kind '$ACTION'; check shipctl version." >&2
-              exit 1
-              ;;
-          esac
+            else
+              echo "Ship: every due routine no-op'd and no pipeline pick available — nothing to do this tick."
+            fi
+          else
+            echo "Ship: completed ${ACTIONS_DONE} action(s) this tick."
+          fi

--- a/backend/app/resources/starter_workflows/ship-trigger-schedule.yml
+++ b/backend/app/resources/starter_workflows/ship-trigger-schedule.yml
@@ -91,27 +91,67 @@ jobs:
             echo "::endgroup::"
             exit 0
           fi
-          # Normal cron path: trigger picks the next routine, run executes it.
+          # Normal cron path. ``shipctl trigger`` returns *all* due
+          # routines sorted drain-first (later SDLC stage outranks
+          # earlier — see ``pipeline_priority`` on each routine).
+          #
+          # We iterate the due list and run as many routines as land
+          # work within the runner's 30-min budget, NOT just the
+          # first one. Two reasons:
+          #
+          #   1. GitHub throttles ``schedule:`` workflows during peak
+          #      load — observed gaps of 4-8 hours between ticks in
+          #      production. The old "one-action-per-tick" rule
+          #      multiplied that latency by the number of stages
+          #      remaining on the pipeline.
+          #   2. A single tick that drains 4-5 tickets through their
+          #      stages fits comfortably in the runner budget
+          #      (≈4 min per agent invocation) and keeps the
+          #      pipeline moving when cron itself is unreliable.
+          #
+          # ``shipctl run`` writes a JSON status to ``--status-file``
+          # on every exit path (noop / ok / error). ``noop`` means
+          # the routine had nothing eligible — try the next one.
+          # ``ok`` means an agent run completed — still try the
+          # next one (multi-action mode). A genuine non-zero exit
+          # bubbles up via ``set -e`` and stops the tick so the
+          # operator sees the failure.
+          MAX_ACTIONS_PER_TICK=${SHIP_MAX_ACTIONS_PER_TICK:-5}
           shipctl trigger --event schedule --repo "$SHIP_REPO" --pipeline-fallback --json > /tmp/ship-action.json
-          ACTION=$(jq -r '.next_action.kind // "noop"' /tmp/ship-action.json)
-          case "$ACTION" in
-            routine)
-              ROUTINE=$(jq -r '.next_action.routine_id' /tmp/ship-action.json)
+          jq '.due_routines[].routine_id' /tmp/ship-action.json | tr -d '"' > /tmp/ship-due-routines.txt || true
+          ACTIONS_DONE=0
+          if [ -s /tmp/ship-due-routines.txt ]; then
+            while IFS= read -r ROUTINE; do
+              [ -z "$ROUTINE" ] && continue
+              if [ "$ACTIONS_DONE" -ge "$MAX_ACTIONS_PER_TICK" ]; then
+                echo "Ship: hit MAX_ACTIONS_PER_TICK=$MAX_ACTIONS_PER_TICK; remaining routines wait for next cron."
+                break
+              fi
               echo "::group::Ship routine ${ROUTINE}"
-              SHIP_REPO="" shipctl run --routine "$ROUTINE" --trigger schedule --commit-and-pr
+              STATUS_FILE="/tmp/ship-status-${ROUTINE//\//_}.json"
+              rm -f "$STATUS_FILE"
+              SHIP_REPO="" shipctl run --routine "$ROUTINE" --trigger schedule --commit-and-pr --status-file "$STATUS_FILE"
               echo "::endgroup::"
-              ;;
-            pipeline_pick)
+              STATUS=$(jq -r '.status // "ok"' "$STATUS_FILE" 2>/dev/null || echo "ok")
+              REASON=$(jq -r '.reason // ""' "$STATUS_FILE" 2>/dev/null || echo "")
+              if [ "$STATUS" = "noop" ]; then
+                echo "Ship: routine ${ROUTINE} noop (reason=${REASON}); trying next."
+                continue
+              fi
+              echo "Ship: routine ${ROUTINE} did work (status=${STATUS}); continuing through due list."
+              ACTIONS_DONE=$((ACTIONS_DONE + 1))
+            done < /tmp/ship-due-routines.txt
+          fi
+          if [ "$ACTIONS_DONE" = "0" ]; then
+            ACTION=$(jq -r '.next_action.kind // "noop"' /tmp/ship-action.json)
+            if [ "$ACTION" = "pipeline_pick" ]; then
               SPECIALIST=$(jq -r '.next_action.specialist' /tmp/ship-action.json)
               echo "::group::Ship pipeline pick — ${SPECIALIST}"
               SHIP_REPO="" shipctl run --specialist "$SPECIALIST" --trigger pipeline_pick --commit-and-pr
               echo "::endgroup::"
-              ;;
-            noop)
-              echo "Ship: nothing to do this tick."
-              ;;
-            *)
-              echo "Ship: unrecognised next_action.kind '$ACTION'; check shipctl version." >&2
-              exit 1
-              ;;
-          esac
+            else
+              echo "Ship: every due routine no-op'd and no pipeline pick available — nothing to do this tick."
+            fi
+          else
+            echo "Ship: completed ${ACTIONS_DONE} action(s) this tick."
+          fi

--- a/backend/app/services/seed_bundle.py
+++ b/backend/app/services/seed_bundle.py
@@ -179,7 +179,19 @@ from backend.app.services.tracker_fsm import (
 #         ticket is closer to value than an intake one, so flush the
 #         tail before feeding the head. Was: YAML iteration order →
 #         ``intake`` always won → tail of the pipeline starved.
-BUNDLE_VERSION: str = "0.31"
+# ``0.32`` → Multi-action-per-tick in the cron trigger workflow.
+#         GitHub throttles ``schedule:`` events under load —
+#         observed 4-8h gaps between ticks on customer repos in
+#         production. The previous one-action-per-tick rule
+#         multiplied that latency by the pipeline depth (8h × 5
+#         stages = 40h per ticket). The new shell iterates the
+#         drain-first ``due_routines`` and runs up to
+#         ``SHIP_MAX_ACTIONS_PER_TICK`` (default 5) routines that
+#         land work in a single tick. Fits the runner's 30-min
+#         budget (≈4 min per agent invocation), so when cron itself
+#         is unreliable the pipeline still drains 4-5 actions per
+#         tick instead of one.
+BUNDLE_VERSION: str = "0.32"
 
 # Default knowledge starters for PR 1. Empty by design: generated knowledge is
 # analyzed post-merge and proposed in a second PR. Historical callers can still


### PR DESCRIPTION
## Summary

Observed in production (askslayer workspace, 18-ticket decomposition): cron tick delivers exactly one routine per fire. Combined with GitHub's heavy throttling of \`schedule:\` events (4-8 hour gaps under load), each ticket advanced one stage per ~6 hours. A 5-stage SDLC = ~30 hours from intake to merge-ready.

Both the ship-on-ship workflow and the customer starter template took \`next_action.routine_id\` once and exited. This PR changes both to iterate the full \`due_routines\` list (already drain-first sorted by \`pipeline_priority\` from #250) and run up to \`SHIP_MAX_ACTIONS_PER_TICK\` (default 5) routines that land work.

\`noop\` rows skip instantly. Each \`ok\` counts toward the cap. \`set -e\` still bubbles up real failures.

Budget: 5 × ~4 min = 20 min, comfortably inside the 30-min runner timeout. Decouples throughput from GitHub's cron cadence — even one tick per 4h now drains 5 actions instead of 1.

\`BUNDLE_VERSION 0.31 → 0.32\` so the next wizard-seed PR delivers the new workflow to customer repos.

## Test plan

- [x] \`backend/tests/test_services_seed_bundle.py\` still green (15 tests)
- [x] No tests asserted the workflow YAML body (verified via grep)
- [ ] After merge: watch one ship-on-ship tick — confirm log shows \"completed N action(s) this tick\" where N > 1 if work available
- [ ] After merge: askslayer workspace re-seeds, next cron processes multiple PAC tickets per tick