### PR TITLE
feat(knowledge): Lighthouse-only reads (K8 core)

### DIFF
--- a/apps/backend/app/integrations/lighthouse/client.py
+++ b/apps/backend/app/integrations/lighthouse/client.py
@@ -39,8 +39,9 @@ class LighthouseClient:
     ) -> list[dict[str, Any]]:
         """Return raw ``/v1/search`` hits (dicts) for the workspace.
 
-        Raises ``httpx.HTTPError`` on transport / non-2xx — callers in
-        the dual-read path treat any failure as "fall back to internal".
+        Raises ``httpx.HTTPError`` on transport / non-2xx — the search
+        wrapper degrades any failure to an empty result (K8: reads are
+        Lighthouse-only, so an outage means "no knowledge", not fallback).
         """
         headers = {"X-Workspace": str(workspace_id)}
         async with httpx.AsyncClient(

--- a/apps/backend/app/services/knowledge_search.py
+++ b/apps/backend/app/services/knowledge_search.py
@@ -389,56 +389,37 @@ async def search_workspace_knowledge(
     limit: int = 20,
     settings: Settings | None = None,
 ) -> list[KnowledgeSearchHit]:
-    """Workspace knowledge search — Lighthouse-first, internal fallback.
+    """Workspace knowledge search — Lighthouse only (K8).
 
-    The per-workspace Lighthouse engine is the target backend. We query
-    it first (scoped by ``workspace_id``); on any failure or an empty
-    result we fall back to Ship's internal index, which still holds
-    everything until the K6 write cutover populates Lighthouse. So the
-    surface degrades gracefully whether or not Lighthouse is wired or
-    populated yet.
-
-    Lighthouse is skipped when it isn't configured (``LIGHTHOUSE_BASE_URL``
-    unset) or when ``bucket_slug`` pins a specific legacy bucket — the
-    flat corpus has no bucket concept, so that filter only the internal
-    index can honour.
+    The internal index + the K5 dual-read fallback are retired: reads
+    come solely from the per-workspace Lighthouse engine. Returns ``[]``
+    when Lighthouse is unconfigured (``LIGHTHOUSE_BASE_URL`` unset) or has
+    nothing for the workspace yet. ``session`` / ``repo_id`` /
+    ``bucket_slug`` are accepted for wire compatibility but unused (the
+    flat corpus has no buckets; scoping is by ``workspace_id``).
     """
     safe_query = (query or "").strip()
     if not safe_query:
         return []
     safe_limit = max(1, min(int(limit), 100))
 
-    if bucket_slug is None:
-        client = build_lighthouse_client(settings or get_settings())
-        if client is not None:
-            try:
-                raw_hits = await client.search(
-                    workspace_id=workspace_id,
-                    query=safe_query,
-                    top_k=safe_limit,
-                )
-            except Exception:
-                logger.warning(
-                    "lighthouse search failed — falling back to internal index",
-                    exc_info=True,
-                )
-                raw_hits = []
-            if raw_hits:
-                total = len(raw_hits)
-                return [
-                    _map_lighthouse_hit(h, rank=i, total=total)
-                    for i, h in enumerate(raw_hits)
-                ][:safe_limit]
-
-    return await _search_internal(
-        session,
-        workspace_id=workspace_id,
-        query=query,
-        repo_id=repo_id,
-        bucket_slug=bucket_slug,
-        limit=limit,
-        settings=settings,
-    )
+    client = build_lighthouse_client(settings or get_settings())
+    if client is None:
+        return []
+    try:
+        raw_hits = await client.search(
+            workspace_id=workspace_id,
+            query=safe_query,
+            top_k=safe_limit,
+        )
+    except Exception:
+        logger.warning("lighthouse search failed", exc_info=True)
+        return []
+    total = len(raw_hits)
+    return [
+        _map_lighthouse_hit(h, rank=i, total=total)
+        for i, h in enumerate(raw_hits)
+    ][:safe_limit]
 
 
 async def _search_internal(

--- a/apps/backend/app/services/repo_intel.py
+++ b/apps/backend/app/services/repo_intel.py
@@ -418,14 +418,10 @@ async def harvest_repo_intel(
 
     articles_written = 0
     if error_text is None:
-        articles_written = await _write_intel_markdown(
-            session,
-            repo=repo,
-            intel=row,
-        )
-        # K6: also ship the repo intel as one document to Lighthouse (S3).
-        # Best-effort + dual-write — the internal projection above stays
-        # as the K5 read-fallback until Lighthouse has ingested.
+        # K8: ship the repo intel to Lighthouse only. The internal
+        # bucket projection (_write_intel_markdown) is retired now that
+        # reads are Lighthouse-only; it's removed with the internal
+        # knowledge tables in the K8 purge.
         await _emit_intel_to_lighthouse(repo=repo, intel=row)
 
     await session.flush()

--- a/apps/backend/tests/test_lighthouse_knowledge.py
+++ b/apps/backend/tests/test_lighthouse_knowledge.py
@@ -1,9 +1,9 @@
-"""K5 — Lighthouse read cutover.
+"""K8 — Lighthouse-only knowledge reads.
 
-Covers the dual-read wrapper (Lighthouse-first, internal fallback), the
-hit mapper, and the HTTP client's workspace scoping. All offline: the
-dual-read tests monkeypatch the client + internal path so no DB is
-needed, and the client test uses an httpx MockTransport.
+Covers the search wrapper (Lighthouse only — the K5 internal dual-read
+fallback is retired), the hit mapper, and the HTTP client's workspace
+scoping. All offline: the search tests monkeypatch the client so no DB
+is needed, and the client test uses an httpx MockTransport.
 """
 
 from __future__ import annotations
