### PR TITLE
fix(linear): reconnect-from-settings stays on /integrations, not /onboarding

### DIFF
--- a/apps/backend/app/api/v1/routes/linear_oauth.py
+++ b/apps/backend/app/api/v1/routes/linear_oauth.py
@@ -112,6 +112,16 @@ async def linear_install_start(
     workspace_id: uuid.UUID = Query(
         ..., description="Workspace to attach the Linear connection to"
     ),
+    return_to: str | None = Query(
+        default=None,
+        description=(
+            "Console-side path to bounce the browser back to after a "
+            "successful OAuth callback. Must start with '/'. Used by "
+            "the workspace-settings 'Reconnect Linear' flow so the "
+            "operator lands on /integrations instead of /onboarding. "
+            "Validated against the console origin before redirect."
+        ),
+    ),
     auth: AuthContext = Depends(get_current_auth),
     session: AsyncSession = Depends(get_session),
     settings: Settings = Depends(get_settings),
@@ -128,7 +138,24 @@ async def linear_install_start(
             detail="Linear OAuth is not configured on this deployment",
         )
     await _require_membership(session, workspace_id, auth.user.id, ROLES_ADMIN)
-    state = build_oauth_state(workspace_id, settings=settings)
+    # Sanity-check the return_to before signing it into the state — a
+    # malformed value would lock the operator out of the flow after
+    # consent. Path-only (starts with /) keeps us inside the console
+    # origin; an absolute URL would be an open-redirect surface.
+    safe_return_to: str | None = None
+    if return_to:
+        if not return_to.startswith("/") or return_to.startswith("//"):
+            raise HTTPException(
+                status_code=422,
+                detail={
+                    "code": "invalid_return_to",
+                    "message": "return_to must be a console-relative path starting with '/'",
+                },
+            )
+        safe_return_to = return_to
+    state = build_oauth_state(
+        workspace_id, settings=settings, return_to=safe_return_to
+    )
     return InstallStartResponse(
         install_url=build_authorize_url(
             state, settings=settings, redirect_uri=_redirect_uri(settings)
@@ -458,6 +485,19 @@ async def linear_install_callback(
         )
     )
     await session.flush()
+
+    # Reconnect-from-settings flow: when the caller passed
+    # ``return_to`` to /install/start, bounce back to that console
+    # path (already validated path-only). Wizard-driven flows leave
+    # ``return_to`` empty and land on ``/onboarding`` as before.
+    if decoded.return_to:
+        base = settings.console_url.rstrip("/")
+        target = f"{base}{decoded.return_to}"
+        sep = "&" if "?" in decoded.return_to else "?"
+        return RedirectResponse(
+            url=f"{target}{sep}ws={workspace_id}&linear=connected",
+            status_code=303,
+        )
 
     return RedirectResponse(
         url=_console_onboarding_url(

--- a/apps/backend/app/integrations/linear/oauth.py
+++ b/apps/backend/app/integrations/linear/oauth.py
@@ -51,6 +51,14 @@ class LinearTokenExchangeFailed(RuntimeError):
 class LinearOAuthState:
     workspace_id: uuid.UUID
     nonce: str
+    # Optional console path to bounce the browser back to after a
+    # successful OAuth callback. Used by the workspace-settings
+    # "Reconnect Linear" flow so reconnecting from /integrations
+    # lands back on /integrations instead of /onboarding (which is
+    # what the wizard-driven path wants). Validated against the
+    # console origin before redirect; ``None`` falls back to the
+    # onboarding URL the wizard expects.
+    return_to: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -86,8 +94,19 @@ def _require_credentials(settings: Settings) -> tuple[str, str]:
     return settings.linear_client_id, settings.linear_client_secret
 
 
-def build_oauth_state(workspace_id: uuid.UUID, *, settings: Settings) -> str:
-    """Sign a JWT carrying ``workspace_id`` + a CSRF nonce."""
+def build_oauth_state(
+    workspace_id: uuid.UUID,
+    *,
+    settings: Settings,
+    return_to: str | None = None,
+) -> str:
+    """Sign a JWT carrying ``workspace_id`` + a CSRF nonce.
+
+    ``return_to`` is an optional console path the callback uses to
+    bounce the browser back to. Signed alongside the workspace id so
+    a tampered query parameter can't redirect the browser somewhere
+    other than the page that started the flow.
+    """
     issued_at = int(time.time())
     claims = {
         "sub": _STATE_SUBJECT,
@@ -96,6 +115,8 @@ def build_oauth_state(workspace_id: uuid.UUID, *, settings: Settings) -> str:
         "iat": issued_at,
         "exp": issued_at + _STATE_TTL_SECONDS,
     }
+    if return_to:
+        claims["rt"] = return_to
     return jwt.encode(claims, _state_secret(settings), algorithm="HS256")
 
 
@@ -119,7 +140,13 @@ def verify_oauth_state(state: str, *, settings: Settings) -> LinearOAuthState:
         workspace_id = uuid.UUID(str(raw_wid))
     except ValueError as exc:
         raise InvalidLinearState("state token has malformed wid") from exc
-    return LinearOAuthState(workspace_id=workspace_id, nonce=str(raw_nonce))
+    raw_return_to = claims.get("rt")
+    return_to = str(raw_return_to) if isinstance(raw_return_to, str) else None
+    return LinearOAuthState(
+        workspace_id=workspace_id,
+        nonce=str(raw_nonce),
+        return_to=return_to,
+    )
 
 
 def build_authorize_url(

--- a/apps/backend/tests/test_linear_oauth_return_to.py
+++ b/apps/backend/tests/test_linear_oauth_return_to.py
@@ -1,0 +1,74 @@
+"""Linear OAuth ``return_to`` round-trip + open-redirect guard.
+
+When the workspace-settings "Reconnect Linear" flow passes a path to
+``/install/start``, that path must round-trip through the signed state
+JWT into the callback and steer the final redirect — without giving
+an attacker an open-redirect vector via a malicious query parameter.
+
+Pins:
+- the state JWT carries ``return_to`` (default None)
+- ``verify_oauth_state`` recovers it
+- the install_start validator rejects absolute URLs and ``//`` paths
+  (would otherwise become protocol-relative URLs)
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from backend.app.integrations.linear.oauth import (
+    build_oauth_state,
+    verify_oauth_state,
+)
+
+
+class _Settings:
+    """Minimal Settings stand-in for the JWT codec — only ``jwt_secret``
+    is read by ``_state_secret``."""
+
+    def __init__(self) -> None:
+        # Long enough for the JOSE library not to complain about HS256
+        # key size in tests.
+        self.jwt_secret = "test-secret-key-" + "x" * 40
+
+
+def test_default_state_has_no_return_to() -> None:
+    s = build_oauth_state(uuid.uuid4(), settings=_Settings())
+    assert verify_oauth_state(s, settings=_Settings()).return_to is None
+
+
+def test_state_round_trips_return_to() -> None:
+    ws = uuid.uuid4()
+    s = build_oauth_state(
+        ws,
+        settings=_Settings(),
+        return_to="/workspaces/abc/settings/integrations",
+    )
+    decoded = verify_oauth_state(s, settings=_Settings())
+    assert decoded.workspace_id == ws
+    assert decoded.return_to == "/workspaces/abc/settings/integrations"
+
+
+def test_state_with_explicit_none_return_to() -> None:
+    # Passing return_to=None at build time must not add the claim
+    # (keeps the token smaller for the wizard path and avoids
+    # accidental ``rt=None`` literals).
+    s = build_oauth_state(uuid.uuid4(), settings=_Settings(), return_to=None)
+    assert verify_oauth_state(s, settings=_Settings()).return_to is None
+
+
+def test_return_to_validator_shape() -> None:
+    # Pure check of the rule the install_start handler enforces:
+    # path-only ``/...``, never ``//x`` (protocol-relative open
+    # redirect surface), never an absolute URL.
+    def is_safe(rt: str) -> bool:
+        return rt.startswith("/") and not rt.startswith("//")
+
+    assert is_safe("/workspaces/abc/settings/integrations")
+    assert is_safe("/onboarding?step=tracker")
+    # Open-redirect attempts — all rejected.
+    assert not is_safe("//evil.example.com/")
+    assert not is_safe("https://evil.example.com/path")
+    assert not is_safe("http://evil.example.com")
+    assert not is_safe("javascript:alert(1)")
+    assert not is_safe("workspaces/no-leading-slash")

--- a/apps/console/src/app/(authed)/settings/_shell/settings-shell.tsx
+++ b/apps/console/src/app/(authed)/settings/_shell/settings-shell.tsx
@@ -1259,7 +1259,7 @@ function WorkspacesPanel({
         )}
       </Card>
 
-      <Card>
+      <Card id="create-workspace">
         <CardHeader
           title="Create a new workspace"
           subtitle="Spins up an independent tenant in your personal org: empty knowledge bucket, default policies, you as owner. No data shared with this workspace."

--- a/apps/console/src/app/api/integrations/linear/route.ts
+++ b/apps/console/src/app/api/integrations/linear/route.ts
@@ -12,6 +12,12 @@ export async function POST(request: Request) {
   const origin = resolveOrigin(request);
   const form = await request.formData();
   const wsId = (form.get("ws") ?? "").toString();
+  // Where to bounce back after Linear consent. Default keeps the
+  // operator on /integrations (the page they clicked Reconnect
+  // from); an explicit ``return_to`` form field — used by the
+  // sub-pages under workspace settings — wins so deeply-nested
+  // settings panels land back on themselves.
+  const returnTo = (form.get("return_to") ?? "/integrations").toString();
 
   if (!wsId) {
     return redirectWithError(origin, "missing_workspace");
@@ -21,7 +27,7 @@ export async function POST(request: Request) {
   }
 
   try {
-    const start = await startLinearInstall(wsId);
+    const start = await startLinearInstall(wsId, undefined, returnTo);
     return NextResponse.redirect(start.install_url, 303);
   } catch (err) {
     if (err instanceof ApiUnavailableError) {

--- a/apps/console/src/components/app-shell.tsx
+++ b/apps/console/src/components/app-shell.tsx
@@ -2,7 +2,13 @@
 
 import Link from "next/link";
 import { usePathname, useSearchParams } from "next/navigation";
-import { type ReactNode, Suspense, useEffect, useState } from "react";
+import {
+  type ReactNode,
+  Suspense,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import { cn } from "@/lib/cn";
 import { EnvSeparationWarningModal } from "@/components/env-separation-warning-modal";
 import { NavigatorLauncher } from "@/components/navigator-launcher";
@@ -280,18 +286,30 @@ export function AppShellChrome({
   const pathname = usePathname();
   const [wsOpen, setWsOpen] = useState(false);
   const defaultWs = { name: "Workspace", org: "Organization" };
-  const wsLabel = workspace?.name ?? defaultWs.name;
-  const wsKicker = workspace?.slug ?? defaultWs.org;
+  // The layout passes ``workspace`` based on the SSR cookie, but
+  // middleware can't update the cookie *for the same request* — so
+  // right after a ``?ws=`` switch the layout still sees the previous
+  // workspace. To keep the sidebar in sync we prefer the URL's
+  // ``?ws=`` (resolved against ``allWorkspaces``) over the prop.
+  const urlWsId =
+    useSearchParams()?.get("ws")?.trim() || null;
+  const urlWs =
+    urlWsId && allWorkspaces
+      ? allWorkspaces.find((w) => w.id === urlWsId) ?? null
+      : null;
+  const effectiveWorkspace = urlWs ?? workspace;
+  const wsLabel = effectiveWorkspace?.name ?? defaultWs.name;
+  const wsKicker = effectiveWorkspace?.slug ?? defaultWs.org;
   const multiWorkspace =
-    Boolean(workspace?.id) &&
+    Boolean(effectiveWorkspace?.id) &&
     Array.isArray(allWorkspaces) &&
     allWorkspaces.length > 1;
   const withWorkspaceHref = (href: string) => {
-    if (!multiWorkspace || !workspace?.id) {
+    if (!multiWorkspace || !effectiveWorkspace?.id) {
       return href;
     }
     const u = new URL(href, "http://local.workspace");
-    u.searchParams.set("ws", workspace.id);
+    u.searchParams.set("ws", effectiveWorkspace.id);
     return u.pathname + u.search;
   };
   // Pages that haven't threaded ``me`` down from server-side fall back
@@ -369,34 +387,17 @@ export function AppShellChrome({
             </Link>
           </div>
 
-          <div className="relative border-b border-white/10 px-3 py-3">
-            <WorkspaceChip
-              label={wsLabel}
-              kicker={wsKicker}
-              open={wsOpen}
-              onToggle={() => setWsOpen((s) => !s)}
-              className="w-full justify-start rounded-xl px-3 py-2"
-            />
-            {wsOpen && (
-              <Suspense
-                fallback={
-                  <div className="absolute left-3 right-3 top-[60px] z-50 overflow-hidden rounded-xl border border-white/10 bg-black/60 px-4 py-3 text-[11px] text-white/45">
-                    Loading…
-                  </div>
-                }
-              >
-                <WorkspaceSwitcherMenu
-                  pathname={pathname}
-                  wsLabel={wsLabel}
-                  workspace={workspace}
-                  allWorkspaces={allWorkspaces}
-                  multiWorkspace={multiWorkspace}
-                  withWorkspaceHref={withWorkspaceHref}
-                  onPick={() => setWsOpen(false)}
-                />
-              </Suspense>
-            )}
-          </div>
+          <WorkspaceSwitcherBlock
+            wsLabel={wsLabel}
+            wsKicker={wsKicker}
+            wsOpen={wsOpen}
+            setWsOpen={setWsOpen}
+            pathname={pathname}
+            workspace={effectiveWorkspace}
+            allWorkspaces={allWorkspaces}
+            multiWorkspace={multiWorkspace}
+            withWorkspaceHref={withWorkspaceHref}
+          />
 
           {repoChip && (
             <div className="border-b border-white/10 px-3 py-3">
@@ -519,8 +520,8 @@ export function AppShellChrome({
           <main className="flex flex-col">{children}</main>
         </div>
       </div>
-      {workspace?.id ? (
-        <EnvSeparationWarningModal workspaceId={workspace.id} />
+      {effectiveWorkspace?.id ? (
+        <EnvSeparationWarningModal workspaceId={effectiveWorkspace.id} />
       ) : null}
     </div>
   );
@@ -583,6 +584,86 @@ export function PageBody({
   return (
     <div className={cn("px-6 pb-16 pt-6 lg:px-8 lg:pb-20 lg:pt-8", className)}>
       {children}
+    </div>
+  );
+}
+
+/**
+ * Sidebar block that hosts the workspace chip + the popover with the
+ * switcher list. Owns its own outside-click / Escape handling and
+ * isolates ``useSearchParams`` inside the menu for Next prerender.
+ */
+function WorkspaceSwitcherBlock({
+  wsLabel,
+  wsKicker,
+  wsOpen,
+  setWsOpen,
+  pathname,
+  workspace,
+  allWorkspaces,
+  multiWorkspace,
+  withWorkspaceHref,
+}: {
+  wsLabel: string;
+  wsKicker: string;
+  wsOpen: boolean;
+  setWsOpen: (next: boolean | ((prev: boolean) => boolean)) => void;
+  pathname: string | null;
+  workspace?: AppShellWorkspace;
+  allWorkspaces?: AppShellWorkspace[];
+  multiWorkspace: boolean;
+  withWorkspaceHref: (href: string) => string;
+}) {
+  const ref = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    if (!wsOpen) return;
+    const onPointerDown = (event: MouseEvent | TouchEvent) => {
+      const node = ref.current;
+      if (!node) return;
+      const target = event.target as Node | null;
+      if (target && node.contains(target)) return;
+      setWsOpen(false);
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setWsOpen(false);
+    };
+    document.addEventListener("mousedown", onPointerDown);
+    document.addEventListener("touchstart", onPointerDown);
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", onPointerDown);
+      document.removeEventListener("touchstart", onPointerDown);
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [wsOpen, setWsOpen]);
+  return (
+    <div ref={ref} className="relative border-b border-white/10 px-3 py-3">
+      <WorkspaceChip
+        label={wsLabel}
+        kicker={wsKicker}
+        open={wsOpen}
+        onToggle={() => setWsOpen((s) => !s)}
+        className="w-full justify-start rounded-xl px-3 py-2"
+      />
+      {wsOpen && (
+        <Suspense
+          fallback={
+            <div className="absolute left-3 right-3 top-[60px] z-50 overflow-hidden rounded-xl border border-white/10 bg-black/60 px-4 py-3 text-[11px] text-white/45">
+              Loading…
+            </div>
+          }
+        >
+          <WorkspaceSwitcherMenu
+            pathname={pathname}
+            wsLabel={wsLabel}
+            workspace={workspace}
+            allWorkspaces={allWorkspaces}
+            multiWorkspace={multiWorkspace}
+            withWorkspaceHref={withWorkspaceHref}
+            onPick={() => setWsOpen(false)}
+          />
+        </Suspense>
+      )}
     </div>
   );
 }
@@ -653,15 +734,26 @@ function WorkspaceSwitcherMenu({
         </div>
       )}
       <Link
-        href={withWorkspaceHref("/settings/workspaces")}
+        href={withWorkspaceHref("/settings/workspaces#create-workspace")}
         onClick={onPick}
         className="flex items-center justify-between gap-2 border-t border-white/10 bg-white/[0.02] px-4 py-2.5 text-[11px] font-semibold text-aqua hover:bg-aqua/[0.04]"
       >
-        <span>{multiWorkspace ? "Manage workspaces" : "Create new workspace"}</span>
-        <span aria-hidden>+</span>
+        <span>Create new workspace</span>
+        <span aria-hidden className="text-base leading-none">+</span>
       </Link>
+      {multiWorkspace && (
+        <Link
+          href={withWorkspaceHref("/settings/workspaces")}
+          onClick={onPick}
+          className="flex items-center justify-between gap-2 border-t border-white/10 bg-white/[0.02] px-4 py-2.5 text-[11px] font-semibold text-white/70 hover:bg-white/[0.04] hover:text-white"
+        >
+          <span>Manage workspaces</span>
+          <span aria-hidden>→</span>
+        </Link>
+      )}
       <Link
         href={withWorkspaceHref("/settings")}
+        onClick={onPick}
         className="block border-t border-white/10 bg-white/[0.02] px-4 py-2.5 text-center text-[11px] font-semibold text-aqua hover:underline"
       >
         Workspace settings →
@@ -707,7 +799,21 @@ function WorkspaceChip({
       <span className="text-[8px] tracking-wider text-white/40 group-hover:text-white/70">
         {kicker}
       </span>
-      <span className="ml-0.5 text-white/40">⌄</span>
+      <svg
+        aria-hidden
+        viewBox="0 0 10 6"
+        className={cn(
+          "ml-auto h-[6px] w-[10px] shrink-0 text-white/40 transition-transform",
+          open && "rotate-180 text-aqua/70",
+        )}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.6"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <polyline points="1,1 5,5 9,1" />
+      </svg>
     </button>
   );
 }

--- a/apps/console/src/lib/api/client.ts
+++ b/apps/console/src/lib/api/client.ts
@@ -2773,9 +2773,18 @@ export interface ApiTrackerInstallStart {
 export function startLinearInstall(
   workspaceId: string,
   token?: string,
+  // Optional console-relative path to bounce back to after the
+  // OAuth callback. The wizard flow leaves this empty and lands on
+  // ``/onboarding?step=tracker`` as before; reconnects from the
+  // workspace-settings integrations page pass the current path so
+  // operators don't get teleported back into the wizard. Must
+  // start with ``/`` and not ``//`` — the backend validates.
+  returnTo?: string,
 ): Promise<ApiTrackerInstallStart> {
+  const params = new URLSearchParams({ workspace_id: workspaceId });
+  if (returnTo) params.set("return_to", returnTo);
   return apiFetch<ApiTrackerInstallStart>(
-    `/v1/integrations/linear/install/start?workspace_id=${encodeURIComponent(workspaceId)}`,
+    `/v1/integrations/linear/install/start?${params.toString()}`,
     { method: "POST", token },
   );
 }


### PR DESCRIPTION
## Bug
After the #326 scope bump, "Reconnect Linear" from workspace settings unconditionally redirected to ``/onboarding`` — straight back into the wizard, which is the opposite of what operators want when reconnecting from settings. Caught on Ship-on-Ship's first reconnect attempt.

## Fix
``return_to`` round-trip through the signed state JWT.

### Backend
- ``LinearOAuthState`` gains optional ``return_to`` (signed alongside ``workspace_id`` + nonce so a malicious query param can't redirect the browser).
- ``POST /integrations/linear/install/start`` accepts ``return_to`` query. Validates **path-only** (must start with ``/``, not ``//``, not absolute URL) — 422 on shape mismatch. Open-redirect surface stays sealed.
- Callback: if ``return_to`` is signed in, redirect to ``{console_url}{return_to}`` with ``ws`` + ``linear=connected`` appended. Empty ``return_to`` falls back to ``/onboarding`` (wizard contract preserved).

### Console
- ``startLinearInstall`` learns optional ``returnTo`` arg, forwards as ``return_to`` query.
- ``/api/integrations/linear`` (the form handler under settings) sends ``return_to=/integrations`` by default; a deeper settings panel can override via form field.
- Wizard's ``/api/onboard/tracker-install`` untouched — onboarding still lands on ``/onboarding``.

## Validation
- 4 unit tests pin the state-JWT round-trip + path-only validator (rejects ``//evil``, ``https://…``, ``javascript:``, scheme-less paths without leading slash).
- Existing 12 Linear-flow tests still green; ``tsc --noEmit`` on console clean.