### PR TITLE
perf(agent): enable Anthropic prompt caching on system + history tail

### DIFF
--- a/apps/backend/app/services/agent/client.py
+++ b/apps/backend/app/services/agent/client.py
@@ -473,6 +473,61 @@ _ANTHROPIC_SERVER_WEB_SEARCH: dict[str, Any] = {
 }
 
 
+#: Anthropic prompt-cache marker (5-min TTL). Stamped on the last
+#: stable prefix segment so subsequent turns replay it from cache
+#: instead of paying full input tokens. The cache hierarchy is
+#: tools → system → messages, so a marker on ``system`` covers both
+#: tools and system; a second marker on the last history message
+#: extends the cached prefix through the conversation tail.
+_CACHE_EPHEMERAL: dict[str, Any] = {"type": "ephemeral"}
+
+
+def _anthropic_usage_dict(u: Any) -> dict[str, int]:
+    """Project Anthropic's usage object into our cross-vendor shape.
+
+    ``prompt_tokens`` stays equal to ``input_tokens`` (the non-cached
+    portion) for back-compat with OpenAI telemetry; the cache counters
+    are surfaced as extra fields so consoles can render hit/miss ratios.
+    Total tokens sums every input class so cost dashboards see the real
+    work the model did.
+    """
+    input_tokens = int(getattr(u, "input_tokens", 0) or 0)
+    output_tokens = int(getattr(u, "output_tokens", 0) or 0)
+    cache_read = int(getattr(u, "cache_read_input_tokens", 0) or 0)
+    cache_create = int(getattr(u, "cache_creation_input_tokens", 0) or 0)
+    return {
+        "prompt_tokens": input_tokens,
+        "completion_tokens": output_tokens,
+        "total_tokens": input_tokens + output_tokens + cache_read + cache_create,
+        "cache_read_input_tokens": cache_read,
+        "cache_creation_input_tokens": cache_create,
+    }
+
+
+def _mark_last_block_cacheable(message: dict[str, Any]) -> None:
+    """Attach ``cache_control`` to the final content block of ``message``.
+
+    Anthropic matches the longest cached prefix on each turn, so marking
+    the freshest message means the *next* turn (where it has become
+    mid-conversation) replays the whole stretch from cache. Handles both
+    string-content and list-of-blocks shapes — string content is
+    upgraded to a single text block since ``cache_control`` is a
+    per-block attribute.
+    """
+    content = message.get("content")
+    if isinstance(content, str):
+        message["content"] = [
+            {
+                "type": "text",
+                "text": content,
+                "cache_control": _CACHE_EPHEMERAL,
+            }
+        ]
+        return
+    if isinstance(content, list) and content and isinstance(content[-1], dict):
+        content[-1]["cache_control"] = _CACHE_EPHEMERAL
+
+
 def _anthropic_tools(tools: Sequence[ToolSpec]) -> list[dict[str, Any]]:
     rendered: list[dict[str, Any]] = [
         {
@@ -666,6 +721,8 @@ class AnthropicAgentClient:
         temperature: float,
     ) -> AsyncIterator[AgentEvent]:
         system, history = _anthropic_messages(messages)
+        if history:
+            _mark_last_block_cacheable(history[-1])
         kwargs: dict[str, Any] = {
             "model": model or self._default_model,
             "messages": history,
@@ -673,7 +730,13 @@ class AnthropicAgentClient:
             "temperature": temperature,
         }
         if system:
-            kwargs["system"] = system
+            kwargs["system"] = [
+                {
+                    "type": "text",
+                    "text": system,
+                    "cache_control": _CACHE_EPHEMERAL,
+                }
+            ]
         if tools:
             kwargs["tools"] = _anthropic_tools(tools)
 
@@ -721,16 +784,7 @@ class AnthropicAgentClient:
                         finish_reason = getattr(message, "stop_reason", "stop") or "stop"
                         u = getattr(message, "usage", None)
                         if u is not None:
-                            usage = {
-                                "prompt_tokens": int(getattr(u, "input_tokens", 0) or 0),
-                                "completion_tokens": int(
-                                    getattr(u, "output_tokens", 0) or 0
-                                ),
-                                "total_tokens": int(
-                                    (getattr(u, "input_tokens", 0) or 0)
-                                    + (getattr(u, "output_tokens", 0) or 0)
-                                ),
-                            }
+                            usage = _anthropic_usage_dict(u)
 
         # Anthropic's ``tool_use`` stop_reason is the signal that the
         # model wants us to run tools; normalise it to the OpenAI-ish
@@ -751,6 +805,8 @@ class AnthropicAgentClient:
         response_format: dict[str, Any] | None = None,
     ) -> str:
         system, history = _anthropic_messages(messages)
