### PR TITLE
feat(onboarding): reuse existing GitHub App installs across workspaces

### DIFF
--- a/apps/backend/app/api/v1/routes/github_app.py
+++ b/apps/backend/app/api/v1/routes/github_app.py
@@ -39,7 +39,7 @@ from backend.app.core.config import Settings, get_settings
 from backend.app.db.models.integrations import GitHubInstallation, WorkspaceRepo
 from backend.app.db.models.lanes import Routine, RoutineRun
 from backend.app.db.models.pipelines import PullRequest, WorkflowRun
-from backend.app.db.models.tenancy import AuditLog
+from backend.app.db.models.tenancy import AuditLog, Workspace, WorkspaceMember
 from backend.app.db.session import get_session
 from backend.app.integrations.github.app_auth import (
     GitHubAppMisconfigured,
@@ -127,6 +127,206 @@ async def install_start(
         install_url=install_url,
         state=state,
     )
+
+
+class AccessibleInstallationOut(BaseModel):
+    """One row of ``GET /integrations/github/installations``.
+
+    Groups by ``installation_id`` — multiple workspaces under the same
+    GitHub App install collapse into a single response row, with
+    ``workspace_slugs`` listing up to a handful of source workspaces so
+    the console can render "already powers @acme · dev / staging" hints.
+    """
+
+    installation_id: int
+    account_login: str | None
+    account_type: str | None
+    repository_selection: str | None
+    installed_at: datetime | None
+    # Slugs (up to 5) of workspaces the caller is a member of that
+    # already bind this install — used for UX context only, never as a
+    # security boundary.
+    workspace_slugs: list[str]
+
+
+@router.get(
+    "/integrations/github/installations",
+    response_model=list[AccessibleInstallationOut],
+)
+async def list_accessible_installations(
+    exclude_workspace_id: uuid.UUID | None = Query(
+        None,
+        description=(
+            "When set, hide installs already bound to this workspace so the "
+            "wizard can show ONLY the candidates worth attaching."
+        ),
+    ),
+    auth: AuthContext = Depends(get_current_auth),
+    session: AsyncSession = Depends(get_session),
+) -> list[AccessibleInstallationOut]:
+    """List GitHub App installations the caller can reach via their
+    workspace memberships, deduped by ``installation_id``.
+
+    Why this endpoint exists: the onboarding wizard step-1 used to send
+    every operator through the GitHub install picker, even when they had
+    already installed Ship on @acme under a different workspace. Multi-
+    workspace per-install is supported (migration 0076) so reusing an
+    existing install is a single DB insert — no GitHub round-trip — but
+    the console needs to know which installs are reachable to even offer
+    that path. This endpoint is the listing primitive; the actual reuse
+    runs through ``POST /integrations/github/install/attach``.
+
+    Member-gated (any workspace role): listing is information the user
+    already has implicitly via their workspace bindings; the admin gate
+    lives on the attach endpoint where the action is destructive.
+    """
+    # All non-suspended installs in workspaces this user is a member of,
+    # joined to the workspace row so we can return the slug for context.
+    stmt = (
+        select(GitHubInstallation, Workspace.slug)
+        .join(Workspace, Workspace.id == GitHubInstallation.workspace_id)
+        .join(
+            WorkspaceMember,
+            WorkspaceMember.workspace_id == GitHubInstallation.workspace_id,
+        )
+        .where(WorkspaceMember.user_id == auth.user.id)
+        .where(GitHubInstallation.suspended_at.is_(None))
+        .order_by(desc(GitHubInstallation.installed_at))
+    )
+    rows = (await session.execute(stmt)).all()
+
+    excluded_ids: set[int] = set()
+    if exclude_workspace_id is not None:
+        excluded_stmt = (
+            select(GitHubInstallation.installation_id)
+            .where(GitHubInstallation.workspace_id == exclude_workspace_id)
+            .where(GitHubInstallation.suspended_at.is_(None))
+        )
+        excluded_ids = {
+            r for r, in (await session.execute(excluded_stmt)).all()
+        }
+
+    # Group by installation_id; first row wins for the descriptive
+    # metadata (most recently installed comes first via ORDER BY above).
+    grouped: dict[int, AccessibleInstallationOut] = {}
+    for install, slug in rows:
+        if install.installation_id in excluded_ids:
+            continue
+        existing = grouped.get(install.installation_id)
+        if existing is None:
+            grouped[install.installation_id] = AccessibleInstallationOut(
+                installation_id=install.installation_id,
+                account_login=install.account_login,
+                account_type=install.account_type,
+                repository_selection=install.repository_selection,
+                installed_at=install.installed_at,
+                workspace_slugs=[slug],
+            )
+        elif len(existing.workspace_slugs) < 5:
+            existing.workspace_slugs.append(slug)
+    return list(grouped.values())
+
+
+class AttachInstallationRequest(BaseModel):
+    workspace_id: uuid.UUID
+    installation_id: int
+
+
+@router.post(
+    "/integrations/github/install/attach",
+    response_model=InstallationOut,
+    status_code=status.HTTP_201_CREATED,
+)
+async def attach_installation(
+    body: AttachInstallationRequest,
+    auth: AuthContext = Depends(get_current_auth),
+    session: AsyncSession = Depends(get_session),
+) -> InstallationOut:
+    """Bind an existing GitHub App install to a *new* workspace.
+
+    Anti-leak: the caller must be admin/owner of the *target* workspace
+    **and** admin/owner of at least one source workspace already binding
+    this ``installation_id``. The second check proves the caller actually
+    has the install reachable through normal membership (rather than
+    just guessing an installation_id off a webhook URL).
+
+    Idempotent: when the compound unique ``(workspace_id, installation_id)``
+    is already satisfied we return the existing row with a 201 anyway —
+    the console treats it as success and moves the wizard forward.
+    """
+    await _require_membership(
+        session, body.workspace_id, auth.user.id, ROLES_ADMIN
+    )
+
+    # Find a source row to copy metadata from + verify admin elsewhere.
+    source_stmt = (
+        select(GitHubInstallation, WorkspaceMember.role)
+        .join(
+            WorkspaceMember,
+            WorkspaceMember.workspace_id == GitHubInstallation.workspace_id,
+        )
+        .where(GitHubInstallation.installation_id == body.installation_id)
+        .where(GitHubInstallation.suspended_at.is_(None))
+        .where(GitHubInstallation.workspace_id != body.workspace_id)
+        .where(WorkspaceMember.user_id == auth.user.id)
+    )
+    source_rows = (await session.execute(source_stmt)).all()
+    if not source_rows:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="installation_not_accessible",
+        )
+    admin_source = next(
+        ((inst, role) for inst, role in source_rows if role in ROLES_ADMIN),
+        None,
+    )
+    if admin_source is None:
+        # The caller has the install in view (so listing would show it),
+        # but isn't admin anywhere it lives — refuse to escalate them by
+        # routing the install into a new workspace where they ARE admin.
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="not_admin_on_source_workspace",
+        )
+    source_install = admin_source[0]
+
+    # Idempotent — second call collapses to a no-op return.
+    existing_stmt = (
+        select(GitHubInstallation)
+        .where(GitHubInstallation.workspace_id == body.workspace_id)
+        .where(GitHubInstallation.installation_id == body.installation_id)
+    )
+    existing = (await session.execute(existing_stmt)).scalar_one_or_none()
+    if existing is not None:
+        return _row_to_out(existing)
+
+    row = GitHubInstallation(
+        workspace_id=body.workspace_id,
+        installation_id=body.installation_id,
+        account_id=source_install.account_id,
+        account_login=source_install.account_login,
+        account_type=source_install.account_type,
+        repository_selection=source_install.repository_selection,
+        settings=dict(source_install.settings or {}),
+        installed_at=datetime.now(timezone.utc),
+    )
+    session.add(row)
+    session.add(
+        AuditLog(
+            workspace_id=body.workspace_id,
+            actor_user_id=auth.user.id,
+            actor_token_id=(auth.token.id if auth.token is not None else None),
+            action="github.install.share",
+            target_kind="github_installation",
+            target_id=str(body.installation_id),
+            payload={
+                "installation_id": body.installation_id,
+                "source_workspace_id": str(source_install.workspace_id),
+            },
+        )
+    )
+    await session.flush()
+    return _row_to_out(row)
 
 
 @router.get("/integrations/github/install/callback")

