### PR TITLE
feat(console): knowledge sweep — wizard inputs to .input-ship

### DIFF
--- a/apps/console/src/app/(authed)/knowledge/import-wizard.tsx
+++ b/apps/console/src/app/(authed)/knowledge/import-wizard.tsx
@@ -175,7 +175,7 @@ export function KnowledgeImportWizard({
             <span className="ml-2">{selected?.hint} Articles are auto-published into buckets with provenance and fingerprint-based skip logic.</span>
           </div>
           <Field label="Source name">
-            <input value={name} onChange={(event) => setName(event.target.value)} className="w-full rounded border border-white/15 bg-black/30 px-3 py-2 text-sm text-white/90" />
+            <input value={name} onChange={(event) => setName(event.target.value)} className="input-ship input-ship-wizard" />
           </Field>
           {kind === "website" && (
             <Field label="Website URL">
@@ -189,7 +189,7 @@ export function KnowledgeImportWizard({
           {kind === "notion" && (
             <>
               <Field label="Notion integration">
-                <select value={selectedIntegrationId} onChange={(event) => setIntegrationId(event.target.value)} className="w-full rounded border border-white/15 bg-black/30 px-3 py-2 text-sm text-white/90">
+                <select value={selectedIntegrationId} onChange={(event) => setIntegrationId(event.target.value)} className="input-ship input-ship-wizard">
                   {matchingIntegrations.length === 0 ? <option value="">No integration connected</option> : matchingIntegrations.map((integration) => <option key={integration.id} value={integration.id}>{integration.kind} - {integration.status}</option>)}
                 </select>
               </Field>
@@ -214,7 +214,7 @@ export function KnowledgeImportWizard({
           {kind === "confluence" && (
             <>
               <Field label="Confluence integration">
-                <select value={selectedIntegrationId} onChange={(event) => setIntegrationId(event.target.value)} className="w-full rounded border border-white/15 bg-black/30 px-3 py-2 text-sm text-white/90">
+                <select value={selectedIntegrationId} onChange={(event) => setIntegrationId(event.target.value)} className="input-ship input-ship-wizard">
                   {matchingIntegrations.length === 0 ? <option value="">No integration connected</option> : matchingIntegrations.map((integration) => <option key={integration.id} value={integration.id}>{integration.kind} - {integration.status}</option>)}
                 </select>
               </Field>
@@ -239,7 +239,7 @@ export function KnowledgeImportWizard({
           {kind === "docs_repo" && (
             <>
               <Field label="Repository">
-                <select value={repoId} onChange={(event) => setRepoId(event.target.value)} className="w-full rounded border border-white/15 bg-black/30 px-3 py-2 text-sm text-white/90">
+                <select value={repoId} onChange={(event) => setRepoId(event.target.value)} className="input-ship input-ship-wizard">
                   {repos.length === 0 ? <option value="">No activated repos</option> : repos.map((repo) => <option key={repo.id} value={repo.id}>{repo.full_name}</option>)}
                 </select>
               </Field>

--- a/apps/console/src/app/(authed)/knowledge/notion-resource-picker.tsx
+++ b/apps/console/src/app/(authed)/knowledge/notion-resource-picker.tsx
@@ -161,7 +161,7 @@ export function NotionResourcePicker({
         value={query}
         onChange={(event) => setQuery(event.target.value)}
         placeholder="Search Notion pages and databases your integration can see…"
-        className="w-full rounded border border-white/15 bg-black/30 px-3 py-2 text-sm text-white/90 placeholder:text-white/35"
+        className="input-ship input-ship-wizard"
         aria-label="Search Notion pages and databases"
       />
 


### PR DESCRIPTION
## Summary

Third slice. Swaps the import-wizard form inputs over to the foundation's `.input-ship` + `.input-ship-wizard` utilities so they match landing's input shape exactly (rounded corners, brand focus ring, consistent placeholder, inset shadow). 6 fields touched:

- Source name text input
- Notion integration select
- Confluence integration select
- Repository select
- Notion search input
- (`.input-ship-wizard` modifier keeps the slightly tighter wizard chrome the rest of `/onboarding` already uses.)

## Test plan

- [x] `tsc --noEmit` clean
- [ ] Manual: open knowledge → Add source → cycle through Website / Notion / Confluence / Docs repo → all inputs should render with the brand focus ring.

## Depends on

#330 (foundation)