@@ -17,17 +17,7 @@ import backend.app.services.knowledge_search as ks
 from backend.app.integrations.lighthouse import provisioning as lh_prov
 from backend.app.integrations.lighthouse.client import LighthouseClient
 from backend.app.services.knowledge_search import (
-    KnowledgeSearchHit,
     _map_lighthouse_hit,
-)
-
-_INTERNAL_SENTINEL = KnowledgeSearchHit(
-    id=uuid.uuid4(),
-    source="internal-sentinel",
-    scope_kind="workspace",
-    score=0.0,
-    rank_bucket="workspace",
-    snippet="from internal index",
 )
 
 
@@ -42,17 +32,6 @@ class _FakeClient:
         if self._exc is not None:
             raise self._exc
         return self._hits
-
-
-@pytest.fixture
-def _patch_internal(monkeypatch):
-    """Replace the internal index path with a sentinel so fallback is
-    observable without seeding Postgres."""
-
-    async def _fake_internal(session, **kwargs):
-        return [_INTERNAL_SENTINEL]
-
-    monkeypatch.setattr(ks, "_search_internal", _fake_internal)
 
 
 def _use_client(monkeypatch, client) -> None:
@@ -89,11 +68,11 @@ def test_map_lighthouse_hit_handles_plain_summary() -> None:
     assert isinstance(hit.id, uuid.UUID)
 
 
-# ---- dual-read --------------------------------------------------------
+# ---- search (Lighthouse only) -----------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_dual_read_returns_mapped_lighthouse_hits(monkeypatch, _patch_internal):
+async def test_search_returns_mapped_lighthouse_hits(monkeypatch):
     ws = uuid.uuid4()
     node = str(uuid.uuid4())
     client = _FakeClient(hits=[{"node_id": node, "summary": "# T\nbody"}])
