### PR TITLE
feat(linear): admin OAuth scope + reconnect guard for webhook setup

### DIFF
--- a/apps/backend/app/api/v1/routes/linear_oauth.py
+++ b/apps/backend/app/api/v1/routes/linear_oauth.py
@@ -655,6 +655,43 @@ async def linear_webhook_provision(
         session, workspace_id=workspace_id
     )
 
+    # Linear gates webhookCreate / webhookDelete behind ``admin``
+    # scope on the OAuth token. Existing connections from before
+    # the scope bump (default updated 2026-05-27) won't have it;
+    # surface that as a clear "reconnect Linear" message instead
+    # of letting it through to a confusing 502 from GraphQL.
+    scope_row = (
+        await session.execute(
+            select(Integration)
+            .where(
+                Integration.workspace_id == workspace_id,
+                Integration.kind == "linear",
+            )
+            .order_by(Integration.updated_at.desc())
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+    token_scope = ""
+    if scope_row and isinstance(scope_row.config, dict):
+        token_scope = str(scope_row.config.get("scope") or "")
+    granted = {s.strip() for s in token_scope.split(",") if s.strip()}
+    if "admin" not in granted:
+        raise HTTPException(
+            status_code=412,
+            detail={
+                "code": "linear_admin_scope_missing",
+                "message": (
+                    "The current Linear OAuth token doesn't include "
+                    "the 'admin' scope (required for webhook setup). "
+                    "Reconnect Linear from the workspace integrations "
+                    "page so the new scope is granted. The user "
+                    "reconnecting MUST be a Linear-side workspace "
+                    "admin."
+                ),
+                "granted_scopes": sorted(granted),
+            },
+        )
+
     legacy = (
         await session.execute(
             select(Integration)

--- a/apps/backend/app/core/config.py
+++ b/apps/backend/app/core/config.py
@@ -422,10 +422,17 @@ class Settings(BaseSettings):
         default=None, alias="LINEAR_WEBHOOK_SECRET"
     )
     # Comma-separated OAuth scopes. ``read,write`` is the minimum the
-    # pilot adapter needs (list issues + post comments). Leave the
-    # defaults unless a tenant explicitly objects.
+    # pilot adapter needs (list issues + post comments); ``admin`` is
+    # required for ``webhookCreate`` / ``webhookDelete`` mutations
+    # which Linear gates behind workspace-admin even when the OAuth
+    # user is one. Without ``admin`` the programmatic webhook
+    # provisioning endpoint (``POST .../webhook/provision``) returns
+    # ``Linear GraphQL error: Invalid role: admin required``.
+    # Workspaces that connected Linear before this default bump need
+    # to reconnect to pick up the new scope; their existing token
+    # stays read+write-only until they do.
     linear_oauth_scopes: str = Field(
-        default="read,write,issues:create,comments:create",
+        default="read,write,admin,issues:create,comments:create",
         alias="LINEAR_OAUTH_SCOPES",
     )
     # How often the ``linear_token_refresh_tick`` cron rotates each

--- a/apps/backend/tests/test_linear_oauth_scopes_default.py
+++ b/apps/backend/tests/test_linear_oauth_scopes_default.py
@@ -1,0 +1,35 @@
+"""Linear OAuth scopes — default must include ``admin``.
+
+``admin`` is what Linear requires for ``webhookCreate`` /
+``webhookDelete`` GraphQL mutations. Without it the programmatic
+webhook provisioning endpoint (``POST .../webhook/provision``)
+returns ``Invalid role: admin required`` and operators fall back to
+pasting URLs in the Linear settings UI by hand.
+
+This test pins the default so a future "tighten OAuth scopes"
+refactor can't quietly drop ``admin`` and re-break programmatic
+provisioning.
+"""
+
+from __future__ import annotations
+
+from backend.app.core.config import Settings
+
+
+def test_default_includes_admin_for_webhook_provisioning() -> None:
+    settings = Settings()
+    scopes = {s.strip() for s in settings.linear_oauth_scopes.split(",")}
+    assert "admin" in scopes, (
+        "LINEAR_OAUTH_SCOPES default must include 'admin' so "
+        "webhookCreate / webhookDelete mutations succeed in the "
+        "programmatic provisioning endpoint."
+    )
+
+
+def test_default_keeps_read_write_for_adapter_path() -> None:
+    # The tracker_adapter path (list issues, post comments) still
+    # needs read+write. Pin them too so a future scope refactor
+    # can't shrink to admin-only and break the day-to-day cascade.
+    settings = Settings()
+    scopes = {s.strip() for s in settings.linear_oauth_scopes.split(",")}
+    assert {"read", "write"}.issubset(scopes)


### PR DESCRIPTION
## Why
Hit on the first live attempt of #325's programmatic provisioning endpoint: Linear gates ``webhookCreate`` behind **``admin`` scope** on the OAuth token, but our default scopes were ``read,write,issues:create,comments:create`` — the day-to-day adapter path works, but ``POST .../webhook/provision`` returns:

```
Linear GraphQL error: Invalid role: admin required
```

This blocks the whole point of #325 (one-click webhook setup → no UI paste).

## What
**1. Default OAuth scope bump.** ``LINEAR_OAUTH_SCOPES`` default gains ``admin``:
```
read,write,admin,issues:create,comments:create
```
New connections request the scope automatically.

**2. Reconnect guard in the provisioning endpoint.** Pre-checks the workspace's saved ``Integration.config.scope`` for ``admin``. When absent → 412 with:
```json
{
  "code": "linear_admin_scope_missing",
  "message": "Reconnect Linear from the workspace integrations page…",
  "granted_scopes": ["comments:create","issues:create","read","write"]
}
```
Console can light up a "Reconnect Linear" button without parsing 502 GraphQL noise.

## Important note
The reconnecting user must themselves be a Linear-side workspace admin. Linear refuses to mint an ``admin`` scope token for a non-admin user even if the OAuth app requests the scope. 412 message spells that out.

## Existing workspaces
Pre-bump connections keep working for everything except webhook provisioning. One-click reconnect picks up ``admin``. Day-to-day cascade unaffected.

## Validation
- 2 new tests pin the default contains both ``admin`` and ``read``/``write`` (no future scope refactor can quietly drop either).
- Existing 10 Linear-webhook tests still green.