+        if history:
+            _mark_last_block_cacheable(history[-1])
         kwargs: dict[str, Any] = {
             "model": model or self._default_fast_model,
             "messages": history,
@@ -758,7 +814,13 @@ class AnthropicAgentClient:
             "temperature": temperature,
         }
         if system:
-            kwargs["system"] = system
+            kwargs["system"] = [
+                {
+                    "type": "text",
+                    "text": system,
+                    "cache_control": _CACHE_EPHEMERAL,
+                }
+            ]
         # Anthropic doesn't have ``response_format=json``; we rely on
         # prompt engineering to produce JSON and json.loads on our side.
         resp = await self._client.messages.create(**kwargs)

--- a/apps/backend/tests/test_agent_client.py
+++ b/apps/backend/tests/test_agent_client.py
@@ -15,6 +15,8 @@ from backend.app.services.agent.client import (
     ToolSpec,
     _anthropic_messages,
     _anthropic_tools,
+    _anthropic_usage_dict,
+    _mark_last_block_cacheable,
     _openai_messages,
     _openai_tools,
 )
@@ -135,3 +137,61 @@ def test_anthropic_messages_splits_system_and_rewrites_tool_use() -> None:
     assert tool_result_msg["role"] == "user"
     assert tool_result_msg["content"][0]["type"] == "tool_result"
     assert tool_result_msg["content"][0]["tool_use_id"] == "toolu_1"
+
+
+def test_mark_last_block_cacheable_upgrades_string_content() -> None:
+    """String-content messages get rewritten to a single text block so
+    ``cache_control`` (which is per-block) has somewhere to land."""
+    msg = {"role": "user", "content": "hello"}
+    _mark_last_block_cacheable(msg)
+    assert msg["content"] == [
+        {
+            "type": "text",
+            "text": "hello",
+            "cache_control": {"type": "ephemeral"},
+        }
+    ]
+
+
+def test_mark_last_block_cacheable_stamps_last_block_in_list() -> None:
+    msg = {
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "first"},
+            {"type": "text", "text": "second"},
+        ],
+    }
+    _mark_last_block_cacheable(msg)
+    assert "cache_control" not in msg["content"][0]
+    assert msg["content"][1]["cache_control"] == {"type": "ephemeral"}
+
+
+def test_anthropic_usage_dict_surfaces_cache_counters() -> None:
+    class FakeUsage:
+        input_tokens = 120
+        output_tokens = 40
+        cache_read_input_tokens = 800
+        cache_creation_input_tokens = 200
+
+    usage = _anthropic_usage_dict(FakeUsage())
+    assert usage["prompt_tokens"] == 120
+    assert usage["completion_tokens"] == 40
+    # Total rolls up every input class so cost dashboards see the real
+    # work — uncached + cache reads + cache writes + output.
+    assert usage["total_tokens"] == 120 + 40 + 800 + 200
+    assert usage["cache_read_input_tokens"] == 800
+    assert usage["cache_creation_input_tokens"] == 200
+
+
+def test_anthropic_usage_dict_handles_missing_cache_fields() -> None:
+    """Older SDK versions / non-cache responses omit the cache fields;
+    the projection must default them to zero rather than crashing."""
+
+    class FakeUsage:
+        input_tokens = 50
+        output_tokens = 10
+
+    usage = _anthropic_usage_dict(FakeUsage())
+    assert usage["cache_read_input_tokens"] == 0
+    assert usage["cache_creation_input_tokens"] == 0
+    assert usage["total_tokens"] == 60


### PR DESCRIPTION
## Summary
- Stamp `cache_control: ephemeral` on the `system` block (covers tools+system per Anthropic's cache hierarchy) and on the last history message (extends cached prefix through the conversation tail) in `AnthropicAgentClient`.
- Surface `cache_read_input_tokens` / `cache_creation_input_tokens` in the cross-vendor `usage` dict so the existing Sentry span loop in `chat.py:1151` picks them up automatically — no console-side wiring needed.
- `total_tokens` now rolls up uncached input + cache reads + cache writes + output so cost dashboards reflect the real work.

## Motivation
Agent consoles showed zero cache usage because our own SDK calls never set `cache_control`. Navigator threads have a large stable `system` + tool list and a growing history — classic prompt-cache fit. Two breakpoints (system + history tail) is enough: on turn N+1 the previous tail becomes mid-conversation and the whole prefix replays from cache (5-min TTL).

## Out of scope
- OpenAI path — its prefix caching is automatic for prefixes >1024 tokens, no markers needed.
- CLI subprocess (`packages/cli/lib/agents/claude.mjs`) — caching is managed by the `claude` binary itself; we only read its usage report.

## Test plan
- [x] `pytest apps/backend/tests/test_agent_client.py` — 8/8 pass (4 new tests pin the cache-control markers + the usage projection)
- [ ] Smoke a real Navigator turn in dev and confirm `cache_creation_input_tokens > 0` on turn 1, `cache_read_input_tokens > 0` on turn 2+