### PR TITLE
feat(console): onboarding sweep — wizard CTAs to gradient pills

### DIFF
--- a/apps/console/src/app/onboarding/page.tsx
+++ b/apps/console/src/app/onboarding/page.tsx
@@ -1060,7 +1060,7 @@ function ReposStep({
             <button
               type="submit"
               data-testid="onboarding-wire-repos"
-              className="rounded-md bg-aqua/15 px-3 py-1.5 text-sm font-semibold text-aqua transition hover:bg-aqua/25"
+              className="btn-primary"
             >
               Wire selected repos &rarr;
             </button>
@@ -1320,7 +1320,7 @@ function TrackerStep({
             <button
               type="submit"
               disabled={connected || tile.id === "github"}
-              className="mt-4 rounded-md bg-aqua/15 px-3 py-1.5 text-sm font-semibold text-aqua transition hover:bg-aqua/25 disabled:cursor-default disabled:bg-aqua/10 disabled:text-aqua/60"
+              className="mt-4 inline-flex items-center justify-center gap-1.5 rounded-full bg-gradient-to-r from-coral via-lilac to-aqua px-5 py-2 text-sm font-semibold text-ink shadow-glow transition hover:brightness-110 active:scale-[0.99] disabled:cursor-default disabled:bg-none disabled:bg-white/[0.05] disabled:text-white/45 disabled:shadow-none"
             >
               {connected
                 ? tile.id === "github"

--- a/apps/console/src/app/onboarding/repo-card.tsx
+++ b/apps/console/src/app/onboarding/repo-card.tsx
@@ -747,7 +747,7 @@ export function RepoCard({
               // them merge it themselves on github.com.
               setPendingSeed(body.result);
             }}
-            className="rounded-md bg-aqua/15 px-3 py-1.5 text-sm font-semibold text-aqua transition hover:bg-aqua/25 disabled:cursor-default disabled:opacity-40"
+            className="inline-flex items-center justify-center gap-1.5 rounded-full bg-gradient-to-r from-coral via-lilac to-aqua px-5 py-2 text-sm font-semibold text-ink shadow-glow transition hover:brightness-110 active:scale-[0.99] disabled:cursor-default disabled:bg-none disabled:bg-white/[0.05] disabled:text-white/45 disabled:shadow-none"
           >
             {seedSaving
               ? "Opening PR..."
@@ -769,7 +769,7 @@ export function RepoCard({
                   setSeedError(null);
                   seedButtonRef.current?.click();
                 }}
-                className="rounded-md bg-aqua/15 px-2.5 py-1 text-xs font-semibold text-aqua hover:bg-aqua/25"
+                className="inline-flex items-center justify-center gap-1.5 rounded-full bg-gradient-to-r from-coral via-lilac to-aqua px-3 py-1 text-xs font-bold text-ink shadow-glow transition hover:brightness-110 active:scale-[0.99]"
               >
                 Retry seed PR
               </button>
@@ -1092,7 +1092,7 @@ function ActivationModal({
             onClick={onActivate}
             disabled={activating || blockedMessage !== null}
             data-testid="onboarding-activate-confirm"
-            className="rounded-md bg-aqua/15 px-3 py-1.5 text-sm font-semibold text-aqua transition hover:bg-aqua/25 disabled:cursor-default disabled:opacity-40"
+            className="inline-flex items-center justify-center gap-1.5 rounded-full bg-gradient-to-r from-coral via-lilac to-aqua px-5 py-2 text-sm font-semibold text-ink shadow-glow transition hover:brightness-110 active:scale-[0.99] disabled:cursor-default disabled:bg-none disabled:bg-white/[0.05] disabled:text-white/45 disabled:shadow-none"
           >
             {activating ? "Activating…" : "Activate Ship now →"}
           </button>


### PR DESCRIPTION
## Summary

Final domain sweep. Wizard primary CTAs now match landing's gradient pill:

- "Wire selected repos →" (repos step) → `.btn-primary`
- Tracker tiles' Connect submit (tracker step) → inline gradient pill with `disabled:bg-none + bg-white/[0.05]` fallback
- "Open seed PR" / "Retry seed PR" (repo card) → gradient pill

Segmented controls (workspace-defaults presets, role picker, tracker selection) intentionally keep the muted `bg-aqua/15` highlight to denote SELECTED state. Repo-name tags stay as is — labels, not CTAs.

## Test plan

- [x] `tsc --noEmit` clean
- [ ] Manual: walk through the wizard end-to-end. Confirm Wire / Connect / Open seed PR / Retry seed PR all render as gradient pills; segmented controls still read as "current pick" highlights.

## Depends on

#330 (foundation)

## Follow-ups (out of scope for the brand-look sweeps)

- Bigger semantic sweep across `<details>`, `<table>`, `<form>` chrome.
- Replace static-upload dropzone border styling for consistency.
- Audit log + r/[owner]/[repo] runs tables for landing-style headers.