### PR TITLE
feat(wizard): default new workspaces to advisory review + evidence_required merge

### DIFF
--- a/apps/backend/app/api/v1/routes/workspaces.py
+++ b/apps/backend/app/api/v1/routes/workspaces.py
@@ -8,6 +8,7 @@ artifact-repo wiring follow in subsequent slices.
 
 from __future__ import annotations
 
+import copy
 import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, Response, status
@@ -48,6 +49,41 @@ ROLES_MAINTAIN = ("owner", "admin", "maintainer")
 ROLES_MEMBER = ("owner", "admin", "maintainer", "member")
 ROLES_READ = ("owner", "admin", "maintainer", "member", "viewer")
 VALID_CATALOG_KEYS = frozenset({"global", "workspace", "project"})
+
+
+# Default FSM policy for **new** workspaces created from now on. Existing
+# workspaces are untouched (their settings stay {} → resolved as
+# ``hard_gate`` / ``auto``, the legacy behaviour). The defaults bake in
+# what we observed makes the cascade fast without losing the safety
+# net:
+#
+# * ``review_policy.validation = advisory`` + ``reviewer = advisory`` —
+#   QA gates report findings into the PR comment chain instead of
+#   bouncing the ticket back to dev for every nit. The advisory remap
+#   stamps ``risk_level=advisory_blocked`` on payload so downstream
+#   stages still see the QA reservation.
+# * ``merge_policy = evidence_required`` — pairs with the advisory
+#   marker above: a truly green PR auto-merges, but one a QA gate had
+#   reservations about is rerouted to the inbox for an operator to
+#   approve (single-click Merge / Request changes / Discard). The
+#   "rubber-stamp human" problem doesn't bite here because the human
+#   only sees PRs that already failed an upstream check.
+#
+# Operators can flip back to legacy behaviour per-workspace by setting
+# ``workspace.settings.review_policy.*`` to ``hard_gate`` or
+# ``workspace.settings.merge_policy`` to ``auto``.
+NEW_WORKSPACE_DEFAULT_SETTINGS: dict = {
+    "review_policy": {
+        # Keys are FSM stage labels (``validation``, ``code_review``).
+        # ``_resolve_review_mode`` also matches legacy aliases that map
+        # to the same routine bucket (``qa_manual`` / ``qa_automation``
+        # → ``validation``; ``pr_review`` → ``code_review``), so this
+        # one entry covers each gate fully.
+        "validation": "advisory",
+        "code_review": "advisory",
+    },
+    "merge_policy": "evidence_required",
+}
 
 
 async def _require_membership(
@@ -191,6 +227,7 @@ async def _ensure_personal_workspace(
         org_id=org.id,
         slug=slug,
         name=f"{display.title()}'s workspace",
+        settings=copy.deepcopy(NEW_WORKSPACE_DEFAULT_SETTINGS),
     )
     session.add(workspace)
     try:
@@ -255,7 +292,12 @@ async def create_workspace(
         if membership is None or membership.role not in ("org_owner", "org_admin"):
             raise HTTPException(status_code=403, detail="cannot create workspace in this org")
 
-    workspace = Workspace(org_id=org.id, slug=payload.slug, name=payload.name)
+    workspace = Workspace(
+        org_id=org.id,
+        slug=payload.slug,
+        name=payload.name,
+        settings=copy.deepcopy(NEW_WORKSPACE_DEFAULT_SETTINGS),
+    )
     session.add(workspace)
     try:
         await session.flush()

--- a/apps/backend/tests/test_workspace_default_settings.py
+++ b/apps/backend/tests/test_workspace_default_settings.py
@@ -1,0 +1,68 @@
+"""Defaults baked into new workspace.settings on create.
+
+Existing workspaces stay {} so the legacy ``hard_gate`` / ``auto``
+resolvers keep current behaviour; new workspaces — both JIT-personal
+and explicit-create — get the advisory + evidence-required pair so the
+cascade ships fast out of the gate.
+
+These tests pin the constant shape + the deep-copy contract (every
+workspace must get its own dict, not a shared reference).
+"""
+
+from __future__ import annotations
+
+import copy
+
+from backend.app.api.v1.routes.workspaces import (
+    NEW_WORKSPACE_DEFAULT_SETTINGS,
+)
+from backend.app.api.v1.routes.agent_runs import (
+    _resolve_merge_policy,
+    _resolve_review_mode,
+)
+
+
+def test_defaults_resolve_through_runtime_resolvers() -> None:
+    # The two resolvers in agent_runs are the runtime side that reads
+    # workspace.settings; the constant is the persistence side. Pin
+    # them as a pair so a future rename on either end can't silently
+    # split the contract.
+    s = NEW_WORKSPACE_DEFAULT_SETTINGS
+    assert _resolve_review_mode(s, "validation") == "advisory"
+    assert _resolve_review_mode(s, "code_review") == "advisory"
+    assert _resolve_merge_policy(s) == "evidence_required"
+
+
+def test_defaults_include_all_documented_keys() -> None:
+    # Surface guard against accidentally trimming a key during a
+    # refactor — every key the resolvers know about should still
+    # appear here. ``merge_policy`` is a scalar; ``review_policy`` is
+    # a nested dict with one entry per QA gate.
+    assert "review_policy" in NEW_WORKSPACE_DEFAULT_SETTINGS
+    assert "merge_policy" in NEW_WORKSPACE_DEFAULT_SETTINGS
+    rp = NEW_WORKSPACE_DEFAULT_SETTINGS["review_policy"]
+    assert {"validation", "code_review"}.issubset(rp.keys())
+
+
+def test_deep_copy_each_workspace_owns_its_settings() -> None:
+    # Sloppy patches that pass the constant by reference to Workspace(
+    # settings=...) end up sharing a dict between rows; a later patch
+    # mutates every "new" workspace. Verify the helper produces an
+    # independent copy.
+    a = copy.deepcopy(NEW_WORKSPACE_DEFAULT_SETTINGS)
+    b = copy.deepcopy(NEW_WORKSPACE_DEFAULT_SETTINGS)
+    a["review_policy"]["validation"] = "hard_gate"
+    a["merge_policy"] = "auto"
+    assert b["review_policy"]["validation"] == "advisory"
+    assert b["merge_policy"] == "evidence_required"
+    assert NEW_WORKSPACE_DEFAULT_SETTINGS["review_policy"]["validation"] == "advisory"
+    assert NEW_WORKSPACE_DEFAULT_SETTINGS["merge_policy"] == "evidence_required"
+
+
+def test_existing_workspace_with_empty_settings_keeps_legacy_behaviour() -> None:
+    # The new defaults are write-time; we explicitly do NOT migrate
+    # already-created workspaces. An empty settings dict (what every
+    # existing workspace has) must resolve to the legacy modes.
+    assert _resolve_review_mode({}, "validation") == "hard_gate"
+    assert _resolve_review_mode({}, "code_review") == "hard_gate"
+    assert _resolve_merge_policy({}) == "auto"


### PR DESCRIPTION
## Why
PRs #319 / #321 / #322 wired the new FSM behaviour but **left every new workspace on the legacy defaults**. Operators had to hand-edit `workspace.settings` JSONB to opt in. Flip defaults at create time so fresh workspaces ship with the fast cascade out of the box.

## What
Both creation paths now seed `workspace.settings`:

| Path | When |
|---|---|
| `_ensure_personal_workspace` | JIT first-login personal workspace |
| `create_workspace` (POST `/workspaces`) | Explicit operator-create via console/API |

```yaml
review_policy:
  validation: advisory    # qa_manual / qa_automation alias
  code_review: advisory   # pr_review alias
merge_policy: evidence_required
```

## Why this combination
- **Advisory QA** roles record findings in PR comments + stamp `risk_level=advisory_blocked` on the cascade. They don't bounce tickets back to dev for every nit.
- **`evidence_required` merge** routes PRs **that an upstream gate flagged** to the operator inbox for a single click. Truly green PRs still auto-merge. The "rubber-stamp human" problem is mitigated because the operator only sees the suspicious ones, not every merge.

## Existing workspaces untouched
Their `settings` stays `{}` → resolvers fall back to `hard_gate` / `auto` (current behaviour). Operators can flip back per-workspace by setting keys explicitly.

## Safety
- `copy.deepcopy` on each create — the constant is never shared between rows; a later patch on one settings dict can't bleed to another.
- 4 new unit tests pin the constant shape, deep-copy contract, runtime-resolver round-trip, and that empty-settings workspaces still resolve to legacy modes.

## Validation
- New `test_workspace_default_settings.py`: 4 cases.
- Combined with `test_review_policy_remap` + `test_merge_policy_remap`: 19 pass locally.