### PR TITLE
feat(fsm): self-aware agent preamble — read ticket before working

### DIFF
--- a/apps/backend/app/api/v1/routes/agent_runs.py
+++ b/apps/backend/app/api/v1/routes/agent_runs.py
@@ -48,7 +48,7 @@ import re
 import struct
 import uuid
 from datetime import datetime, timedelta, timezone
-from typing import Any, Literal
+from typing import Any, Final, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field
@@ -74,6 +74,7 @@ from backend.app.services.inbox.sweep import sweep_auto_resolvable
 from backend.app.services.dispatcher import (
     ENV_SEPARATION_ACK_KEY,
     ENV_SEPARATION_PENDING_KEY,
+    _STAGE_TO_ROUTINE,
     env_separation_handle,
     normalize_routine_id,
 )
@@ -1182,6 +1183,21 @@ async def get_next_task(
             file_coordination_warning = overlap.warning_markdown
 
     body = pick.get("body") if isinstance(pick.get("body"), str) else None
+    # Self-aware preamble — surface this role's recent finish outcomes on
+    # this ticket so the agent can detect "I already did this, just need
+    # to transition" before re-doing work. Pairs with system.md's
+    # "Read before working" decision rule. Best-effort: a DB hiccup
+    # degrades silently, the ticket-body fallback still carries the brief.
+    if ticket_ref:
+        prior = await _fetch_prior_finishes_section(
+            session,
+            workspace_id=workspace_id,
+            ticket_ref=ticket_ref,
+            current_role=_STAGE_TO_ROUTINE.get(state) or state,
+        )
+        if prior:
+            body = f"{body}\n\n{prior}" if body else prior
+
     # Conversation context for EVERY role (not just the dev): the recent
     # SDLC verdict thread + operator hints. The dev gets it framed as
     # "feedback to address" (the dev_not_converging fix); reviewer /
@@ -1944,6 +1960,103 @@ def _extract_project_sections(
 
 _OPERATOR_HINT_MARKERS: tuple[str, ...] = ("[Operator hint", "[Operator]")
 _REVIEWER_FEEDBACK_CAP_BYTES = 6 * 1024
+
+# How many previous finishes we surface in the self-aware preamble.
+# Three is "your last few attempts on this ticket" — enough context
+# to spot a retry-loop or an orphan-finish without dumping the full
+# audit. Older runs are still in the verdict thread via
+# ``_fetch_reviewer_feedback_section``; this block is the agent's own
+# log, not the cross-role conversation.
+_PRIOR_FINISHES_LIMIT: Final[int] = 3
+_PRIOR_FINISH_DESCRIPTION_CAP: Final[int] = 400
+
+
+async def _fetch_prior_finishes_section(
+    session: AsyncSession,
+    *,
+    workspace_id: uuid.UUID,
+    ticket_ref: str,
+    current_role: str,
+) -> str | None:
+    """Markdown block listing this role's recent ``agent_run.finish``
+    rows on this ticket, or ``None`` when there are none.
+
+    Pairs with ``system.md``'s "Read before working" preamble: the
+    decision rule there tells the agent to detect "I already did this,
+    just need to transition forward" before re-doing work, and this
+    block is the data feed that lets it do so. Cross-role conversation
+    is still in :func:`_fetch_reviewer_feedback_section` — this is
+    *your own* log, role-scoped to keep the signal sharp.
+
+    Best-effort: a DB hiccup degrades to ``None`` (the agent still has
+    the verdict thread from the reviewer-feedback section to work
+    from); the call is one indexed audit_log query so it's cheap.
+    """
+    from sqlalchemy import desc as _sa_desc
+    try:
+        rows = (
+            await session.execute(
+                select(AuditLog)
+                .where(
+                    AuditLog.workspace_id == workspace_id,
+                    AuditLog.action == "agent_run.finish",
+                    AuditLog.payload["ticket_ref"].astext == ticket_ref,
+                )
+                .order_by(_sa_desc(AuditLog.created_at))
+                .limit(_PRIOR_FINISHES_LIMIT * 4)  # over-fetch, filter by role
+            )
+        ).scalars().all()
+    except Exception as exc:  # noqa: BLE001 — best-effort
+        logger.debug(
+            "prior_finishes: query failed ws=%s ticket=%s err=%s",
+            workspace_id, ticket_ref, exc,
+        )
+        return None
+
+    # Filter to this role's own finishes — keeps the block focused on
+    # "what I did" vs the verdict thread that already shows what other
+    # roles thought. We match by stage→routine mapping so a workspace
+    # using legacy stage names (qa_manual, pr_review) still groups
+    # correctly under the canonical routine bucket.
+    mine: list[tuple[AuditLog, str, str, str | None]] = []
+    for row in rows:
+        payload = row.payload or {}
+        stage = str(payload.get("fsm_stage") or "") or None
+        routine = _STAGE_TO_ROUTINE.get(stage or "") if stage else None
+        if (routine or stage) != current_role:
+            continue
+        outcome = str(payload.get("outcome") or "noop")
+        description = payload.get("description")
+        desc = (
+            str(description).strip()[:_PRIOR_FINISH_DESCRIPTION_CAP]
+            if isinstance(description, str) and description.strip()
+            else None
+        )
+        mine.append((row, outcome, stage or "", desc))
+        if len(mine) >= _PRIOR_FINISHES_LIMIT:
+            break
+
+    if not mine:
+        return None
+
+    lines: list[str] = [
+        "## Your prior runs on this ticket",
+        "",
+        (
+            "These are the most recent `agent_run.finish` rows from "
+            "your own role on this ticket. Use them to detect "
+            "orphan-finish recovery (work landed but the ticket "
+            "didn't move) before re-doing work. Pair with the open "
+            "PR (search for it) and the verdict thread below."
+        ),
+        "",
+    ]
+    for row, outcome, stage, desc in mine:
+        ts = row.created_at.isoformat() if row.created_at else "?"
+        lines.append(f"- **{ts}** — `outcome={outcome}` stage=`{stage or '?'}`")
+        if desc:
+            lines.append(f"  > {desc}")
+    return "\n".join(lines)
 
 
 async def _fetch_reviewer_feedback_section(

--- a/apps/backend/app/resources/agent_roles/system.md
+++ b/apps/backend/app/resources/agent_roles/system.md
@@ -16,6 +16,56 @@ they appear in the **Workspace policies** preamble above. Follow
 them strictly; this section is operator context, not the rules
 themselves.
 
+## Read before working — you are not starting from scratch
+
+Ship is a **re-entrant** pipeline. The same ticket can be picked up
+by your role multiple times — a previous run may have completed the
+work but failed to transition the ticket, or may have stalled
+mid-way. Before you write any code or open any tools, **read the
+ticket itself** and reconcile what already exists:
+
+1. **Read the Linear ticket end to end.** Title, description, every
+   comment, current workflow state, every label. Comments with a
+   `[Ship SDLC:role-…]` marker are previous SDLC verdicts on this
+   ticket — they tell you what each role thought, in order. The most
+   recent one is the freshest signal.
+2. **Read the open PR if one exists.** Search the repo for a PR
+   whose head branch matches this ticket (`fix/{{ISSUE}}-auto`,
+   `cursor/ship-*-{{ISSUE}}`, or referenced from the ticket
+   description / a comment). If a PR exists: its diff IS your prior
+   work. CI checks on it are your prior signals.
+3. **Check your own previous attempt.** If a `[Ship SDLC:role-…]`
+   comment from **your own role** is the most recent verdict, that
+   was your last run. Re-read your own outcome and `description`
+   before deciding what to do now.
+
+### Decision rule
+
+After the read-pass, choose one:
+
+- **You already did the work, and the ticket is now correctly in
+  your stage** (typical orphan-finish recovery — previous run pushed
+  a PR, finish callback failed, FSM re-dispatched you). **Transition
+  the ticket forward** (sidecar `outcome=ready_next_step` with
+  `comment` summarising what's already done, `pr` set to the existing
+  PR URL, **no new commits**). Don't re-do work that's already
+  landed.
+- **You already did the work, but a reviewer / validator left a
+  specific finding.** Address that finding only. Don't rewrite the
+  rest of the diff.
+- **Prior PR exists but is stale / closed / unrelated** (different
+  ticket reuses the branch namespace, branch was force-pushed, etc).
+  Treat as fresh work, but call this out in `comment` so the audit
+  log records your reasoning.
+- **No prior work / fresh ticket.** Proceed normally.
+
+If a previous run from your role finished `blocked` or
+`needs_clarification` and the operator has not posted a hint since,
+**do not silently retry the same approach** — either change tack
+explicitly (and say so in `comment`) or finish `needs_clarification`
+again with a sharper question. Identical re-runs are how loops
+start.
+
 ## Required exit protocol
 
 **Do not call Ship's finish API directly.** Write your intended


### PR DESCRIPTION
## Why

The biggest single source of wasted FSM dispatches is **agents starting from a clean slate every run**. If a previous run did the work but `/finish` dropped (runner crash, network, GitHub 5xx), the next dispatched agent has no idea — it re-clones, re-writes, re-pushes, burns another agent cycle. Same shape underlies the dev_not_converging loop.

ElMundi's pipeline avoids this by having the operator-agent **read the ticket state on every pickup**. Bringing the same shape into Ship.

## What changes

### `system.md` — new section "Read before working"
Every role, regardless of stage, is now instructed to:
1. Read the Linear ticket end-to-end including `[Ship SDLC:role-…]` verdict comments.
2. Find and read the open PR for this ticket.
3. Check whether their **own** prior run already did the work.
4. Follow an explicit **decision rule** — transition forward (`outcome=ready_next_step`, `comment` summarising prior work, no new commits) instead of re-doing landed work.

### `agent_runs.get_next_task` — `_fetch_prior_finishes_section`
Surfaces the role's last 3 `agent_run.finish` rows for this ticket (`outcome` / `stage` / capped `description`) into the task body. Role-scoped — the agent sees its own log distinct from cross-role verdicts (which already come from `_fetch_reviewer_feedback_section`). Best-effort: DB hiccup degrades to no block.

## Out of scope (next PRs)
- **PR snapshot block** (open PR url + CI checks) — for MVP we instruct the agent to look up the PR itself (gh / MCP). If lookups prove flaky we layer a backend snapshot.
- **Linear-state full block** — agent already has `state` + `labels` in current payload; can read fuller context from the ticket itself.

## Risk

- No FSM transitions, no API surface changes, no feature flag — only the prompt becomes smarter.
- Prompt grows ~30 lines + last-3-finishes block; +5-10k tokens per run (~$0.01-0.02).
- Backward compat: old `shipctl` builds still receive the data inside `body`, no schema break.

## Validation
- `py_compile` + module import smoke pass.
- Neighbouring agent_runs tests (19) pass locally.
- Behaviour change is prompt-side, smoke-testable against a live workspace once deployed.