@@ -107,38 +86,38 @@ async def test_dual_read_returns_mapped_lighthouse_hits(monkeypatch, _patch_inte
 
 
 @pytest.mark.asyncio
-async def test_dual_read_falls_back_when_lighthouse_empty(monkeypatch, _patch_internal):
+async def test_search_empty_when_lighthouse_empty(monkeypatch):
+    # No internal fallback (K8): empty engine → empty result.
     _use_client(monkeypatch, _FakeClient(hits=[]))
     hits = await ks.search_workspace_knowledge(
         None, workspace_id=uuid.uuid4(), query="auth", settings=object()
     )
-    assert hits == [_INTERNAL_SENTINEL]
+    assert hits == []
 
 
 @pytest.mark.asyncio
-async def test_dual_read_falls_back_on_error(monkeypatch, _patch_internal):
+async def test_search_empty_on_error(monkeypatch):
+    # Engine outage degrades to empty, never raises.
     _use_client(monkeypatch, _FakeClient(exc=httpx.ConnectError("down")))
     hits = await ks.search_workspace_knowledge(
         None, workspace_id=uuid.uuid4(), query="auth", settings=object()
     )
-    assert hits == [_INTERNAL_SENTINEL]
+    assert hits == []
 
 
 @pytest.mark.asyncio
-async def test_dual_read_uses_internal_when_lighthouse_disabled(
-    monkeypatch, _patch_internal
-):
+async def test_search_empty_when_lighthouse_disabled(monkeypatch):
     _use_client(monkeypatch, None)  # build_lighthouse_client → None
     hits = await ks.search_workspace_knowledge(
         None, workspace_id=uuid.uuid4(), query="auth", settings=object()
     )
-    assert hits == [_INTERNAL_SENTINEL]
+    assert hits == []
 
 
 @pytest.mark.asyncio
-async def test_dual_read_skips_lighthouse_when_bucket_slug_pinned(
-    monkeypatch, _patch_internal
-):
+async def test_search_ignores_bucket_slug_and_still_queries_lighthouse(monkeypatch):
+    # bucket_slug is accepted for wire-compat but no longer routes to an
+    # internal index — Lighthouse is still queried (flat corpus has no buckets).
     client = _FakeClient(hits=[{"node_id": str(uuid.uuid4()), "summary": "x"}])
     _use_client(monkeypatch, client)
     hits = await ks.search_workspace_knowledge(
@@ -148,13 +127,12 @@ async def test_dual_read_skips_lighthouse_when_bucket_slug_pinned(
         bucket_slug="runbooks",
         settings=object(),
     )
-    # A pinned bucket only the internal index can honour → Lighthouse skipped.
-    assert hits == [_INTERNAL_SENTINEL]
-    assert client.calls == []
+    assert [h.source for h in hits] == ["lighthouse"]
+    assert len(client.calls) == 1
 
 
 @pytest.mark.asyncio
-async def test_dual_read_blank_query_returns_empty(monkeypatch, _patch_internal):
+async def test_search_blank_query_returns_empty(monkeypatch):
     _use_client(monkeypatch, _FakeClient(hits=[{"node_id": "x", "summary": "y"}]))
     hits = await ks.search_workspace_knowledge(
         None, workspace_id=uuid.uuid4(), query="   ", settings=object()

--- a/apps/backend/tests/test_services_repo_intel.py
+++ b/apps/backend/tests/test_services_repo_intel.py
@@ -28,16 +28,8 @@ from sqlalchemy import select, text
 
 from backend.app.db.models.agent_memory import (
     BucketArticle,
-    BucketArticleSource,
-    BucketArticleStatus,
-    BucketScope,
-    BucketSource,
-    KnowledgeBucket,
     KnowledgeImportSource,
     KnowledgeImportSourceKind,
-    KnowledgeIngestionRun,
-    KnowledgeIngestionStatus,
-    KnowledgeSourceItem,
 )
 from backend.app.db.models.integrations import (
     GitHubInstallation,
@@ -534,15 +526,24 @@ async def test_commit_style_freeform_when_unmatched(
 
 
 # ---------------------------------------------------------------------------
-# 10. Knowledge-bucket projection
+# 10. Lighthouse emit (K8) — repo intel ships to Lighthouse only; the
+# internal knowledge-bucket projection is retired.
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_writes_repo_intel_md_to_workspace_import_source(
-    db_session, seed_activated_repo
+async def test_emits_repo_intel_to_lighthouse_without_internal_projection(
+    db_session, seed_activated_repo, monkeypatch
 ) -> None:
     workspace, repo, _ = seed_activated_repo
+
+    emitted: list[tuple] = []
+
+    async def _capture_emit(*, repo, intel):
+        emitted.append((repo.id, intel.id))
+
+    monkeypatch.setattr(svc, "_emit_intel_to_lighthouse", _capture_emit)
+
     gw = FakeCodeHost(
         files={
             "main.py": _FakeFile(path="main.py", content="x"),
@@ -560,19 +561,21 @@ async def test_writes_repo_intel_md_to_workspace_import_source(
         gateway=gw,
         commit_fetcher=_no_commits,
     )
-    assert report.knowledge_articles_written == 6
 
-    repo_bucket = (
+    # K8: shipped to Lighthouse once; no internal articles written.
+    assert report.knowledge_articles_written == 0
+    assert emitted == [(repo.id, report.intel_id)]
+
+    # No internal bucket projection / import source / ingestion run.
+    articles = (
         await db_session.execute(
-            select(KnowledgeBucket).where(
-                KnowledgeBucket.workspace_id == workspace.id,
-                KnowledgeBucket.repo_id == repo.id,
-                KnowledgeBucket.scope_kind == BucketScope.REPO,
-                KnowledgeBucket.source_kind == BucketSource.REPO_CONTEXT,
+            select(BucketArticle)
+            .where(
+                BucketArticle.provenance["repo_id"].astext == str(repo.id),
             )
         )
-    ).scalars().first()
-    assert repo_bucket is None
+    ).scalars().all()
+    assert articles == []
 
     source = (
         await db_session.execute(
@@ -582,66 +585,8 @@ async def test_writes_repo_intel_md_to_workspace_import_source(
                 KnowledgeImportSource.kind == KnowledgeImportSourceKind.DOCS_REPO,
             )
         )
-    ).scalars().one()
-    assert source.config["harvester"] == "repo_intel"
-    assert source.content_fingerprint
-
-    articles = (
-        await db_session.execute(
-            select(BucketArticle, KnowledgeBucket)
-            .join(KnowledgeBucket, KnowledgeBucket.id == BucketArticle.bucket_id)
-            .where(
-                KnowledgeBucket.workspace_id == workspace.id,
-                KnowledgeBucket.scope_kind == BucketScope.WORKSPACE,
-                BucketArticle.status == BucketArticleStatus.PUBLISHED,
-                BucketArticle.provenance["repo_id"].astext == str(repo.id),
-            )
-        )
-    ).all()
-    repo_slug = repo.full_name.replace("/", "-")
-    assert {article.slug for article, _ in articles} == {
-        f"{repo_slug}-{slug}"
-        for slug in {
-            "architecture",
-            "dev-environment",
-            "overview",
-            "rules",
-            "visual-style",
-            "workflow",
-        }
-    }
-    assert {bucket.scope_kind for _, bucket in articles} == {BucketScope.WORKSPACE}
-    overview = next(
-        article
-        for article, _ in articles
-        if article.slug == f"{repo_slug}-overview"
-    )
-    assert "# Repository overview" in overview.body_md
-    assert "next.js" in overview.body_md
-    assert overview.provenance.get("source") == "repo_context"
-
-    items = (
-        await db_session.execute(
-            select(KnowledgeSourceItem).where(
-                KnowledgeSourceItem.source_id == source.id,
-            )
-        )
-    ).scalars().all()
-    assert len(items) == 6
-    run = (
-        await db_session.execute(
-            select(KnowledgeIngestionRun).where(
-                KnowledgeIngestionRun.source_id == source.id
-            )
-        )
-    ).scalars().one()
-    assert run.status == KnowledgeIngestionStatus.DONE
-    links = (
-        await db_session.execute(
-            select(BucketArticleSource).where(BucketArticleSource.run_id == run.id)
-        )
-    ).scalars().all()
-    assert len(links) == 6
+    ).scalars().first()
+    assert source is None
 
 
 # ---------------------------------------------------------------------------

--- a/apps/backend/tests/test_v1_knowledge_search.py
+++ b/apps/backend/tests/test_v1_knowledge_search.py
@@ -1,311 +1,75 @@
-"""HTTP tests for workspace knowledge search.
+"""HTTP tests for workspace knowledge search (K8 — Lighthouse only).
 
-Covers the vector-search ranking and the tsvector keyword fallback
-that kicks in when the embedding provider isn't configured.
-
-Embeddings are deterministic-stubbed through ``monkeypatch`` so the
-test suite stays offline — cosine distance on unit-length basis
-vectors is exactly predictable, which is all we need to pin the
-ranker without shipping a vector-quality evaluation into pytest.
+The internal vector/keyword index is retired: the route now delegates
+to the per-workspace Lighthouse engine and returns whatever it holds.
+These tests monkeypatch the Lighthouse client so the suite stays
+offline — engine retrieval quality is covered in whafr, not here.
 """
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from typing import Sequence
+import uuid
 
 import pytest
-import pytest_asyncio
+
+import backend.app.services.knowledge_search as ks
 
 
-EMBED_DIM = 1536
+class _FakeClient:
+    def __init__(self, *, hits=None):
+        self._hits = hits or []
+        self.calls: list[tuple] = []
+
+    async def search(self, *, workspace_id, query, top_k):
+        self.calls.append((str(workspace_id), query, top_k))
+        return self._hits
 
 
-def _unit_vec(index: int) -> list[float]:
-    """Basis vector e_index — cosine_distance(e_i, e_j) == 1 when
-    i != j and 0 when i == j. Perfect for pinning "which seed wins
-    which query" without any real embedding service."""
-    v = [0.0] * EMBED_DIM
-    v[index % EMBED_DIM] = 1.0
-    return v
+def _use_client(monkeypatch, client) -> None:
+    monkeypatch.setattr(ks, "build_lighthouse_client", lambda settings: client)
 
 
-class _FakeEmbedder:
-    """Callable stand-in for :func:`embed_text`.
-
-    Maps a curated set of query strings onto deterministic basis
-    vectors so the surrounding test can assert ordering without
-    poking at pgvector internals. Unknown queries get a "far from
-    everything" vector so the query is still valid but scores stay
-    low.
-    """
-
-    def __init__(self, mapping: dict[str, int]):
-        self._mapping = mapping
-        self.calls: list[str] = []
-
-    async def __call__(self, query: str, *, settings=None) -> list[float]:
-        self.calls.append(query)
-        idx = self._mapping.get(query.strip())
-        if idx is None:
-            return _unit_vec(999)
-        return _unit_vec(idx)
-
-
-@pytest_asyncio.fixture
-async def seed_search_workspace(db_session, seed_workspace):
-    """Seed two activated repos + a mix of workspace/repo buckets.
-
-    The per-test database fixture rolls back on teardown, so the
-    articles + chunks planted here only live for the duration of the
-    test that consumes the fixture.
-    """
-    from backend.app.db.models.agent_memory import (
-        BucketArticle,
-        BucketScope,
-        BucketSource,
-        KbChunk,
-        KnowledgeBucket,
-    )
-    from backend.app.db.models.integrations import (
-        GitHubInstallation,
-        WorkspaceRepo,
-    )
-
+@pytest.mark.asyncio
+async def test_search_returns_lighthouse_hits(
+    v1_client, seed_workspace, monkeypatch
+) -> None:
     _, raw, workspace = seed_workspace
+    headers = {"Authorization": f"Bearer {raw}"}
 
-    install = GitHubInstallation(
-        workspace_id=workspace.id,
-        installation_id=9_700_001,
-        account_login="ks",
-        account_type="Organization",
-        repository_selection="selected",
-        installed_at=datetime.now(timezone.utc),
+    node = str(uuid.uuid4())
+    client = _FakeClient(
+        hits=[{"node_id": node, "summary": "# Auth\nUse PKCE for SPAs."}]
     )
-    db_session.add(install)
-    await db_session.flush()
-
-    repo_a = WorkspaceRepo(
-        workspace_id=workspace.id,
-        installation_id=install.id,
-        provider="github",
-        external_id=50001,
-        full_name="ks/api",
-        default_branch="main",
-        private=False,
-        html_url="https://github.com/ks/api",
-        activated_at=datetime.now(timezone.utc),
-    )
-    repo_b = WorkspaceRepo(
-        workspace_id=workspace.id,
-        installation_id=install.id,
-        provider="github",
-        external_id=50002,
-        full_name="ks/web",
-        default_branch="main",
-        private=False,
-        html_url="https://github.com/ks/web",
-        activated_at=datetime.now(timezone.utc),
-    )
-    db_session.add_all([repo_a, repo_b])
-    await db_session.flush()
-
-    # Workspace-canonical bucket + article (vec idx 2).
-    ws_bucket = KnowledgeBucket(
-        workspace_id=workspace.id,
-        slug="auth-runbook",
-        name="Auth runbook",
-        description="Workspace canonical auth knowledge.",
-        scope_kind=BucketScope.WORKSPACE,
-        source_kind=BucketSource.AGENT_MEMORY,
-    )
-    db_session.add(ws_bucket)
-    await db_session.flush()
-
-    ws_article = BucketArticle(
-        bucket_id=ws_bucket.id,
-        slug="main",
-        title="Auth runbook (workspace)",
-        body_md="Workspace canonical guidance for the auth subsystem.",
-        content_sha="ws" + "0" * 62,
-        embedding=_unit_vec(2),
-    )
-    db_session.add(ws_article)
-    await db_session.flush()
-
-    # Repo-A bucket + article (vec idx 0).
-    repo_a_bucket = KnowledgeBucket(
-        workspace_id=workspace.id,
-        slug="auth-runbook",
-        name="Auth runbook (api)",
-        description="Repo-specific auth knowledge.",
-        scope_kind=BucketScope.REPO,
-        source_kind=BucketSource.REPO_FILES,
-        repo_id=repo_a.id,
-    )
-    db_session.add(repo_a_bucket)
-    await db_session.flush()
-
-    repo_a_article = BucketArticle(
-        bucket_id=repo_a_bucket.id,
-        slug="main",
-        title="Auth runbook (api)",
-        body_md="Repo-A specific auth guidance for ks/api.",
-        content_sha="ra" + "0" * 62,
-        embedding=_unit_vec(0),
-    )
-    db_session.add(repo_a_article)
-    await db_session.flush()
-
-    # Repo-B bucket + article (vec idx 1).
-    repo_b_bucket = KnowledgeBucket(
-        workspace_id=workspace.id,
-        slug="auth-runbook",
-        name="Auth runbook (web)",
-        description="Repo-B specific auth knowledge.",
-        scope_kind=BucketScope.REPO,
-        source_kind=BucketSource.REPO_FILES,
-        repo_id=repo_b.id,
-    )
-    db_session.add(repo_b_bucket)
-    await db_session.flush()
-
-    repo_b_article = BucketArticle(
-        bucket_id=repo_b_bucket.id,
-        slug="main",
-        title="Auth runbook (web)",
-        body_md="Repo-B specific auth guidance for ks/web.",
-        content_sha="rb" + "0" * 62,
-        embedding=_unit_vec(1),
-    )
-    db_session.add(repo_b_article)
-    await db_session.flush()
-
-    # KbChunks in each repo so we exercise the chunk half of the
-    # union as well. These share the basis vectors with their parent
-    # repo's article so the test can assert "hits from repo_a" via
-    # either source.
-    db_session.add_all(
-        [
-            KbChunk(
-                workspace_id=workspace.id,
-                repo_id=repo_a.id,
-                source_path=".ship/knowledge/auth.md",
-                content="Chunk of repo-A auth docs.",
-                chunk_index=0,
-                content_sha="cha" + "0" * 61,
-                embedding=_unit_vec(0),
-            ),
-            KbChunk(
-                workspace_id=workspace.id,
-                repo_id=repo_b.id,
-                source_path=".ship/knowledge/auth.md",
-                content="Chunk of repo-B auth docs.",
-                chunk_index=0,
-                content_sha="chb" + "0" * 61,
-                embedding=_unit_vec(1),
-            ),
-        ]
-    )
-    await db_session.flush()
-
-    return {
-        "raw": raw,
-        "workspace": workspace,
-        "repo_a": repo_a,
-        "repo_b": repo_b,
-        "ws_bucket": ws_bucket,
-        "ws_article": ws_article,
-        "repo_a_bucket": repo_a_bucket,
-        "repo_a_article": repo_a_article,
-        "repo_b_bucket": repo_b_bucket,
-        "repo_b_article": repo_b_article,
-    }
-
-
-def _patch_embedder(monkeypatch, embedder: _FakeEmbedder) -> None:
-    # PR-7C extracted the embedding call into
-    # ``backend.app.services.knowledge_search``; the HTTP route now
-    # delegates to that module, so tests patch there.
-    import backend.app.services.knowledge_search as mod
-
-    monkeypatch.setattr(mod, "embed_text", embedder)
-
-
-@pytest.mark.asyncio
-async def test_search_returns_workspace_hits_only_even_with_repo_hint(
-    v1_client, seed_search_workspace, monkeypatch
-) -> None:
-    ctx = seed_search_workspace
-    headers = {"Authorization": f"Bearer {ctx['raw']}"}
-
-    embedder = _FakeEmbedder({"auth": 0})
-    _patch_embedder(monkeypatch, embedder)
+    _use_client(monkeypatch, client)
 
     resp = await v1_client.post(
-        f"/v1/workspaces/{ctx['workspace'].id}/knowledge/search",
-        headers=headers,
-        json={
-            "query": "auth",
-            "repo_id": str(ctx["repo_a"].id),
-            "limit": 10,
-        },
-    )
-    assert resp.status_code == 200, resp.text
-    body = resp.json()
-    assert [hit["rank_bucket"] for hit in body["hits"]] == ["workspace"]
-    assert body["hits"][0]["repo_id"] is None
-
-
-@pytest.mark.asyncio
-async def test_search_ranks_workspace_first_without_repo_match(
-    v1_client, seed_search_workspace, monkeypatch
-) -> None:
-    ctx = seed_search_workspace
-    headers = {"Authorization": f"Bearer {ctx['raw']}"}
-
-    embedder = _FakeEmbedder({"auth": 0})
-    _patch_embedder(monkeypatch, embedder)
-
-    resp = await v1_client.post(
-        f"/v1/workspaces/{ctx['workspace'].id}/knowledge/search",
+        f"/v1/workspaces/{workspace.id}/knowledge/search",
         headers=headers,
         json={"query": "auth", "limit": 10},
     )
     assert resp.status_code == 200, resp.text
     body = resp.json()
-    rank_buckets = [hit["rank_bucket"] for hit in body["hits"]]
-
-    assert rank_buckets == ["workspace"]
+    assert body["query"] == "auth"
+    assert [hit["source"] for hit in body["hits"]] == ["lighthouse"]
+    assert body["hits"][0]["title"] == "Auth"
+    # Scoped by workspace, top_k forwarded.
+    assert client.calls == [(str(workspace.id), "auth", 10)]
 
 
 @pytest.mark.asyncio
-async def test_search_falls_back_to_keyword_when_embeddings_unconfigured(
-    v1_client, seed_search_workspace, monkeypatch
+async def test_search_empty_when_engine_unconfigured(
+    v1_client, seed_workspace, monkeypatch
 ) -> None:
-    """When the embedding provider is unconfigured, search returns a
-    tsvector keyword-match result set instead of 412'ing."""
-    ctx = seed_search_workspace
-    headers = {"Authorization": f"Bearer {ctx['raw']}"}
+    _, raw, workspace = seed_workspace
+    headers = {"Authorization": f"Bearer {raw}"}
 
-    import backend.app.services.knowledge_search as mod
-
-    async def _boom(_query: str, *, settings=None) -> list[float]:
-        raise RuntimeError("OPENAI_API_KEY is not configured.")
-
-    monkeypatch.setattr(mod, "embed_text", _boom)
+    _use_client(monkeypatch, None)  # build_lighthouse_client → None
 
     resp = await v1_client.post(
-        f"/v1/workspaces/{ctx['workspace'].id}/knowledge/search",
+        f"/v1/workspaces/{workspace.id}/knowledge/search",
         headers=headers,
         json={"query": "auth"},
     )
     assert resp.status_code == 200, resp.text
     body = resp.json()
-    assert body["query"] == "auth"
-    # Keyword fallback returns hits the embedding path would have
-    # surfaced too; we don't pin a specific count because the seed
-    # corpus + tsvector tokenisation can move with seed tweaks.
-    assert isinstance(body["hits"], list)
-
-
+    assert body["hits"] == []


### PR DESCRIPTION
## Summary
K8 functional core of the Knowledge → Lighthouse per-workspace epic: cut Ship over to **Lighthouse-only** knowledge reads and stop the last internal dual-write.

- `search_workspace_knowledge` now reads **solely** from the per-workspace Lighthouse engine. The K5 dual-read fallback to Ship's internal index is retired — an unconfigured/unreachable engine or an empty corpus returns `[]` (the accepted search blackout) rather than falling back.
- `repo_intel.harvest_repo_intel` stops the internal bucket projection (`_write_intel_markdown`) dual-write and ships repo intel to Lighthouse only (`_emit_intel_to_lighthouse`).
- `EmbeddingsUnavailable` / `KnowledgeSearchHit` stay exported (route + agent tools still import them); the internal-index machinery (`_search_internal` + helpers) and the knowledge tables remain as dead code on purpose.

## Scope note — the table-drop/dead-code purge is a deliberate follow-up
Literally dropping the internal knowledge tables and deleting `_search_internal`/`_write_intel_markdown` is entangled with ~27 core backend files (chat, seed_bundle, agent/tools, agent/topic, inbox/side_effects, dashboard_live_system, …) that still reference the models. Doing it blind breaks those features — worse than the accepted read blackout. That purge gets its own PR.

## Test plan
- [x] `tests/test_lighthouse_knowledge.py` — rewrote the dual-read tests for Lighthouse-only semantics (empty/error/disabled → `[]`; `bucket_slug` ignored but engine still queried)
- [x] `tests/test_v1_knowledge_search.py` — replaced the internal vector/keyword HTTP tests with Lighthouse-only route tests
- [x] `tests/test_services_repo_intel.py` — projection test now asserts emit-to-Lighthouse + no internal artifacts
- [x] `61 passed` across the knowledge/lighthouse/repo_intel suites; ruff clean on changed files