### PR TITLE
fix(linear): preserve team_id on reconnect + team-repick endpoint

### DIFF
--- a/apps/backend/app/api/v1/routes/linear_oauth.py
+++ b/apps/backend/app/api/v1/routes/linear_oauth.py
@@ -284,9 +284,22 @@ async def linear_install_callback(
     row.updated_at = datetime.now(timezone.utc)
 
     # E14 provisioning. Auto-pick team if exactly one (typical solo
-    # operator); leave unset and surface a banner if more — the wizard
-    # then routes the operator to a "pick a team" step before the
-    # integration is actually usable.
+    # operator on a fresh connect); leave unset and surface a banner
+    # when there are multiple — the wizard then routes the operator
+    # to a "pick a team" step before the integration is actually
+    # usable.
+    #
+    # IMPORTANT — reconnect semantics: if the row already carries a
+    # ``team_id`` (a previous connect or a manual repick), do *not*
+    # overwrite it just because the new OAuth session's
+    # ``list_teams`` happens to return a single team. The pilot was
+    # bitten by this when an admin-scope reconnect from a Linear
+    # session that only had Buzz team accessible silently rebound
+    # Ship-on-Ship's workspace from its elship team to Buzz, leaving
+    # the dashboard ``list_projects`` query filtered to a wrong team
+    # (zero projects). The operator's repick is sticky; if the saved
+    # team is no longer in the visible options the wizard's team
+    # picker should be reopened, never auto-overwritten.
     try:
         from backend.app.integrations.linear.tracker_adapter import LinearTracker
         from backend.app.services import linear_provisioner
@@ -298,7 +311,39 @@ async def linear_install_callback(
             {"id": t["id"], "key": t["key"], "name": t["name"]}
             for t in teams
         ]
-        if len(teams) == 1:
+        existing_team_id = merged.get("team_id")
+        existing_in_options = any(
+            t["id"] == existing_team_id for t in teams
+        )
+        if existing_team_id and existing_in_options:
+            # Reconnect on a workspace that already has a valid team
+            # binding — preserve it, just refresh ``team_options`` so
+            # the picker UI stays accurate. fsm_provisioned stays as
+            # whatever the original provision left it.
+            logger.info(
+                "Linear reconnect preserved existing team binding "
+                "for workspace=%s team=%s (%d teams visible)",
+                workspace_id,
+                merged.get("team_key"),
+                len(teams),
+            )
+        elif existing_team_id and not existing_in_options:
+            # Saved team is no longer reachable from the new OAuth
+            # session (operator switched accounts, lost membership,
+            # or the team was deleted). Leave team_id alone so the
+            # admin can still see what the binding was, but mark the
+            # row as needing repick so the dashboard surfaces a
+            # banner instead of silently filtering to a stale team.
+            merged["fsm_provisioned"] = False
+            merged["needs_team_repick"] = True
+            logger.warning(
+                "Linear reconnect: saved team_id=%s for workspace=%s "
+                "is no longer visible (%d teams). Marked needs_team_repick.",
+                existing_team_id,
+                workspace_id,
+                len(teams),
+            )
+        elif len(teams) == 1:
             picked = teams[0]
             result = await linear_provisioner.provision_team(
                 tracker=live, team_key=picked["key"], settings=settings
@@ -315,6 +360,7 @@ async def linear_install_callback(
                     "fsm_provisioned": True,
                 }
             )
+            merged.pop("needs_team_repick", None)
             logger.info(
                 "Linear FSM provisioned for workspace=%s team=%s "
                 "(%d stage labels, %d signal labels, %d states, "
@@ -861,6 +907,178 @@ async def linear_webhook_provision(
         url=public_url,
         resource_types=list(_LINEAR_WEBHOOK_RESOURCE_TYPES),
         replaced_previous=replaced,
+    )
+
+
+class LinearTeamRepickIn(BaseModel):
+    """Body for ``POST .../linear/team`` — admin-driven team rebind."""
+
+    team_key: str
+    """Linear team key (e.g. ``ELS`` / ``BUZ``). Must appear in the
+    workspace's current ``team_options`` snapshot OR be visible to the
+    live OAuth token's ``list_teams`` call."""
+
+
+class LinearTeamRepickOut(BaseModel):
+    team_id: str
+    team_key: str
+    fsm_provisioned: bool
+
+
+@router.post(
+    "/workspaces/{workspace_id}/integrations/linear/team",
+    response_model=LinearTeamRepickOut,
+)
+async def linear_team_repick(
+    workspace_id: uuid.UUID,
+    body: LinearTeamRepickIn,
+    auth: AuthContext = Depends(get_current_auth),
+    session: AsyncSession = Depends(get_session),
+    settings: Settings = Depends(get_settings),
+) -> LinearTeamRepickOut:
+    """Re-bind a Linear workspace to a different team in the same org.
+
+    Use case: the OAuth callback's "exactly one team visible →
+    auto-pick" path silently overwrote a workspace's legitimate team
+    binding during a reconnect (e.g. admin-scope upgrade ran from a
+    Linear session where only one team was reachable, even though the
+    workspace's real team was a different one in the same org).
+    Operators need a non-destructive way to set it back without
+    reconnecting again.
+
+    Validates:
+    - Caller is admin/owner on the workspace.
+    - Linear OAuth token exists.
+    - ``team_key`` resolves to a real team via the live OAuth's
+      ``list_teams`` (we don't trust the cached ``team_options``
+      because it may be stale).
+
+    On success, re-runs the FSM provisioner for the picked team so
+    ``state_id_by_name`` / ``label_id_by_stage`` / ``signal_label_ids``
+    are accurate for the new team, then persists the updated config.
+    """
+    await _require_membership(
+        session, workspace_id, auth.user.id, ROLES_ADMIN
+    )
+
+    _install, token = await _fetch_live_linear_token(
+        session, workspace_id=workspace_id
+    )
+
+    from backend.app.integrations.linear.tracker_adapter import LinearTracker
+    from backend.app.services import linear_provisioner
+
+    live = LinearTracker(token)
+    try:
+        teams = await linear_provisioner.list_teams(live)
+    except Exception as exc:  # noqa: BLE001
+        raise HTTPException(
+            status_code=502,
+            detail={
+                "code": "linear_list_teams_failed",
+                "message": f"Linear list_teams failed: {exc!s}"[:300],
+            },
+        ) from exc
+
+    target = next(
+        (t for t in teams if str(t.get("key") or "") == body.team_key),
+        None,
+    )
+    if target is None:
+        raise HTTPException(
+            status_code=404,
+            detail={
+                "code": "team_not_visible",
+                "message": (
+                    f"Linear OAuth session has no team {body.team_key!r}. "
+                    f"Visible team keys: "
+                    f"{sorted(str(t.get('key') or '') for t in teams)}"
+                ),
+            },
+        )
+
+    try:
+        result = await linear_provisioner.provision_team(
+            tracker=live, team_key=target["key"], settings=settings
+        )
+    except Exception as exc:  # noqa: BLE001
+        raise HTTPException(
+            status_code=502,
+            detail={
+                "code": "linear_provision_failed",
+                "message": f"FSM provision failed: {exc!s}"[:300],
+            },
+        ) from exc
+
+    legacy = (
+        await session.execute(
+            select(Integration)
+            .where(
+                Integration.workspace_id == workspace_id,
+                Integration.kind == "linear",
+            )
+            .order_by(Integration.updated_at.desc())
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+    if legacy is None:
+        raise HTTPException(
+            status_code=404,
+            detail={
+                "code": "linear_integration_missing",
+                "message": (
+                    "No Linear Integration row exists for this workspace "
+                    "yet — finish OAuth before repicking a team."
+                ),
+            },
+        )
+
+    config = dict(legacy.config or {})
+    previous_team_id = config.get("team_id")
+    previous_team_key = config.get("team_key")
+    config.update(
+        {
+            "team_id": result.team_id,
+            "team_key": result.team_key,
+            "team_options": [
+                {"id": t["id"], "key": t["key"], "name": t["name"]}
+                for t in teams
+            ],
+            "state_id_by_name": result.state_id_by_name,
+            "label_id_by_stage": result.label_id_by_stage,
+            "signal_label_ids": result.signal_label_ids,
+            "canonical_to_native": result.canonical_to_native,
+            "canonical_resolution_meta": result.canonical_resolution_meta,
+            "fsm_provisioned": True,
+        }
+    )
+    config.pop("needs_team_repick", None)
+    legacy.config = config
+    legacy.updated_at = datetime.now(timezone.utc)
+    session.add(legacy)
+
+    session.add(
+        AuditLog(
+            workspace_id=workspace_id,
+            actor_user_id=auth.user.id,
+            actor_token_id=auth.token.id if auth.token else None,
+            action="linear.team.repick",
+            target_kind="integration",
+            target_id=str(legacy.id),
+            payload={
+                "from_team_id": previous_team_id,
+                "from_team_key": previous_team_key,
+                "to_team_id": result.team_id,
+                "to_team_key": result.team_key,
+            },
+        )
+    )
+    await session.flush()
+
+    return LinearTeamRepickOut(
+        team_id=result.team_id,
+        team_key=result.team_key,
+        fsm_provisioned=True,
     )
 
 

--- a/apps/backend/app/services/tracker_resolver.py
+++ b/apps/backend/app/services/tracker_resolver.py
@@ -319,8 +319,15 @@ def _resolve_from_legacy_row(
         if token is None:
             return None
         scope_raw = (row.config or {}).get("scope")
+        # Linear returns OAuth ``scope`` space-separated per RFC 6749;
+        # accept comma too because some Ship-side code paths historically
+        # stored it comma-separated. Mirrors the normaliser in
+        # ``linear_oauth.linear_install_callback`` so the dashboard's
+        # scope tuple is consistent across both storage shapes (#337).
         scopes = tuple(
-            s.strip() for s in str(scope_raw or "").split(",") if s.strip()
+            s.strip()
+            for s in str(scope_raw or "").replace(",", " ").split()
+            if s.strip()
         )
         return _build_linear_resolved(
             token,

--- a/apps/backend/tests/test_v1_linear_oauth.py
+++ b/apps/backend/tests/test_v1_linear_oauth.py
@@ -291,3 +291,370 @@ async def test_linear_install_callback_handles_exchange_failure(
         )
     ).scalar_one_or_none()
     assert row is None
+
+
+# ---------------------------------------------------------------------------
+# Reconnect-doesn't-overwrite-team_id + team-repick endpoint.
+# ---------------------------------------------------------------------------
+
+
+def _patch_oauth_exchange(monkeypatch, scope: str = "admin read write"):
+    """Stub the OAuth code-exchange + native side-effects so the callback
+    only exercises the team-binding logic that the new tests care about."""
+    from backend.app.integrations.linear import oauth as linear_oauth_mod
+    from backend.app.integrations.linear.oauth import LinearTokenBundle
+
+    async def _fake_exchange(code, *, settings, redirect_uri, client=None):
+        return LinearTokenBundle(
+            access_token="lin_access_repick_test",
+            token_type="Bearer",
+            scope=scope,
+            expires_in=None,
+        )
+
+    monkeypatch.setattr(
+        "backend.app.api.v1.routes.linear_oauth.exchange_code_for_token",
+        _fake_exchange,
+    )
+    monkeypatch.setattr(linear_oauth_mod, "exchange_code_for_token", _fake_exchange)
+
+
+def _patch_provisioner(
+    monkeypatch,
+    *,
+    teams: list[dict],
+    provisioned: dict | None = None,
+):
+    """Stub linear_provisioner.{list_teams, provision_team} so the
+    callback / repick endpoint can run without a live Linear org."""
+    from backend.app.services import linear_provisioner
+
+    async def _list_teams(_tracker):
+        return list(teams)
+
+    async def _provision_team(*, tracker, team_key, settings):
+        target = next((t for t in teams if t["key"] == team_key), None)
+        if target is None:
+            raise RuntimeError(f"team {team_key} not in stub list")
+        result = provisioned or {
+            "state_id_by_name": {"Todo": f"todo-{team_key}"},
+            "label_id_by_stage": {"plan": f"plan-{team_key}"},
+            "signal_label_ids": {},
+            "canonical_to_native": {},
+            "canonical_resolution_meta": {},
+        }
+        return linear_provisioner.ProvisionResult(
+            team_id=target["id"],
+            team_key=target["key"],
+            state_id_by_name=result["state_id_by_name"],
+            label_id_by_stage=result["label_id_by_stage"],
+            signal_label_ids=result["signal_label_ids"],
+            canonical_to_native=result["canonical_to_native"],
+            canonical_resolution_meta=result["canonical_resolution_meta"],
+        )
+
+    monkeypatch.setattr(linear_provisioner, "list_teams", _list_teams)
+    monkeypatch.setattr(linear_provisioner, "provision_team", _provision_team)
+
+
+@pytest.mark.asyncio
+async def test_callback_preserves_existing_team_on_reconnect(
+    v1_client, db_session, seed_workspace, linear_env, monkeypatch
+) -> None:
+    """Reconnect must not overwrite a previously-bound ``team_id``.
+
+    The pilot bug: an admin-scope reconnect ran from a Linear session
+    where ``list_teams`` returned only one team. The auto-pick path
+    silently rebound the workspace from its original team to the
+    only-visible one, leaving the dashboard's project filter pointing
+    at a wrong team (zero projects).
+    """
+    from backend.app.core.config import get_settings
+    from backend.app.db.models.tenancy import Integration
+    from backend.app.integrations.linear.oauth import build_oauth_state
+
+    _, _, workspace = seed_workspace
+    workspace_id = workspace.id
+
+    # Pre-existing Integration row with the original team binding.
+    original = Integration(
+        workspace_id=workspace_id,
+        kind="linear",
+        status="ok",
+        config={
+            "team_id": "team-elship-uuid",
+            "team_key": "ELS",
+            "team_options": [
+                {"id": "team-elship-uuid", "key": "ELS", "name": "elship"},
+            ],
+            "fsm_provisioned": True,
+        },
+    )
+    db_session.add(original)
+    await db_session.flush()
+
+    _patch_oauth_exchange(monkeypatch)
+    # Simulate the reconnect session where Linear's list_teams now also
+    # exposes the ELS team alongside a sibling Buzz team — the ELS row
+    # must win because it was the saved binding.
+    _patch_provisioner(
+        monkeypatch,
+        teams=[
+            {"id": "team-elship-uuid", "key": "ELS", "name": "elship"},
+            {"id": "team-buzz-uuid", "key": "BUZ", "name": "Buzzz"},
+        ],
+    )
+
+    state = build_oauth_state(workspace_id, settings=get_settings())
+    response = await v1_client.get(
+        "/v1/integrations/linear/install/callback",
+        params={"state": state, "code": "auth-code"},
+        follow_redirects=False,
+    )
+    assert response.status_code in (302, 303, 307)
+
+    await db_session.refresh(original)
+    config = original.config
+    assert config["team_id"] == "team-elship-uuid"
+    assert config["team_key"] == "ELS"
+    # team_options should be refreshed to whatever the new session sees.
+    keys = sorted(t["key"] for t in config["team_options"])
+    assert keys == ["BUZ", "ELS"]
+
+
+@pytest.mark.asyncio
+async def test_callback_marks_needs_repick_when_saved_team_lost(
+    v1_client, db_session, seed_workspace, linear_env, monkeypatch
+) -> None:
+    """Reconnect from an OAuth session that no longer sees the saved
+    team must surface a ``needs_team_repick`` flag rather than silently
+    auto-picking a different team."""
+    from backend.app.core.config import get_settings
+    from backend.app.db.models.tenancy import Integration
+    from backend.app.integrations.linear.oauth import build_oauth_state
+
+    _, _, workspace = seed_workspace
+    workspace_id = workspace.id
+
+    original = Integration(
+        workspace_id=workspace_id,
+        kind="linear",
+        status="ok",
+        config={
+            "team_id": "team-elship-uuid",
+            "team_key": "ELS",
+            "team_options": [
+                {"id": "team-elship-uuid", "key": "ELS", "name": "elship"},
+            ],
+            "fsm_provisioned": True,
+        },
+    )
+    db_session.add(original)
+    await db_session.flush()
+
+    _patch_oauth_exchange(monkeypatch)
+    # Reconnect session no longer sees ELS, only BUZ.
+    _patch_provisioner(
+        monkeypatch,
+        teams=[{"id": "team-buzz-uuid", "key": "BUZ", "name": "Buzzz"}],
+    )
+
+    state = build_oauth_state(workspace_id, settings=get_settings())
+    response = await v1_client.get(
+        "/v1/integrations/linear/install/callback",
+        params={"state": state, "code": "auth-code"},
+        follow_redirects=False,
+    )
+    assert response.status_code in (302, 303, 307)
+
+    await db_session.refresh(original)
+    config = original.config
+    # team_id stays as the original — we never silently rebind.
+    assert config["team_id"] == "team-elship-uuid"
+    assert config["team_key"] == "ELS"
+    assert config["needs_team_repick"] is True
+    assert config["fsm_provisioned"] is False
+
+
+@pytest.mark.asyncio
+async def test_team_repick_endpoint_updates_binding(
+    v1_client, db_session, seed_workspace, linear_env, monkeypatch
+) -> None:
+    """``POST .../linear/team`` re-binds the workspace to a different
+    team in the same org and re-provisions FSM state for it."""
+    from backend.app.db.models.tenancy import AuditLog, Integration
+
+    user, raw, workspace = seed_workspace
+    workspace_id = workspace.id
+
+    original = Integration(
+        workspace_id=workspace_id,
+        kind="linear",
+        status="ok",
+        secret_ciphertext=b"placeholder",  # ignored by stubs below
+        config={
+            "team_id": "team-buzz-uuid",
+            "team_key": "BUZ",
+            "team_options": [
+                {"id": "team-elship-uuid", "key": "ELS", "name": "elship"},
+                {"id": "team-buzz-uuid", "key": "BUZ", "name": "Buzzz"},
+            ],
+            "fsm_provisioned": True,
+            "needs_team_repick": True,
+            "scope": "admin read write",
+        },
+    )
+    db_session.add(original)
+    await db_session.flush()
+
+    # Bypass the live token-fetch helper — the repick endpoint pulls a
+    # decrypted access token via ``_fetch_live_linear_token`` which
+    # touches the encrypted secret + native install table. Stub it so
+    # the test focuses on the team-binding behaviour.
+    async def _fake_token(_session, *, workspace_id):
+        return None, "lin_access_repick_test"
+
+    monkeypatch.setattr(
+        "backend.app.api.v1.routes.linear_oauth._fetch_live_linear_token",
+        _fake_token,
+    )
+
+    _patch_provisioner(
+        monkeypatch,
+        teams=[
+            {"id": "team-elship-uuid", "key": "ELS", "name": "elship"},
+            {"id": "team-buzz-uuid", "key": "BUZ", "name": "Buzzz"},
+        ],
+    )
+
+    response = await v1_client.post(
+        f"/v1/workspaces/{workspace_id}/integrations/linear/team",
+        json={"team_key": "ELS"},
+        headers={"Authorization": f"Bearer {raw}"},
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["team_id"] == "team-elship-uuid"
+    assert body["team_key"] == "ELS"
+    assert body["fsm_provisioned"] is True
+
+    await db_session.refresh(original)
+    config = original.config
+    assert config["team_id"] == "team-elship-uuid"
+    assert config["team_key"] == "ELS"
+    assert config["fsm_provisioned"] is True
+    assert "needs_team_repick" not in config
+
+    audit = (
+        await db_session.execute(
+            select(AuditLog).where(
+                AuditLog.workspace_id == workspace_id,
+                AuditLog.action == "linear.team.repick",
+            )
+        )
+    ).scalar_one()
+    assert audit.payload["from_team_key"] == "BUZ"
+    assert audit.payload["to_team_key"] == "ELS"
+
+
+@pytest.mark.asyncio
+async def test_team_repick_endpoint_404_for_unknown_team(
+    v1_client, db_session, seed_workspace, linear_env, monkeypatch
+) -> None:
+    """Repick with a team key the live OAuth doesn't expose → 404."""
+    from backend.app.db.models.tenancy import Integration
+
+    _, raw, workspace = seed_workspace
+    workspace_id = workspace.id
+
+    db_session.add(
+        Integration(
+            workspace_id=workspace_id,
+            kind="linear",
+            status="ok",
+            secret_ciphertext=b"placeholder",
+            config={"team_id": "team-buzz-uuid", "team_key": "BUZ"},
+        )
+    )
+    await db_session.flush()
+
+    async def _fake_token(_session, *, workspace_id):
+        return None, "lin_access_repick_test"
+
+    monkeypatch.setattr(
+        "backend.app.api.v1.routes.linear_oauth._fetch_live_linear_token",
+        _fake_token,
+    )
+    _patch_provisioner(
+        monkeypatch,
+        teams=[{"id": "team-buzz-uuid", "key": "BUZ", "name": "Buzzz"}],
+    )
+
+    response = await v1_client.post(
+        f"/v1/workspaces/{workspace_id}/integrations/linear/team",
+        json={"team_key": "ELS"},
+        headers={"Authorization": f"Bearer {raw}"},
+    )
+    assert response.status_code == 404
+    assert response.json()["detail"]["code"] == "team_not_visible"
+
+
+@pytest.mark.asyncio
+async def test_team_repick_endpoint_requires_admin(
+    v1_client, db_session, seed_workspace, linear_env, monkeypatch
+) -> None:
+    """Non-admin members cannot rebind workspace credentials."""
+    import secrets as secrets_mod
+    from backend.app.api.v1.deps import PAT_PREFIX, _hash_token
+    from backend.app.db.models.tenancy import (
+        ApiToken,
+        Integration,
+        User,
+        WorkspaceMember,
+    )
+
+    _, _, workspace = seed_workspace
+    workspace_id = workspace.id
+
+    # Spin a second user with "member" role on the same workspace.
+    member_user = User(
+        email=f"member-{uuid.uuid4().hex[:6]}@example.com",
+        display_name="member",
+    )
+    db_session.add(member_user)
+    await db_session.flush()
+    db_session.add(
+        WorkspaceMember(
+            workspace_id=workspace_id,
+            user_id=member_user.id,
+            role="member",
+            answer_specialist_slugs=["*"],
+        )
+    )
+    raw_member = f"{PAT_PREFIX}{secrets_mod.token_urlsafe(24)}"
+    db_session.add(
+        ApiToken(
+            user_id=member_user.id,
+            name="member-pat",
+            hashed_secret=_hash_token(raw_member),
+            prefix=PAT_PREFIX,
+            scopes=["workspace:read"],
+        )
+    )
+    db_session.add(
+        Integration(
+            workspace_id=workspace_id,
+            kind="linear",
+            status="ok",
+            secret_ciphertext=b"placeholder",
+            config={"team_id": "team-buzz-uuid", "team_key": "BUZ"},
+        )
+    )
+    await db_session.flush()
+
+    response = await v1_client.post(
+        f"/v1/workspaces/{workspace_id}/integrations/linear/team",
+        json={"team_key": "ELS"},
+        headers={"Authorization": f"Bearer {raw_member}"},
+    )
+    assert response.status_code == 403


### PR DESCRIPTION
## Root cause

Pilot bug. Admin-scope reconnect (PR #326) ran from a Linear OAuth session where `list_teams` returned only the operator's personal Buzz team. The callback's `if len(teams) == 1` branch silently auto-picked it, rebinding the workspace from its original elship team to Buzz.

Dashboard's `list_projects` then filters to `accessibleTeams: {some: {id: {eq: <Buzz-id>}}}` → zero projects under Buzz → priorities panel shows the empty "Add a project in Linear" placeholder, even though Linear still says `synced 1h ago` (health probe passes, list_projects just returns []).

Confirmed by `GET /v1/workspaces/.../integrations` on Ship-on-Ship:

```json
{
  "team_id": "9bdc694c-...",
  "team_key": "BUZ",
  "team_options": [{"key": "BUZ", "name": "Buzzz"}],
  "scope": "admin comments:create issues:create read write"
}
```

## What this PR changes

**Prevention** — `linear_oauth.py` callback gets three explicit branches:

1. Saved `team_id` is in new `list_teams` snapshot → preserve it, only refresh `team_options`.
2. Saved `team_id` is NOT in snapshot → leave it, stamp `needs_team_repick: true` + `fsm_provisioned: false` so the dashboard banners instead of silently rebinding.
3. No saved binding + exactly one visible team → auto-pick as before (fresh connect).

**Recovery** — new `POST /workspaces/{id}/integrations/linear/team` endpoint. Admin-only, takes `{team_key}`, validates via live `list_teams`, re-provisions FSM state/label maps, persists config, audits.

**Resolver scope-split** — `tracker_resolver._resolve_from_legacy_row` was the third site PR #337 missed. Mirrored the space+comma normaliser so the scope tuple is consistent across native + legacy storage shapes.

## After merge

Once deployed I'll call:

```
POST /v1/workspaces/d591af28-225e-477e-8448-7a4b9b06fbfc/integrations/linear/team
{"team_key": "ELS"}
```

to rebind Ship-on-Ship to the elship team and restore the dashboard.

## Test plan

- [x] 5 new pytest cases: preserves existing team, marks needs_repick when saved team lost, repick happy path, repick 404 on unknown team, repick 403 for non-admin. 12/12 file passing.
- [x] ruff clean
- [ ] Manual after deploy: confirm dashboard prioritizer fills back in with elship projects.