### PR TITLE
feat(knowledge): surface Lighthouse corpus on /knowledge (K7)

### DIFF
--- a/apps/backend/app/api/v1/routes/knowledge.py
+++ b/apps/backend/app/api/v1/routes/knowledge.py
@@ -25,6 +25,7 @@ from backend.app.db.models.agent_memory import (
 from backend.app.db.models.integrations import GitHubInstallation, WorkspaceRepo
 from backend.app.db.models.tenancy import Workspace
 from backend.app.db.session import get_session
+from backend.app.integrations.lighthouse import build_lighthouse_client
 from backend.app.services.knowledge_search import (
     EmbeddingsUnavailable,
     KnowledgeSearchHit,
@@ -200,6 +201,72 @@ async def search_workspace_knowledge(
         ) from exc
 
     return KnowledgeSearchResponse(query=payload.query, hits=hits)
+
+
+# ---------------------------------------------------------------------------
+# Lighthouse corpus overview (K7) — what the per-workspace engine actually
+# holds, for the knowledge dashboard. Kept above /{slug} so "corpus" isn't
+# captured as a slug.
+# ---------------------------------------------------------------------------
+
+
+class KnowledgeCorpusSourceOut(BaseModel):
+    source: str
+    chunk_count: int
+    recipes: list[str] = Field(default_factory=list)
+    last_ingest_at: str | None = None
+
+
+class KnowledgeCorpusOut(BaseModel):
+    """Lighthouse corpus roll-up for the workspace. ``configured`` is
+    False when Lighthouse isn't wired (``LIGHTHOUSE_BASE_URL`` unset) or
+    unreachable — the dashboard then shows an "engine not connected"
+    state instead of erroring."""
+
+    configured: bool
+    total_chunks: int = 0
+    total_sources: int = 0
+    last_ingest_at: str | None = None
+    sources: list[KnowledgeCorpusSourceOut] = Field(default_factory=list)
+
+
+@router.get("/corpus", response_model=KnowledgeCorpusOut)
+async def get_workspace_corpus(
+    workspace_id: uuid.UUID,
+    auth: AuthContext = Depends(get_current_auth),
+    session: AsyncSession = Depends(get_session),
+) -> KnowledgeCorpusOut:
+    """Lighthouse corpus stats + per-source roll-up for the workspace."""
+    await _require_membership(session, workspace_id, auth.user.id, ROLES_READ)
+
+    client = build_lighthouse_client(get_settings())
+    if client is None:
+        return KnowledgeCorpusOut(configured=False)
+    try:
+        stats = await client.corpus_stats(workspace_id=workspace_id)
+        raw_sources = await client.corpus_sources(workspace_id=workspace_id)
+    except Exception:
+        logger.warning(
+            "lighthouse corpus fetch failed for ws=%s", workspace_id,
+            exc_info=True,
+        )
+        return KnowledgeCorpusOut(configured=False)
+
+    return KnowledgeCorpusOut(
+        configured=True,
+        total_chunks=int(stats.get("total_chunks") or 0),
+        total_sources=int(stats.get("total_sources") or 0),
+        last_ingest_at=stats.get("last_ingest_at"),
+        sources=[
+            KnowledgeCorpusSourceOut(
+                source=str(s.get("source") or ""),
+                chunk_count=int(s.get("chunk_count") or 0),
+                recipes=list(s.get("recipes") or []),
+                last_ingest_at=s.get("last_ingest_at"),
+            )
+            for s in raw_sources
+        ],
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/apps/backend/app/integrations/lighthouse/client.py
+++ b/apps/backend/app/integrations/lighthouse/client.py
@@ -54,6 +54,36 @@ class LighthouseClient:
             resp.raise_for_status()
             return list(resp.json().get("hits", []))
 
+    async def corpus_stats(
+        self, *, workspace_id: uuid.UUID | str
+    ) -> dict[str, Any]:
+        """Return ``/v1/corpus/stats`` for the workspace (chunk/source
+        counts, last ingest)."""
+        headers = {"X-Workspace": str(workspace_id)}
+        async with httpx.AsyncClient(
+            base_url=self._base_url, timeout=_TIMEOUT
+        ) as client:
+            resp = await client.get("/v1/corpus/stats", headers=headers)
+            resp.raise_for_status()
+            return dict(resp.json())
+
+    async def corpus_sources(
+        self, *, workspace_id: uuid.UUID | str, limit: int = 100
+    ) -> list[dict[str, Any]]:
+        """Return ``/v1/corpus/sources`` for the workspace (per-source
+        roll-up: chunk count, recipes, last ingest)."""
+        headers = {"X-Workspace": str(workspace_id)}
+        async with httpx.AsyncClient(
+            base_url=self._base_url, timeout=_TIMEOUT
+        ) as client:
+            resp = await client.get(
+                "/v1/corpus/sources",
+                params={"limit": limit, "order": "recent"},
+                headers=headers,
+            )
+            resp.raise_for_status()
+            return list(resp.json())
+
     async def provision_s3_importer(
         self, *, workspace_id: uuid.UUID | str
     ) -> dict[str, Any]:

--- a/apps/backend/tests/test_lighthouse_knowledge.py
+++ b/apps/backend/tests/test_lighthouse_knowledge.py
@@ -198,6 +198,38 @@ async def test_client_search_scopes_by_workspace_header(monkeypatch):
     assert hits == [{"node_id": "n1", "summary": "# A\nb"}]
 
 
+# ---- corpus (K7) ------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_client_corpus_stats_and_sources(monkeypatch):
+    seen: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request.url.path)
+        if request.url.path == "/v1/corpus/stats":
+            assert request.headers.get("x-workspace") == "ws-1"
+            return httpx.Response(
+                200, json={"total_chunks": 7, "total_sources": 2, "last_ingest_at": "2026-05-26T00:00:00Z"}
+            )
+        return httpx.Response(
+            200,
+            json=[{"source": "repo-intel", "chunk_count": 5, "recipes": ["workspace-s3"], "last_ingest_at": None}],
+        )
+
+    orig = httpx.AsyncClient
+    monkeypatch.setattr(
+        "backend.app.integrations.lighthouse.client.httpx.AsyncClient",
+        lambda **kw: orig(transport=httpx.MockTransport(handler), **kw),
+    )
+    client = LighthouseClient(base_url="https://lh.example")
+    stats = await client.corpus_stats(workspace_id="ws-1")
+    sources = await client.corpus_sources(workspace_id="ws-1")
+    assert stats["total_chunks"] == 7
+    assert sources[0]["source"] == "repo-intel"
+    assert seen == ["/v1/corpus/stats", "/v1/corpus/sources"]
+
+
 # ---- provisioning (best-effort) ---------------------------------------
 
 

--- a/apps/console/src/app/(authed)/knowledge/knowledge-control-center.tsx
+++ b/apps/console/src/app/(authed)/knowledge/knowledge-control-center.tsx
@@ -31,6 +31,7 @@ import { useState, useTransition } from "react";
 import { cn } from "@/lib/cn";
 import type {
   ApiActivatedRepo,
+  ApiKnowledgeCorpus,
   ApiKnowledgeSearchHit,
   ApiKnowledgeSearchResponse,
 } from "@/lib/api/client";
@@ -64,6 +65,7 @@ type Props = {
   sources: KnowledgeSourceRow[];
   repos: ApiActivatedRepo[];
   integrations: ApiIntegration[];
+  corpus: ApiKnowledgeCorpus | null;
 };
 
 
@@ -73,6 +75,7 @@ export function KnowledgeControlCenter({
   sources,
   repos,
   integrations,
+  corpus,
 }: Props) {
   const [query, setQuery] = useState("");
   const [searchHits, setSearchHits] = useState<ApiKnowledgeSearchHit[] | null>(null);
@@ -142,6 +145,8 @@ export function KnowledgeControlCenter({
         workspaceId={workspace.id}
       />
 
+      <CorpusSummary corpus={corpus} />
+
       {pending && <p className="text-xs text-white/45">Searching…</p>}
       {searchError && <p className="text-sm text-coral">{searchError}</p>}
 
@@ -162,6 +167,49 @@ export function KnowledgeControlCenter({
         <EditorialLayout topicViews={topicViews} sources={sources} />
       )}
     </div>
+  );
+}
+
+
+// ---------------------------------------------------------------------------
+// Lighthouse corpus summary (K7) — what the per-workspace engine holds
+// ---------------------------------------------------------------------------
+
+
+function CorpusSummary({ corpus }: { corpus: ApiKnowledgeCorpus | null }) {
+  // Render nothing until Lighthouse is wired + has content — the
+  // editorial canon view below stays the primary surface meanwhile.
+  if (!corpus || !corpus.configured || corpus.total_chunks === 0) return null;
+  const top = corpus.sources.slice(0, 8);
+  const ingested = corpus.last_ingest_at?.slice(0, 10) ?? null;
+  return (
+    <section className="rounded-lg border border-white/10 bg-white/[0.02] p-4">
+      <div className="flex items-baseline justify-between gap-3">
+        <p className="text-xs uppercase tracking-wide text-aqua/80">
+          Lighthouse corpus
+        </p>
+        <p className="text-xs text-white/45">
+          {corpus.total_chunks} chunk{corpus.total_chunks === 1 ? "" : "s"} ·{" "}
+          {corpus.total_sources} source{corpus.total_sources === 1 ? "" : "s"}
+          {ingested ? ` · last ingest ${ingested}` : ""}
+        </p>
+      </div>
+      {top.length > 0 && (
+        <ul className="mt-3 divide-y divide-white/5 text-sm">
+          {top.map((s) => (
+            <li
+              key={s.source}
+              className="flex items-center justify-between gap-3 py-1.5"
+            >
+              <span className="truncate text-white/70">{s.source}</span>
+              <span className="shrink-0 text-xs text-white/40">
+                {s.chunk_count}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
   );
 }
 

--- a/apps/console/src/app/(authed)/knowledge/page.tsx
+++ b/apps/console/src/app/(authed)/knowledge/page.tsx
@@ -5,7 +5,9 @@ import { PageBody, PageHeader } from "@/components/app-shell";
 import { ScopePill } from "@/components/scope-pill";
 import {
   type ApiActivatedRepo,
+  type ApiKnowledgeCorpus,
   ApiHttpError,
+  getWorkspaceCorpus,
   listActivatedRepos,
   listIntegrations,
   listKnowledgeImportSources,
@@ -37,6 +39,7 @@ type LiveData = {
   sources: KnowledgeSourceRow[];
   repos: ApiActivatedRepo[];
   integrations: ApiIntegration[];
+  corpus: ApiKnowledgeCorpus | null;
   me: Awaited<ReturnType<typeof getCachedMe>>;
 };
 
@@ -68,7 +71,7 @@ async function load(
     // silently broken). If the canon is empty, the page should look
     // empty — that's the signal that something upstream needs
     // attention.
-    const [repos, integrations, me, rawTopicViews, importSources] =
+    const [repos, integrations, me, rawTopicViews, importSources, corpus] =
       await Promise.all([
         listActivatedRepos(workspace.id, token).catch(() => [] as ApiActivatedRepo[]),
         listIntegrations(workspace.id, token).catch(() => [] as ApiIntegration[]),
@@ -76,6 +79,11 @@ async function load(
         listTopicViews(workspace.id, { limit: 200 }, token),
         listKnowledgeImportSources(workspace.id, token).catch(
           () => [] as ApiKnowledgeImportSource[],
+        ),
+        // Lighthouse corpus roll-up. Best-effort — the page renders the
+        // legacy canon view too, so a missing engine just hides the panel.
+        getWorkspaceCorpus(workspace.id, token).catch(
+          () => null as ApiKnowledgeCorpus | null,
         ),
       ]);
 
@@ -94,6 +102,7 @@ async function load(
         sources,
         repos,
         integrations,
+        corpus,
         me,
       },
     };
@@ -126,7 +135,7 @@ export default async function KnowledgeIndexPage({
     );
   }
 
-  const { workspace, topicViews, sources, repos, integrations, me } =
+  const { workspace, topicViews, sources, repos, integrations, corpus, me } =
     result.data;
 
   const scopePill = (
@@ -158,6 +167,7 @@ export default async function KnowledgeIndexPage({
           sources={sources}
           repos={repos}
           integrations={integrations}
+          corpus={corpus}
         />
       </PageBody>
     </>

--- a/apps/console/src/lib/api/client.ts
+++ b/apps/console/src/lib/api/client.ts
@@ -3145,6 +3145,31 @@ export async function listTopicViews(
   return Array.isArray(payload) ? payload : [];
 }
 
+export type ApiKnowledgeCorpusSource = {
+  source: string;
+  chunk_count: number;
+  recipes: string[];
+  last_ingest_at: string | null;
+};
+
+export type ApiKnowledgeCorpus = {
+  configured: boolean;
+  total_chunks: number;
+  total_sources: number;
+  last_ingest_at: string | null;
+  sources: ApiKnowledgeCorpusSource[];
+};
+
+export async function getWorkspaceCorpus(
+  workspaceId: string,
+  token?: string,
+): Promise<ApiKnowledgeCorpus> {
+  return apiFetch<ApiKnowledgeCorpus>(
+    `/v1/workspaces/${workspaceId}/knowledge/corpus`,
+    { token },
+  );
+}
+
 export type ApiClaimSourceLink = {
   source_item_id: string | null;
   external_url: string | null;


### PR DESCRIPTION
## Summary
Repoints the console **/knowledge** dashboard at the per-workspace **Lighthouse** engine (search already routes there via K5; this adds the corpus view).

- **`LighthouseClient.corpus_stats()` / `corpus_sources()`** — `GET /v1/corpus/*` scoped by `X-Workspace`.
- **Backend** `GET /v1/workspaces/{ws}/knowledge/corpus` — proxies the engine roll-up (chunks / sources / last-ingest). Best-effort: `configured=false` when Lighthouse is unwired/unreachable so the page degrades gracefully. Registered above `/{slug}`.
- **Console** `getWorkspaceCorpus()` + a compact **"Lighthouse corpus"** panel (totals + top sources) on the knowledge page; hidden until the engine is wired and has content. The legacy canon view stays until K8 removes the internal tables + dual-read fallback.

## Test plan
- [x] backend: corpus client methods (mocked transport) — `test_lighthouse_knowledge.py` 13 passed.
- [x] backend ruff clean on changed files.
- [x] console `tsc --noEmit` clean.
- [ ] **Browser QA pending** (couldn't click through the console here): verify the corpus panel renders for a workspace with Lighthouse data and is hidden otherwise.