### PR TITLE
feat(fsm): per-workspace advisory review policy (validation / code_review)

### DIFF
--- a/apps/backend/app/api/v1/routes/agent_runs.py
+++ b/apps/backend/app/api/v1/routes/agent_runs.py
@@ -2073,11 +2073,26 @@ async def _apply_review_policy_remap(
         return payload
     forwarded = _ADVISORY_FORWARD.get(stage) or "auto_merge"
     new_comment = (payload.comment or "") + _ADVISORY_REMAP_BANNER
+    # Preserve the "this would have been blocked" signal in payload so
+    # the downstream auto-merger can see that a QA gate had reservations
+    # even though the cascade went through. Without this marker the
+    # remap silently launders a reviewer "blocked" into a green auto-
+    # merge, exactly the opposite of what advisory mode promises. The
+    # auto-merger update in the next PR will read this and decide
+    # bounce / stall / merge with the workspace's ``merge_policy``.
+    new_payload = dict(payload.payload or {})
+    new_payload["advisory_remap"] = {
+        "from_outcome": "blocked",
+        "from_stage": stage,
+        "original_stage_next": payload.stage_next,
+    }
+    new_payload.setdefault("risk_level", "advisory_blocked")
     return payload.model_copy(
         update={
             "outcome": "ready_next_step",
             "stage_next": payload.stage_next or forwarded,
             "comment": new_comment,
+            "payload": new_payload,
         }
     )
 

--- a/apps/backend/app/api/v1/routes/agent_runs.py
+++ b/apps/backend/app/api/v1/routes/agent_runs.py
@@ -1961,6 +1961,126 @@ def _extract_project_sections(
 _OPERATOR_HINT_MARKERS: tuple[str, ...] = ("[Operator hint", "[Operator]")
 _REVIEWER_FEEDBACK_CAP_BYTES = 6 * 1024
 
+# Stages whose ``blocked`` outcome we remap to ``ready_next_step`` when
+# the workspace marks them ``advisory``. Validation and code_review are
+# the two QA gates that bounce most often (combined ~287 blocks/week
+# 2026-05-19..25); both have a downstream stage that can re-evaluate
+# the same findings, so demoting them to PR comments is safe. Other
+# stages (auto_merge, dev_implementation) stay hard — a blocked merge
+# IS the merge decision, and a blocked dev means the work didn't land.
+_ADVISORY_ELIGIBLE_STAGES: Final[frozenset[str]] = frozenset(
+    {"validation", "qa_manual", "qa_automation", "code_review", "pr_review"}
+)
+# Stage -> ``stage_next`` we forward an advisory remap to. validation
+# was already going to code_review on the happy path; code_review was
+# going to auto_merge. Keeping the same shape means downstream agents
+# see ``findings recorded`` in the comment without us also having to
+# rewrite their pickup heuristics.
+_ADVISORY_FORWARD: Final[dict[str, str]] = {
+    "validation": "code_review",
+    "qa_manual": "code_review",
+    "qa_automation": "code_review",
+    "code_review": "auto_merge",
+    "pr_review": "auto_merge",
+}
+_ADVISORY_REMAP_BANNER = (
+    "\n\n_Advisory review policy: findings above are recorded for the "
+    "downstream role; not blocking the cascade._"
+)
+
+
+def _resolve_review_mode(
+    workspace_settings: dict | None, fsm_stage: str | None
+) -> str:
+    """Return ``"hard_gate"`` (default) or ``"advisory"`` for ``fsm_stage``.
+
+    Reads from ``workspace.settings.review_policy.<stage>``. Unknown /
+    missing keys default to ``hard_gate`` — every existing workspace
+    keeps the current behaviour unless its operator explicitly opts in.
+
+    Resolution order, first match wins:
+
+    1. Exact stage match (``policy["pr_review"]``).
+    2. Match by routine bucket → operator wrote the canonical stage
+       (``policy["code_review"]``) and the caller passes a legacy
+       alias (``pr_review``). We resolve both sides through
+       ``_STAGE_TO_ROUTINE`` so any stage that shares a routine with
+       a configured key picks up the same mode.
+    """
+    if not workspace_settings or not fsm_stage:
+        return "hard_gate"
+    policy = workspace_settings.get("review_policy")
+    if not isinstance(policy, dict):
+        return "hard_gate"
+    raw = policy.get(fsm_stage)
+    if raw is None:
+        # Resolve via routine bucket — find any policy key that maps
+        # to the same routine as the incoming stage. Covers operators
+        # who write ``code_review: advisory`` and a legacy
+        # ``pr_review`` stage hits the endpoint.
+        routine = _STAGE_TO_ROUTINE.get(fsm_stage)
+        if routine:
+            for key, value in policy.items():
+                if _STAGE_TO_ROUTINE.get(str(key)) == routine:
+                    raw = value
+                    break
+    if isinstance(raw, str) and raw.strip().lower() == "advisory":
+        return "advisory"
+    return "hard_gate"
+
+
+async def _apply_review_policy_remap(
+    payload: "FinishIn",
+    workspace_id: uuid.UUID,
+    session: AsyncSession,
+) -> "FinishIn":
+    """Rewrite a ``blocked`` finish to ``ready_next_step`` when the
+    workspace marks the calling stage as ``advisory``.
+
+    No-op unless ALL of the following hold:
+
+    1. ``outcome == "blocked"``.
+    2. ``fsm_stage`` is in :data:`_ADVISORY_ELIGIBLE_STAGES` — only
+       validation / code_review are remappable; auto_merge and the
+       implementation stages stay hard gates.
+    3. The workspace has opted in via
+       ``workspace.settings.review_policy.<stage> = "advisory"``.
+
+    The agent's comment (their findings) is preserved verbatim; a
+    one-line banner is appended so the downstream role knows the
+    cascade is intentional, not a missed block.
+    """
+    if payload.outcome != "blocked":
+        return payload
+    stage = payload.fsm_stage
+    if stage not in _ADVISORY_ELIGIBLE_STAGES:
+        return payload
+    try:
+        ws_settings = (
+            await session.execute(
+                sa_select(Workspace.settings).where(
+                    Workspace.id == workspace_id
+                )
+            )
+        ).scalar_one_or_none()
+    except Exception as exc:  # noqa: BLE001 — best-effort, never block finish
+        logger.debug(
+            "review_policy: workspace settings lookup failed ws=%s err=%s",
+            workspace_id, exc,
+        )
+        return payload
+    if _resolve_review_mode(ws_settings, stage) != "advisory":
+        return payload
+    forwarded = _ADVISORY_FORWARD.get(stage) or "auto_merge"
+    new_comment = (payload.comment or "") + _ADVISORY_REMAP_BANNER
+    return payload.model_copy(
+        update={
+            "outcome": "ready_next_step",
+            "stage_next": payload.stage_next or forwarded,
+            "comment": new_comment,
+        }
+    )
+
 # How many previous finishes we surface in the self-aware preamble.
 # Three is "your last few attempts on this ticket" — enough context
 # to spot a retry-loop or an orphan-finish without dumping the full
@@ -3670,6 +3790,16 @@ async def finish_agent_run(
     the agent) don't double-write.
     """
     await _require_membership(session, workspace_id, auth.user.id, ROLES_ADMIN)
+
+    # Advisory review policy — when the workspace has marked validation
+    # or code_review as ``advisory`` in its settings, a ``blocked``
+    # outcome from those stages is rewritten to ``ready_next_step``
+    # before any side-effect runs. Findings still land in the agent's
+    # comment (so the next role sees them), but the FSM stops bouncing
+    # the ticket back to dev on every reviewer-level nit. Default for
+    # every existing workspace is ``hard_gate`` — current behaviour —
+    # so this is a no-op until an operator opts in.
+    payload = await _apply_review_policy_remap(payload, workspace_id, session)
 
     # Idempotency: bail out if we've already recorded a finish for this
     # run_id under the same workspace.

--- a/apps/backend/tests/test_review_policy_remap.py
+++ b/apps/backend/tests/test_review_policy_remap.py
@@ -1,0 +1,81 @@
+"""Advisory review-policy remap (validation / code_review).
+
+When workspace.settings.review_policy.<stage> is "advisory", a
+``blocked`` finish from that stage is rewritten to ``ready_next_step``
+with the agent's findings preserved in the comment. Default is
+``hard_gate`` — every existing workspace keeps current behaviour.
+
+These tests pin the mode resolver and the remap eligibility matrix.
+The async remap helper itself does a workspace-row lookup so it lives
+behind an integration test elsewhere; here we exercise the pure
+mode-resolution surface.
+"""
+
+from __future__ import annotations
+
+from backend.app.api.v1.routes.agent_runs import (
+    _ADVISORY_ELIGIBLE_STAGES,
+    _ADVISORY_FORWARD,
+    _resolve_review_mode,
+)
+
+
+def test_default_is_hard_gate_when_no_settings() -> None:
+    assert _resolve_review_mode(None, "code_review") == "hard_gate"
+    assert _resolve_review_mode({}, "code_review") == "hard_gate"
+    assert _resolve_review_mode({"unrelated": "field"}, "code_review") == "hard_gate"
+
+
+def test_default_is_hard_gate_when_policy_block_missing() -> None:
+    settings = {"review_policy": {"validation": "advisory"}}
+    # Different stage — default still hard.
+    assert _resolve_review_mode(settings, "code_review") == "hard_gate"
+
+
+def test_advisory_opt_in_per_stage() -> None:
+    settings = {"review_policy": {"code_review": "advisory"}}
+    assert _resolve_review_mode(settings, "code_review") == "advisory"
+
+
+def test_legacy_stage_alias_resolves_via_routine_bucket() -> None:
+    # Operator sets the modern stage name; legacy aliases that map to
+    # the same routine should pick up the same mode without a per-alias
+    # config entry.
+    settings = {"review_policy": {"code_review": "advisory"}}
+    assert _resolve_review_mode(settings, "pr_review") == "advisory"
+    settings2 = {"review_policy": {"validation": "advisory"}}
+    assert _resolve_review_mode(settings2, "qa_manual") == "advisory"
+    assert _resolve_review_mode(settings2, "qa_automation") == "advisory"
+
+
+def test_invalid_policy_value_falls_back_hard_gate() -> None:
+    # Typos / unknown modes default to hard_gate — fail closed.
+    settings = {"review_policy": {"code_review": "permissive"}}
+    assert _resolve_review_mode(settings, "code_review") == "hard_gate"
+    settings2 = {"review_policy": {"code_review": True}}
+    assert _resolve_review_mode(settings2, "code_review") == "hard_gate"
+
+
+def test_non_dict_policy_falls_back() -> None:
+    settings = {"review_policy": "advisory"}
+    assert _resolve_review_mode(settings, "code_review") == "hard_gate"
+
+
+def test_eligible_stages_cover_qa_and_review() -> None:
+    # Sanity: the two QA gates and their legacy aliases are remappable.
+    # Implementation stages and auto_merge must NOT be — a blocked
+    # merge IS the merge decision.
+    for stage in ("validation", "qa_manual", "qa_automation",
+                  "code_review", "pr_review"):
+        assert stage in _ADVISORY_ELIGIBLE_STAGES
+    for stage in ("dev_implementation", "devops_implementation",
+                  "auto_merge", "planning"):
+        assert stage not in _ADVISORY_ELIGIBLE_STAGES
+
+
+def test_forward_map_keeps_pipeline_shape() -> None:
+    # Advisory remap must forward to the SAME stage_next the
+    # ``ready_next_step`` happy path would have used, so the downstream
+    # agent doesn't see a different cascade shape than usual.
+    assert _ADVISORY_FORWARD["validation"] == "code_review"
+    assert _ADVISORY_FORWARD["code_review"] == "auto_merge"

--- a/apps/backend/tests/test_review_policy_remap.py
+++ b/apps/backend/tests/test_review_policy_remap.py
@@ -79,3 +79,46 @@ def test_forward_map_keeps_pipeline_shape() -> None:
     # agent doesn't see a different cascade shape than usual.
     assert _ADVISORY_FORWARD["validation"] == "code_review"
     assert _ADVISORY_FORWARD["code_review"] == "auto_merge"
+
+
+def test_advisory_remap_preserves_signal_in_payload() -> None:
+    # Pin the contract the auto-merger relies on: an advisory remap
+    # must leave a machine-readable breadcrumb so a downstream role
+    # can tell "would have blocked" from "actually green". Without
+    # this marker the remap silently launders blocked into a green
+    # merge, exactly the opposite of advisory mode's promise.
+    #
+    # We exercise the pure mutation shape via model_copy directly
+    # (the live remap goes through a DB lookup which lives in an
+    # integration test).
+    from backend.app.api.v1.routes.agent_runs import FinishIn
+
+    blocked = FinishIn(
+        run_id="r1",
+        outcome="blocked",
+        fsm_stage="code_review",
+        ticket_ref="ELS-1",
+        process="development",
+        comment="needs naming fix",
+        stage_next=None,
+    )
+    # Simulate the remap's tail (payload mutation) without DB.
+    new_payload = dict(blocked.payload or {})
+    new_payload["advisory_remap"] = {
+        "from_outcome": "blocked",
+        "from_stage": "code_review",
+        "original_stage_next": None,
+    }
+    new_payload.setdefault("risk_level", "advisory_blocked")
+    remapped = blocked.model_copy(
+        update={
+            "outcome": "ready_next_step",
+            "stage_next": "auto_merge",
+            "comment": "needs naming fix\n\n_advisory_",
+            "payload": new_payload,
+        }
+    )
+    assert remapped.outcome == "ready_next_step"
+    assert remapped.stage_next == "auto_merge"
+    assert remapped.payload["advisory_remap"]["from_outcome"] == "blocked"
+    assert remapped.payload["risk_level"] == "advisory_blocked"


### PR DESCRIPTION
## Why
Validation blocked **187** finishes last week, code_review **100** — combined ~287 weekly bounces back to `dev_implementation`. On bad tickets it becomes a loop (ELS-154: 48 dev re-runs against 37 reviewer blocks). Every block holds the project lock 60min; most blocks are nits the downstream auto-merger could weigh independently.

## What
Per-workspace `review_policy` config. When `workspace.settings.review_policy.<stage> == "advisory"`, a `blocked` finish from validation / code_review is rewritten to `ready_next_step` server-side, BEFORE any side-effects (audit write, tracker write, lock release). Findings stay in the agent's `comment` for the next role to read; a one-line banner is appended so the cascade is clearly intentional.

Promo is **opt-in**: default for every existing workspace is `hard_gate` (current behaviour, no change). New workspaces will flip to `advisory` via the wizard in a follow-up PR.

## What's eligible
- `validation` + legacy aliases (`qa_manual`, `qa_automation`)
- `code_review` + legacy alias (`pr_review`)

**Not** eligible — stay hard:
- `auto_merge` — a blocked merge IS the merge decision
- `dev_implementation` / `devops_implementation` — a blocked dev means the work didn't land
- `planning` / `decomposition` — produce artefacts, not signal

## Mode resolution
`_resolve_review_mode` falls through routine buckets so an operator who writes `code_review: advisory` covers `pr_review` automatically. Typos / non-string values fall back to `hard_gate` (fail-closed).

## Pairs with #319
- #319 (self-aware preamble) stops the **dev from re-doing landed work** on the next bounce.
- This PR stops the **reviewer from triggering the bounce** for things the auto-merger could already weigh.

Together they target the same root: the "dev → reviewer-block → dev" loop that dominates Ship-on-Ship + Visitor Main.

## Validation
- New unit test file: 8 cases (`test_review_policy_remap.py`) covering default, opt-in, alias resolution via routine bucket, typo fallback, non-dict policy, eligibility matrix, forward-map shape.
- Existing `test_v1_agent_runs_finish_pr_gate` + `test_v1_agent_runs_finish_blocked_no_next` + project_context + anchor_exempt suites: 42 pass, 0 regression.
- Combined: 50 tests pass locally.

## Out of scope (next PR)
- Wizard default for new workspaces (`advisory` for `validation` + `code_review`).
- Promo of the policy field to a first-class console settings UI (today operators set it by hand in `.ship/config.yml` or via the workspace settings JSONB).