### PR TITLE
fix(knowledge): surface Lighthouse corpus panel when empty

### DIFF
--- a/apps/console/src/app/(authed)/knowledge/knowledge-control-center.tsx
+++ b/apps/console/src/app/(authed)/knowledge/knowledge-control-center.tsx
@@ -177,11 +177,13 @@ export function KnowledgeControlCenter({
 
 
 function CorpusSummary({ corpus }: { corpus: ApiKnowledgeCorpus | null }) {
-  // Render nothing until Lighthouse is wired + has content — the
-  // editorial canon view below stays the primary surface meanwhile.
-  if (!corpus || !corpus.configured || corpus.total_chunks === 0) return null;
+  // Render nothing only until Lighthouse is wired. Once configured, we
+  // surface the panel even when empty so the operator can see the new
+  // engine is live (and that the corpus just hasn't been populated yet).
+  if (!corpus || !corpus.configured) return null;
   const top = corpus.sources.slice(0, 8);
   const ingested = corpus.last_ingest_at?.slice(0, 10) ?? null;
+  const empty = corpus.total_chunks === 0;
   return (
     <section className="rounded-lg border border-white/10 bg-white/[0.02] p-4">
       <div className="flex items-baseline justify-between gap-3">
@@ -194,20 +196,29 @@ function CorpusSummary({ corpus }: { corpus: ApiKnowledgeCorpus | null }) {
           {ingested ? ` · last ingest ${ingested}` : ""}
         </p>
       </div>
-      {top.length > 0 && (
-        <ul className="mt-3 divide-y divide-white/5 text-sm">
-          {top.map((s) => (
-            <li
-              key={s.source}
-              className="flex items-center justify-between gap-3 py-1.5"
-            >
-              <span className="truncate text-white/70">{s.source}</span>
-              <span className="shrink-0 text-xs text-white/40">
-                {s.chunk_count}
-              </span>
-            </li>
-          ))}
-        </ul>
+      {empty ? (
+        <p className="mt-3 text-sm text-white/55">
+          Engine connected — no documents have been ingested into this
+          workspace yet. Once Ship emits its first knowledge document
+          (repo intel, resolved clarification, inbox comment), the next
+          importer run picks it up and it shows up here.
+        </p>
+      ) : (
+        top.length > 0 && (
+          <ul className="mt-3 divide-y divide-white/5 text-sm">
+            {top.map((s) => (
+              <li
+                key={s.source}
+                className="flex items-center justify-between gap-3 py-1.5"
+              >
+                <span className="truncate text-white/70">{s.source}</span>
+                <span className="shrink-0 text-xs text-white/40">
+                  {s.chunk_count}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )
       )}
     </section>
   );


### PR DESCRIPTION
## Summary
The K7 corpus panel was gated on `total_chunks > 0`, so a freshly wired engine with no documents looked identical to a not-connected one — the page just hid the panel entirely. Now we render the panel whenever the engine is `configured`, with an explicit empty-state copy so the operator can see the new wiring is live AND what's missing.

This is the immediate fix for "I don't see the new knowledge UI" — Lighthouse-ship is live and reachable from Ship, but the corpus is currently empty (no organic emit triggers have fired yet in prod), so the panel was hiding itself.

## Test plan
- [x] `npx tsc --noEmit` clean on the console
- [ ] Verify in browser: with Lighthouse configured + 0 chunks, the panel shows "Engine connected — no documents ingested yet"
- [ ] Verify in browser: once any document lands in Lighthouse, the panel switches to the per-source list