### PR TITLE
feat(console): settings sweep — integrations Save to gradient pill

### DIFF
--- a/apps/console/src/components/integrations-workspace-body.tsx
+++ b/apps/console/src/components/integrations-workspace-body.tsx
@@ -856,7 +856,7 @@ function NativeRepoBindingForm({
           <div className="mt-2 flex justify-end">
             <button
               type="submit"
-              className="rounded-full bg-aqua/15 px-3 py-1 text-[10px] font-bold text-aqua hover:bg-aqua/25"
+              className="inline-flex items-center justify-center gap-1.5 rounded-full bg-gradient-to-r from-coral via-lilac to-aqua px-3 py-1 text-[10px] font-bold text-ink shadow-glow transition hover:brightness-110 active:scale-[0.99]"
             >
               Save repo access
             </button>


### PR DESCRIPTION
## Summary

Fifth slice. Integrations panel's "Save repo access" submit (the last muted-aqua primary CTA on the settings tabs) becomes a gradient pill. Foundation #330 already handled General Save + Create-workspace + Add-repository; agent-roles and policy lists use `<ButtonPrimary>` which auto-upgraded with the new `size="md"` default.

The remaining `bg-aqua/15` matches across policy surfaces are SELECTED-state highlights on segmented controls (current pick) — those stay muted on purpose.

## Test plan

- [x] `tsc --noEmit` clean
- [ ] Manual: settings → Integrations → pick repos for an integration → confirm "Save repo access" renders as gradient pill.

## Depends on

#330 (foundation)