### PR TITLE
fix: tick budget headroom (timeout 45m, MAX_ACTIONS 4)

### DIFF
--- a/.github/workflows/ship-trigger-schedule.yml
+++ b/.github/workflows/ship-trigger-schedule.yml
@@ -29,7 +29,12 @@ concurrency:
 jobs:
   trigger:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # 45-min budget (was 30): one production tick hit the 30-min
+    # ceiling running 5 routines back-to-back (multi-action drain
+    # from v0.32). 4 routines × ~4-7 min agent + ~2 min setup is
+    # comfortably under 45; the higher ceiling absorbs the
+    # occasional slow run without GHA hard-killing mid-stage.
+    timeout-minutes: 45
     steps:
       - name: Checkout (full history for agent introspection + branch push)
         uses: actions/checkout@v4
@@ -100,7 +105,7 @@ jobs:
           # earlier — see ``pipeline_priority``).
           #
           # We iterate the due list and run up to
-          # ``SHIP_MAX_ACTIONS_PER_TICK`` (default 5) routines that
+          # ``SHIP_MAX_ACTIONS_PER_TICK`` (default 4) routines that
           # land work, NOT just the first. Two reasons:
           #
           #   1. GitHub throttles ``schedule:`` workflows during peak
@@ -118,7 +123,7 @@ jobs:
           # eligible). Each ``ok`` row counts toward the cap. A
           # genuine non-zero exit from ``shipctl run`` bubbles up
           # via ``set -e`` and stops the tick.
-          MAX_ACTIONS_PER_TICK=${SHIP_MAX_ACTIONS_PER_TICK:-5}
+          MAX_ACTIONS_PER_TICK=${SHIP_MAX_ACTIONS_PER_TICK:-4}
           shipctl trigger --event schedule --repo "$SHIP_REPO" --pipeline-fallback --json > /tmp/ship-action.json
           jq '.due_routines[].routine_id' /tmp/ship-action.json | tr -d '"' > /tmp/ship-due-routines.txt || true
           ACTIONS_DONE=0

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -389,8 +389,8 @@ class Settings(BaseSettings):
     # dispatches via ``workflow_dispatch`` gives operators a
     # deterministic cadence. 5-field crontab expression, UTC. Default
     # ``0 * * * *`` = every hour at :00 — pairs with the customer
-    # workflow's ``SHIP_MAX_ACTIONS_PER_TICK=5`` (5 × ~4 min ≈ 20 min,
-    # fits the 30-min runner budget).
+    # workflow's ``SHIP_MAX_ACTIONS_PER_TICK=4`` (4 × ~4-7 min ≈
+    # 16-28 min, fits the 45-min runner budget with headroom).
     workflow_dispatch_cron_expr: str = Field(
         default="0 * * * *",
         alias="WORKFLOW_DISPATCH_CRON_EXPR",

--- a/backend/app/resources/starter_workflows/ship-trigger-schedule.yml
+++ b/backend/app/resources/starter_workflows/ship-trigger-schedule.yml
@@ -32,7 +32,12 @@ concurrency:
 jobs:
   trigger:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # 45-min budget (was 30): one production tick hit the 30-min
+    # ceiling running 5 routines back-to-back (multi-action drain
+    # from v0.32). 4 routines × ~4-7 min agent + ~2 min setup is
+    # comfortably under 45; the higher ceiling absorbs the
+    # occasional slow run without GHA hard-killing mid-stage.
+    timeout-minutes: 45
     steps:
       - name: Checkout (full history for agent introspection + branch push)
         uses: actions/checkout@v4
@@ -123,7 +128,7 @@ jobs:
           # next one (multi-action mode). A genuine non-zero exit
           # bubbles up via ``set -e`` and stops the tick so the
           # operator sees the failure.
-          MAX_ACTIONS_PER_TICK=${SHIP_MAX_ACTIONS_PER_TICK:-5}
+          MAX_ACTIONS_PER_TICK=${SHIP_MAX_ACTIONS_PER_TICK:-4}
           shipctl trigger --event schedule --repo "$SHIP_REPO" --pipeline-fallback --json > /tmp/ship-action.json
           jq '.due_routines[].routine_id' /tmp/ship-action.json | tr -d '"' > /tmp/ship-due-routines.txt || true
           ACTIONS_DONE=0

--- a/backend/app/services/seed_bundle.py
+++ b/backend/app/services/seed_bundle.py
@@ -202,7 +202,17 @@ from backend.app.services.tracker_fsm import (
 #         sub-second and rate-limit safe at closed-beta scale. Manual
 #         ``workflow_dispatch`` from the Actions UI stays as a debug
 #         harness.
-BUNDLE_VERSION: str = "0.33"
+# ``0.34`` → Tick budget headroom. Observed in production: one
+#         visitor-back tick hit ``timeout-minutes: 30`` running 5
+#         routines back-to-back (multi-action drain from v0.32 +
+#         per-agent slow path). Two changes:
+#           - ``timeout-minutes`` 30 → 45 on the trigger job.
+#           - ``SHIP_MAX_ACTIONS_PER_TICK`` default 5 → 4.
+#         4 × ~4-7 min ≈ 16-28 min, comfortably under 45-min ceiling.
+#         Still drains 4× more per tick than the pre-v0.32 single-
+#         action mode; just leaves headroom for the occasional 7-min
+#         agent without GHA hard-killing mid-stage.
+BUNDLE_VERSION: str = "0.34"
 
 # Default knowledge starters for PR 1. Empty by design: generated knowledge is
 # analyzed post-merge and proposed in a second PR. Historical callers can still


### PR DESCRIPTION
## Summary

Post-deploy observation on askslayer: one visitor-back tick hit \`timeout-minutes: 30\` running 5 routines back-to-back. Multi-action drain (#252) + a 7-min agent run = 28 min wallclock, GHA hard-killed mid-stage.

Two small knobs to absorb the slow path:

- \`timeout-minutes\` 30 → **45** (both ship-on-ship workflow and customer starter template)
- \`SHIP_MAX_ACTIONS_PER_TICK\` default 5 → **4** — 4 × ~4-7 min ≈ 16-28 min, comfortably under 45-min ceiling

Still drains 4× more per tick than pre-v0.32 single-action mode. Just leaves room for the occasional slow agent.

\`BUNDLE_VERSION 0.33 → 0.34\` so customer repos get the bumped timeout on next re-seed.

## Test plan

- [x] \`test_services_seed_bundle.py\` still green (15 tests)
- [ ] After merge: watch one heavy tick — confirm no more \`timeout-minutes\` kills