### PR TITLE
feat: backend-driven trigger scheduler (replaces GHA throttled cron)

### DIFF
--- a/.github/workflows/ship-trigger-schedule.yml
+++ b/.github/workflows/ship-trigger-schedule.yml
@@ -11,8 +11,12 @@ on:
         description: "Pin the agent to this ticket (only used with routine_id). e.g. ELS-42"
         required: false
         type: string
-  schedule:
-    - cron: "*/30 * * * *"
+  # ``schedule:`` was removed — Ship's own backend cron now
+  # dispatches this workflow via the Actions API (see
+  # ``backend/app/services/workflow_dispatch_cron.py`` and
+  # ``WORKFLOW_DISPATCH_CRON_EXPR``, default hourly). GitHub
+  # throttles ``schedule:`` events under load (4-8h gaps observed
+  # in production); backend dispatch gives a deterministic cadence.
 
 permissions:
   contents: write

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -384,6 +384,18 @@ class Settings(BaseSettings):
         alias="LINEAR_TOKEN_REFRESH_HOURS",
     )
 
+    # Ship-side trigger-workflow scheduler. GHA throttles ``schedule:``
+    # events under load (4-8h gaps in production); a backend cron that
+    # dispatches via ``workflow_dispatch`` gives operators a
+    # deterministic cadence. 5-field crontab expression, UTC. Default
+    # ``0 * * * *`` = every hour at :00 — pairs with the customer
+    # workflow's ``SHIP_MAX_ACTIONS_PER_TICK=5`` (5 × ~4 min ≈ 20 min,
+    # fits the 30-min runner budget).
+    workflow_dispatch_cron_expr: str = Field(
+        default="0 * * * *",
+        alias="WORKFLOW_DISPATCH_CRON_EXPR",
+    )
+
     # --- Notion OAuth (pilot Day 2 — tracker WOW flow) ---
     # Public Notion integration credentials from
     # https://www.notion.so/profile/integrations . Notion calls these

--- a/backend/app/resources/starter_workflows/ship-trigger-schedule.yml
+++ b/backend/app/resources/starter_workflows/ship-trigger-schedule.yml
@@ -1,6 +1,15 @@
 name: Ship · Schedule trigger
 
 on:
+  # Backend-driven dispatch: Ship's own scheduler (configurable via
+  # ``WORKFLOW_DISPATCH_CRON_EXPR``, default hourly) fires this
+  # workflow via the Actions API. The previous ``schedule: */30``
+  # block was removed in bundle v0.33 because GitHub heavily
+  # throttles scheduled events under load — 4-8h gaps between
+  # ticks observed in production. Backend dispatch gives a
+  # deterministic cadence and bypasses the throttle entirely.
+  # Manual ``workflow_dispatch`` from the Actions UI stays as a
+  # debug / on-demand harness.
   workflow_dispatch:
     inputs:
       routine_id:
@@ -11,8 +20,6 @@ on:
         description: "Pin the agent to this ticket (only used with routine_id). e.g. ELS-42"
         required: false
         type: string
-  schedule:
-    - cron: "*/30 * * * *"
 
 permissions:
   contents: write

--- a/backend/app/services/cron.py
+++ b/backend/app/services/cron.py
@@ -90,6 +90,13 @@ class CronLockId(IntEnum):
     KNOWLEDGE_TOPIC_RENDER = 1008
     KNOWLEDGE_CLAIM_DECAY = 1009
     LINEAR_TOKEN_REFRESH = 1010
