### PR TITLE
fix(knowledge): remove legacy editorial UI (Recent / Browse by area / Sources)

### DIFF
--- a/apps/console/src/app/(authed)/knowledge/knowledge-control-center.tsx
+++ b/apps/console/src/app/(authed)/knowledge/knowledge-control-center.tsx
@@ -1,87 +1,41 @@
 "use client";
 
 /**
- * Knowledge index — editorial multi-column.
+ * Knowledge index — Lighthouse-only surface.
  *
- * Layout (≥ lg):
+ * The legacy editorial layout (Recent topic-views / Browse by area /
+ * Sources sidebar, all backed by the retired internal claim-graph
+ * pipeline) has been removed. What remains:
  *
- *   ┌──────────────────────────────────────────────────────────┐
- *   │  Search · Import source · Export ZIP                      │
- *   ├──────────────────────────────────┬───────────────────────┤
- *   │  Recent (col-span-8)             │  Browse by area (4)    │
- *   │    Lede article                  │    Sticky bucket nav   │
- *   │    Recent rows (divide-y)        │                        │
- *   ├──────────────────────────────────┴───────────────────────┤
- *   │  Sources (collapsed)                                      │
- *   └──────────────────────────────────────────────────────────┘
+ *   - a search bar that hits the per-workspace Lighthouse engine
+ *   - the Lighthouse corpus panel (what the engine actually holds)
+ *   - search results when a query is active
  *
- * Below ``lg``: collapses to a single column with the bucket nav
- * lifted above Recent (so the IA is visible without scrolling).
- *
- * Style cues: Linear changelog rhythm + Stripe Press editorial ledes.
- * No bordered cards; sections separated by whitespace + a single
- * hairline rule. ``aqua`` (champagne gold) is reserved for editorial
- * accents (lede hairline, link hover); ``lilac`` for bucket nav;
- * ``coral`` for errors only.
+ * The internal-index data fetches in ``page.tsx`` were dropped at the
+ * same time, so this component no longer takes topic-views / sources
+ * / repos / integrations.
  */
 
-import Link from "next/link";
 import { useState, useTransition } from "react";
 
-import { cn } from "@/lib/cn";
 import type {
-  ApiActivatedRepo,
   ApiKnowledgeCorpus,
   ApiKnowledgeSearchHit,
   ApiKnowledgeSearchResponse,
 } from "@/lib/api/client";
-import type { ApiIntegration } from "@/lib/api/types";
 
-import { archiveImportSourceAction } from "./actions";
-import { KnowledgeImportWizard } from "./import-wizard";
-
-
-export type KnowledgeTopicViewRow = {
-  topicTag: string;
-  title: string;
-  snippet: string | null;
-  claimCount: number;
-  renderedByModel: string | null;
-  lastRenderedAt: string;
-};
-
-export type KnowledgeSourceRow = {
-  id: string;
-  name: string;
-  kind: string;
-  status: string;
-  lastSyncedAt: string | null;
-  lastError: string | null;
-};
 
 type Props = {
   workspace: { id?: string; slug: string; name: string };
-  topicViews: KnowledgeTopicViewRow[];
-  sources: KnowledgeSourceRow[];
-  repos: ApiActivatedRepo[];
-  integrations: ApiIntegration[];
   corpus: ApiKnowledgeCorpus | null;
 };
 
 
