### PR TITLE
feat(console): foundation pass — brand palette + utility classes + AppShell glass

### DIFF
--- a/apps/console/src/app/(authed)/knowledge/import-wizard.tsx
+++ b/apps/console/src/app/(authed)/knowledge/import-wizard.tsx
@@ -268,7 +268,7 @@ export function KnowledgeImportWizard({
             <input type="checkbox" checked={syncNow} onChange={(event) => setSyncNow(event.target.checked)} className="accent-aqua" />
             Sync immediately after creating the source
           </label>
-          <div className="flex justify-end"><button type="button" disabled={pending} onClick={submit} className="rounded-full border border-aqua/50 bg-aqua/15 px-4 py-2 text-sm font-bold text-aqua transition hover:bg-aqua/25 disabled:cursor-not-allowed disabled:opacity-50">{pending ? "Creating..." : "Create source"}</button></div>
+          <div className="flex justify-end"><button type="button" disabled={pending} onClick={submit} className="btn-primary disabled:cursor-not-allowed disabled:opacity-50">{pending ? "Creating..." : "Create source"}</button></div>
           {result && <ResultBox result={result} />}
           <div className="text-[11px] text-white/45">Default scope: {defaultScope}. Sources route into workspace buckets.</div>
         </div>

--- a/apps/console/src/app/(authed)/settings/_shell/settings-shell.tsx
+++ b/apps/console/src/app/(authed)/settings/_shell/settings-shell.tsx
@@ -686,7 +686,7 @@ function RepositoriesPanel({
       <div className="mt-4">
         <a
           href={`/onboarding?step=repos&ws=${encodeURIComponent(workspaceId)}`}
-          className="inline-flex rounded-full border border-aqua/40 bg-aqua/15 px-4 py-1.5 text-xs font-bold text-aqua transition hover:bg-aqua/25"
+          className="btn-primary"
         >
           + Add another repository
         </a>
@@ -1214,10 +1214,7 @@ function WorkspacesPanel({
             </div>
           </label>
           <div className="flex items-end">
-            <button
-              type="submit"
-              className="rounded-full border border-aqua/40 bg-aqua/15 px-4 py-1.5 text-xs font-bold text-aqua transition hover:bg-aqua/25"
-            >
+            <button type="submit" className="btn-primary">
               Save
             </button>
           </div>
@@ -1300,10 +1297,7 @@ function WorkspacesPanel({
             </div>
           </label>
           <div className="md:col-span-2 flex items-center justify-end">
-            <button
-              type="submit"
-              className="rounded-full border border-aqua/40 bg-aqua/15 px-4 py-1.5 text-xs font-bold text-aqua transition hover:bg-aqua/25"
-            >
+            <button type="submit" className="btn-primary">
               Create workspace
             </button>
           </div>

--- a/apps/console/src/app/globals.css
+++ b/apps/console/src/app/globals.css
@@ -12,18 +12,59 @@ html {
 
 body {
   @apply bg-ink text-mist antialiased;
+  /* Match the landing site exactly — the console used to render with
+   * dimmer alphas (0.18 / 0.12 / 0.10) which left the operator-side
+   * feeling colder than the marketing surface. Same numbers as
+   * apps/landing/src/app/globals.css so the two sit on a single
+   * brand palette. */
   background-image: radial-gradient(
       ellipse 120% 80% at 50% -20%,
-      rgba(179, 136, 255, 0.18),
+      rgba(179, 136, 255, 0.35),
       transparent 55%
     ),
-    radial-gradient(ellipse 80% 50% at 100% 0%, rgba(207, 169, 107, 0.12), transparent 45%),
-    radial-gradient(ellipse 60% 40% at 0% 20%, rgba(255, 92, 108, 0.1), transparent 40%);
+    radial-gradient(ellipse 80% 50% at 100% 0%, rgba(207, 169, 107, 0.2), transparent 45%),
+    radial-gradient(ellipse 60% 40% at 0% 20%, rgba(255, 92, 108, 0.18), transparent 40%);
 }
 
 ::selection {
   background: rgba(207, 169, 107, 0.35);
   color: #fff;
+}
+
+/* ------------------------------------------------------------------ *
+ * Brand-shared surfaces                                              *
+ *                                                                    *
+ * These mirror the landing site's :root utilities so every console   *
+ * surface lands on the same primitives — apply `.glass-panel` for    *
+ * dark translucent cards, `.btn-primary` for the coral→lilac→aqua    *
+ * CTA pill, `.input-ship` for form fields. Keeping them defined in   *
+ * one place per app (vs an npm package) is fine because both apps    *
+ * are small and the duplication is auditable in CSS.                 *
+ * ------------------------------------------------------------------ */
+
+.glass-panel {
+  @apply rounded-3xl border border-white/10 bg-white/[0.04] backdrop-blur-xl;
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.25), inset 0 1px 0 rgba(255, 255, 255, 0.06);
+}
+
+.input-ship {
+  @apply w-full rounded-2xl border border-white/15 bg-white/[0.06] px-4 py-3 text-sm text-white outline-none ring-aqua/40 transition placeholder:text-white/35 focus:border-aqua/50 focus:ring-2;
+}
+
+.input-ship.input-ship-wizard {
+  @apply rounded-xl border-white/10 bg-black/45 py-2.5 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)];
+}
+
+.btn-primary {
+  @apply inline-flex items-center justify-center gap-2 rounded-full bg-gradient-to-r from-coral via-lilac to-aqua px-8 py-3.5 text-sm font-semibold text-ink shadow-glow transition hover:brightness-110 active:scale-[0.99];
+}
+
+.btn-secondary {
+  @apply inline-flex items-center justify-center gap-2 rounded-full border border-white/20 bg-white/[0.06] px-6 py-3 text-sm font-semibold text-white/90 backdrop-blur transition hover:border-white/35 hover:bg-white/10;
+}
+
+.btn-ghost {
+  @apply inline-flex items-center justify-center gap-2 rounded-full border border-white/15 bg-transparent px-6 py-3 text-sm font-semibold text-white/70 transition hover:border-white/40 hover:bg-white/5 hover:text-white;
 }
 
 /* --- Navigator / single-window chat ---------------------------------- */

--- a/apps/console/src/app/onboarding/done-step.tsx
+++ b/apps/console/src/app/onboarding/done-step.tsx
@@ -112,10 +112,7 @@ export async function DoneStep({
       <WhatsNextGrid workspaceId={wsId} />
 
       <footer className="mt-10 flex flex-wrap items-center justify-between gap-3 border-t border-white/[0.08] pt-5">
-        <Link
-          href={dashboardHref}
-          className="rounded-md bg-aqua/15 px-3 py-1.5 text-sm font-semibold text-aqua transition hover:bg-aqua/25"
-        >
+        <Link href={dashboardHref} className="btn-primary">
           Open dashboard →
         </Link>
       </footer>

--- a/apps/console/src/app/onboarding/page.tsx
+++ b/apps/console/src/app/onboarding/page.tsx
@@ -860,7 +860,7 @@ function GitHubStep({
           <button
             type="submit"
             data-testid="onboarding-install-github"
-            className="rounded-md bg-aqua/15 px-3 py-1.5 text-sm font-semibold text-aqua transition hover:bg-aqua/25"
+            className="btn-primary"
           >
             Install Ship on GitHub &rarr;
           </button>

--- a/apps/console/src/components/app-shell.tsx
+++ b/apps/console/src/components/app-shell.tsx
@@ -371,10 +371,15 @@ export function AppShellChrome({
     : null;
 
   return (
-    <div className="min-h-screen bg-ink text-mist">
+    // No ``bg-ink`` here — the body already paints the brand radials
+    // (lilac top-centre, gold top-right, coral mid-left) and an ink fill
+    // on the chrome wrapper would hide them. ``text-mist`` keeps the
+    // default body colour for the operator content.
+    <div className="min-h-screen text-mist">
       <div className="flex w-full gap-0">
-        {/* sidebar */}
-        <aside className="sticky top-0 hidden h-screen w-64 shrink-0 flex-col border-r border-white/10 bg-black/30 backdrop-blur-xl lg:flex">
+        {/* sidebar — semi-translucent so the body radials still bleed
+            through, with the same inset blik landing's panels use. */}
+        <aside className="sticky top-0 hidden h-screen w-64 shrink-0 flex-col border-r border-white/10 bg-black/20 shadow-[inset_-1px_0_0_rgba(255,255,255,0.04)] backdrop-blur-xl lg:flex">
           <div className="border-b border-white/10 px-4 py-5">
             <Link
               href={withWorkspaceHref("/")}
@@ -545,7 +550,7 @@ export function PageHeader({
   scopePill?: ReactNode;
 }) {
   return (
-    <header className="sticky top-0 z-40 border-b border-white/10 bg-ink/80 backdrop-blur-xl">
+    <header className="sticky top-0 z-40 border-b border-white/10 bg-ink/60 shadow-[inset_0_-1px_0_rgba(255,255,255,0.04)] backdrop-blur-xl">
       <div className="flex items-center gap-3 px-6 py-4 lg:px-8">
         <div className="relative min-w-0 flex-1">
           <div className="flex flex-wrap items-center gap-2">

--- a/apps/console/src/components/ui.tsx
+++ b/apps/console/src/components/ui.tsx
@@ -8,25 +8,51 @@ import { cn } from "@/lib/cn";
  * and copy rather than re-defining badges/cards/empty states inline.
  */
 
+/**
+ * Default card surface — dark translucent glass with a subtle inset blik
+ * so it sits on the radial-gradient body the same way landing's
+ * ``.glass-panel`` does. Pass ``variant="glass"`` for hero-scale panels
+ * that should match the landing site's rounded-3xl chrome exactly.
+ */
 export function Card({
   children,
   className,
   padded = true,
   id,
+  variant = "default",
   "data-testid": dataTestId,
 }: {
   children: ReactNode;
   className?: string;
   padded?: boolean;
   id?: string;
+  /** ``glass`` bumps radius to 3xl + uses the landing's ``.glass-panel``
+   * tokens verbatim. Use sparingly — only for marketing-grade hero
+   * surfaces. The default is the operator-dense ``rounded-2xl``. */
+  variant?: "default" | "glass";
   "data-testid"?: string;
 }) {
+  if (variant === "glass") {
+    return (
+      <div
+        id={id}
+        data-testid={dataTestId}
+        className={cn("glass-panel", padded && "p-6", className)}
+      >
+        {children}
+      </div>
+    );
+  }
   return (
     <div
       id={id}
       data-testid={dataTestId}
       className={cn(
+        // Inset blik (``inset 0 1px 0 rgba(255,255,255,0.06)``) is what
+        // gives the landing's panels their lit top-edge — porting it
+        // here so dashboard cards stop reading as flat against the bg.
         "rounded-2xl border border-white/10 bg-white/[0.04] backdrop-blur-xl shadow-card",
+        "shadow-[0_4px_24px_rgba(0,0,0,0.25),inset_0_1px_0_rgba(255,255,255,0.06)]",
         padded && "p-5",
         className
       )}
@@ -133,23 +159,41 @@ export function ButtonGhost({
   );
 }
 
+/**
+ * Primary CTA — coral→lilac→aqua gradient pill, ``text-ink`` for max
+ * contrast against the warm body radials. Three sizes:
+ *
+ *  - ``sm``  — chip-row affordance (table action button, inline confirm).
+ *  - ``md``  — the default; matches the size landing uses for in-flow
+ *               CTAs like "See how the process works".
+ *  - ``lg``  — hero / wizard primary action; same px-8 py-3.5 as
+ *               landing's ``.btn-primary``.
+ *
+ * ``className`` still wins — pass utilities to override padding /
+ * radius / fonts when a one-off needs it.
+ */
 export function ButtonPrimary({
   children,
   onClick,
   className,
   type = "button",
+  size = "md",
 }: {
   children: ReactNode;
   onClick?: () => void;
   className?: string;
   type?: "button" | "submit";
+  size?: "sm" | "md" | "lg";
 }) {
   return (
     <button
       type={type}
       onClick={onClick}
       className={cn(
-        "inline-flex items-center gap-1.5 rounded-full bg-gradient-to-r from-coral via-lilac to-aqua px-3.5 py-1.5 text-xs font-bold text-ink shadow-glow transition hover:brightness-110",
+        "inline-flex items-center justify-center gap-1.5 rounded-full bg-gradient-to-r from-coral via-lilac to-aqua font-semibold text-ink shadow-glow transition hover:brightness-110 active:scale-[0.99]",
+        size === "sm" && "px-3.5 py-1.5 text-xs font-bold",
+        size === "md" && "px-5 py-2 text-sm",
+        size === "lg" && "px-8 py-3.5 text-sm",
         className
       )}
     >


### PR DESCRIPTION
## Summary

Console color tokens and font stack are already aligned with the landing site, but the rendered output reads colder — dimmer body radials, cards without the lit-top-edge blik, primary CTAs as muted `bg-aqua/15` chips instead of the brand gradient pill. This is the foundation slice of the wider \"console-on-landing-look\" effort: ports the utility classes and tweaks the primitives so subsequent per-domain PRs can sweep with minimal churn.

**Globals**
- Bump body radial-gradient alphas from 0.18 / 0.12 / 0.10 → 0.35 / 0.20 / 0.18 (exact match to landing).
- Port `.glass-panel`, `.input-ship`, `.btn-primary` (coral→lilac→aqua), `.btn-secondary`, `.btn-ghost` verbatim from `apps/landing/src/app/globals.css`. Same numbers, same shadow stack, same brand palette.

**UI primitives (`src/components/ui.tsx`)**
- `<Card>` now stacks the inset blik (`inset 0 1px 0 rgba(255,255,255,0.06)`) on top of `shadow-card`, giving every card the lit top-edge from landing. New `variant=\"glass\"` opts in to the `rounded-3xl` hero look.
- `<ButtonPrimary>` adds `size` prop. Default ramped from chip-tier (`px-3.5 py-1.5 text-xs`) to landing's mid-tier (`px-5 py-2 text-sm font-semibold`), so all 36 existing call-sites visually upgrade. `lg` matches `.btn-primary` exactly.

**Shell**
- AppShellChrome no longer paints `bg-ink` on the wrapper — the body radials now bleed through. Sidebar drops to `bg-black/20` + inset blik on the right edge; header drops to `bg-ink/60` + inset blik on the bottom.

**CTA sweep (high-traffic)**
- `btn-primary` on: Install Ship on GitHub, Open dashboard, Workspace Save, Create workspace, Add repository, Create knowledge source.

## What's next

Subsequent PRs sweep per-domain: inbox/knowledge/process/audit. The shared primitives mean each will be small (mostly className swaps).

## Test plan

- [x] `tsc --noEmit` clean
- [x] `next lint` clean
- [ ] Manual: dashboard, inbox, knowledge, settings, onboarding step-1 — confirm the body gradients are louder, cards have the lit blik, primary CTAs render as gradient pills.
- [ ] Manual: AppShell sidebar still readable against the radials.