### PR TITLE
feat(console): process + analytics sweep

### DIFF
--- a/apps/console/src/app/(authed)/process/flow-schedule-panel.tsx
+++ b/apps/console/src/app/(authed)/process/flow-schedule-panel.tsx
@@ -240,7 +240,7 @@ export function FlowSchedulePanel({
             <button
               type="submit"
               disabled={!repoId || !dirty || warnings.length > 0}
-              className="h-9 whitespace-nowrap rounded-full border border-aqua/30 bg-aqua/10 px-4 text-xs font-bold text-aqua transition hover:bg-aqua/15 disabled:cursor-not-allowed disabled:border-white/10 disabled:bg-white/[0.05] disabled:text-white/35"
+              className="inline-flex h-9 items-center justify-center gap-1.5 whitespace-nowrap rounded-full bg-gradient-to-r from-coral via-lilac to-aqua px-4 text-xs font-semibold text-ink shadow-glow transition hover:brightness-110 active:scale-[0.99] disabled:cursor-not-allowed disabled:bg-none disabled:bg-white/[0.05] disabled:text-white/35 disabled:shadow-none"
             >
               Review changes
             </button>


### PR DESCRIPTION
## Summary

Fourth slice. Process surface's primary "Review changes" submit now uses the foundation gradient pill; analytics was already clean (DORA `<StatTile>` inherits the inset blik from the foundation `<Card>` change).

## Test plan

- [x] `tsc --noEmit` clean
- [ ] Manual: process → edit schedule → confirm "Review changes" renders as gradient pill when dirty, muted grey when nothing's queued.
- [ ] Manual: analytics page → DORA cards have the lit top-edge.

## Depends on

#330 (foundation)