+    # Ship-side scheduler — fires the customer-side trigger workflow
+    # via GitHub ``workflow_dispatch`` on a deterministic cadence.
+    # Replaces the GHA ``schedule:`` cron in the starter workflow,
+    # which GitHub heavily throttles under load (observed 4-8 hour
+    # gaps between ticks in production). Backend-driven dispatch
+    # gives operators a predictable "every N minutes" cycle.
+    WORKFLOW_DISPATCH = 1011
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/services/cron_jobs.py
+++ b/backend/app/services/cron_jobs.py
@@ -482,6 +482,35 @@ async def _knowledge_decay_tick() -> None:
 
 
 @cron_with_lock(
+    lock=CronLockId.WORKFLOW_DISPATCH, name="workflow_dispatch"
+)
+async def _workflow_dispatch_tick() -> None:
+    """Fan-out the trigger workflow to every activated customer repo.
+
+    Backend-driven scheduling replaces GHA ``schedule:`` cron which
+    GitHub throttles under load (production saw 4-8h gaps).
+    Dispatching via ``workflow_dispatch`` is sub-second; per-tick
+    rate is bounded by GitHub's Actions-API limit (~5000/hour per
+    install token) which closed-beta scale is nowhere near.
+
+    Failures are logged + audited per-repo; the loop never raises so
+    one bad install (404 / token revoked) can't starve the fleet.
+    """
+    from backend.app.core.config import get_settings
+    from backend.app.services.workflow_dispatch_cron import dispatch_due_repos
+
+    settings = get_settings()
+    sm = get_sessionmaker()
+    async with sm() as session:
+        try:
+            await dispatch_due_repos(session, settings=settings)
+            await session.commit()
+        except Exception:
+            await session.rollback()
+            raise
+
+
+@cron_with_lock(
     lock=CronLockId.LINEAR_TOKEN_REFRESH, name="linear_token_refresh"
 )
 async def _linear_token_refresh_tick() -> None:
@@ -608,6 +637,15 @@ def register_all() -> None:
         fn=_linear_token_refresh_tick,
         cron_expr="5 * * * *",  # hourly at :05 (gated by per-install age)
         job_id="linear_token_refresh",
+    )
+    # Ship-side trigger-workflow scheduler. Cadence comes from
+    # ``WORKFLOW_DISPATCH_CRON_EXPR`` so operators can tune it
+    # without redeploying. Default ``0 * * * *`` — every hour at :00.
+    settings = get_settings()
+    register_cron(
+        fn=_workflow_dispatch_tick,
+        cron_expr=settings.workflow_dispatch_cron_expr,
+        job_id="workflow_dispatch",
     )
 
 

