### PR TITLE
fix(fsm): synthetic finish on picker-null exits — break dispatch re-fire loop

### DIFF
--- a/apps/backend/app/api/v1/routes/agent_runs.py
+++ b/apps/backend/app/api/v1/routes/agent_runs.py
@@ -833,6 +833,20 @@ async def get_next_task(
             ticket=None, fsm_stage=state, tracker_kind=resolved.kind
         )
     if not rows:
+        # Bug-A fix: when the dispatcher pinned a ticket (ticket_ref
+        # query) but list_tickets returned nothing for it (label drift,
+        # ticket archived, FSM-stage gate stripped) — write a
+        # synthetic finish so fsm_self_heal stops re-firing the dead
+        # pin every tick.
+        if ticket_ref:
+            await _write_synthetic_picker_noop_finish(
+                session,
+                workspace_id=workspace_id,
+                ticket_ref=ticket_ref,
+                fsm_stage=state,
+                reason="picker_no_rows",
+                tracker_kind=resolved.kind,
+            )
         return TaskResponseOut(
             ticket=None, fsm_stage=state, tracker_kind=resolved.kind
         )
@@ -973,6 +987,19 @@ async def get_next_task(
                     resolved=resolved,
                     ticket_ref=ticket_ref,
                     reason=f"picker_{skipped_kind}",
+                )
+                # Bug-A fix (2026-05-27): write a synthetic finish so
+                # fsm_self_heal sees the dispatch's terminal record and
+                # the refire_cap counter can do its job. Without this
+                # the dispatcher fires every hour for the same dead
+                # ticket (askslayer/PAC-21 today: 9d in this loop).
+                await _write_synthetic_picker_noop_finish(
+                    session,
+                    workspace_id=workspace_id,
+                    ticket_ref=ticket_ref,
+                    fsm_stage=state,
+                    reason=f"picker_{skipped_kind}",
+                    tracker_kind=resolved.kind,
                 )
         return TaskResponseOut(
             ticket=None, fsm_stage=state, tracker_kind=resolved.kind
@@ -1118,6 +1145,18 @@ async def get_next_task(
                 resolved=resolved,
                 ticket_ref=ticket_ref,
                 reason="picker_refire_capped",
+            )
+            # Bug-A fix (2026-05-27): see comment on the picker_skipped
+            # path above. Synthetic finish so the loop guard sees a
+            # terminal record and stops re-firing dispatches that the
+            # picker is going to refuse the same way every tick.
+            await _write_synthetic_picker_noop_finish(
+                session,
+                workspace_id=workspace_id,
+                ticket_ref=ticket_ref,
+                fsm_stage=state,
+                reason="picker_refire_capped",
+                tracker_kind=resolved.kind,
             )
             return TaskResponseOut(
                 ticket=None, fsm_stage=state, tracker_kind=resolved.kind
@@ -1266,6 +1305,69 @@ def _collect_project_sections(payload: "FinishIn") -> list["ProjectSectionPatch"
         except Exception:  # noqa: BLE001 — drop malformed silently
             continue
     return out
+
+
+async def _write_synthetic_picker_noop_finish(
+    session: AsyncSession,
+    *,
+    workspace_id: uuid.UUID,
+    ticket_ref: str,
+    fsm_stage: str,
+    reason: str,
+    tracker_kind: str | None = None,
+) -> None:
+    """Audit a synthetic ``agent_run.finish(outcome=noop)`` when the
+    picker returned null for a dispatcher-pinned ticket.
+
+    Closes the *Bug A* leak from the 2026-05-18 project_lock-leak
+    post-mortem: the dispatcher records ``agent_run.dispatch`` and
+    triggers the runner; the runner asks ``/tracker/next`` for work;
+    the picker returns ``ticket=None`` (orphan / overlay-frozen /
+    priority-skipped / no eligible row / refire-capped); the runner
+    exits without ``/finish``; ``fsm_self_heal`` sees a dispatch with
+    no matching finish and re-fires the same dead route every tick.
+
+    Writing a synthetic finish here gives the loop guard something to
+    count, breaks the re-fire chain at ``refire_cap``, and keeps the
+    dispatch→finish latency metric honest. ``reason`` becomes the
+    payload's ``reason`` field so a post-mortem can see why the
+    picker walked the ticket past — same vocabulary the existing
+    ``_release_project_lock_for_ticket`` uses.
+
+    No-op on missing ``ticket_ref`` (no dispatcher-pin, no leak to
+    close) so workspace-bundle paths can call us unconditionally.
+    """
+    if not ticket_ref:
+        return
+    try:
+        session.add(
+            AuditLog(
+                workspace_id=workspace_id,
+                actor_user_id=None,
+                actor_token_id=None,
+                action="agent_run.finish",
+                target_kind="agent_run",
+                # Use the reason as the synthetic run handle so audit
+                # readers can tell this finish from a real Cursor run
+                # (run_<hex>). Reason is unique per workspace+ticket+
+                # tick window which is enough to dedup downstream.
+                target_id=f"picker_noop:{workspace_id}:{ticket_ref}:{reason}",
+                payload={
+                    "outcome": "noop",
+                    "fsm_stage": fsm_stage,
+                    "ticket_ref": ticket_ref,
+                    "reason": reason,
+                    "synthetic": True,
+                    "source": "picker_noop_finish",
+                    "tracker_kind": tracker_kind,
+                },
+            )
+        )
+    except Exception as exc:  # noqa: BLE001 — never fail the picker over audit
+        logger.warning(
+            "picker_noop_finish audit failed ws=%s ticket=%s err=%s",
+            workspace_id, ticket_ref, exc,
+        )
 
 
 async def _release_project_lock_for_ticket(

--- a/apps/backend/tests/test_picker_null_synthetic_finish.py
+++ b/apps/backend/tests/test_picker_null_synthetic_finish.py
@@ -1,0 +1,117 @@
+"""Bug-A fix — picker null exits write a synthetic agent_run.finish.
+
+When the dispatcher pinned a ticket (workflow_dispatch with
+ticket_ref) and the picker then returns ticket=None — orphan,
+overlay-frozen, priority-skipped, no eligible row, refire-capped — we
+must record a terminal finish so fsm_self_heal can count it and stop
+re-firing the same dead pin every tick.
+
+Pre-fix the dispatch fired hourly forever (askslayer/PAC-21 today: 9
+days in this loop). Pin the audit shape so a future picker refactor
+can't quietly skip the finish write again.
+
+These tests exercise the synthetic-finish helper directly with a
+recording session stub — no DB, no Linear.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from types import SimpleNamespace
+
+from backend.app.api.v1.routes.agent_runs import (
+    _write_synthetic_picker_noop_finish,
+)
+
+
+class _RecordingSession:
+    """Minimal Session stand-in — captures everything passed to add()."""
+
+    def __init__(self) -> None:
+        self.added: list = []
+
+    def add(self, row) -> None:  # noqa: ANN001 — duck typing matches Session
+        self.added.append(row)
+
+
+def _run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def test_writes_audit_row_with_expected_shape() -> None:
+    session = _RecordingSession()
+    ws = uuid.uuid4()
+    _run(
+        _write_synthetic_picker_noop_finish(
+            session,
+            workspace_id=ws,
+            ticket_ref="PAC-21",
+            fsm_stage="auto_merge",
+            reason="picker_refire_capped",
+            tracker_kind="linear",
+        )
+    )
+    assert len(session.added) == 1
+    row = session.added[0]
+    assert row.action == "agent_run.finish"
+    assert row.target_kind == "agent_run"
+    assert row.target_id == f"picker_noop:{ws}:PAC-21:picker_refire_capped"
+    payload = row.payload
+    assert payload["outcome"] == "noop"
+    assert payload["fsm_stage"] == "auto_merge"
+    assert payload["ticket_ref"] == "PAC-21"
+    assert payload["reason"] == "picker_refire_capped"
+    assert payload["synthetic"] is True
+    assert payload["source"] == "picker_noop_finish"
+    assert payload["tracker_kind"] == "linear"
+
+
+def test_noop_when_ticket_ref_missing() -> None:
+    # Workspace-bundle paths (self-heal / daily-digest) pick without a
+    # ticket pin and don't suffer from the leak. The helper must be a
+    # no-op there so callers can invoke it unconditionally.
+    session = _RecordingSession()
+    _run(
+        _write_synthetic_picker_noop_finish(
+            session,
+            workspace_id=uuid.uuid4(),
+            ticket_ref="",
+            fsm_stage="workspace_self_heal",
+            reason="picker_no_rows",
+        )
+    )
+    assert session.added == []
+
+
+def test_target_id_uniqueness_per_reason() -> None:
+    # Same ticket, different skip reason → different target_id so a
+    # downstream audit query can tell them apart. Same ticket, same
+    # reason → same target_id (idempotent within a tick).
+    ws = uuid.uuid4()
+    s1, s2, s3 = _RecordingSession(), _RecordingSession(), _RecordingSession()
+    _run(_write_synthetic_picker_noop_finish(s1, workspace_id=ws, ticket_ref="X-1", fsm_stage="auto_merge", reason="picker_refire_capped"))
+    _run(_write_synthetic_picker_noop_finish(s2, workspace_id=ws, ticket_ref="X-1", fsm_stage="auto_merge", reason="picker_no_rows"))
+    _run(_write_synthetic_picker_noop_finish(s3, workspace_id=ws, ticket_ref="X-1", fsm_stage="auto_merge", reason="picker_refire_capped"))
+    assert s1.added[0].target_id != s2.added[0].target_id
+    assert s1.added[0].target_id == s3.added[0].target_id
+
+
+def test_distinguishable_from_real_runs_in_audit() -> None:
+    # Real agent runs use ``run_<hex>`` style ids; synthetic finishes
+    # must NOT collide with that pattern so audit consumers (the
+    # dev_not_converging detector + the refire_cap counter) can tell
+    # them apart if they need to.
+    session = _RecordingSession()
+    _run(
+        _write_synthetic_picker_noop_finish(
+            session,
+            workspace_id=uuid.uuid4(),
+            ticket_ref="ELS-7",
+            fsm_stage="auto_merge",
+            reason="picker_overlay_frozen",
+        )
+    )
+    target_id = session.added[0].target_id
+    assert target_id.startswith("picker_noop:")
+    assert not target_id.startswith("run_")


### PR DESCRIPTION
## Bug A from the 2026-05-18 project_lock leak postmortem

When the dispatcher pins a ticket (`workflow_dispatch` with `ticket_ref`) and the picker then refuses it — orphan / overlay-frozen / no eligible row / refire-capped — the route returns `ticket=None` without writing `agent_run.finish`. `fsm_self_heal` reads `/finish` records to gate re-fire eligibility, so the absence of one means the dispatcher re-fires the same dead pin every hour forever. askslayer/`PAC-21` today: 9 days stuck in this loop.

## Fix

Write a synthetic `agent_run.finish` audit row on every picker-null exit that had a `ticket_ref`:

- `outcome=noop`
- `payload.synthetic=true`
- `payload.source=picker_noop_finish`
- `target_id=picker_noop:<ws>:<ticket>:<reason>` — distinct from real `run_<hex>` ids so audit consumers can tell them apart

The `refire_cap` counter then sees a terminal record and the loop stops at the cap (and `fsm_self_heal` correctly recognizes the picker is rejecting this pin).

## Paths covered

1. `skipped_kind` branch (orphan / overlay-frozen / priority-skipped) — line ~977
2. `not rows` branch (label drift, ticket archived, FSM-stage gate stripped) — line ~835
3. `refire_capped` branch — line ~1115

Workspace-bundle picks (self-heal / daily-digest) call without a ticket pin; the helper short-circuits when `ticket_ref` is empty.

## Test plan

- [x] `tests/test_picker_null_synthetic_finish.py` — pins audit shape, target-id uniqueness, no-op when `ticket_ref` empty, non-collision with `run_<hex>` ids
- [x] `pytest -q` — 4/4 green, no warnings
- [ ] After rollout: `audit_log` rows for `PAC-21` should accumulate `agent_run.finish(outcome=noop, synthetic=true)` once per dispatch tick until the refire cap, then dispatches stop firing for that ticket