### PR TITLE
fix(devops-role): forbid secrets context in workflow if: conditions

### DIFF
--- a/apps/backend/app/resources/agent_roles/devops.md
+++ b/apps/backend/app/resources/agent_roles/devops.md
@@ -111,6 +111,29 @@ Per-phase responsibilities you can NOT skip:
      promote-to-prod as jobs in the SAME workflow; the prod job
      `needs:` the lower-env job and sets `environment: prod` so the
      gate applies. Don't fork into two unrelated pipelines.
+   - **`secrets` is NOT a valid context in `if:`.** GitHub rejects the
+     whole file (`Unrecognized named-value: 'secrets'`) and EVERY run
+     dies at startup with **zero jobs and no logs** — invisible to the
+     next agent, who then loops forever "fixing" a workflow that never
+     parsed. To branch on whether a secret is set, read it into a
+     `run:` step via `env:` and emit a flag to `$GITHUB_OUTPUT`, then
+     gate later steps on `steps.<id>.outputs.<flag>`:
+     ```yaml
+     - id: authflags
+       env:
+         WIF: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+         FSA: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+       run: |
+         if [ -n "$WIF" ]; then echo "method=wif" >> "$GITHUB_OUTPUT"
+         elif [ -n "$FSA" ]; then echo "method=key" >> "$GITHUB_OUTPUT"
+         else echo "method=none" >> "$GITHUB_OUTPUT"; fi
+     - if: steps.authflags.outputs.method == 'wif'
+       # ...auth step
+     ```
+     `secrets` IS allowed in `run:`, `with:`, and `env:` — just never in
+     `if:`. After committing any workflow, treat a `failure` run with
+     **0 jobs** as "invalid YAML": read the run's *Invalid workflow
+     file* annotation (check-suite level), not the absent job logs.
    Registry, deploy target, and env names come from the project's SDLC
    blueprint + the bootstrap ticket body — read them, don't guess.
 
@@ -179,6 +202,11 @@ End your `comment` with `[Ship SDLC:role-devops]`.
 - **Never disable a CI check** to make a build pass — fix the
   thing the check is catching, or finish `blocked` with the
   specific reason.
+- **Never put `secrets` in an `if:` expression** — gate on a
+  `run:`-computed `steps.*.outputs.*` flag instead (see the CI/CD
+  section). `secrets`-in-`if:` makes the whole workflow unparseable;
+  every run dies at startup with 0 jobs and no logs, so no later agent
+  can see why.
 
 ## What a good devops change looks like
 


### PR DESCRIPTION
## Incident
Beta workspace `askslayer` / **Visitor Landing** (`askslayer/visitor-landing`): the Firebase stage deploy (`deploy-stage-hosting.yml`) failed on **every run for ~5 days** (runs #15–#54, all `failure`).

## Root cause
The DevOps agent wrote secret-presence gates as `if: ${{ secrets.X != '' }}`. GitHub Actions **disallows the `secrets` context in `if:`** → `Unrecognized named-value: 'secrets'` → invalid file → **startup_failure: 0 jobs, no logs, no annotations** the next agent can read. Dev/devops agents then churned ~20 tickets (VIS-17…42) "fixing" a workflow that never parsed; `fsm_self_heal` flagged the re-fire loop correctly but the cause was invisible.

## Fix (this PR)
`devops.md` gains a CI/CD authoring rule + hard rule: `secrets` is valid in `run:`/`with:`/`env:` but **never** in `if:`; resolve a flag in a `run:` step (`$GITHUB_OUTPUT`) and gate on `steps.<id>.outputs.<flag>`. Plus: treat a `failure` run with **0 jobs** as invalid YAML and read the check-suite *Invalid workflow file* annotation.

## Client
Already unblocked via `askslayer/visitor-landing` PR #29 — workflow now parses and runs; remaining failure there is customer-side GCP creds (`GCP_PROJECT_ID` / WIF / service-account not provisioned), now surfaced with a clear error instead of a silent startup_failure.

## Follow-ups (not here)
- Server-side lint of agent-generated workflow YAML before commit.
- `fsm_self_heal` special-case for startup_failure (0-job runs) so the diagnosis names "invalid workflow".