--- a/backend/app/services/seed_bundle.py
+++ b/backend/app/services/seed_bundle.py
@@ -191,7 +191,18 @@ from backend.app.services.tracker_fsm import (
 #         budget (≈4 min per agent invocation), so when cron itself
 #         is unreliable the pipeline still drains 4-5 actions per
 #         tick instead of one.
-BUNDLE_VERSION: str = "0.32"
+# ``0.33`` → ``schedule:`` removed from the customer trigger workflow.
+#         Ship's backend now dispatches via ``workflow_dispatch`` on
+#         a deterministic cadence (``WORKFLOW_DISPATCH_CRON_EXPR``,
+#         default hourly) — see
+#         ``backend/app/services/workflow_dispatch_cron.py``. The GHA
+#         schedule block was bypassing throttle visibility: operators
+#         thought ``*/30`` meant "every 30 min" while actual ticks
+#         happened every 4-8 hours under load. Backend dispatch is
+#         sub-second and rate-limit safe at closed-beta scale. Manual
+#         ``workflow_dispatch`` from the Actions UI stays as a debug
+#         harness.
+BUNDLE_VERSION: str = "0.33"
 
 # Default knowledge starters for PR 1. Empty by design: generated knowledge is
 # analyzed post-merge and proposed in a second PR. Historical callers can still

--- a/backend/app/services/workflow_dispatch_cron.py
+++ b/backend/app/services/workflow_dispatch_cron.py
@@ -1,0 +1,209 @@
+"""Ship-side scheduler for the customer trigger workflow.
+
+The customer's ``ship-trigger-schedule.yml`` carries a
+``schedule: */30 * * * *`` block, but GitHub heavily throttles
+scheduled events under load — production observed 4-8 hour gaps
+between ticks on busy days. The result is operators see "cron runs
+every 30 min" in the YAML but real cadence is "between 30 min and
+8 hours, whatever GitHub feels like". A single ticket needed 6+
+hours to advance one SDLC stage; a 5-stage pipeline took 30+ hours
+end-to-end.
+
+This module replaces (or, in transition, supplements) the GHA
+schedule with a backend cron that calls ``workflow_dispatch`` on
+each active customer repo at a deterministic cadence. Backend
+cadence is set by :data:`Settings.workflow_dispatch_cron_expr`
+(default ``0 * * * *`` — every hour at :00). Each dispatch fires
+the workflow with NO inputs, so the workflow's shell falls into
+the normal cron path (``shipctl trigger`` → drain due routines)
+exactly as a schedule-event would have.
+
+Why hourly + multi-action-per-tick is the right shape:
+
+* The runner's wall-clock budget is 30 minutes per job. The
+  customer template (since v0.32) drains up to 5 due routines per
+  tick, ~4 min each = 20 min. Hourly dispatch comfortably fits.
+* GHA scheduled-event throttling never matters because we're
+  dispatching, not scheduling. Dispatch latency is sub-second.
+* Skipping a tick is cheap: ``shipctl trigger`` returns no due
+  routines → workflow exits in ~30 sec without spawning an agent.
+
+What this cron does NOT do:
+
+* It does not push code. ``contents:write`` is unused. The only
+  GitHub permission needed is ``actions:write`` on the repo, which
+  the App already has from install time.
+* It does not pick routines itself. The picker lives in
+  ``shipctl trigger`` (drain-first by ``pipeline_priority``); this
+  cron only triggers the workflow.
+* It does not gate on workspace-level state (e.g. paused, frozen).
+  A separate ``activated_at IS NOT NULL`` check is enough for
+  closed beta; richer gating belongs on the workspace row once we
+  need it.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+
+import httpx
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.app.core.config import Settings
+from backend.app.db.models.integrations import GitHubInstallation, WorkspaceRepo
+from backend.app.db.models.tenancy import AuditLog
+from backend.app.integrations.github.workflows import (
+    WorkflowDispatchError,
+    dispatch_workflow,
+)
+
+
+log = logging.getLogger(__name__)
+
+
+# Hard-coded path is fine: every customer install ships the same
+# filename via the starter-workflow bundle. Bumping the bundle
+# version that renames it would require updating this constant in
+# the same PR — easier to spot a rename than to debug a silent
+# 404 dispatch.
+_WORKFLOW_FILE: str = "ship-trigger-schedule.yml"
+
+
+@dataclass(slots=True)
+class DispatchTickResult:
+    """Counters returned from one ``dispatch_due_repos`` invocation.
+
+    Surfaced via the cron-job log so an operator can grep one line
+    per tick to see "did the dispatch fan-out actually fire". The
+    failures list carries enough context to drill into a stuck
+    workspace from the dashboard without re-running the cron.
+    """
+
+    dispatched: int = 0
+    skipped_no_install: int = 0
+    failed: int = 0
+    failures: list[dict[str, str]] = field(default_factory=list)
+
+
+async def dispatch_due_repos(
+    session: AsyncSession,
+    *,
+    settings: Settings,
+    client: httpx.AsyncClient | None = None,
+) -> DispatchTickResult:
+    """Dispatch the trigger workflow on every activated repo.
+
+    The query joins ``workspace_repos`` to ``github_installations``
+    so a repo whose install row was revoked silently skips instead
+    of crashing the tick. Closed-beta scale (<50 active repos)
+    makes the per-repo sequential dispatch fine; if we hit hundreds
+    we can fan out via ``asyncio.gather`` with a Semaphore — the
+    bottleneck would be GitHub API rate limits, not DB roundtrips.
+    """
+    result = DispatchTickResult()
+
+    rows = (
+        await session.execute(
+            select(WorkspaceRepo, GitHubInstallation)
+            .join(
+                GitHubInstallation,
+                GitHubInstallation.id == WorkspaceRepo.installation_id,
+            )
+            .where(WorkspaceRepo.activated_at.is_not(None))
+        )
+    ).all()
+
+    if not rows:
+        log.info("workflow_dispatch tick: no activated repos")
+        return result
+
+    for repo, install in rows:
+        if install is None:
+            # Defensive — the INNER JOIN above already filters this
+            # out, but keep the early-out so future refactors that
+            # widen the query don't crash on a missing install row.
+            result.skipped_no_install += 1
+            continue
+        try:
+            await dispatch_workflow(
+                repo,
+                install,
+                _WORKFLOW_FILE,
+                inputs={},
+                settings=settings,
+                client=client,
+            )
+        except WorkflowDispatchError as exc:
+            # 404 on the workflow file means the customer hasn't
+            # merged the wizard-seed PR yet (or merged it on a
+            # non-default branch). Logged but not raised so the
+            # cron tick keeps dispatching to the rest of the fleet.
+            log.warning(
+                "workflow_dispatch failed: repo=%s status=%s msg=%s",
+                repo.full_name,
+                exc.status_code,
+                exc.message[:200],
+            )
+            result.failed += 1
+            result.failures.append(
+                {
+                    "repo": repo.full_name,
+                    "status": str(exc.status_code),
+                    "error": exc.message[:200],
+                }
+            )
+            session.add(
+                AuditLog(
+                    workspace_id=repo.workspace_id,
+                    action="workflow_dispatch.failed",
+                    target_kind="workspace_repo",
+                    target_id=str(repo.id),
+                    payload={
+                        "repo_full_name": repo.full_name,
+                        "workflow_file": _WORKFLOW_FILE,
+                        "upstream_status": exc.status_code,
+                        "error": exc.message[:512],
+                    },
+                )
+            )
+            continue
+        except Exception as exc:  # noqa: BLE001 — never break the loop
+            log.exception(
+                "workflow_dispatch unexpected error: repo=%s", repo.full_name
+            )
+            result.failed += 1
+            result.failures.append(
+                {
+                    "repo": repo.full_name,
+                    "status": "exception",
+                    "error": str(exc)[:200],
+                }
+            )
+            continue
+
+        result.dispatched += 1
+        session.add(
+            AuditLog(
+                workspace_id=repo.workspace_id,
+                action="workflow_dispatch.tick",
+                target_kind="workspace_repo",
+                target_id=str(repo.id),
+                payload={
+                    "repo_full_name": repo.full_name,
+                    "workflow_file": _WORKFLOW_FILE,
+                },
+            )
+        )
+
+    log.info(
+        "workflow_dispatch tick: dispatched=%d failed=%d",
+        result.dispatched,
+        result.failed,
+    )
+    return result
+
+
+__all__ = ["DispatchTickResult", "dispatch_due_repos"]

--- a/backend/tests/test_services_seed_bundle.py
+++ b/backend/tests/test_services_seed_bundle.py
@@ -282,20 +282,26 @@ def test_compose_default_bundle_emits_dedup_workflows() -> None:
     assert workflow_paths
     assert ".github/workflows/ship-trigger-schedule.yml" in workflow_paths
 
-    # Phase 2 scheduler shape — the trigger workflow runs at 30-min
-    # cadence (free-tier math) and dispatches a single ``next_action``
-    # per tick (one routine OR one pipeline-pick OR noop). Pin both
-    # so a regression in the starter doesn't silently flip cadence
-    # back to 15 min or reintroduce the legacy while-loop fan-out.
+    # Scheduler shape — bundle v0.33 removed the GHA ``schedule:``
+    # cron block; the customer trigger workflow now runs ONLY on
+    # ``workflow_dispatch``, fired by Ship's backend cron at a
+    # deterministic cadence (see ``workflow_dispatch_cron.py``).
+    # GHA scheduled events were silently throttled to 4-8h gaps
+    # under load, which the operator-facing ``*/30`` made invisible.
+    # Pin both invariants so a regression can't reintroduce the
+    # throttled schedule path.
     workflow_body = next(
         c for p, c in bundle.files if p == ".github/workflows/ship-trigger-schedule.yml"
     )
-    assert 'cron: "*/30 * * * *"' in workflow_body
+    assert 'cron:' not in workflow_body, (
+        "v0.33 removed the GHA schedule block — backend dispatches "
+        "this workflow via the Actions API, no client-side cron"
+    )
+    assert "workflow_dispatch:" in workflow_body
     assert "--pipeline-fallback" in workflow_body
-    assert "next_action.kind" in workflow_body
     assert "shipctl run --specialist" in workflow_body
-    # The legacy while-loop is gone in Phase 2.
-    assert "while IFS= read -r routine" not in workflow_body
+    # Multi-action shell (v0.32) — drain the due list, not one-shot.
+    assert "MAX_ACTIONS_PER_TICK" in workflow_body
 
 
 def test_compose_omits_generated_knowledge_by_default() -> None:

--- a/backend/tests/test_workflow_dispatch_cron.py
+++ b/backend/tests/test_workflow_dispatch_cron.py
@@ -1,0 +1,207 @@
+"""Backend-driven trigger-workflow dispatcher.
+
+Background: the customer trigger workflow used to ride on a GHA
+``schedule: */30 * * * *`` block, but GitHub throttles scheduled
+events under load — production observed 4-8 hour gaps between
+ticks on busy days. This module's cron fires ``workflow_dispatch``
+on every activated repo at a deterministic cadence so the picker
+actually runs when it's supposed to.
+
+These tests pin the load-bearing behaviour of ``dispatch_due_repos``:
+
+* Activated repos get dispatched; not-activated ones are ignored.
+* A 404 from GitHub on one repo doesn't poison the whole tick —
+  the dispatcher keeps going through the fleet.
+* Every dispatch lands an ``audit_log`` row so an operator can
+  reconstruct "did Ship fire the workflow for repo X at time Y"
+  without rummaging through GitHub's audit log.
+"""
+
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from datetime import datetime, timezone
+
+from backend.app.core.config import get_settings
+from backend.app.db.models.integrations import GitHubInstallation, WorkspaceRepo
+from backend.app.db.models.tenancy import AuditLog
+from backend.app.integrations.github.workflows import WorkflowDispatchError
+from backend.app.services.workflow_dispatch_cron import dispatch_due_repos
+from sqlalchemy import select
+
+
+@pytest_asyncio.fixture
+async def seed_two_repos(db_session, seed_workspace):
+    """One activated repo + one inactive repo on the same install.
+
+    The inactive row exercises the ``activated_at IS NULL`` filter
+    — Ship doesn't dispatch to repos the operator hasn't completed
+    the install handshake on, even if the GitHub App is technically
+    granted access.
+    """
+    _, _, workspace = seed_workspace
+    install = GitHubInstallation(
+        workspace_id=workspace.id,
+        installation_id=777_001,
+        account_login="acme",
+        account_type="Organization",
+        repository_selection="selected",
+        installed_at=datetime.now(timezone.utc),
+    )
+    db_session.add(install)
+    await db_session.flush()
+
+    active = WorkspaceRepo(
+        workspace_id=workspace.id,
+        installation_id=install.id,
+        provider="github",
+        external_id=42_777_001,
+        full_name="acme/visitor-web",
+        default_branch="main",
+        private=False,
+        html_url="https://github.com/acme/visitor-web",
+        activated_at=datetime.now(timezone.utc),
+    )
+    inactive = WorkspaceRepo(
+        workspace_id=workspace.id,
+        installation_id=install.id,
+        provider="github",
+        external_id=42_777_002,
+        full_name="acme/visitor-mob",
+        default_branch="main",
+        private=False,
+        html_url="https://github.com/acme/visitor-mob",
+        activated_at=None,
+    )
+    db_session.add_all([active, inactive])
+    await db_session.flush()
+    return workspace, install, active, inactive
+
+
+@pytest.mark.asyncio
+async def test_dispatch_due_repos_fires_only_on_activated(
+    db_session, seed_two_repos, monkeypatch
+) -> None:
+    """The dispatcher must skip the inactive repo on the same install.
+
+    Otherwise an operator who half-finished a connect flow would
+    burn cron ticks on a repo whose workflow isn't even installed
+    yet, and the resulting 404s would noise up the audit log
+    every hour.
+    """
+    workspace, install, active, inactive = seed_two_repos
+
+    calls: list[tuple[str, dict[str, str]]] = []
+
+    async def _fake_dispatch(
+        repo, _install, workflow_file, *, inputs, settings, ref=None, client=None
+    ):
+        calls.append((repo.full_name, dict(inputs)))
+
+    monkeypatch.setattr(
+        "backend.app.services.workflow_dispatch_cron.dispatch_workflow",
+        _fake_dispatch,
+    )
+
+    result = await dispatch_due_repos(db_session, settings=get_settings())
+
+    assert result.dispatched == 1
+    assert result.failed == 0
+    assert calls == [("acme/visitor-web", {})], (
+        "only the activated repo should receive a dispatch; inputs "
+        "are empty so the workflow falls into the normal cron path "
+        "exactly as a schedule-event would have"
+    )
+
+
+@pytest.mark.asyncio
+async def test_dispatch_due_repos_keeps_going_after_404(
+    db_session, seed_two_repos, monkeypatch
+) -> None:
+    """One 404 must not starve the rest of the fleet.
+
+    Reproduction case: customer hasn't merged the wizard-seed PR
+    on ``visitor-mob`` yet, so the workflow file 404s. We want
+    ``visitor-web`` (also on the cron) to still get its dispatch
+    in the same tick. Without this guarantee, a single
+    half-installed repo would silently hold the entire workspace.
+    """
+    workspace, install, active, inactive = seed_two_repos
+
+    # Activate the second repo too so both should be dispatched —
+    # then make the first one 404.
+    inactive.activated_at = datetime.now(timezone.utc)
+    await db_session.flush()
+
+    calls: list[str] = []
+
+    async def _fake_dispatch(
+        repo, _install, workflow_file, *, inputs, settings, ref=None, client=None
+    ):
+        calls.append(repo.full_name)
+        if repo.full_name == "acme/visitor-web":
+            raise WorkflowDispatchError(404, "workflow_file not found")
+
+    monkeypatch.setattr(
+        "backend.app.services.workflow_dispatch_cron.dispatch_workflow",
+        _fake_dispatch,
+    )
+
+    result = await dispatch_due_repos(db_session, settings=get_settings())
+
+    assert result.failed == 1
+    assert result.dispatched == 1
+    assert set(calls) == {"acme/visitor-web", "acme/visitor-mob"}
+    assert any(
+        f["repo"] == "acme/visitor-web" and f["status"] == "404"
+        for f in result.failures
+    )
+
+
+@pytest.mark.asyncio
+async def test_dispatch_due_repos_audits_each_dispatch(
+    db_session, seed_two_repos, monkeypatch
+) -> None:
+    """Each dispatch lands an ``audit_log`` row.
+
+    Failures land their own row too (with the upstream status +
+    error excerpt), so an operator chasing "why did repo X stop
+    ticking" can reconstruct the cron's view from the dashboard
+    without re-running the job or scraping GitHub's audit log.
+    """
+    workspace, install, active, inactive = seed_two_repos
+    inactive.activated_at = datetime.now(timezone.utc)
+    await db_session.flush()
+
+    async def _fake_dispatch(
+        repo, _install, workflow_file, *, inputs, settings, ref=None, client=None
+    ):
+        if repo.full_name == "acme/visitor-mob":
+            raise WorkflowDispatchError(502, "Bad Gateway")
+
+    monkeypatch.setattr(
+        "backend.app.services.workflow_dispatch_cron.dispatch_workflow",
+        _fake_dispatch,
+    )
+
+    await dispatch_due_repos(db_session, settings=get_settings())
+    await db_session.flush()
+
+    rows = (
+        await db_session.execute(
+            select(AuditLog).where(AuditLog.workspace_id == workspace.id)
+        )
+    ).scalars().all()
+    actions = {r.action for r in rows}
+    assert "workflow_dispatch.tick" in actions, (
+        "successful dispatches must produce a ``workflow_dispatch.tick`` "
+        "audit row keyed on the repo"
+    )
+    assert "workflow_dispatch.failed" in actions, (
+        "failures must produce a ``workflow_dispatch.failed`` row "
+        "carrying the upstream status + error message"
+    )
+    failed_row = next(r for r in rows if r.action == "workflow_dispatch.failed")
+    assert failed_row.payload["upstream_status"] == 502
+    assert failed_row.payload["repo_full_name"] == "acme/visitor-mob"


### PR DESCRIPTION
## Summary

Move trigger-workflow scheduling from GHA \`schedule:\` cron (which GitHub silently throttles to 4-8h gaps under load) to Ship's own backend cron + \`workflow_dispatch\` API.

**Before:** customer workflow had \`schedule: \"*/30 * * * *\"\`. Operator saw \"30 min cron\" in the YAML; reality was 4-8h gaps. One ticket needed 30+ hours to traverse a 5-stage SDLC pipeline.

**After:** Ship's backend cron \`_workflow_dispatch_tick\` fires every hour (configurable via \`WORKFLOW_DISPATCH_CRON_EXPR\`) and calls \`POST /repos/{owner}/{repo}/actions/workflows/ship-trigger-schedule.yml/dispatches\` on every activated repo. Sub-second dispatch latency. Bypasses GitHub's schedule throttle entirely.

Pairs with the v0.32 multi-action-per-tick shell — each dispatched tick now drains up to 5 routines (\`SHIP_MAX_ACTIONS_PER_TICK\`, default 5; ≈20 min, fits the 30-min runner budget).

## Changes

- \`backend/app/services/workflow_dispatch_cron.py\` (new) — \`dispatch_due_repos\` fans out to all \`WorkspaceRepo.activated_at IS NOT NULL\` rows. 404s on one repo don't poison the loop; every call (success or failure) audits.
- \`backend/app/services/cron_jobs.py\` — new \`_workflow_dispatch_tick\` registered at \`WORKFLOW_DISPATCH_CRON_EXPR\`.
- \`backend/app/services/cron.py\` — new \`CronLockId.WORKFLOW_DISPATCH = 1011\`.
- \`backend/app/core/config.py\` — new \`workflow_dispatch_cron_expr\` setting (default \`0 * * * *\`).
- \`backend/app/resources/starter_workflows/ship-trigger-schedule.yml\` — \`schedule:\` block removed; only \`workflow_dispatch:\` remains.
- \`.github/workflows/ship-trigger-schedule.yml\` — same removal for ship-on-ship.
- BUNDLE_VERSION \`0.32 → 0.33\`.

## Test plan

- [x] \`test_workflow_dispatch_cron.py\` (3 new): activated-filter, 404-resilience, audit-log shape
- [x] \`test_services_seed_bundle.py\` updated to assert \`cron:\` absent (regression guard)
- [x] Local smoke imports
- [ ] After merge: confirm backend logs show \`workflow_dispatch tick: dispatched=N\` at the top of the hour
- [ ] After merge: askslayer re-seeds (Bundle 0.33 available banner) → next hourly tick fires from backend, runs 5 routines, drains PAC tickets faster