### PR TITLE
feat(knowledge): ship agent records to Lighthouse via S3 (K6b)

### DIFF
--- a/apps/backend/app/api/v1/routes/clarifications.py
+++ b/apps/backend/app/api/v1/routes/clarifications.py
@@ -45,6 +45,7 @@ from backend.app.db.models.agent_surface import Clarification
 from backend.app.db.models.lanes import RoutineRun
 from backend.app.db.models.tenancy import AuditLog, User
 from backend.app.db.session import get_session
+from backend.app.integrations.lighthouse import emit_knowledge_document
 from backend.app.services import clarifications_sync
 from backend.app.services.inbox.dual_write import (
     mirror_clarification_create,
@@ -125,6 +126,20 @@ def _to_out(row: Clarification, answered_by_email: str | None) -> ClarificationO
         created_at=row.created_at,
         updated_at=row.updated_at,
     )
+
+
+def _clarification_document(row: Clarification) -> str:
+    """Render an answered clarification as a markdown knowledge document
+    (Q&A + provenance) for Lighthouse ingestion."""
+    lines = ["# Clarification", ""]
+    if row.ticket_ref:
+        lines.append(f"- Ticket: {row.ticket_ref}")
+    if row.tracker_issue_url:
+        lines.append(f"- Issue: {row.tracker_issue_url}")
+    if row.answered_at is not None:
+        lines.append(f"- Answered at: {row.answered_at.isoformat()}")
+    lines += ["", "## Question", "", row.question or "", "", "## Answer", "", row.answer or ""]
+    return "\n".join(lines).strip() + "\n"
 
 
 async def _enrich(
@@ -335,6 +350,17 @@ async def update_clarification(
             clarification=row,
             actor_user_id=auth.user.id,
             actor_kind="user",
+        )
+    # K6: ship an answered clarification to Lighthouse as a knowledge
+    # document (best-effort; no-op until S3 is configured). Skipped
+    # clarifications carry no answer, so there's nothing to ingest.
+    if new_status == "answered" and (row.answer or "").strip():
+        await emit_knowledge_document(
+            workspace_id=row.workspace_id,
+            source="clarifications",
+            name=str(row.id),
+            markdown=_clarification_document(row),
+            settings=settings,
         )
     email: str | None = None
     if row.answered_by_user_id:

--- a/apps/backend/app/api/v1/routes/inbox.py
+++ b/apps/backend/app/api/v1/routes/inbox.py
@@ -62,6 +62,7 @@ from backend.app.api.v1.routes.workspaces import (
     ROLES_READ,
     _require_membership,
 )
+from backend.app.core.config import get_settings
 from backend.app.db.models.agent_surface import ChatMessage, ChatThread
 from backend.app.db.models.inbox import (
     InboxItem,
@@ -70,6 +71,7 @@ from backend.app.db.models.inbox import (
 from backend.app.db.models.lanes import RoutineRun
 from backend.app.db.models.tenancy import AuditLog, User, WorkspaceMember
 from backend.app.db.session import get_session
+from backend.app.integrations.lighthouse import emit_knowledge_document
 from backend.app.services.inbox.classification import (
     ACTIONABLE_CATEGORIES,
     derive_lane,
@@ -446,6 +448,16 @@ async def _project_items_out(
         lane = derive_lane(item, run=run)
         out.append(_to_item_out(item, owner, lane=lane))
     return out
+
+
+def _inbox_comment_document(item: InboxItem, body_text: str) -> str:
+    """Render an inbox comment as a markdown knowledge document for
+    Lighthouse ingestion."""
+    lines = ["# Inbox comment", "", f"- Item: {item.id}"]
+    if getattr(item, "title", None):
+        lines.append(f"- Title: {item.title}")
+    lines += ["", body_text or ""]
+    return "\n".join(lines).strip() + "\n"
 
 
 def _to_event_out(event: InboxItemEvent) -> InboxItemEventOut:
@@ -2154,6 +2166,16 @@ async def append_event(
     session.add(event)
     await session.flush()
     await session.refresh(event)
+    # K6: ship the comment to Lighthouse as a knowledge document
+    # (best-effort; no-op until S3 is configured).
+    if (body.body or "").strip():
+        await emit_knowledge_document(
+            workspace_id=workspace_id,
+            source="inbox-comments",
+            name=str(event.id),
+            markdown=_inbox_comment_document(item, body.body),
+            settings=get_settings(),
+        )
     return _to_event_out(event)
 
 

--- a/apps/backend/app/integrations/lighthouse/__init__.py
+++ b/apps/backend/app/integrations/lighthouse/__init__.py
@@ -16,6 +16,7 @@ from backend.app.integrations.lighthouse.provisioning import (
 from backend.app.integrations.lighthouse.s3_writer import (
     KnowledgeS3Writer,
     build_knowledge_s3_writer,
+    emit_knowledge_document,
 )
 
 __all__ = [
@@ -23,5 +24,6 @@ __all__ = [
     "LighthouseClient",
     "build_knowledge_s3_writer",
     "build_lighthouse_client",
+    "emit_knowledge_document",
     "provision_workspace_knowledge",
 ]

--- a/apps/backend/app/integrations/lighthouse/s3_writer.py
+++ b/apps/backend/app/integrations/lighthouse/s3_writer.py
@@ -78,6 +78,40 @@ class KnowledgeS3Writer:
         return key
 
 
+async def emit_knowledge_document(
+    *,
+    workspace_id,
+    source: str,
+    name: str,
+    markdown: str,
+    settings: "Settings",
+) -> bool:
+    """Best-effort: write one knowledge document to S3 for Lighthouse.
+
+    Returns ``True`` when written, ``False`` when S3 isn't configured or
+    the write failed (logged). Never raises — emitting a knowledge
+    document must not fail the operation that produced it (a resolved
+    clarification, an inbox comment, …).
+    """
+    writer = build_knowledge_s3_writer(settings)
+    if writer is None:
+        return False
+    try:
+        await writer.write_document(
+            workspace_id=workspace_id, source=source, name=name, markdown=markdown
+        )
+        return True
+    except Exception:
+        logger.warning(
+            "lighthouse knowledge emit failed (source=%s name=%s) — "
+            "will retry on next change",
+            source,
+            name,
+            exc_info=True,
+        )
+        return False
+
+
 def build_knowledge_s3_writer(settings: "Settings") -> KnowledgeS3Writer | None:
     """Construct the writer when S3 (DO Spaces) credentials are configured.
 

--- a/apps/backend/tests/test_lighthouse_agent_records.py
+++ b/apps/backend/tests/test_lighthouse_agent_records.py
@@ -1,0 +1,105 @@
+"""K6b — agent records → Lighthouse documents.
+
+Offline: the emitter test monkeypatches the writer; the document-builder
+tests use lightweight stand-ins (no DB / network / boto).
+"""
+
+from __future__ import annotations
+
+import types
+import uuid
+
+import pytest
+
+import backend.app.integrations.lighthouse.s3_writer as s3w
+from backend.app.api.v1.routes.clarifications import _clarification_document
+from backend.app.api.v1.routes.inbox import _inbox_comment_document
+
+
+class _FakeWriter:
+    def __init__(self, *, exc=None):
+        self._exc = exc
+        self.calls: list[tuple] = []
+
+    async def write_document(self, *, workspace_id, source, name, markdown):
+        self.calls.append((str(workspace_id), source, name, markdown))
+        if self._exc is not None:
+            raise self._exc
+        return f"{workspace_id}/{source}/{name}.md"
+
+
+# ---- shared emitter ---------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_emit_noop_when_s3_disabled(monkeypatch):
+    monkeypatch.setattr(s3w, "build_knowledge_s3_writer", lambda settings: None)
+    ok = await s3w.emit_knowledge_document(
+        workspace_id=uuid.uuid4(),
+        source="clarifications",
+        name="x",
+        markdown="# x",
+        settings=object(),
+    )
+    assert ok is False
+
+
+@pytest.mark.asyncio
+async def test_emit_writes_when_configured(monkeypatch):
+    fake = _FakeWriter()
+    monkeypatch.setattr(s3w, "build_knowledge_s3_writer", lambda settings: fake)
+    ws = uuid.uuid4()
+    ok = await s3w.emit_knowledge_document(
+        workspace_id=ws,
+        source="clarifications",
+        name="abc",
+        markdown="# doc",
+        settings=object(),
+    )
+    assert ok is True
+    assert fake.calls == [(str(ws), "clarifications", "abc", "# doc")]
+
+
+@pytest.mark.asyncio
+async def test_emit_swallows_writer_errors(monkeypatch):
+    monkeypatch.setattr(
+        s3w,
+        "build_knowledge_s3_writer",
+        lambda settings: _FakeWriter(exc=RuntimeError("spaces down")),
+    )
+    ok = await s3w.emit_knowledge_document(
+        workspace_id=uuid.uuid4(),
+        source="inbox-comments",
+        name="n",
+        markdown="m",
+        settings=object(),
+    )
+    assert ok is False
+
+
+# ---- document builders ------------------------------------------------
+
+
+def test_clarification_document_has_qa_and_provenance() -> None:
+    row = types.SimpleNamespace(
+        ticket_ref="ENG-42",
+        tracker_issue_url="https://linear.app/x/ENG-42",
+        answered_at=None,
+        question="How do we auth SPAs?",
+        answer="Use PKCE; no implicit flow.",
+    )
+    doc = _clarification_document(row)
+    assert doc.startswith("# Clarification")
+    assert "ENG-42" in doc
+    assert "https://linear.app/x/ENG-42" in doc
+    assert "## Question" in doc and "How do we auth SPAs?" in doc
+    assert "## Answer" in doc and "Use PKCE" in doc
+
+
+def test_inbox_comment_document_includes_title_and_body() -> None:
+    item = types.SimpleNamespace(id=uuid.uuid4(), title="Deploy failed on prod")
+    doc = _inbox_comment_document(item, "Restarted the runner; root cause was OOM.")
+    assert doc.startswith("# Inbox comment")
+    assert str(item.id) in doc
+    assert "Deploy failed on prod" in doc
+    assert "Restarted the runner" in doc


### PR DESCRIPTION
## Summary
Continues the write cutover (K6b): **agent records** become documents Lighthouse ingests (S3 → importer pulls), rather than feeding Ship's now-retiring knowledge-processing pipeline.

- **`emit_knowledge_document(...)`** — shared best-effort emitter in `integrations/lighthouse` (no-op until S3 is configured; swallows errors so it never fails the operation that produced the record).
- **Resolved clarifications** — `update_clarification` emits an answered clarification (question + answer + provenance) as one document (`source="clarifications"`) on resolve. Skipped clarifications carry no answer → not shipped.
- **Inbox comments** — `append_event` emits each comment as a document (`source="inbox-comments"`).

**Deferred:** agent "save to knowledge" feedback — the `ArtifactFeedback` routes aren't wired yet, so there's no live hook. Add it once those endpoints land.

Builds on K6a (#312, merged). Same dual-write/no-op-until-configured posture as the rest of the epic.

## Test plan
- [x] `tests/test_lighthouse_agent_records.py` — shared emitter (no-op / configured / error-swallow) + clarification & inbox document builders (offline).
- [x] `-k "clarification or inbox or lighthouse"` — 134 passed; `test_v1_clarifications` runs `update_clarification` (emit hook executes as a no-op with S3 unconfigured) → no regression.
- [ ] With Spaces creds + a provisioned importer: resolve a clarification / add an inbox comment → object lands under `<ws>/clarifications/` or `<ws>/inbox-comments/` → Lighthouse ingests → `/v1/search` returns it.