-export function KnowledgeControlCenter({
-  workspace,
-  topicViews,
-  sources,
-  repos,
-  integrations,
-  corpus,
-}: Props) {
+export function KnowledgeControlCenter({ workspace, corpus }: Props) {
   const [query, setQuery] = useState("");
   const [searchHits, setSearchHits] = useState<ApiKnowledgeSearchHit[] | null>(null);
   const [searchedFor, setSearchedFor] = useState("");
   const [searchError, setSearchError] = useState<string | null>(null);
-  const [importOpen, setImportOpen] = useState(false);
   const [pending, startTransition] = useTransition();
 
   function runSearch(event?: React.FormEvent) {
@@ -140,9 +94,6 @@ export function KnowledgeControlCenter({
         onSubmit={runSearch}
         onClear={clearSearch}
         isSearching={isSearching}
-        importOpen={importOpen}
-        onToggleImport={() => setImportOpen((v) => !v)}
-        workspaceId={workspace.id}
       />
 
       <CorpusSummary corpus={corpus} />
@@ -150,21 +101,8 @@ export function KnowledgeControlCenter({
       {pending && <p className="text-xs text-white/45">Searching…</p>}
       {searchError && <p className="text-sm text-coral">{searchError}</p>}
 
-      {importOpen && (
-        <ImportPanel
-          repos={repos}
-          integrations={integrations}
-          sources={sources}
-          workspaceId={workspace.id}
-        />
-      )}
-
-      {isSearching ? (
+      {isSearching && (
         <SearchResults hits={searchHits ?? []} queriedFor={searchedFor} />
-      ) : topicViews.length === 0 ? (
-        <EmptyTopics hasSources={sources.length > 0} />
-      ) : (
-        <EditorialLayout topicViews={topicViews} sources={sources} />
       )}
     </div>
   );
@@ -172,14 +110,11 @@ export function KnowledgeControlCenter({
 
 
 // ---------------------------------------------------------------------------
-// Lighthouse corpus summary (K7) — what the per-workspace engine holds
+// Lighthouse corpus summary — what the per-workspace engine holds
 // ---------------------------------------------------------------------------
 
 
 function CorpusSummary({ corpus }: { corpus: ApiKnowledgeCorpus | null }) {
-  // Render nothing only until Lighthouse is wired. Once configured, we
-  // surface the panel even when empty so the operator can see the new
-  // engine is live (and that the corpus just hasn't been populated yet).
   if (!corpus || !corpus.configured) return null;
   const top = corpus.sources.slice(0, 8);
   const ingested = corpus.last_ingest_at?.slice(0, 10) ?? null;
@@ -226,262 +161,7 @@ function CorpusSummary({ corpus }: { corpus: ApiKnowledgeCorpus | null }) {
 
 
 // ---------------------------------------------------------------------------
-// Editorial layout — Lede + Recent rows + Browse-by-area sidebar
-// ---------------------------------------------------------------------------
-
-
-function EditorialLayout({
-  topicViews,
-  sources,
-}: {
-  topicViews: KnowledgeTopicViewRow[];
-  sources: KnowledgeSourceRow[];
-}) {
-  // Topic views arrive sorted by claim_count desc from the API. The
-  // first row is the lede (deepest topic = most-attested area in the
-  // workspace canon); the next ~12 are the recent stack. Anything
-  // past that lives only in the sidebar so the main column stays
-  // scannable on a laptop screen.
-  const lede = topicViews[0];
-  const rest = topicViews.slice(1, 13);
-  const areas = clusterTopicsByPrefix(topicViews);
-
-  return (
-    <div className="grid grid-cols-1 gap-x-12 gap-y-12 lg:grid-cols-12 2xl:gap-x-16">
-      <section className="space-y-8 lg:col-span-8 2xl:col-span-7">
-        <SectionKicker tone="aqua">
-          Recent
-          <span className="ml-2 text-white/40">· {topicViews.length}</span>
-        </SectionKicker>
-        <LedeTopic view={lede} />
-        {rest.length > 0 && (
-          <ul className="divide-y divide-white/5">
-            {rest.map((view) => (
-              <li key={view.topicTag} className="py-5 first:pt-6">
-                <TopicRow view={view} />
-              </li>
-            ))}
-          </ul>
-        )}
-      </section>
-
-      <aside className="space-y-6 lg:col-span-4 lg:sticky lg:top-24 lg:self-start 2xl:col-span-3">
-        <SectionKicker tone="lilac">Browse by area</SectionKicker>
-        <AreaDirectory areas={areas} />
-      </aside>
-
-      {sources.length > 0 && (
-        <section className="space-y-3 lg:col-span-12 2xl:col-span-2 2xl:sticky 2xl:top-24 2xl:self-start">
-          <SectionKicker tone="muted">Sources</SectionKicker>
-          <ConnectedSources sources={sources} />
-        </section>
-      )}
-    </div>
-  );
-}
-
-
-function LedeTopic({ view }: { view: KnowledgeTopicViewRow }) {
-  const isAuto =
-    view.renderedByModel && view.renderedByModel !== "deterministic";
-  return (
-    <Link
-      href={`/knowledge/topics/${encodeURIComponent(view.topicTag)}`}
-      className="group block space-y-3 border-b border-aqua/30 pb-8"
-    >
-      <h3 className="font-display text-2xl font-bold leading-tight text-white group-hover:text-aqua md:text-3xl">
-        {view.title}
-      </h3>
-      {view.snippet && (
-        <p className="line-clamp-3 text-base leading-relaxed text-white/65">
-          {view.snippet}
-        </p>
-      )}
-      <p className="flex flex-wrap items-center gap-x-2 text-[11px] uppercase tracking-widest text-white/40">
-        <span>
-          {view.claimCount} claim{view.claimCount === 1 ? "" : "s"}
-        </span>
-        <span className="text-white/20">·</span>
-        <span>{relativeDate(view.lastRenderedAt)}</span>
-        {!isAuto && (
-          <>
-            <span className="text-white/20">·</span>
-            <span className="text-coral/70">deterministic fallback</span>
-          </>
-        )}
-      </p>
-    </Link>
-  );
-}
-
-
-function TopicRow({ view }: { view: KnowledgeTopicViewRow }) {
-  const isAuto =
-    view.renderedByModel && view.renderedByModel !== "deterministic";
-  return (
-    <Link
-      href={`/knowledge/topics/${encodeURIComponent(view.topicTag)}`}
-      className="group block space-y-1.5"
-    >
-      <div className="text-base font-semibold text-white group-hover:text-aqua">
-        {view.title}
-      </div>
-      {view.snippet && (
-        <p className="line-clamp-2 text-sm leading-relaxed text-white/55">
-          {view.snippet}
-        </p>
-      )}
-      <div className="text-[11px] text-white/40">
-        <span>
-          {view.claimCount} claim{view.claimCount === 1 ? "" : "s"}
-        </span>
-        <span className="mx-2 text-white/20">·</span>
-        <span>{relativeDate(view.lastRenderedAt)}</span>
-        {!isAuto && (
-          <>
-            <span className="mx-2 text-white/20">·</span>
-            <span className="text-coral/70">deterministic</span>
-          </>
-        )}
-      </div>
-    </Link>
-  );
-}
-
-
-// ---------------------------------------------------------------------------
-// Browse by area — auto-clustered topics
-// ---------------------------------------------------------------------------
-
-
-type Area = {
-  key: string;
-  label: string;
-  topics: KnowledgeTopicViewRow[];
-};
-
-
-function clusterTopicsByPrefix(views: KnowledgeTopicViewRow[]): Area[] {
-  // Heuristic: cluster on the first ``-``-separated token of the
-  // topic_tag. ``inbox-disposition`` + ``inbox-routing`` group under
-  // ``inbox``; standalone tags whose token has no other members go
-  // into a synthetic ``Other`` bucket so the sidebar stays compact.
-  const buckets = new Map<string, KnowledgeTopicViewRow[]>();
-  for (const view of views) {
-    const token = view.topicTag.split("-", 1)[0] || view.topicTag;
-    const list = buckets.get(token) ?? [];
-    list.push(view);
-    buckets.set(token, list);
-  }
-  const areas: Area[] = [];
-  const orphans: KnowledgeTopicViewRow[] = [];
-  for (const [key, topics] of buckets) {
-    if (topics.length === 1) {
-      orphans.push(topics[0]);
-      continue;
-    }
-    areas.push({
-      key,
-      label: humaniseTag(key),
-      topics: topics.sort((a, b) => b.claimCount - a.claimCount),
-    });
-  }
-  if (orphans.length > 0) {
-    areas.push({
-      key: "_other",
-      label: "Other",
-      topics: orphans.sort((a, b) => b.claimCount - a.claimCount),
-    });
-  }
-  return areas.sort((a, b) => {
-    // Bigger clusters first, "_other" pinned to the bottom.
-    if (a.key === "_other") return 1;
-    if (b.key === "_other") return -1;
-    const aTotal = a.topics.reduce((sum, t) => sum + t.claimCount, 0);
-    const bTotal = b.topics.reduce((sum, t) => sum + t.claimCount, 0);
-    return bTotal - aTotal;
-  });
-}
-
-
-function humaniseTag(tag: string): string {
-  return tag
-    .split(/[-_]/)
-    .filter(Boolean)
-    .map((part) => part[0].toUpperCase() + part.slice(1))
-    .join(" ");
-}
-
-
-function AreaDirectory({ areas }: { areas: Area[] }) {
-  if (areas.length === 0) return null;
-  return (
-    <ul className="divide-y divide-white/5">
-      {areas.map((area) => (
-        <li key={area.key} className="py-3 first:pt-0">
-          <div className="flex items-baseline justify-between gap-3">
-            <div className="font-display text-sm font-bold uppercase tracking-wider text-white/85">
-              {area.label}
-            </div>
-            <span className="shrink-0 font-mono text-xs text-white/35">
-              {area.topics.length}
-            </span>
-          </div>
-          <ul className="mt-2 space-y-1.5">
-            {area.topics.slice(0, 5).map((topic) => (
-              <li key={topic.topicTag}>
-                <Link
-                  href={`/knowledge/topics/${encodeURIComponent(topic.topicTag)}`}
-                  className="group flex items-baseline justify-between gap-3 text-xs text-white/55 hover:text-lilac"
-                >
-                  <span className="truncate">{topic.title}</span>
-                  <span className="shrink-0 font-mono text-white/30">
-                    {topic.claimCount}
-                  </span>
-                </Link>
-              </li>
-            ))}
-            {area.topics.length > 5 && (
-              <li className="text-[11px] text-white/30">
-                + {area.topics.length - 5} more
-              </li>
-            )}
-          </ul>
-        </li>
-      ))}
-    </ul>
-  );
-}
-
-
-function EmptyTopics({ hasSources }: { hasSources: boolean }) {
-  return (
-    <div className="space-y-3 text-sm text-white/55">
-      <p>
-        No topics rendered yet. The claim-graph pipeline groups extracted
-        atomic facts by ``topic_tag`` once at least three claims land per
-        topic.
-      </p>
-      {!hasSources ? (
-        <p>
-          Connect an import source (top right) so the extractor has
-          something to read.
-        </p>
-      ) : (
-        <p>
-          Sources are connected — wait for the next ``*/20`` extractor tick
-          and the ``15,45`` topic-render tick. If nothing appears within
-          an hour, the pipeline is broken upstream and you should ping
-          ops.
-        </p>
-      )}
-    </div>
-  );
-}
-
-
-// ---------------------------------------------------------------------------
-// Header — search + actions
+// Header — search
 // ---------------------------------------------------------------------------
 
 
@@ -491,61 +171,40 @@ function SearchHeader({
   onSubmit,
   onClear,
   isSearching,
-  importOpen,
-  onToggleImport,
-  workspaceId,
 }: {
   query: string;
   onChange: (v: string) => void;
   onSubmit: (e?: React.FormEvent) => void;
   onClear: () => void;
   isSearching: boolean;
-  importOpen: boolean;
-  onToggleImport: () => void;
-  workspaceId?: string;
 }) {
   return (
-    <div className="flex flex-col gap-3">
-      <form onSubmit={onSubmit} className="relative">
-        <input
-          type="search"
-          value={query}
-          onChange={(event) => onChange(event.target.value)}
-          placeholder="Search workspace knowledge…"
-          className="w-full border-b border-white/15 bg-transparent px-1 pb-3 pt-1 text-lg text-white placeholder:text-white/30 outline-none transition focus:border-aqua/60"
-          aria-label="Search workspace knowledge"
-        />
-        {(query || isSearching) && (
-          <button
-            type="button"
-            onClick={onClear}
-            aria-label="Clear search"
-            className="absolute right-1 top-2 text-xs text-white/45 hover:text-white"
-          >
-            clear
-          </button>
-        )}
-      </form>
-
-      <div className="flex items-center gap-3 text-xs">
+    <form onSubmit={onSubmit} className="relative">
+      <input
+        type="search"
+        value={query}
+        onChange={(event) => onChange(event.target.value)}
+        placeholder="Search workspace knowledge…"
+        className="w-full border-b border-white/15 bg-transparent px-1 pb-3 pt-1 text-lg text-white placeholder:text-white/30 outline-none transition focus:border-aqua/60"
+        aria-label="Search workspace knowledge"
+      />
+      {(query || isSearching) && (
         <button
           type="button"
-          onClick={onToggleImport}
-          className={cn(
-            "transition",
-            importOpen ? "text-aqua" : "text-white/55 hover:text-white",
-          )}
+          onClick={onClear}
+          aria-label="Clear search"
+          className="absolute right-1 top-2 text-xs text-white/45 hover:text-white"
         >
-          {importOpen ? "Close import" : "Import source"}
+          clear
         </button>
-      </div>
-    </div>
+      )}
+    </form>
   );
 }
 
 
 // ---------------------------------------------------------------------------
-// Search results — same shape as Recent rows, single column inside the grid
+// Search results
 // ---------------------------------------------------------------------------
 
 
@@ -558,9 +217,9 @@ function SearchResults({
 }) {
   return (
     <section className="space-y-6">
-      <SectionKicker tone="aqua">
+      <h2 className="text-[11px] font-bold uppercase tracking-[0.22em] text-aqua/75">
         Results for “{queriedFor}”
-      </SectionKicker>
+      </h2>
       {hits.length === 0 ? (
         <p className="text-sm text-white/55">
           {queriedFor ? `Nothing matched “${queriedFor}”.` : "No matches."}
@@ -580,195 +239,18 @@ function SearchResults({
 
 
 function SearchHitRow({ hit }: { hit: ApiKnowledgeSearchHit }) {
-  const title =
-    hit.title?.trim() ||
-    hit.bucket_slug ||
-    (hit.source === "kb_chunk" ? "Repo chunk" : "Article");
-  const href =
-    hit.source === "bucket_article" && hit.bucket_slug
-      ? `/knowledge/${encodeURIComponent(hit.bucket_slug)}?article=${encodeURIComponent(hit.id)}`
-      : null;
-  const content = (
-    <>
-      <div className="text-base font-semibold text-white group-hover:text-aqua">
-        {title}
-      </div>
+  const title = hit.title?.trim() || "Result";
+  return (
+    <div className="space-y-1.5">
+      <div className="text-base font-semibold text-white">{title}</div>
       {hit.snippet && (
-        <p className="mt-1 line-clamp-2 text-sm leading-relaxed text-white/55">
+        <p className="line-clamp-2 text-sm leading-relaxed text-white/55">
           {hit.snippet}
         </p>
       )}
-      <div className="mt-1 flex items-center gap-2 text-[11px] text-white/40">
-        {hit.bucket_slug && (
-          <>
-            <span>{hit.bucket_slug}</span>
-            <span className="text-white/20">·</span>
-          </>
-        )}
+      <div className="flex items-center gap-2 text-[11px] text-white/40">
         <span className="font-mono">{hit.score.toFixed(3)}</span>
       </div>
-    </>
+    </div>
   );
-  return href ? (
-    <Link href={href} className="group block">
-      {content}
-    </Link>
-  ) : (
-    <div className="group block">{content}</div>
-  );
-}
-
-
-// ---------------------------------------------------------------------------
-// Sources — wizard + connected list, full-width footer
-// ---------------------------------------------------------------------------
-
-
-function ImportPanel({
-  repos,
-  integrations,
-  sources,
-  workspaceId,
-}: {
-  repos: ApiActivatedRepo[];
-  integrations: ApiIntegration[];
-  sources: KnowledgeSourceRow[];
-  workspaceId: string | undefined;
-}) {
-  return (
-    <section className="space-y-6 border-l border-aqua/30 pl-6">
-      <KnowledgeImportWizard
-        integrations={integrations}
-        repos={repos}
-        defaultScope="workspace"
-        workspaceId={workspaceId}
-      />
-      {sources.length > 0 && <ConnectedSources sources={sources} />}
-    </section>
-  );
-}
-
-
-function ConnectedSources({ sources }: { sources: KnowledgeSourceRow[] }) {
-  if (sources.length === 0) return null;
-  return (
-    <ul className="divide-y divide-white/5">
-      {sources.map((source) => (
-        <ConnectedSourceRow key={source.id} source={source} />
-      ))}
-    </ul>
-  );
-}
-
-
-function ConnectedSourceRow({ source }: { source: KnowledgeSourceRow }) {
-  const [archived, setArchived] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [pending, startTransition] = useTransition();
-
-  if (archived) return null;
-
-  function archive() {
-    if (!confirm(`Archive “${source.name}”? It will stop syncing and disappear from this list.`)) {
-      return;
-    }
-    setError(null);
-    startTransition(async () => {
-      const result = await archiveImportSourceAction(source.id);
-      if (result.ok) {
-        setArchived(true);
-      } else {
-        setError(result.message);
-      }
-    });
-  }
-
-  return (
-    <li className="grid grid-cols-[1fr_auto_auto] items-center gap-3 py-3">
-      <div className="min-w-0">
-        <div className="flex items-center gap-2">
-          <span className="truncate text-sm font-semibold text-white">
-            {source.name}
-          </span>
-          <span className="text-[11px] uppercase tracking-widest text-white/40">
-            {source.kind}
-          </span>
-        </div>
-        {(source.lastError || error) && (
-          <p className="mt-0.5 line-clamp-1 text-[11px] text-coral">
-            {error ?? source.lastError}
-          </p>
-        )}
-      </div>
-      <div className="flex flex-col items-end text-[11px] text-white/45">
-        <span className={statusColor(source.status)}>{source.status}</span>
-        <span>
-          {source.lastSyncedAt ? relativeDate(source.lastSyncedAt) : "never"}
-        </span>
-      </div>
-      <button
-        type="button"
-        disabled={pending}
-        onClick={archive}
-        className="rounded-full border border-white/10 px-2.5 py-1 text-[11px] text-white/55 transition hover:border-coral/40 hover:text-coral disabled:cursor-not-allowed disabled:opacity-50"
-        data-testid={`source-archive-${source.id}`}
-      >
-        {pending ? "Archiving…" : "Archive"}
-      </button>
-    </li>
-  );
-}
-
-
-function statusColor(status: string): string {
-  if (status === "error") return "text-coral";
-  if (status === "syncing") return "text-aqua";
-  if (status === "ready") return "text-emerald-400";
-  return "text-white/55";
-}
-
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-
-function SectionKicker({
-  children,
-  tone,
-}: {
-  children: React.ReactNode;
-  tone: "aqua" | "lilac" | "muted";
-}) {
-  const toneClass =
-    tone === "aqua"
-      ? "text-aqua/75"
-      : tone === "lilac"
-        ? "text-lilac/75"
-        : "text-white/40";
-  return (
-    <h2
-      className={cn(
-        "text-[11px] font-bold uppercase tracking-[0.22em]",
-        toneClass,
-      )}
-    >
-      {children}
-    </h2>
-  );
-}
-
-
-function relativeDate(value: string | null | undefined): string {
-  if (!value) return "—";
-  const date = Date.parse(value);
-  if (Number.isNaN(date)) return "—";
-  const diff = Date.now() - date;
-  const minute = 60_000;
-  const hour = 60 * minute;
-  const day = 24 * hour;
-  if (diff < hour) return `${Math.max(1, Math.round(diff / minute))}m ago`;
-  if (diff < day) return `${Math.round(diff / hour)}h ago`;
-  if (diff < 30 * day) return `${Math.round(diff / day)}d ago`;
-  return new Date(date).toLocaleDateString();
 }

--- a/apps/console/src/app/(authed)/knowledge/page.tsx
+++ b/apps/console/src/app/(authed)/knowledge/page.tsx
@@ -9,9 +9,6 @@ import {
   ApiHttpError,
   getWorkspaceCorpus,
   listActivatedRepos,
-  listIntegrations,
-  listKnowledgeImportSources,
-  listTopicViews,
 } from "@/lib/api/client";
 import {
   getCachedMe,
@@ -20,25 +17,14 @@ import {
 } from "@/lib/api/session-cache.server";
 import { getResolvedWorkspaceId } from "@/lib/workspace-resolve.server";
 import { pickWorkspace } from "@/lib/workspace-scope";
-import type {
-  ApiIntegration,
-  ApiKnowledgeImportSource,
-} from "@/lib/api/types";
 
-import {
-  KnowledgeControlCenter,
-  type KnowledgeSourceRow,
-  type KnowledgeTopicViewRow,
-} from "./knowledge-control-center";
+import { KnowledgeControlCenter } from "./knowledge-control-center";
 
 export const dynamic = "force-dynamic";
 
 type LiveData = {
   workspace: { id: string; slug: string; name: string };
-  topicViews: KnowledgeTopicViewRow[];
-  sources: KnowledgeSourceRow[];
   repos: ApiActivatedRepo[];
-  integrations: ApiIntegration[];
   corpus: ApiKnowledgeCorpus | null;
   me: Awaited<ReturnType<typeof getCachedMe>>;
 };
@@ -63,32 +49,13 @@ async function load(
   const workspace = pickWorkspace(workspaceRows, resolved);
 
   try {
-    // Knowledge index reads the claim-graph canon directly. Legacy
-    // ``bucket_articles`` are intentionally NOT fetched here: keeping
-    // them on the page masks pipeline failures (operator sees stale
-    // articles from days ago and assumes the system is fine while
-    // the new extractor / reconciler / renderer chain has been
-    // silently broken). If the canon is empty, the page should look
-    // empty — that's the signal that something upstream needs
-    // attention.
-    const [repos, integrations, me, rawTopicViews, importSources, corpus] =
-      await Promise.all([
-        listActivatedRepos(workspace.id, token).catch(() => [] as ApiActivatedRepo[]),
-        listIntegrations(workspace.id, token).catch(() => [] as ApiIntegration[]),
-        getCachedMe(),
-        listTopicViews(workspace.id, { limit: 200 }, token),
-        listKnowledgeImportSources(workspace.id, token).catch(
-          () => [] as ApiKnowledgeImportSource[],
-        ),
-        // Lighthouse corpus roll-up. Best-effort — the page renders the
-        // legacy canon view too, so a missing engine just hides the panel.
-        getWorkspaceCorpus(workspace.id, token).catch(
-          () => null as ApiKnowledgeCorpus | null,
-        ),
-      ]);
-
-    const topicViews: KnowledgeTopicViewRow[] = rawTopicViews.map(toTopicViewRow);
-    const sources: KnowledgeSourceRow[] = importSources.map(toSourceRow);
+    const [repos, me, corpus] = await Promise.all([
+      listActivatedRepos(workspace.id, token).catch(() => [] as ApiActivatedRepo[]),
+      getCachedMe(),
+      getWorkspaceCorpus(workspace.id, token).catch(
+        () => null as ApiKnowledgeCorpus | null,
+      ),
+    ]);
 
     return {
       status: "live",
@@ -98,10 +65,7 @@ async function load(
           slug: workspace.slug,
           name: workspace.name,
         },
-        topicViews,
-        sources,
         repos,
-        integrations,
         corpus,
         me,
       },
@@ -135,8 +99,7 @@ export default async function KnowledgeIndexPage({
     );
   }
 
-  const { workspace, topicViews, sources, repos, integrations, corpus, me } =
-    result.data;
+  const { workspace, repos, corpus, me } = result.data;
 
   const scopePill = (
     <ScopePill
@@ -161,48 +124,8 @@ export default async function KnowledgeIndexPage({
     <>
       <PageHeader title="Knowledge" scopePill={scopePill} />
       <PageBody>
-        <KnowledgeControlCenter
-          workspace={workspace}
-          topicViews={topicViews}
-          sources={sources}
-          repos={repos}
-          integrations={integrations}
-          corpus={corpus}
-        />
+        <KnowledgeControlCenter workspace={workspace} corpus={corpus} />
       </PageBody>
     </>
   );
 }
-
-
-// ---------------------------------------------------------------------------
-// Mappers
-// ---------------------------------------------------------------------------
-
-
-function toTopicViewRow(
-  view: import("@/lib/api/client").ApiTopicViewSummary,
-): KnowledgeTopicViewRow {
-  return {
-    topicTag: view.topic_tag,
-    title: view.title || view.topic_tag,
-    snippet: view.snippet,
-    claimCount: view.claim_count,
-    renderedByModel: view.rendered_by_model,
-    lastRenderedAt: view.last_rendered_at,
-  };
-}
-
-
-function toSourceRow(source: ApiKnowledgeImportSource): KnowledgeSourceRow {
-  return {
-    id: source.id,
-    name: source.name,
-    kind: source.kind,
-    status: source.status,
-    lastSyncedAt: source.last_synced_at,
-    lastError: source.last_error,
-  };
-}
-
-


### PR DESCRIPTION
## Summary
The /knowledge page still rendered the retired claim-graph pipeline's editorial layout — `Recent` topic-views, `Browse by area` auto-clusters, the `Sources` sidebar, and the import wizard — all backed by internal tables that no producer writes to anymore (K6c retired the processing crons). Strip it.

After this PR the page shows:
- search bar (hits the per-workspace Lighthouse engine)
- Lighthouse corpus panel (K7)
- search results when a query is active

`page.tsx` now fetches only `getWorkspaceCorpus` + `listActivatedRepos`; `listTopicViews` / `listKnowledgeImportSources` / `listIntegrations` calls are gone.

The orphaned route files (`/knowledge/topics/[topicTag]`, `/knowledge/[slug]`) and the import-wizard components become true dead code — they'll be removed alongside the table-drop in the K8 purge follow-up.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `vitest run` — 38 passed
- [ ] Browser: /knowledge shows search + corpus panel only; no Recent / Browse by area / Sources