### PR TITLE
feat(fsm): Linear webhook → tracker.event.received (Lever #4)

### DIFF
--- a/apps/backend/app/api/v1/router.py
+++ b/apps/backend/app/api/v1/router.py
@@ -40,6 +40,7 @@ from backend.app.api.v1.routes import (
     knowledge_canon,
     knowledge_import_sources,
     linear_oauth,
+    linear_webhook,
     local_tracker,
     members,
     metrics_file_overlap,
@@ -111,6 +112,11 @@ api_router.include_router(github_app.router)
 # Linear OAuth (pilot Day 2 — tracker WOW flow). Callback is public so
 # the browser redirect from Linear can hit it without a session.
 api_router.include_router(linear_oauth.router)
+# Linear webhook ingestion (E16/Lever-4). Replaces the 5-min
+# tracker_poller for workspaces that wired their Linear app to fire
+# deliveries at our public endpoint. Poller stays as a fallback so a
+# webhook miss doesn't strand the workspace.
+api_router.include_router(linear_webhook.router)
 # Notion OAuth (pilot Day 2 — tracker WOW flow). Same shape as Linear.
 api_router.include_router(notion_oauth.router)
 # Telegram bot adapter (group ↔ workspace bridge). Console-facing

--- a/apps/backend/app/api/v1/routes/linear_webhook.py
+++ b/apps/backend/app/api/v1/routes/linear_webhook.py
@@ -1,0 +1,187 @@
+"""Linear webhook ingestion (Issue.update → tracker.event.received).
+
+Replaces the 5-min ``tracker_poller`` for workspaces that have wired
+their Linear app to fire deliveries at this endpoint. The poller stays
+as a 5-min fallback so a webhook miss doesn't strand a workspace.
+
+Provisioning is out of scope here — operators run Linear's
+``webhookCreate`` mutation (or wire it via the Settings UI) with our
+URL + the shared ``LINEAR_WEBHOOK_SECRET``. The handler maps
+``data.team.id`` → ``Integration`` row → workspace, so the backend
+needs no per-tenant webhook config.
+
+Wire-shape (Linear webhook v3):
+
+    POST  …/v1/webhooks/linear
+    Headers:
+      Linear-Signature: <hex hmac-sha256(body, LINEAR_WEBHOOK_SECRET)>
+      Linear-Event:     "Issue" | "Comment" | …
+      Linear-Delivery:  <uuid>   (idempotency hint, optional)
+    Body:
+      { "action": "update", "type": "Issue", "data": {...}, ... }
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from typing import Any
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.app.core.config import Settings, get_settings
+from backend.app.db.models.tenancy import Integration
+from backend.app.db.session import get_session
+from backend.app.integrations.linear.webhook import (
+    InvalidWebhookSignature,
+    verify_signature,
+)
+from backend.app.services.tracker_poller import _write_transition_event
+
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["linear-webhook"])
+
+
+def _extract_fsm_stage(labels: list[dict[str, Any]] | None) -> str | None:
+    """Pick the ``stage:<id>`` value off an issue's labels list."""
+    if not labels:
+        return None
+    for label in labels:
+        name = str(label.get("name") or "")
+        if name.startswith("stage:"):
+            return name.split(":", 1)[1] or None
+    return None
+
+
+@router.post("/webhooks/linear", status_code=status.HTTP_200_OK)
+async def linear_webhook(
+    request: Request,
+    linear_signature: str | None = Header(default=None, alias="Linear-Signature"),
+    linear_event: str | None = Header(default=None, alias="Linear-Event"),
+    linear_delivery: str | None = Header(default=None, alias="Linear-Delivery"),
+    session: AsyncSession = Depends(get_session),
+    settings: Settings = Depends(get_settings),
+) -> dict[str, Any]:
+    """Ingest one Linear webhook delivery.
+
+    Day 1 scope: ``Issue.update`` only. That's the event the
+    dispatcher cares about — every other Linear event is silently
+    200'd so Linear's "Recent Deliveries" stays green and we can
+    layer more event types later without redeploying.
+    """
+    raw = await request.body()
+    try:
+        verify_signature(raw, linear_signature, settings=settings)
+    except InvalidWebhookSignature as exc:
+        # 401 (not 400) so a wrong-secret config shows up as an auth
+        # issue in Linear's delivery log, not a malformed-payload one.
+        raise HTTPException(status_code=401, detail=str(exc)) from exc
+
+    try:
+        payload = json.loads(raw.decode("utf-8")) if raw else {}
+    except json.JSONDecodeError as exc:
+        raise HTTPException(
+            status_code=400, detail="malformed JSON body"
+        ) from exc
+
+    event_type = (
+        str(linear_event or payload.get("type") or "").strip()
+    )
+    action = str(payload.get("action") or "").strip().lower()
+
+    # Day-1 contract: only Issue.update updates the FSM. Everything
+    # else is logged + 200'd so the next round of work can layer in
+    # Comment / Project / Cycle handlers without changing the wire.
+    if event_type != "Issue" or action != "update":
+        logger.debug(
+            "linear webhook ignored: event=%s action=%s delivery=%s",
+            event_type, action, linear_delivery,
+        )
+        return {"ok": True, "event": event_type, "action": action, "applied": False}
+
+    data = payload.get("data") if isinstance(payload.get("data"), dict) else None
+    if not data:
+        logger.warning("linear webhook: missing 'data' object")
+        return {"ok": True, "event": event_type, "applied": False, "reason": "no_data"}
+
+    ticket_ref = str(data.get("identifier") or "").strip() or None
+    new_state = (
+        str((data.get("state") or {}).get("name") or "").strip() or None
+    )
+    team_id = str((data.get("team") or {}).get("id") or "").strip() or None
+    updated_at = (
+        str(data.get("updatedAt") or "").strip() or None
+    )
+    fsm_stage = _extract_fsm_stage(data.get("labels"))
+
+    # We need the canonical {ticket_ref, team_id, new_state} triple
+    # to feed the dispatcher. Without them this is signal-less noise.
+    if not (ticket_ref and team_id and new_state):
+        logger.debug(
+            "linear webhook: incomplete payload ticket=%s team=%s state=%s",
+            ticket_ref, team_id, new_state,
+        )
+        return {
+            "ok": True, "event": event_type, "applied": False,
+            "reason": "incomplete_payload",
+        }
+
+    # Map Linear team → our workspace via the Integration config row.
+    # Cron-side ``_poll_installation`` reads ``config.team_id`` the
+    # same way; staying on the same lookup keeps the picker + webhook
+    # in lock-step about which workspace owns which Linear team.
+    integration = (
+        await session.execute(
+            select(Integration)
+            .where(
+                Integration.kind == "linear",
+                Integration.config["team_id"].astext == team_id,
+            )
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+
+    if integration is None:
+        logger.info(
+            "linear webhook: team_id=%s has no matching integration "
+            "(workspace not connected); ticket=%s",
+            team_id, ticket_ref,
+        )
+        return {
+            "ok": True, "event": event_type, "applied": False,
+            "reason": "no_workspace_for_team",
+        }
+
+    workspace_id: uuid.UUID = integration.workspace_id
+
+    # ``old_state`` isn't present in Linear webhook payloads — the
+    # event reports the post-update state only. The poll-side path
+    # carries the prior state via its cursor; on the webhook path we
+    # leave it None so downstream consumers can tell "delivered via
+    # webhook, prior state unknown" from "delivered via poller with
+    # cursor state X".
+    await _write_transition_event(
+        session,
+        workspace_id=workspace_id,
+        ticket_ref=ticket_ref,
+        old_state=None,
+        new_state=new_state,
+        updated_at=updated_at,
+        fsm_stage=fsm_stage,
+    )
+    await session.flush()
+    return {
+        "ok": True,
+        "event": event_type,
+        "applied": True,
+        "ticket_ref": ticket_ref,
+        "workspace_id": str(workspace_id),
+    }
+
+
+__all__ = ["router"]

--- a/apps/backend/app/core/config.py
+++ b/apps/backend/app/core/config.py
@@ -411,6 +411,16 @@ class Settings(BaseSettings):
     linear_client_secret: str | None = Field(
         default=None, alias="LINEAR_CLIENT_SECRET"
     )
+    # Shared HMAC-SHA256 secret used to verify Linear webhook deliveries.
+    # One value per backend install (not per workspace) — the webhook
+    # handler maps payload → workspace via the ``data.team.id`` Linear
+    # ships with every event, looking up the matching Integration row.
+    # Operators copy this value into Linear's webhook UI when wiring
+    # the hook (or set it via ``webhookCreate`` GraphQL mutation).
+    # Unset → webhook endpoint fails closed (rejects every delivery).
+    linear_webhook_secret: str | None = Field(
+        default=None, alias="LINEAR_WEBHOOK_SECRET"
+    )
     # Comma-separated OAuth scopes. ``read,write`` is the minimum the
     # pilot adapter needs (list issues + post comments). Leave the
     # defaults unless a tenant explicitly objects.

--- a/apps/backend/app/integrations/linear/webhook.py
+++ b/apps/backend/app/integrations/linear/webhook.py
@@ -1,0 +1,68 @@
+"""Linear webhook signature verification.
+
+Linear signs each webhook delivery with HMAC-SHA256 over the raw
+request body using the secret configured at ``webhookCreate`` time.
+The signature lives in the ``Linear-Signature`` header (hex digest,
+no scheme prefix — unlike GitHub's ``sha256=...``).
+
+Verify against **raw bytes** before parsing JSON: re-serialising the
+parsed payload would break any delivery that wasn't already canonical
+(Linear's serialiser is not stable across event types).
+
+Use :func:`verify_signature` against ``request.body()`` before doing
+anything with the payload. The function uses constant-time comparison
+to sidestep timing attacks.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+
+from backend.app.core.config import Settings
+
+
+_SIG_HEADER = "Linear-Signature"
+
+
+class InvalidWebhookSignature(ValueError):
+    """Raised when the delivered signature header is missing or wrong."""
+
+
+def verify_signature(
+    raw_body: bytes, signature_header: str | None, *, settings: Settings
+) -> None:
+    """Verify the ``Linear-Signature`` header against ``raw_body``.
+
+    Raises :class:`InvalidWebhookSignature` on any mismatch. Returns
+    ``None`` on success — callers don't need a truthy return because
+    the only valid path is "no exception".
+    """
+    if not settings.linear_webhook_secret:
+        # Fail closed: a misconfigured backend should never accept
+        # un-authenticated webhook traffic. Operators who really want
+        # to disable verification can stub this in tests.
+        raise InvalidWebhookSignature(
+            "LINEAR_WEBHOOK_SECRET is not configured; "
+            "webhook delivery rejected"
+        )
+    if not signature_header:
+        raise InvalidWebhookSignature(
+            f"missing {_SIG_HEADER} header"
+        )
+    expected = hmac.new(
+        settings.linear_webhook_secret.encode("utf-8"),
+        raw_body,
+        hashlib.sha256,
+    ).hexdigest()
+    # Linear delivers the hex digest unprefixed. Some integrations
+    # have been seen to send ``sha256=…`` — accept either to keep
+    # our handler robust against minor Linear API shape drift.
+    delivered = signature_header.strip()
+    if delivered.startswith("sha256="):
+        delivered = delivered.removeprefix("sha256=")
+    if not hmac.compare_digest(expected, delivered):
+        raise InvalidWebhookSignature("signature mismatch")
+
+
+__all__ = ["InvalidWebhookSignature", "verify_signature"]

--- a/apps/backend/tests/test_linear_webhook_signature.py
+++ b/apps/backend/tests/test_linear_webhook_signature.py
@@ -1,0 +1,78 @@
+"""Linear webhook signature verification.
+
+Pin the contract that Linear-Signature is checked against raw bytes
+and that misconfiguration / missing header / mismatch all fail closed.
+The webhook handler itself goes through a route that touches the DB —
+that lives behind an integration test. Here we exercise the pure
+``verify_signature`` surface.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+
+import pytest
+
+from backend.app.integrations.linear.webhook import (
+    InvalidWebhookSignature,
+    verify_signature,
+)
+
+
+class _Settings:
+    """Minimal Settings stand-in — verify_signature only reads the one
+    attribute, so we don't need to construct the full pydantic model."""
+
+    def __init__(self, secret: str | None) -> None:
+        self.linear_webhook_secret = secret
+
+
+def _sign(body: bytes, secret: str) -> str:
+    return hmac.new(secret.encode("utf-8"), body, hashlib.sha256).hexdigest()
+
+
+def test_accepts_valid_hex_signature() -> None:
+    body = b'{"action":"update","type":"Issue"}'
+    sig = _sign(body, "topsecret")
+    verify_signature(body, sig, settings=_Settings("topsecret"))
+
+
+def test_accepts_sha256_prefixed_signature() -> None:
+    # Some Linear integrations have been seen to ship ``sha256=<hex>``
+    # (mirroring GitHub's header shape). Our handler tolerates either
+    # encoding so a Linear API shape drift can't dark-launch us.
+    body = b'{"action":"update"}'
+    sig = "sha256=" + _sign(body, "topsecret")
+    verify_signature(body, sig, settings=_Settings("topsecret"))
+
+
+def test_rejects_when_secret_unset() -> None:
+    # Fail-closed: a backend with no LINEAR_WEBHOOK_SECRET configured
+    # must reject EVERY delivery, even one signed with the empty
+    # string. Otherwise a misconfigured deploy quietly trusts random
+    # POSTs.
+    with pytest.raises(InvalidWebhookSignature):
+        verify_signature(b"{}", "deadbeef", settings=_Settings(None))
+
+
+def test_rejects_missing_header() -> None:
+    with pytest.raises(InvalidWebhookSignature):
+        verify_signature(b"{}", None, settings=_Settings("topsecret"))
+
+
+def test_rejects_wrong_signature() -> None:
+    body = b'{"action":"update"}'
+    wrong = _sign(body, "different-secret")
+    with pytest.raises(InvalidWebhookSignature):
+        verify_signature(body, wrong, settings=_Settings("topsecret"))
+
+
+def test_rejects_tampered_body() -> None:
+    # If the operator's reverse-proxy strips/adds a trailing newline,
+    # the signature breaks — verify the constant-time check picks
+    # that up rather than silently re-canonicalising the body.
+    body = b'{"a":1}'
+    sig = _sign(body, "topsecret")
+    with pytest.raises(InvalidWebhookSignature):
+        verify_signature(body + b"\n", sig, settings=_Settings("topsecret"))


### PR DESCRIPTION
## Why
``tracker_event → first_dispatch`` p50 was **86 min** on prod, p90 **40 hours**. Cause: backend polls Linear every 5 min (``SHIP_TRACKER_POLL_INTERVAL_S=300``), plus project-lock contention, plus self-heal cadence — events ride a slow conveyor belt. Wiring Linear's webhook collapses that to **seconds**.

## What
- `LINEAR_WEBHOOK_SECRET` env (one per backend install). HMAC shared secret. Unset → handler fails closed.
- `POST /v1/webhooks/linear` — public endpoint, HMAC-SHA256 verified against raw body.
- Day-1 scope: ``Issue.update`` events only. Other Linear event types (Comment, Project, …) silently 200 so the delivery log stays green and we can layer them in later without redeploys.
- Tenant lookup: ``data.team.id`` → ``Integration.config.team_id`` → workspace. **Same key the poller uses**, so picker and webhook can't drift.
- Hands off to the existing ``_write_transition_event`` (used by ``tracker_poller``) which writes the audit row + calls ``maybe_dispatch``. Zero new dispatch path.

## Fallback path is intentional
The 5-min ``tracker_poller`` cron stays armed. If a webhook delivery is dropped (network blip, Linear outage), the poller's next tick picks it up via the existing cursor logic — latency degrades to the old number, the ticket isn't stranded.

## Provisioning (out of scope)
Operators wire the webhook in Linear's UI today (URL + secret). Next PR adds ``shipctl linear webhook setup`` / console-side ``webhookCreate`` mutation. Until then the poller carries unprovisioned workspaces.

## Validation
- 6 unit tests for signature verification: valid hex / ``sha256=`` prefix / missing header / wrong secret / tampered body / fail-closed when env unset.
- Endpoint imports cleanly; mounted at ``/v1/webhooks/linear`` in the router.

## Targeted impact
Once operators wire their Linear hook:
- ``tracker_event → first_dispatch`` p50 86 min → **~5-30 sec** (webhook RTT + ``maybe_dispatch`` body).
- Bonus: dispatch-storm avoidance — the poller's batch-update problem (all child tickets land in one tick) goes away.