### PR TITLE
feat(knowledge): ship repo intel to Lighthouse via S3 (K6a)

### DIFF
--- a/apps/backend/app/integrations/lighthouse/__init__.py
+++ b/apps/backend/app/integrations/lighthouse/__init__.py
@@ -13,9 +13,15 @@ from backend.app.integrations.lighthouse.client import (
 from backend.app.integrations.lighthouse.provisioning import (
     provision_workspace_knowledge,
 )
+from backend.app.integrations.lighthouse.s3_writer import (
+    KnowledgeS3Writer,
+    build_knowledge_s3_writer,
+)
 
 __all__ = [
+    "KnowledgeS3Writer",
     "LighthouseClient",
+    "build_knowledge_s3_writer",
     "build_lighthouse_client",
     "provision_workspace_knowledge",
 ]

--- a/apps/backend/app/integrations/lighthouse/s3_writer.py
+++ b/apps/backend/app/integrations/lighthouse/s3_writer.py
@@ -1,0 +1,100 @@
+"""Write knowledge documents to S3 for the Lighthouse importer to pull.
+
+Ship emits raw markdown documents to
+``s3://<bucket>/<workspace_id>/<source>/<name>.md``; the per-workspace
+Lighthouse S3 importer (provisioned at workspace setup) pulls that prefix
+and does the chunking/embedding/retrieval.
+
+"S3" is the S3-compatible API — the backing store is **DigitalOcean
+Spaces**, reached via ``s3_endpoint_url`` with explicit Spaces keys.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import aioboto3
+
+if TYPE_CHECKING:
+    from backend.app.core.config import Settings
+
+logger = logging.getLogger(__name__)
+
+
+class KnowledgeS3Writer:
+    """Stateless S3 (DO Spaces) document writer.
+
+    A fresh aioboto3 client per call — these writes are low-frequency
+    (one per harvest / agent record), so a per-call client avoids
+    event-loop / lifespan ownership questions in the worker + request
+    paths.
+    """
+
+    def __init__(
+        self,
+        *,
+        bucket: str,
+        endpoint_url: str | None = None,
+        access_key: str | None = None,
+        secret_key: str | None = None,
+        region: str = "us-east-1",
+    ) -> None:
+        self._bucket = bucket
+        self._endpoint_url = endpoint_url
+        self._access_key = access_key
+        self._secret_key = secret_key
+        self._region = region
+
+    async def write_document(
+        self,
+        *,
+        workspace_id,
+        source: str,
+        name: str,
+        markdown: str,
+    ) -> str:
+        """Put one markdown document; returns the S3 key written.
+
+        Layout ``<workspace_id>/<source>/<name>.md`` keeps every tenant's
+        uploads under its own prefix (the importer is scoped to
+        ``<workspace_id>/``).
+        """
+        key = f"{workspace_id}/{source}/{name}.md"
+        session = aioboto3.Session()
+        async with session.client(
+            "s3",
+            endpoint_url=self._endpoint_url,
+            aws_access_key_id=self._access_key,
+            aws_secret_access_key=self._secret_key,
+            region_name=self._region,
+        ) as s3:
+            await s3.put_object(
+                Bucket=self._bucket,
+                Key=key,
+                Body=markdown.encode("utf-8"),
+                ContentType="text/markdown; charset=utf-8",
+            )
+        return key
+
+
+def build_knowledge_s3_writer(settings: "Settings") -> KnowledgeS3Writer | None:
+    """Construct the writer when S3 (DO Spaces) credentials are configured.
+
+    Returns ``None`` when knowledge-to-S3 isn't wired (local dev, or
+    before the K6 cutover) — callers then skip the emit. DO Spaces needs
+    explicit keys (no instance IAM), so the presence of both keys is the
+    enable signal; ``s3_bucket`` has a non-empty default so it can't gate.
+    """
+    access = getattr(settings, "s3_access_key", None)
+    secret = getattr(settings, "s3_secret_key", None)
+    bucket = getattr(settings, "s3_bucket", None)
+    if not (access and secret and bucket):
+        return None
+    return KnowledgeS3Writer(
+        bucket=bucket,
+        endpoint_url=getattr(settings, "s3_endpoint_url", None),
+        access_key=access,
+        secret_key=secret,
+        region=getattr(settings, "s3_region", None) or "us-east-1",
+    )

--- a/apps/backend/app/services/repo_intel.py
+++ b/apps/backend/app/services/repo_intel.py
@@ -423,6 +423,10 @@ async def harvest_repo_intel(
             repo=repo,
             intel=row,
         )
+        # K6: also ship the repo intel as one document to Lighthouse (S3).
+        # Best-effort + dual-write — the internal projection above stays
+        # as the K5 read-fallback until Lighthouse has ingested.
+        await _emit_intel_to_lighthouse(repo=repo, intel=row)
 
     await session.flush()
 
@@ -1717,6 +1721,47 @@ def _render_repo_context_articles(
         ("visual-style", "Visual style", _render_visual_style_article(intel=intel, repo=repo)),
         ("rules", "Rules", _render_rules_article(intel=intel, repo=repo)),
     ]
+
+
+def _consolidate_intel_document(
+    *, repo: WorkspaceRepo, articles: list[tuple[str, str, str]]
+) -> str:
+    """Join the rendered repo-context sections into ONE markdown document
+    for Lighthouse (one document per repo, not N bucket articles)."""
+    sections = [body for _, _, body in articles if body.strip()]
+    return "\n\n".join(sections).strip() + "\n"
+
+
+async def _emit_intel_to_lighthouse(
+    *, repo: WorkspaceRepo, intel: RepoIntel
+) -> None:
+    """Best-effort: ship the repo intel as one markdown document to S3 so
+    the per-workspace Lighthouse importer ingests it. No-op when S3 isn't
+    configured; never raises — the harvest must not fail because the
+    knowledge engine / object store is unreachable."""
+    from backend.app.core.config import get_settings
+    from backend.app.integrations.lighthouse import build_knowledge_s3_writer
+
+    writer = build_knowledge_s3_writer(get_settings())
+    if writer is None:
+        return
+    document = _consolidate_intel_document(
+        repo=repo,
+        articles=_render_repo_context_articles(intel=intel, repo=repo),
+    )
+    try:
+        await writer.write_document(
+            workspace_id=repo.workspace_id,
+            source="repo-intel",
+            name=_slugify_repo(repo.full_name),
+            markdown=document,
+        )
+    except Exception:
+        logger.warning(
+            "lighthouse S3 emit failed for repo=%s — will retry next harvest",
+            repo.id,
+            exc_info=True,
+        )
 
 
 def _article_header(title: str, *, intel: RepoIntel, repo: WorkspaceRepo) -> list[str]:

--- a/apps/backend/tests/test_lighthouse_s3_writer.py
+++ b/apps/backend/tests/test_lighthouse_s3_writer.py
@@ -1,0 +1,202 @@
+"""K6a — S3 (DO Spaces) knowledge writer + repo_intel emit.
+
+Offline: the writer test mocks aioboto3.Session; the repo_intel emit
+tests monkeypatch the writer + renderer so no DB / network / boto.
+"""
+
+from __future__ import annotations
+
+import types
+import uuid
+
+import pytest
+
+import backend.app.integrations.lighthouse.s3_writer as s3w
+import backend.app.services.repo_intel as ri
+from backend.app.integrations.lighthouse.s3_writer import (
+    KnowledgeS3Writer,
+    build_knowledge_s3_writer,
+)
+
+
+# ---- build gate -------------------------------------------------------
+
+
+def test_build_writer_disabled_without_credentials() -> None:
+    cfg = types.SimpleNamespace(
+        s3_bucket="ship-documents",
+        s3_access_key=None,
+        s3_secret_key=None,
+        s3_endpoint_url=None,
+        s3_region="fra1",
+    )
+    assert build_knowledge_s3_writer(cfg) is None
+
+
+def test_build_writer_enabled_with_credentials() -> None:
+    cfg = types.SimpleNamespace(
+        s3_bucket="ship-documents",
+        s3_access_key="AKIA",
+        s3_secret_key="secret",
+        s3_endpoint_url="https://fra1.digitaloceanspaces.com",
+        s3_region="fra1",
+    )
+    writer = build_knowledge_s3_writer(cfg)
+    assert isinstance(writer, KnowledgeS3Writer)
+
+
+# ---- write_document (mock aioboto3) -----------------------------------
+
+
+class _FakeS3:
+    def __init__(self, captured: dict):
+        self._captured = captured
+
+    async def put_object(self, **kwargs):
+        self._captured["put"] = kwargs
+
+
+class _FakeClientCM:
+    def __init__(self, captured: dict):
+        self._captured = captured
+
+    async def __aenter__(self):
+        return _FakeS3(self._captured)
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _FakeSession:
+    def __init__(self, captured: dict):
+        self._captured = captured
+
+    def client(self, service, **kwargs):
+        self._captured["service"] = service
+        self._captured["client_kwargs"] = kwargs
+        return _FakeClientCM(self._captured)
+
+
+@pytest.mark.asyncio
+async def test_write_document_puts_to_workspace_prefixed_key(monkeypatch):
+    captured: dict = {}
+    monkeypatch.setattr(s3w.aioboto3, "Session", lambda: _FakeSession(captured))
+
+    writer = KnowledgeS3Writer(
+        bucket="ship-documents",
+        endpoint_url="https://fra1.digitaloceanspaces.com",
+        access_key="AKIA",
+        secret_key="secret",
+        region="fra1",
+    )
+    ws = uuid.uuid4()
+    key = await writer.write_document(
+        workspace_id=ws, source="repo-intel", name="ks-api", markdown="# hi\nbody"
+    )
+
+    assert key == f"{ws}/repo-intel/ks-api.md"
+    assert captured["service"] == "s3"
+    assert captured["client_kwargs"]["endpoint_url"] == (
+        "https://fra1.digitaloceanspaces.com"
+    )
+    put = captured["put"]
+    assert put["Bucket"] == "ship-documents"
+    assert put["Key"] == f"{ws}/repo-intel/ks-api.md"
+    assert put["Body"] == b"# hi\nbody"
+    assert put["ContentType"].startswith("text/markdown")
+
+
+# ---- repo_intel emit --------------------------------------------------
+
+
+class _FakeWriter:
+    def __init__(self, *, exc=None):
+        self._exc = exc
+        self.calls: list[dict] = []
+
+    async def write_document(self, *, workspace_id, source, name, markdown):
+        self.calls.append(
+            {
+                "workspace_id": workspace_id,
+                "source": source,
+                "name": name,
+                "markdown": markdown,
+            }
+        )
+        if self._exc is not None:
+            raise self._exc
+        return f"{workspace_id}/{source}/{name}.md"
+
+
+def _fake_repo():
+    return types.SimpleNamespace(
+        full_name="ks/api", workspace_id=uuid.uuid4(), id=uuid.uuid4()
+    )
+
+
+def _patch_render(monkeypatch):
+    monkeypatch.setattr(
+        ri,
+        "_render_repo_context_articles",
+        lambda *, intel, repo: [
+            ("overview", "Overview", "# Overview\nalpha"),
+            ("architecture", "Architecture", "# Architecture\nbeta"),
+        ],
+    )
+
+
+def test_consolidate_joins_sections() -> None:
+    doc = ri._consolidate_intel_document(
+        repo=_fake_repo(),
+        articles=[("a", "A", "# A\nx"), ("b", "B", "# B\ny")],
+    )
+    assert doc == "# A\nx\n\n# B\ny\n"
+
+
+@pytest.mark.asyncio
+async def test_emit_ships_one_document_when_configured(monkeypatch):
+    _patch_render(monkeypatch)
+    writer = _FakeWriter()
+    monkeypatch.setattr(
+        "backend.app.integrations.lighthouse.build_knowledge_s3_writer",
+        lambda settings: writer,
+    )
+    repo = _fake_repo()
+    await ri._emit_intel_to_lighthouse(repo=repo, intel=types.SimpleNamespace())
+
+    assert len(writer.calls) == 1
+    call = writer.calls[0]
+    assert call["source"] == "repo-intel"
+    assert call["name"] == ri._slugify_repo("ks/api")
+    assert call["workspace_id"] == repo.workspace_id
+    # One consolidated document with both sections.
+    assert "# Overview" in call["markdown"]
+    assert "# Architecture" in call["markdown"]
+
+
+@pytest.mark.asyncio
+async def test_emit_is_noop_when_s3_disabled(monkeypatch):
+    _patch_render(monkeypatch)
+    monkeypatch.setattr(
+        "backend.app.integrations.lighthouse.build_knowledge_s3_writer",
+        lambda settings: None,
+    )
+    # No raise, no writer — just returns.
+    await ri._emit_intel_to_lighthouse(
+        repo=_fake_repo(), intel=types.SimpleNamespace()
+    )
+
+
+@pytest.mark.asyncio
+async def test_emit_swallows_writer_errors(monkeypatch):
+    _patch_render(monkeypatch)
+    writer = _FakeWriter(exc=RuntimeError("spaces down"))
+    monkeypatch.setattr(
+        "backend.app.integrations.lighthouse.build_knowledge_s3_writer",
+        lambda settings: writer,
+    )
+    # Harvest must survive a knowledge-engine outage.
+    await ri._emit_intel_to_lighthouse(
+        repo=_fake_repo(), intel=types.SimpleNamespace()
+    )
+    assert len(writer.calls) == 1


### PR DESCRIPTION
## Summary
First slice of the **write cutover** (K6a): Ship supplies the per-workspace Lighthouse engine with raw **documents** (S3 → importer pulls) rather than running its own knowledge-processing pipeline. The processing producers (synth / claim-extractor / topic-renderer / distiller / summary) are being **retired, not ported** — Lighthouse does chunking/embedding/retrieval now.

- **`integrations/lighthouse/s3_writer`** — `KnowledgeS3Writer` (aioboto3) writes markdown to `s3://<bucket>/<workspace_id>/<source>/<name>.md` on **DigitalOcean Spaces** (S3-compatible; `S3_ENDPOINT_URL` + Spaces keys). `build_knowledge_s3_writer` returns `None` until creds are configured → no-op in local dev / before cutover.
- **`repo_intel` harvest** — emits the rendered repo-context sections as **one consolidated markdown document per repo** (`source="repo-intel"`). Dual-write: the internal bucket projection stays as the K5 read fallback until Lighthouse has ingested. Best-effort — a Spaces outage never fails the harvest.

Builds on K5 (#311, merged). Next (K6b): ship agent records (resolved clarifications, inbox comments, agent feedback).

## Test plan
- [x] `tests/test_lighthouse_s3_writer.py` — writer key/layout + `put_object` (mocked aioboto3) + disabled gate; repo_intel emit (configured / disabled / error-swallow) + doc consolidation. Offline.
- [x] `-k "repo_intel or lighthouse"` — 61 passed, no harvest regression (emit is a no-op when S3 unconfigured).
- [ ] Once Spaces creds + a provisioned importer exist in an env, smoke: harvest a repo → object lands under `<ws>/repo-intel/` → Lighthouse ingests → `/v1/search` returns it.