### PR TITLE
feat(knowledge): Lighthouse read cutover + client (K5)

### DIFF
--- a/apps/backend/app/api/v1/routes/workspaces.py
+++ b/apps/backend/app/api/v1/routes/workspaces.py
@@ -24,6 +24,7 @@ from backend.app.api.v1.schemas import (
     WorkspaceOut,
     WorkspaceUpdate,
 )
+from backend.app.core.config import get_settings
 from backend.app.db.models.tenancy import (
     AuditLog,
     Org,
@@ -32,6 +33,7 @@ from backend.app.db.models.tenancy import (
     WorkspaceMember,
 )
 from backend.app.db.session import get_session
+from backend.app.integrations.lighthouse import provision_workspace_knowledge
 from backend.app.services.policies_seed import seed_default_policies
 from backend.app.services.seed_bundle import seed_default_knowledge
 
@@ -292,6 +294,9 @@ async def create_workspace(
         session=session,
         workspace_id=workspace.id,
     )
+    # Best-effort: stand up the workspace's S3 source on Lighthouse.
+    # No-op until LIGHTHOUSE_BASE_URL is configured; never fails setup.
+    await provision_workspace_knowledge(workspace.id, settings=get_settings())
     return WorkspaceOut.model_validate(workspace)
 
 

--- a/apps/backend/app/core/config.py
+++ b/apps/backend/app/core/config.py
@@ -283,6 +283,16 @@ class Settings(BaseSettings):
     s3_secret_key: str | None = Field(default=None, alias="S3_SECRET_KEY")
     s3_region: str = Field(default="us-east-1", alias="S3_REGION")
 
+    # --- Lighthouse (per-workspace knowledge engine, whafr) ---
+    # When unset, the knowledge-search path stays on Ship's internal
+    # index. Set the base URL to route reads at the per-workspace
+    # Lighthouse instance (the engine scopes by the X-Workspace header).
+    # The admin token gates importer provisioning; retrieval is open.
+    lighthouse_base_url: str | None = Field(default=None, alias="LIGHTHOUSE_BASE_URL")
+    lighthouse_admin_token: str | None = Field(
+        default=None, alias="LIGHTHOUSE_ADMIN_TOKEN"
+    )
+
     # --- Auth / secrets ---
     jwt_secret: str = Field(default="dev-only-not-for-prod-change-me", alias="JWT_SECRET")
     jwt_algorithm: str = Field(default="HS256", alias="JWT_ALGORITHM")

--- a/apps/backend/app/integrations/lighthouse/__init__.py
+++ b/apps/backend/app/integrations/lighthouse/__init__.py
@@ -1,0 +1,21 @@
+"""Client for the per-workspace Lighthouse knowledge engine (whafr).
+
+Lighthouse is the multi-tenant flat-RAG retrieval engine that replaces
+Ship's internal knowledge index. Reads are scoped per workspace via the
+``X-Workspace`` header; retrieval is unauthenticated (network-gated), the
+admin importer surface takes an optional bearer token.
+"""
+
+from backend.app.integrations.lighthouse.client import (
+    LighthouseClient,
+    build_lighthouse_client,
+)
+from backend.app.integrations.lighthouse.provisioning import (
+    provision_workspace_knowledge,
+)
+
+__all__ = [
+    "LighthouseClient",
+    "build_lighthouse_client",
+    "provision_workspace_knowledge",
+]

--- a/apps/backend/app/integrations/lighthouse/client.py
+++ b/apps/backend/app/integrations/lighthouse/client.py
@@ -1,0 +1,86 @@
+"""Thin async HTTP client for the Lighthouse ``/v1`` surface.
+
+Two operations Ship needs:
+
+- :meth:`search` — ``GET /v1/search`` scoped by ``X-Workspace``. The
+  read path for the knowledge cutover.
+- :meth:`provision_s3_importer` — ``POST /v1/importers/provision/s3`` to
+  idempotently set up the per-workspace S3 source on workspace setup.
+
+The client is intentionally stateless (a fresh ``httpx.AsyncClient`` per
+call): these are low-frequency calls and a per-call client sidesteps
+event-loop / lifespan ownership questions in the worker + request paths.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING, Any
+
+import httpx
+
+if TYPE_CHECKING:
+    from backend.app.core.config import Settings
+
+_TIMEOUT = httpx.Timeout(10.0, connect=5.0)
+
+
+class LighthouseClient:
+    def __init__(self, *, base_url: str, admin_token: str | None = None) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._admin_token = admin_token
+
+    async def search(
+        self,
+        *,
+        workspace_id: uuid.UUID | str,
+        query: str,
+        top_k: int = 20,
+    ) -> list[dict[str, Any]]:
+        """Return raw ``/v1/search`` hits (dicts) for the workspace.
+
+        Raises ``httpx.HTTPError`` on transport / non-2xx — callers in
+        the dual-read path treat any failure as "fall back to internal".
+        """
+        headers = {"X-Workspace": str(workspace_id)}
+        async with httpx.AsyncClient(
+            base_url=self._base_url, timeout=_TIMEOUT
+        ) as client:
+            resp = await client.get(
+                "/v1/search",
+                params={"q": query, "top_k": top_k},
+                headers=headers,
+            )
+            resp.raise_for_status()
+            return list(resp.json().get("hits", []))
+
+    async def provision_s3_importer(
+        self, *, workspace_id: uuid.UUID | str
+    ) -> dict[str, Any]:
+        """Idempotently provision the per-workspace S3 importer."""
+        headers = {"X-Workspace": str(workspace_id)}
+        if self._admin_token:
+            headers["Authorization"] = f"Bearer {self._admin_token}"
+        async with httpx.AsyncClient(
+            base_url=self._base_url, timeout=_TIMEOUT
+        ) as client:
+            resp = await client.post(
+                "/v1/importers/provision/s3", headers=headers
+            )
+            resp.raise_for_status()
+            return dict(resp.json())
+
+
+def build_lighthouse_client(settings: "Settings") -> LighthouseClient | None:
+    """Construct a client when ``LIGHTHOUSE_BASE_URL`` is configured.
+
+    Returns ``None`` when Lighthouse isn't wired (local dev, or before
+    the cutover) — callers then use Ship's internal index.
+    """
+    base = getattr(settings, "lighthouse_base_url", None)
+    if not base:
+        return None
+    return LighthouseClient(
+        base_url=base,
+        admin_token=getattr(settings, "lighthouse_admin_token", None),
+    )

--- a/apps/backend/app/integrations/lighthouse/provisioning.py
+++ b/apps/backend/app/integrations/lighthouse/provisioning.py
@@ -1,0 +1,46 @@
+"""Best-effort per-workspace Lighthouse provisioning.
+
+Called on workspace setup to create the per-workspace S3 importer on the
+Lighthouse engine. Deliberately best-effort: a missing/unreachable
+Lighthouse must never fail Ship's workspace creation. It's a no-op when
+Lighthouse isn't configured (``LIGHTHOUSE_BASE_URL`` unset), and the
+underlying provision call is idempotent, so re-running is safe.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import TYPE_CHECKING
+
+from backend.app.integrations.lighthouse.client import build_lighthouse_client
+
+if TYPE_CHECKING:
+    from backend.app.core.config import Settings
+
+logger = logging.getLogger(__name__)
+
+
+async def provision_workspace_knowledge(
+    workspace_id: uuid.UUID, *, settings: "Settings"
+) -> bool:
+    """Provision the workspace's S3 importer on Lighthouse.
+
+    Returns ``True`` when provisioning was attempted and succeeded,
+    ``False`` when Lighthouse is disabled or the call failed (logged).
+    Never raises.
+    """
+    client = build_lighthouse_client(settings)
+    if client is None:
+        return False
+    try:
+        await client.provision_s3_importer(workspace_id=workspace_id)
+        return True
+    except Exception:
+        logger.warning(
+            "lighthouse provisioning failed for workspace=%s — will retry "
+            "on next setup (idempotent)",
+            workspace_id,
+            exc_info=True,
+        )
+        return False