--- a/apps/backend/tests/test_v1_github_app.py
+++ b/apps/backend/tests/test_v1_github_app.py
@@ -14,10 +14,21 @@ from __future__ import annotations
 import hashlib
 import hmac
 import json
+import secrets
 import uuid
+from datetime import datetime, timezone
 
 import pytest
 from sqlalchemy import select
+
+from backend.app.db.models.integrations import GitHubInstallation
+from backend.app.db.models.tenancy import (
+    Org,
+    OrgMember,
+    User,
+    Workspace,
+    WorkspaceMember,
+)
 
 
 WEBHOOK_SECRET = "wh_test_secret"
@@ -344,3 +355,402 @@ async def test_webhook_created_event_backfills_account_metadata(
     assert row.account_login == "acme"
     assert row.account_type == "Organization"
     assert row.repository_selection == "selected"
+
+
+# ---------------------------------------------------------------------------
+# Accessible-installations listing + cross-workspace attach.
+# ---------------------------------------------------------------------------
+#
+# These tests cover the "reuse an existing install in a new workspace"
+# branch the wizard takes when the operator already connected Ship to
+# the org under a different workspace. They share a small builder for
+# orgs / workspaces / installs because the matrix needs at least two
+# workspaces and sometimes a second user.
+
+
+async def _make_workspace(
+    db_session,
+    user,
+    org=None,
+    *,
+    role: str = "owner",
+    slug_prefix: str = "ws",
+):
+    """Create a Workspace + Org (if needed) + WorkspaceMember for ``user``."""
+    if org is None:
+        org = Org(
+            slug=f"org-{uuid.uuid4().hex[:8]}",
+            name="Test org",
+            plan="free",
+        )
+        db_session.add(org)
+        await db_session.flush()
+        db_session.add(
+            OrgMember(org_id=org.id, user_id=user.id, role="org_owner")
+        )
+    ws = Workspace(
+        org_id=org.id,
+        slug=f"{slug_prefix}-{uuid.uuid4().hex[:6]}",
+        name=f"{slug_prefix} workspace",
+    )
+    db_session.add(ws)
+    await db_session.flush()
+    db_session.add(
+        WorkspaceMember(
+            workspace_id=ws.id,
+            user_id=user.id,
+            role=role,
+            answer_specialist_slugs=["*"],
+        )
+    )
+    await db_session.flush()
+    return ws, org
+
+
+async def _make_user_with_token(db_session, label: str = "extra"):
+    from backend.app.api.v1.deps import PAT_PREFIX, _hash_token
+    from backend.app.db.models.tenancy import ApiToken
+
+    user = User(
+        email=f"{label}-{uuid.uuid4().hex[:6]}@example.com",
+        display_name=f"{label} user",
+    )
+    db_session.add(user)
+    await db_session.flush()
+    raw = f"{PAT_PREFIX}{secrets.token_urlsafe(24)}"
+    db_session.add(
+        ApiToken(
+            user_id=user.id,
+            name=f"{label}-pat",
+            hashed_secret=_hash_token(raw),
+            prefix=PAT_PREFIX,
+            scopes=["workspace:read", "workspace:write"],
+        )
+    )
+    await db_session.flush()
+    return user, raw
+
+
+@pytest.mark.asyncio
+async def test_list_accessible_installations_dedupes_by_installation_id(
+    v1_client, db_session, seed_workspace
+) -> None:
+    """One install shared across two workspaces collapses into one row.
+
+    The two source workspace slugs ride along on ``workspace_slugs`` so
+    the wizard can render "already powers @acme · ws-a / ws-b" context.
+    """
+    user, raw, ws_a = seed_workspace
+    ws_b, _ = await _make_workspace(db_session, user, slug_prefix="ws-b")
+    shared_install_id = 901
+    for ws in (ws_a, ws_b):
+        db_session.add(
+            GitHubInstallation(
+                workspace_id=ws.id,
+                installation_id=shared_install_id,
+                account_login="acme",
+                account_type="Organization",
+                installed_at=datetime.now(timezone.utc),
+            )
+        )
+    await db_session.flush()
+
+    response = await v1_client.get(
+        "/v1/integrations/github/installations",
+        headers={"Authorization": f"Bearer {raw}"},
+    )
+    assert response.status_code == 200, response.text
+    rows = response.json()
+    assert len(rows) == 1
+    only = rows[0]
+    assert only["installation_id"] == shared_install_id
+    assert only["account_login"] == "acme"
+    assert sorted(only["workspace_slugs"]) == sorted([ws_a.slug, ws_b.slug])
+
+
+@pytest.mark.asyncio
+async def test_list_accessible_installations_hides_other_users_installs(
+    v1_client, db_session, seed_workspace
+) -> None:
+    """Strangers' installs never appear in the response."""
+    _, raw, _ = seed_workspace
+    stranger, _ = await _make_user_with_token(db_session, label="stranger")
+    stranger_ws, _ = await _make_workspace(
+        db_session, stranger, slug_prefix="stranger-ws"
+    )
+    db_session.add(
+        GitHubInstallation(
+            workspace_id=stranger_ws.id,
+            installation_id=8888,
+            account_login="other-org",
+            installed_at=datetime.now(timezone.utc),
+        )
+    )
+    await db_session.flush()
+
+    response = await v1_client.get(
+        "/v1/integrations/github/installations",
+        headers={"Authorization": f"Bearer {raw}"},
+    )
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+@pytest.mark.asyncio
+async def test_list_accessible_installations_excludes_target_workspace(
+    v1_client, db_session, seed_workspace
+) -> None:
+    """``exclude_workspace_id`` drops installs already bound to that ws.
+
+    The wizard passes the new workspace id so the candidate list shows
+    installs the user *could* attach, not ones they already have.
+    """
+    user, raw, ws_a = seed_workspace
+    ws_b, _ = await _make_workspace(db_session, user, slug_prefix="ws-b")
+    install_id = 7001
+    db_session.add(
+        GitHubInstallation(
+            workspace_id=ws_a.id,
+            installation_id=install_id,
+            account_login="acme",
+            installed_at=datetime.now(timezone.utc),
+        )
+    )
+    db_session.add(
+        GitHubInstallation(
+            workspace_id=ws_b.id,
+            installation_id=install_id,
+            account_login="acme",
+            installed_at=datetime.now(timezone.utc),
+        )
+    )
+    await db_session.flush()
+
+    response = await v1_client.get(
+        "/v1/integrations/github/installations",
+        params={"exclude_workspace_id": str(ws_b.id)},
+        headers={"Authorization": f"Bearer {raw}"},
+    )
+    assert response.status_code == 200
+    # The install exists under ws_b → excluded entirely (matching on
+    # installation_id, not just workspace_id).
+    assert response.json() == []
+
+
+@pytest.mark.asyncio
+async def test_list_accessible_installations_hides_suspended(
+    v1_client, db_session, seed_workspace
+) -> None:
+    _, raw, ws = seed_workspace
+    db_session.add(
+        GitHubInstallation(
+            workspace_id=ws.id,
+            installation_id=10,
+            account_login="acme",
+            installed_at=datetime.now(timezone.utc),
+            suspended_at=datetime.now(timezone.utc),
+        )
+    )
+    await db_session.flush()
+
+    response = await v1_client.get(
+        "/v1/integrations/github/installations",
+        headers={"Authorization": f"Bearer {raw}"},
+    )
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+@pytest.mark.asyncio
+async def test_attach_installation_happy_path(
+    v1_client, db_session, seed_workspace
+) -> None:
+    """Admin on source + target → install row appears under target."""
+    user, raw, ws_source = seed_workspace
+    ws_target, _ = await _make_workspace(db_session, user, slug_prefix="target")
+    db_session.add(
+        GitHubInstallation(
+            workspace_id=ws_source.id,
+            installation_id=5005,
+            account_id=42,
+            account_login="acme",
+            account_type="Organization",
+            repository_selection="selected",
+            installed_at=datetime.now(timezone.utc),
+            settings={"selected_repositories": ["acme/payments"]},
+        )
+    )
+    await db_session.flush()
+
+    response = await v1_client.post(
+        "/v1/integrations/github/install/attach",
+        json={
+            "workspace_id": str(ws_target.id),
+            "installation_id": 5005,
+        },
+        headers={"Authorization": f"Bearer {raw}"},
+    )
+    assert response.status_code == 201, response.text
+    body = response.json()
+    assert body["installation_id"] == 5005
+    assert body["account_login"] == "acme"
+    assert body["repository_selection"] == "selected"
+
+    rows = (
+        await db_session.execute(
+            select(GitHubInstallation).where(
+                GitHubInstallation.installation_id == 5005,
+                GitHubInstallation.workspace_id == ws_target.id,
+            )
+        )
+    ).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].settings == {"selected_repositories": ["acme/payments"]}
+
+
+@pytest.mark.asyncio
+async def test_attach_installation_requires_target_admin(
+    v1_client, db_session, seed_workspace
+) -> None:
+    """Caller has source admin but only member role on target → 403."""
+    user, raw, ws_source = seed_workspace
+    # Spin a second workspace where ``user`` has the lower ``member`` role
+    # — they can read it but aren't allowed to bind credentials there.
+    ws_target, _ = await _make_workspace(
+        db_session, user, role="member", slug_prefix="target"
+    )
+    db_session.add(
+        GitHubInstallation(
+            workspace_id=ws_source.id,
+            installation_id=6006,
+            account_login="acme",
+            installed_at=datetime.now(timezone.utc),
+        )
+    )
+    await db_session.flush()
+
+    response = await v1_client.post(
+        "/v1/integrations/github/install/attach",
+        json={
+            "workspace_id": str(ws_target.id),
+            "installation_id": 6006,
+        },
+        headers={"Authorization": f"Bearer {raw}"},
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_attach_installation_blocked_when_no_admin_anywhere(
+    v1_client, db_session, seed_workspace
+) -> None:
+    """Caller knows the install id but isn't admin where it lives → 403.
+
+    Source workspace exists, caller is a low-role member there (so the
+    install IS in their listing), and they're admin on the target — the
+    intended anti-leak is that we still refuse because they don't have
+    privilege to redirect the install.
+    """
+    user, raw, ws_target = seed_workspace  # caller is owner here
+    # Stranger owns the source workspace + install.
+    stranger, _ = await _make_user_with_token(db_session, label="stranger")
+    ws_source, _ = await _make_workspace(
+        db_session, stranger, slug_prefix="src"
+    )
+    # Caller is added as a low-role member on the source workspace so
+    # the install IS visible to them via the listing, but they don't
+    # have admin there.
+    db_session.add(
+        WorkspaceMember(
+            workspace_id=ws_source.id,
+            user_id=user.id,
+            role="member",
+            answer_specialist_slugs=["*"],
+        )
+    )
+    db_session.add(
+        GitHubInstallation(
+            workspace_id=ws_source.id,
+            installation_id=7007,
+            account_login="acme",
+            installed_at=datetime.now(timezone.utc),
+        )
+    )
+    await db_session.flush()
+
+    response = await v1_client.post(
+        "/v1/integrations/github/install/attach",
+        json={
+            "workspace_id": str(ws_target.id),
+            "installation_id": 7007,
+        },
+        headers={"Authorization": f"Bearer {raw}"},
+    )
+    assert response.status_code == 403
+    assert response.json()["detail"] == "not_admin_on_source_workspace"
+
+
+@pytest.mark.asyncio
+async def test_attach_installation_404_for_unknown_install(
+    v1_client, db_session, seed_workspace
+) -> None:
+    _, raw, ws_target = seed_workspace
+
+    response = await v1_client.post(
+        "/v1/integrations/github/install/attach",
+        json={
+            "workspace_id": str(ws_target.id),
+            "installation_id": 999999,
+        },
+        headers={"Authorization": f"Bearer {raw}"},
+    )
+    assert response.status_code == 404
+    assert response.json()["detail"] == "installation_not_accessible"
+
+
+@pytest.mark.asyncio
+async def test_attach_installation_idempotent(
+    v1_client, db_session, seed_workspace
+) -> None:
+    """Second attach returns the same row; UniqueConstraint isn't tripped."""
+    user, raw, ws_source = seed_workspace
+    ws_target, _ = await _make_workspace(db_session, user, slug_prefix="target")
+    db_session.add(
+        GitHubInstallation(
+            workspace_id=ws_source.id,
+            installation_id=8008,
+            account_login="acme",
+            installed_at=datetime.now(timezone.utc),
+        )
+    )
+    await db_session.flush()
+
+    first = await v1_client.post(
+        "/v1/integrations/github/install/attach",
+        json={
+            "workspace_id": str(ws_target.id),
+            "installation_id": 8008,
+        },
+        headers={"Authorization": f"Bearer {raw}"},
+    )
+    assert first.status_code == 201, first.text
+
+    second = await v1_client.post(
+        "/v1/integrations/github/install/attach",
+        json={
+            "workspace_id": str(ws_target.id),
+            "installation_id": 8008,
+        },
+        headers={"Authorization": f"Bearer {raw}"},
+    )
+    assert second.status_code == 201, second.text
+
+    rows = (
+        await db_session.execute(
+            select(GitHubInstallation).where(
+                GitHubInstallation.installation_id == 8008,
+                GitHubInstallation.workspace_id == ws_target.id,
+            )
+        )
+    ).scalars().all()
+    assert len(rows) == 1

--- a/apps/console/src/app/api/onboard/github-attach/route.ts
+++ b/apps/console/src/app/api/onboard/github-attach/route.ts
@@ -1,0 +1,80 @@
+/**
+ * Onboarding step — attach an *existing* GitHub App installation to
+ * this workspace instead of redirecting through GitHub's install picker.
+ *
+ * Triggered by the "Use @acme" CTA on step-1 when the user already has
+ * Ship installed somewhere they can reach. We:
+ *
+ * 1. POST to the backend `/integrations/github/install/attach` with the
+ *    chosen `installation_id` + the target workspace.
+ * 2. 303-redirect the browser straight into the wizard's repo picker —
+ *    same destination GitHub's callback would land them on after a
+ *    fresh install. That keeps the two branches indistinguishable for
+ *    every downstream step.
+ *
+ * Mirrors the shape of `github-install/route.ts` (POST form → redirect)
+ * so the wizard can use a plain `<form>` without any client JS.
+ */
+
+import { NextResponse } from "next/server";
+
+import {
+  ApiHttpError,
+  ApiUnavailableError,
+  attachGitHubInstallation,
+  isApiConfigured,
+} from "@/lib/api/client";
+import { resolveOrigin } from "@/lib/api/origin";
+
+export async function POST(request: Request) {
+  const origin = resolveOrigin(request);
+  const form = await request.formData();
+  const wsId = (form.get("ws") ?? "").toString();
+  const installationRaw = (form.get("installation_id") ?? "").toString();
+
+  if (!wsId) {
+    return NextResponse.redirect(new URL("/onboarding", origin), 303);
+  }
+  const installationId = Number.parseInt(installationRaw, 10);
+  if (!Number.isFinite(installationId) || installationId <= 0) {
+    return wizardError(origin, wsId, "bad_installation");
+  }
+
+  if (!isApiConfigured()) {
+    return wizardError(origin, wsId, "api_unavailable");
+  }
+
+  try {
+    await attachGitHubInstallation(wsId, installationId);
+    // Same landing as the GitHub redirect path so the wizard doesn't
+    // need a separate "you attached" success state.
+    const next = new URL("/onboarding", origin);
+    next.searchParams.set("step", "repos");
+    next.searchParams.set("ws", wsId);
+    next.searchParams.set("github", "installed");
+    return NextResponse.redirect(next, 303);
+  } catch (err) {
+    if (err instanceof ApiUnavailableError)
+      return wizardError(origin, wsId, "api_unavailable");
+    if (err instanceof ApiHttpError) {
+      if (err.status === 401)
+        return NextResponse.redirect(
+          new URL("/login?error=session_expired", origin),
+          303,
+        );
+      if (err.status === 403) return wizardError(origin, wsId, "forbidden");
+      if (err.status === 404)
+        return wizardError(origin, wsId, "installation_not_accessible");
+      return wizardError(origin, wsId, `http_${err.status}`);
+    }
+    return wizardError(origin, wsId, "unknown");
+  }
+}
+
+function wizardError(origin: string, wsId: string, code: string) {
+  const url = new URL("/onboarding", origin);
+  url.searchParams.set("step", "github");
+  url.searchParams.set("ws", wsId);
+  url.searchParams.set("error", code);
+  return NextResponse.redirect(url, 303);
+}

--- a/apps/console/src/app/onboarding/page.tsx
+++ b/apps/console/src/app/onboarding/page.tsx
@@ -41,10 +41,12 @@ import {
   checkAgentSecrets,
   getRepoTrackerBinding,
   isApiConfigured,
+  listAccessibleInstallations,
   listActivatedRepos,
   listAvailableRepos,
   listIntegrations,
   listWorkspaces,
+  type ApiAccessibleInstallation,
   type ApiActivatedRepo,
   type ApiAgentSecretStatus,
   type ApiAvailableRepo,
@@ -89,6 +91,10 @@ const GITHUB_ERRORS: Record<string, string> = {
     "GitHub App env vars are missing on the backend (GITHUB_APP_ID / GITHUB_APP_PRIVATE_KEY / GITHUB_APP_WEBHOOK_SECRET). Ask ops to wire them up and try again.",
   bad_state:
     "Install link expired or was tampered with. Start the install again from this step.",
+  bad_installation:
+    "That installation is no longer reachable. Pick a different account or install fresh.",
+  installation_not_accessible:
+    "We couldn't reach that GitHub install with your current role — make sure you're admin on the workspace that owns it, or install fresh on another account.",
   unknown: "Couldn't start the install flow. Try again.",
 };
 
@@ -307,6 +313,11 @@ export default async function OnboardingPage({
   // assumption than rendering a stale ✓.
   let githubAppInstalled = false;
   let activatedRepoCount = 0;
+  // Installs the user can already reach via *other* workspaces — drives
+  // the "Use @acme" reuse rows on step-1 so a new workspace doesn't
+  // force them back through the GitHub install picker when they already
+  // have Ship installed somewhere.
+  let accessibleInstalls: ApiAccessibleInstallation[] = [];
   if (wsId && apiConfigured) {
     try {
       const installed = await listAvailableRepos(
@@ -332,6 +343,18 @@ export default async function OnboardingPage({
       // Other errors silently leave the flags at false; the UI then
       // surfaces the standard "not installed" path which is the
       // worst-case-but-safe rendering.
+    }
+    // Always fetch the reusable installs list — cheap DB query, and we
+    // want it even on the "already installed for this ws" path so that
+    // reinstall flows still see siblings. Best-effort: a failure here
+    // just means we won't render the reuse rows.
+    try {
+      accessibleInstalls = await listAccessibleInstallations(
+        wsId,
+        sessionToken ?? undefined,
+      );
+    } catch {
+      accessibleInstalls = [];
     }
   }
 
@@ -594,6 +617,7 @@ export default async function OnboardingPage({
             error={error}
             githubReason={pick(params.github)}
             installed={githubAppInstalled}
+            accessibleInstalls={accessibleInstalls}
           />
         )}
         {step === "repos" && wsId && (
@@ -749,6 +773,7 @@ function GitHubStep({
   error,
   githubReason,
   installed,
+  accessibleInstalls,
 }: {
   wsId: string;
   error?: string;
@@ -760,12 +785,20 @@ function GitHubStep({
    * connected, leaving operators clicking Install on an installed
    * workspace and confusing themselves about state. */
   installed: boolean;
+  /** Installations the operator can reach via *other* workspaces —
+   * surfaced as "Use @acme" rows so a new workspace can attach to an
+   * install they already created instead of going through the GitHub
+   * picker a second time. Empty when nothing's reusable (first-time
+   * users, single-workspace operators) — the cold-start install button
+   * is the only CTA in that case. */
+  accessibleInstalls: ApiAccessibleInstallation[];
 }) {
   const message = error ? GITHUB_ERRORS[error] ?? error : null;
   // Backend redirects to `?step=repos&github=installed` after a
   // successful install; the only `github=` value we ever see on this
   // step is `request` (org-admin approval pending) or nothing at all.
   const requested = githubReason === "request";
+  const showReuse = !installed && accessibleInstalls.length > 0;
 
   return (
     <section>
@@ -773,7 +806,11 @@ function GitHubStep({
         Step 1 of 5 &middot; Connect your code
       </p>
       <h1 className="mt-2 font-display text-2xl font-bold leading-tight">
-        {installed ? "Ship is installed on GitHub." : "Install Ship on GitHub."}
+        {installed
+          ? "Ship is installed on GitHub."
+          : showReuse
+          ? "Reuse an existing GitHub connection."
+          : "Install Ship on GitHub."}
       </h1>
       <p className="mt-3 max-w-2xl text-sm leading-relaxed text-white/70">
         {installed ? (
@@ -782,6 +819,13 @@ function GitHubStep({
             Manage permissions or revoke the App on GitHub any time —
             nothing else on this step needs your attention unless you
             want to add / remove repos.
+          </>
+        ) : showReuse ? (
+          <>
+            You&rsquo;ve already installed Ship on at least one GitHub
+            account. Pick one to attach to this workspace — no second
+            install required — or install fresh on another org / account
+            below.
           </>
         ) : (
           <>
@@ -844,6 +888,36 @@ function GitHubStep({
             Continue to repos →
           </Link>
         </div>
+      ) : showReuse ? (
+        <div className="mt-7 space-y-3">
+          <ul className="space-y-2">
+            {accessibleInstalls.map((inst) => (
+              <li key={inst.installation_id}>
+                <AccessibleInstallRow wsId={wsId} install={inst} />
+              </li>
+            ))}
+          </ul>
+          <form
+            action="/api/onboard/github-install"
+            method="POST"
+            className="flex flex-wrap items-center gap-3 pt-2"
+            suppressHydrationWarning
+          >
+            <input
+              type="hidden"
+              name="ws"
+              value={wsId}
+              suppressHydrationWarning
+            />
+            <button
+              type="submit"
+              data-testid="onboarding-install-github"
+              className="text-xs font-semibold text-white/70 hover:text-white"
+            >
+              Install on another org / account →
+            </button>
+          </form>
+        </div>
       ) : (
         <form
           action="/api/onboard/github-install"
@@ -895,6 +969,83 @@ function GitHubStep({
       )}
     </section>
   );
+}
+
+/**
+ * Single reusable-install row on step-1. Submits a plain `<form>` so the
+ * branch works without any client JS — the BFF route handles the attach
+ * + redirect to the repo picker.
+ */
+function AccessibleInstallRow({
+  wsId,
+  install,
+}: {
+  wsId: string;
+  install: ApiAccessibleInstallation;
+}) {
+  const label = install.account_login?.trim() || `installation ${install.installation_id}`;
+  const accountType = install.account_type?.trim() || "";
+  const installedAgo = formatInstalledAgo(install.installed_at);
+  const siblingSlugs = install.workspace_slugs.filter(Boolean);
+  return (
+    <form
+      action="/api/onboard/github-attach"
+      method="POST"
+      className="flex flex-wrap items-center gap-3 rounded-xl border border-white/[0.08] bg-white/[0.03] px-4 py-3 transition hover:border-aqua/30 hover:bg-white/[0.05]"
+      suppressHydrationWarning
+    >
+      <input type="hidden" name="ws" value={wsId} suppressHydrationWarning />
+      <input
+        type="hidden"
+        name="installation_id"
+        value={String(install.installation_id)}
+        suppressHydrationWarning
+      />
+      <span className="grid h-9 w-9 shrink-0 place-items-center rounded-lg bg-gradient-to-br from-lilac via-aqua to-coral text-[11px] font-bold text-ink">
+        {label.slice(0, 2).toUpperCase()}
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="block truncate text-sm font-semibold text-white">
+          @{label}
+        </span>
+        <span className="block truncate text-[11px] text-white/55">
+          {accountType ? `${accountType} · ` : ""}
+          {installedAgo ? `installed ${installedAgo}` : "active"}
+          {siblingSlugs.length > 0 && (
+            <>
+              {" · "}also on {siblingSlugs.slice(0, 2).join(" / ")}
+              {siblingSlugs.length > 2 ? ` +${siblingSlugs.length - 2}` : ""}
+            </>
+          )}
+        </span>
+      </span>
+      <button
+        type="submit"
+        data-testid="onboarding-reuse-install"
+        className="rounded-full border border-aqua/40 bg-aqua/[0.08] px-3.5 py-1.5 text-xs font-semibold text-aqua transition hover:bg-aqua/[0.2]"
+      >
+        Use @{label} →
+      </button>
+    </form>
+  );
+}
+
+function formatInstalledAgo(iso: string | null): string {
+  if (!iso) return "";
+  const when = Date.parse(iso);
+  if (!Number.isFinite(when)) return "";
+  const diffMs = Date.now() - when;
+  if (diffMs < 0) return "just now";
+  const minutes = Math.round(diffMs / 60_000);
+  if (minutes < 60) return minutes <= 1 ? "just now" : `${minutes}m ago`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.round(hours / 24);
+  if (days < 30) return `${days}d ago`;
+  const months = Math.round(days / 30);
+  if (months < 12) return `${months}mo ago`;
+  const years = Math.round(months / 12);
+  return `${years}y ago`;
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/console/src/lib/api/client.ts
+++ b/apps/console/src/lib/api/client.ts
@@ -422,6 +422,63 @@ export function startGitHubAppInstall(
   return apiFetch<ApiGitHubInstallStart>(path, { method: "POST", token });
 }
 
+/**
+ * One row of `GET /v1/integrations/github/installations` — a GitHub App
+ * installation the caller can reach via their workspace memberships.
+ * The wizard shows this list on step-1 so a new workspace can attach to
+ * an install the operator already created under a sibling workspace,
+ * skipping the GitHub install picker entirely.
+ */
+export interface ApiAccessibleInstallation {
+  installation_id: number;
+  account_login: string | null;
+  account_type: string | null;
+  repository_selection: string | null;
+  installed_at: string | null;
+  /** Slugs (≤5) of workspaces already binding this install — UI context. */
+  workspace_slugs: string[];
+}
+
+export function listAccessibleInstallations(
+  excludeWorkspaceId?: string,
+  token?: string,
+): Promise<ApiAccessibleInstallation[]> {
+  const params = excludeWorkspaceId
+    ? `?exclude_workspace_id=${encodeURIComponent(excludeWorkspaceId)}`
+    : "";
+  return apiFetch<ApiAccessibleInstallation[]>(
+    `/v1/integrations/github/installations${params}`,
+    { token },
+  );
+}
+
+export interface ApiAttachedInstallation {
+  workspace_id: string;
+  installation_id: number;
+  account_login: string | null;
+  account_type: string | null;
+  repository_selection: string | null;
+  installed_at: string | null;
+}
+
+export function attachGitHubInstallation(
+  workspaceId: string,
+  installationId: number,
+  token?: string,
+): Promise<ApiAttachedInstallation> {
+  return apiFetch<ApiAttachedInstallation>(
+    "/v1/integrations/github/install/attach",
+    {
+      method: "POST",
+      token,
+      body: {
+        workspace_id: workspaceId,
+        installation_id: installationId,
+      },
+    },
+  );
+}
+
 // --- Workspace repos (Day-2 picker) ----------------------------------------
 
 /**


### PR DESCRIPTION
## Summary

When an operator spins up a second workspace, step-1 of the wizard used to force them through GitHub's install picker even though their @org already had Ship attached under a sibling workspace. Multi-workspace per-install has been supported since migration 0076 (the install callback even has a `github.install.share` branch for it), but the wizard never offered that path — so users hit a redundant GitHub round-trip every time.

This PR wires the reuse path end-to-end.

**Backend (`/v1/integrations/github/*`)**

- `GET .../installations` — lists installs the caller can reach via workspace membership, deduped by `installation_id`. Returns up to 5 sibling workspace slugs per install for "@acme · also on ws-a / ws-b" hints. Optional `?exclude_workspace_id=<new-ws>` drops already-bound candidates.
- `POST .../install/attach` — binds an existing install to a new workspace in one DB insert. Anti-leak: caller must be admin/owner on the *target* workspace **and** admin/owner on at least one source workspace already binding this `installation_id`. Idempotent on the compound unique key.

**Console**

- `POST /api/onboard/github-attach` BFF forwarder mirrors the shape of `github-install` (form POST → 303 redirect into `?step=repos&github=installed`, the same landing as a fresh GitHub callback) so every downstream step is blind to the branch.
- Step-1 UI now has three states: (a) installed-for-this-workspace → unchanged Manage / Reinstall / Continue; (b) not installed *but* reusable installs in view → list of "Use @acme" rows with secondary "Install on another org / account →"; (c) nothing reusable → unchanged single Install button.

## Test plan

- [x] Backend: 9 new pytest cases — dedup, suspended filter, exclude-workspace, stranger isolation, attach happy path, target-admin gate, source-admin gate, unknown install, idempotency. `19/19 passing` on the file.
- [x] Console: `tsc --noEmit` + `next lint` clean.
- [ ] Manual: create workspace A → install Ship on @denys-99938640 via wizard → create workspace B → step-1 shows @denys-99938640 in the reuse list → click `Use @denys-99938640` → land on `?step=repos&github=installed` with picker populated.
- [ ] Manual: cold-start user (no prior workspaces) → step-1 still shows the single "Install Ship on GitHub" button (no reuse list).
- [ ] Manual: workspace that already has install → step-1 still shows Manage / Reinstall / Continue (unchanged path).

## Out of scope

- Sandbox seed endpoint + Playwright spec for the reuse branch — backend tests cover the contract end-to-end, and the reuse branch lands on the same URL as the existing GitHub callback path that's already e2e-covered. Easy follow-up if we want explicit UI coverage.
- GitHub user OAuth discovery (`/user/installations`) so we could surface orgs where Ship *isn't yet* installed but the user has permission to install — separate epic.