### PR TITLE
fix(onboarding): stop skipping the Roles step (step 4)

### DIFF
--- a/apps/console/src/app/api/onboard/tracker-install/route.ts
+++ b/apps/console/src/app/api/onboard/tracker-install/route.ts
@@ -138,12 +138,14 @@ function forward(
   wsId: string,
   extra?: Record<string, string>,
 ) {
-  // Wave-8c: after the workspace-level tracker OAuth, drop the user
-  // into the per-repo Confirm bootstrap step. That's where they
-  // review the canonical Plays bundle, bind a tracker / push agent
-  // secrets per repo and open the unified seed PR.
+  // After the workspace-level tracker OAuth, advance to the Roles step
+  // (step 4). It used to jump straight to Confirm — a Wave-8c leftover
+  // from before the Roles step existed, which orphaned step 4 (reachable
+  // only by clicking the stepper). Roles → Confirm is wired in
+  // roles-step.tsx, so the natural flow now walks
+  // github → repos → tracker → roles → confirm.
   const url = new URL("/onboarding", origin);
-  url.searchParams.set("step", "confirm");
+  url.searchParams.set("step", "roles");
   url.searchParams.set("ws", wsId);
   for (const [key, value] of Object.entries(extra ?? {})) {
     url.searchParams.set(key, value);

--- a/apps/console/src/app/onboarding/page.tsx
+++ b/apps/console/src/app/onboarding/page.tsx
@@ -226,9 +226,11 @@ async function resumeStep(
         (r) => r.installed_bundle_version !== null,
       );
       if (anySeeded) return "hub";
-      // Activated repos but none seeded yet → tunnel them through
-      // confirm so they finish bootstrapping.
-      return "confirm";
+      // Activated repos but none seeded yet → resume at Roles (step 4),
+      // not Confirm. Landing on Confirm skipped the Roles step entirely
+      // for anyone auto-resumed; Roles → Confirm is one click for users
+      // who already configured it.
+      return "roles";
     }
   } catch {
     /* fall through — treat as unknown */


### PR DESCRIPTION
## Bug
The onboarding wizard shows 5 steps — **github → repos → tracker → roles → confirm** — but the Roles step (step 4) was unreachable from the normal flow; only a stepper-label click landed on it. Two Wave-8c leftovers (from before Roles existed) routed straight to `confirm`:

1. `api/onboard/tracker-install/route.ts` redirected to `?step=confirm` after tracker OAuth/skip → "Continue from Integrations" skipped Roles.
2. `onboarding/page.tsx` `resumeStep()` returned `"confirm"` for *activated-repos-but-none-seeded* → auto-resume skipped Roles.

## Fix
Both now target `roles`. `roles → confirm` is already wired in `roles-step.tsx`, so the flow walks all five steps. A returning user who already set roles just clicks Continue once.

## Context
Found while debugging why a fresh workspace (Baltic 9 / `omolynad/baltic-nine`) never finished setup. Separate issue there: the repo is **empty (zero commits)**, so `commit_bundle_pr` 409s ("Git Repository is empty") and the seed PR can't be created — tracked separately.