--- a/apps/backend/app/services/knowledge_search.py
+++ b/apps/backend/app/services/knowledge_search.py
@@ -36,6 +36,7 @@ Removed in the bucket-consolidation cleanup (KB-5+):
 
 from __future__ import annotations
 
+import logging
 import uuid
 from typing import Any
 
@@ -54,8 +55,10 @@ from backend.app.db.models.agent_memory import (
     KnowledgeTopicView,
 )
 from backend.app.db.models.integrations import WorkspaceRepo
+from backend.app.integrations.lighthouse import build_lighthouse_client
 from backend.app.services.agent.embedding import embed_text
 
+logger = logging.getLogger(__name__)
 
 _SNIPPET_MAX_CHARS = 400
 
@@ -333,7 +336,112 @@ def _claim_hit(claim: KnowledgeClaim, score: float) -> KnowledgeSearchHit:
     )
 
 
+def _map_lighthouse_hit(
+    raw: dict[str, Any], *, rank: int, total: int
+) -> KnowledgeSearchHit:
+    """Adapter — one Lighthouse ``/v1/search`` hit → KnowledgeSearchHit.
+
+    The engine returns ``summary`` as ``# <name>\\n<snippet>``; split it
+    back into title + snippet. ``/v1/search`` doesn't expose a score, so
+    we synthesise a descending rank score (the engine already returned
+    hits best-first). ``node_id`` is the chunk uuid.
+    """
+    summary = str(raw.get("summary") or "")
+    title: str | None = None
+    snippet = summary
+    if summary.startswith("# "):
+        nl = summary.find("\n")
+        if nl == -1:
+            title, snippet = summary[2:].strip(), ""
+        else:
+            title, snippet = summary[2:nl].strip(), summary[nl + 1 :].strip()
+    if len(snippet) > _SNIPPET_MAX_CHARS:
+        snippet = snippet[: _SNIPPET_MAX_CHARS - 1].rstrip() + "…"
+
+    node_id = str(raw.get("node_id") or "")
+    try:
+        hit_id = uuid.UUID(node_id)
+    except (ValueError, TypeError):
+        hit_id = uuid.uuid5(uuid.NAMESPACE_URL, f"lighthouse:{node_id}")
+
+    return KnowledgeSearchHit(
+        id=hit_id,
+        source="lighthouse",
+        bucket_slug=None,
+        bucket_id=None,
+        repo_id=None,
+        scope_kind="lighthouse",
+        score=round(1.0 - (rank / max(total, 1)), 4),
+        rank_bucket="canon",
+        snippet=snippet,
+        title=title or None,
+        repo_full_name=None,
+    )
+
+
 async def search_workspace_knowledge(
+    session: AsyncSession,
+    *,
+    workspace_id: uuid.UUID,
+    query: str,
+    repo_id: uuid.UUID | None = None,
+    bucket_slug: str | None = None,
+    limit: int = 20,
+    settings: Settings | None = None,
+) -> list[KnowledgeSearchHit]:
+    """Workspace knowledge search — Lighthouse-first, internal fallback.
+
+    The per-workspace Lighthouse engine is the target backend. We query
+    it first (scoped by ``workspace_id``); on any failure or an empty
+    result we fall back to Ship's internal index, which still holds
+    everything until the K6 write cutover populates Lighthouse. So the
+    surface degrades gracefully whether or not Lighthouse is wired or
+    populated yet.
+
+    Lighthouse is skipped when it isn't configured (``LIGHTHOUSE_BASE_URL``
+    unset) or when ``bucket_slug`` pins a specific legacy bucket — the
+    flat corpus has no bucket concept, so that filter only the internal
+    index can honour.
+    """
+    safe_query = (query or "").strip()
+    if not safe_query:
+        return []
+    safe_limit = max(1, min(int(limit), 100))
+
+    if bucket_slug is None:
+        client = build_lighthouse_client(settings or get_settings())
+        if client is not None:
+            try:
+                raw_hits = await client.search(
+                    workspace_id=workspace_id,
+                    query=safe_query,
+                    top_k=safe_limit,
+                )
+            except Exception:
+                logger.warning(
+                    "lighthouse search failed — falling back to internal index",
+                    exc_info=True,
+                )
+                raw_hits = []
+            if raw_hits:
+                total = len(raw_hits)
+                return [
+                    _map_lighthouse_hit(h, rank=i, total=total)
+                    for i, h in enumerate(raw_hits)
+                ][:safe_limit]
+
+    return await _search_internal(
+        session,
+        workspace_id=workspace_id,
+        query=query,
+        repo_id=repo_id,
+        bucket_slug=bucket_slug,
+        limit=limit,
+        settings=settings,
+    )
+
+
+async def _search_internal(
     session: AsyncSession,
     *,
     workspace_id: uuid.UUID,
@@ -343,7 +451,7 @@ async def search_workspace_knowledge(
     limit: int = 20,
     settings: Settings | None = None,
 ) -> list[KnowledgeSearchHit]:
-    """Run the workspace-wide knowledge search and return ranked hits.
+    """Ship's internal knowledge index (the pre-Lighthouse path).
 
     Returns an empty list for blank queries. ``repo_id`` is accepted
     for wire compatibility but no longer participates in ranking now

--- a/apps/backend/tests/test_lighthouse_knowledge.py
+++ b/apps/backend/tests/test_lighthouse_knowledge.py
@@ -1,0 +1,246 @@
+"""K5 — Lighthouse read cutover.
+
+Covers the dual-read wrapper (Lighthouse-first, internal fallback), the
+hit mapper, and the HTTP client's workspace scoping. All offline: the
+dual-read tests monkeypatch the client + internal path so no DB is
+needed, and the client test uses an httpx MockTransport.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import httpx
+import pytest
+
+import backend.app.services.knowledge_search as ks
+from backend.app.integrations.lighthouse import provisioning as lh_prov
+from backend.app.integrations.lighthouse.client import LighthouseClient
+from backend.app.services.knowledge_search import (
+    KnowledgeSearchHit,
+    _map_lighthouse_hit,
+)
+
+_INTERNAL_SENTINEL = KnowledgeSearchHit(
+    id=uuid.uuid4(),
+    source="internal-sentinel",
+    scope_kind="workspace",
+    score=0.0,
+    rank_bucket="workspace",
+    snippet="from internal index",
+)
+
+
+class _FakeClient:
+    def __init__(self, *, hits=None, exc=None):
+        self._hits = hits or []
+        self._exc = exc
+        self.calls: list[tuple] = []
+
+    async def search(self, *, workspace_id, query, top_k):
+        self.calls.append((str(workspace_id), query, top_k))
+        if self._exc is not None:
+            raise self._exc
+        return self._hits
+
+
+@pytest.fixture
+def _patch_internal(monkeypatch):
+    """Replace the internal index path with a sentinel so fallback is
+    observable without seeding Postgres."""
+
+    async def _fake_internal(session, **kwargs):
+        return [_INTERNAL_SENTINEL]
+
+    monkeypatch.setattr(ks, "_search_internal", _fake_internal)
+
+
+def _use_client(monkeypatch, client) -> None:
+    monkeypatch.setattr(ks, "build_lighthouse_client", lambda settings: client)
+
+
+# ---- mapper -----------------------------------------------------------
+
+
+def test_map_lighthouse_hit_splits_title_and_snippet() -> None:
+    node = str(uuid.uuid4())
+    hit = _map_lighthouse_hit(
+        {"node_id": node, "summary": "# OAuth flow\nUse PKCE for SPAs.",
+         "episode_ids": [node]},
+        rank=0,
+        total=1,
+    )
+    assert hit.id == uuid.UUID(node)
+    assert hit.title == "OAuth flow"
+    assert hit.snippet == "Use PKCE for SPAs."
+    assert hit.source == "lighthouse"
+    assert hit.score == 1.0
+
+
+def test_map_lighthouse_hit_handles_plain_summary() -> None:
+    hit = _map_lighthouse_hit(
+        {"node_id": "not-a-uuid", "summary": "just a snippet"},
+        rank=1,
+        total=2,
+    )
+    assert hit.title is None
+    assert hit.snippet == "just a snippet"
+    # Non-uuid node_id is mapped to a stable derived uuid (no crash).
+    assert isinstance(hit.id, uuid.UUID)
+
+
+# ---- dual-read --------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dual_read_returns_mapped_lighthouse_hits(monkeypatch, _patch_internal):
+    ws = uuid.uuid4()
+    node = str(uuid.uuid4())
+    client = _FakeClient(hits=[{"node_id": node, "summary": "# T\nbody"}])
+    _use_client(monkeypatch, client)
+
+    hits = await ks.search_workspace_knowledge(
+        None, workspace_id=ws, query="auth", limit=5, settings=object()
+    )
+    assert [h.source for h in hits] == ["lighthouse"]
+    assert client.calls == [(str(ws), "auth", 5)]
+
+
+@pytest.mark.asyncio
+async def test_dual_read_falls_back_when_lighthouse_empty(monkeypatch, _patch_internal):
+    _use_client(monkeypatch, _FakeClient(hits=[]))
+    hits = await ks.search_workspace_knowledge(
+        None, workspace_id=uuid.uuid4(), query="auth", settings=object()
+    )
+    assert hits == [_INTERNAL_SENTINEL]
+
+
+@pytest.mark.asyncio
+async def test_dual_read_falls_back_on_error(monkeypatch, _patch_internal):
+    _use_client(monkeypatch, _FakeClient(exc=httpx.ConnectError("down")))
+    hits = await ks.search_workspace_knowledge(
+        None, workspace_id=uuid.uuid4(), query="auth", settings=object()
+    )
+    assert hits == [_INTERNAL_SENTINEL]
+
+
+@pytest.mark.asyncio
+async def test_dual_read_uses_internal_when_lighthouse_disabled(
+    monkeypatch, _patch_internal
+):
+    _use_client(monkeypatch, None)  # build_lighthouse_client → None
+    hits = await ks.search_workspace_knowledge(
+        None, workspace_id=uuid.uuid4(), query="auth", settings=object()
+    )
+    assert hits == [_INTERNAL_SENTINEL]
+
+
+@pytest.mark.asyncio
+async def test_dual_read_skips_lighthouse_when_bucket_slug_pinned(
+    monkeypatch, _patch_internal
+):
+    client = _FakeClient(hits=[{"node_id": str(uuid.uuid4()), "summary": "x"}])
+    _use_client(monkeypatch, client)
+    hits = await ks.search_workspace_knowledge(
+        None,
+        workspace_id=uuid.uuid4(),
+        query="auth",
+        bucket_slug="runbooks",
+        settings=object(),
+    )
+    # A pinned bucket only the internal index can honour → Lighthouse skipped.
+    assert hits == [_INTERNAL_SENTINEL]
+    assert client.calls == []
+
+
+@pytest.mark.asyncio
+async def test_dual_read_blank_query_returns_empty(monkeypatch, _patch_internal):
+    _use_client(monkeypatch, _FakeClient(hits=[{"node_id": "x", "summary": "y"}]))
+    hits = await ks.search_workspace_knowledge(
+        None, workspace_id=uuid.uuid4(), query="   ", settings=object()
+    )
+    assert hits == []
+
+
+# ---- client -----------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_client_search_scopes_by_workspace_header(monkeypatch):
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["path"] = request.url.path
+        captured["q"] = request.url.params.get("q")
+        captured["ws"] = request.headers.get("x-workspace")
+        return httpx.Response(
+            200,
+            json={"query": "auth", "hits": [{"node_id": "n1", "summary": "# A\nb"}]},
+        )
+
+    orig = httpx.AsyncClient
+
+    def _factory(**kwargs):
+        kwargs["transport"] = httpx.MockTransport(handler)
+        return orig(**kwargs)
+
+    monkeypatch.setattr(
+        "backend.app.integrations.lighthouse.client.httpx.AsyncClient", _factory
+    )
+
+    client = LighthouseClient(base_url="https://lh.example")
+    ws = uuid.uuid4()
+    hits = await client.search(workspace_id=ws, query="auth", top_k=7)
+
+    assert captured["path"] == "/v1/search"
+    assert captured["q"] == "auth"
+    assert captured["ws"] == str(ws)
+    assert hits == [{"node_id": "n1", "summary": "# A\nb"}]
+
+
+# ---- provisioning (best-effort) ---------------------------------------
+
+
+class _FakeProvClient:
+    def __init__(self, *, exc=None):
+        self._exc = exc
+        self.calls: list[str] = []
+
+    async def provision_s3_importer(self, *, workspace_id):
+        self.calls.append(str(workspace_id))
+        if self._exc is not None:
+            raise self._exc
+        return {"id": "imp-1", "workspace_id": str(workspace_id)}
+
+
+@pytest.mark.asyncio
+async def test_provision_noop_when_lighthouse_disabled(monkeypatch):
+    monkeypatch.setattr(lh_prov, "build_lighthouse_client", lambda settings: None)
+    ok = await lh_prov.provision_workspace_knowledge(
+        uuid.uuid4(), settings=object()
+    )
+    assert ok is False
+
+
+@pytest.mark.asyncio
+async def test_provision_calls_client_when_configured(monkeypatch):
+    fake = _FakeProvClient()
+    monkeypatch.setattr(lh_prov, "build_lighthouse_client", lambda settings: fake)
+    ws = uuid.uuid4()
+    ok = await lh_prov.provision_workspace_knowledge(ws, settings=object())
+    assert ok is True
+    assert fake.calls == [str(ws)]
+
+
+@pytest.mark.asyncio
+async def test_provision_swallows_errors(monkeypatch):
+    monkeypatch.setattr(
+        lh_prov,
+        "build_lighthouse_client",
+        lambda settings: _FakeProvClient(exc=httpx.ConnectError("down")),
+    )
+    # Never raises — workspace setup must not fail on a Lighthouse outage.
+    ok = await lh_prov.provision_workspace_knowledge(
+        uuid.uuid4(), settings=object()
+    )
+    assert ok is False


### PR DESCRIPTION
## Summary
- First consumer of the per-workspace Lighthouse (whafr) `/v1` surface.
- `integrations/lighthouse`: async HTTP client (`search` scoped by the `X-Workspace` header; `provision_s3_importer`) + a best-effort provisioning helper that never fails workspace setup.
- `search_workspace_knowledge` is now **Lighthouse-first with internal-index fallback**: queries Lighthouse (scoped by `workspace_id`), maps hits → `KnowledgeSearchHit`, and on any failure / empty result falls back to the existing internal search (which still holds everything until the K6 write cutover). The internal path is preserved verbatim as `_search_internal`. The agent tool, TopicService and `shipctl knowledge fetch` all funnel through this function, so they follow for free.
- Skipped when Lighthouse is unconfigured (`LIGHTHOUSE_BASE_URL` unset) or when a legacy `bucket_slug` is pinned.
- `create_workspace` provisions the per-workspace S3 importer (best-effort, no-op until configured).
- config: `LIGHTHOUSE_BASE_URL` + `LIGHTHOUSE_ADMIN_TOKEN`.

This is part of the Knowledge→Lighthouse per-workspace epic (K5). With Lighthouse unconfigured (current default), behaviour is unchanged — `test_v1_knowledge_search` still green.

## Test plan
- [x] `tests/test_lighthouse_knowledge.py` — hit mapper, dual-read decision matrix (hits / empty / error / disabled / bucket-pinned / blank), client workspace-header scoping, best-effort provisioning (offline; no DB/network).
- [x] Enabled knowledge suite (`-k "knowledge_search or lighthouse"`) — 16 passed, no regression with Lighthouse off.
- [ ] Once Lighthouse is configured in an env, smoke `/v1/search` end-to-end (post-K6 data).