### PR TITLE
feat(fsm): auto-advance to next ticket / next epic after PR merge

### DIFF
--- a/apps/backend/app/api/v1/routes/github_app.py
+++ b/apps/backend/app/api/v1/routes/github_app.py
@@ -684,6 +684,18 @@ async def _apply_pull_request_event(
             workspace_id=repo_row.workspace_id,
             pr_title=title,
         )
+        # Phase 3 (2026-05-28): walk the queue. Find the next ready
+        # ticket in the same project (or the next project if this one
+        # is now empty) and fire ``maybe_dispatch`` so the cascade
+        # picks up without a cron tick or human re-touch. If the queue
+        # is empty the helper writes ``dispatch.queue_idle`` and the
+        # workspace genuinely stops firing dispatches until something
+        # enqueues fresh work.
+        await _dispatch_next_eligible_ticket(
+            session,
+            workspace_id=repo_row.workspace_id,
+            pr_title=title,
+        )
 
     # Same pattern for "closed without merge" — operator abandoned the
     # work, so the linked ticket lands in ``Canceled`` rather than
@@ -1140,6 +1152,256 @@ async def _maybe_complete_project_on_merge(
     except Exception as exc:  # noqa: BLE001 — best-effort, never fail the webhook
         logger.debug(
             "project auto-complete on merge failed ws=%s pr_title=%s err=%s",
+            workspace_id, pr_title, exc,
+        )
+
+
+async def _dispatch_next_eligible_ticket(
+    session: AsyncSession,
+    *,
+    workspace_id: uuid.UUID,
+    pr_title: str,
+) -> None:
+    """Phase 3 of the FSM event-driven rearchitecture (2026-05-28).
+
+    When a PR merges and its Linear ticket reaches ``Done``, advance
+    the workspace's work queue automatically: find the next ready
+    ticket in the **same** Linear project (epic) and fire
+    ``maybe_dispatch`` so it starts walking the SDLC chain. If the
+    just-merged ticket was the project's last open one, fall back to
+    the **next** project in the workspace (Linear state ``started`` or
+    ``planned``, ordered by ``updatedAt`` desc — newest first, matching
+    Linear's UI). If neither yields a candidate, the queue is empty:
+    write ``dispatch.queue_idle`` and return. No cron will pick this
+    up — the queue stays idle until a human enqueues fresh work or
+    Linear webhooks fire on a state change.
+
+    Discovery shape — keep it cheap because we're inside the PR-merge
+    webhook ack:
+
+    1. Parse the PR title for the ticket ref (same regex the lock
+       release / completion helpers use; PR title is the source of
+       truth for "which ticket merged").
+    2. Resolve the workspace's tracker; pull the merged ticket's
+       snapshot for ``project_id``.
+    3. Same-project pass: list ``Backlog`` tickets under that
+       ``project_id``, sorted by ``createdAt`` ascending. Take the
+       first one and transition to entry stage ``planning``
+       (Backlog → Todo + ``stage:planning`` breadcrumb).
+    4. Next-project pass: ``list_projects(state="started")`` excluding
+       the current id; if empty, try ``state="planned"``. Take the
+       first project, list its ``Backlog`` tickets, take the first.
+    5. If neither pass found a candidate, write
+       ``dispatch.queue_idle`` audit + return.
+    6. For the chosen candidate: ``gateway.transition(ref,
+       to_state="planning")`` then ``maybe_dispatch(... ,
+       trigger_kind="project_next" | "next_epic")``. Both produce the
+       same downstream cascade chain as the operator-driven flow that
+       moved ELS-141 end-to-end on 2026-05-28.
+
+    Failure mode: best-effort. Anything that raises (tracker hiccup,
+    project deleted between merge and lookup, dispatcher gate refusal,
+    …) is logged + swallowed. The PR-merge webhook must still ack
+    GitHub within seconds; queue stalls are recovered next time the
+    operator touches a ticket in Linear.
+
+    Note: an overlay-frozen candidate (``blocked`` /
+    ``needs:clarification`` label) DOES land here — we don't fetch
+    labels ahead of dispatch. The dispatcher's picker overlay-freeze
+    filter catches it cleanly (verified on PAC-21 2026-05-28), at the
+    cost of one ~30-second runner that exits noop. Phase 4 will move
+    the overlay check into the candidate query and skip the wasted
+    runner entirely.
+    """
+    refs = TICKET_REF_PR_TITLE_RE.findall(pr_title or "")
+    if not refs:
+        return
+    merged_ref = refs[0]
+    try:
+        from backend.app.core.config import get_settings as _gs
+        from backend.app.integrations.gateway.tracker import TicketRef as _TR
+        from backend.app.services.dispatcher import maybe_dispatch
+        from backend.app.services.tracker_resolver import (
+            resolve_for_workspace as _resolve,
+        )
+
+        settings = _gs()
+        resolved = await _resolve(
+            session=session, settings=settings, workspace_id=workspace_id
+        )
+        if resolved is None:
+            return
+        gw = resolved.gateway
+        snap_fn = getattr(gw, "get_ticket_snapshot", None)
+        if snap_fn is None:
+            return
+        snap = await snap_fn(
+            _TR(kind=resolved.kind, workspace_hint=None, id=merged_ref)
+        )
+        current_project_id = str((snap or {}).get("project_id") or "")
+        # No project on the just-merged ticket → can't compute "same
+        # epic". Skip; queue stays idle. (Orphan tickets are already
+        # filtered out of the picker upstream.)
+        if not current_project_id:
+            return
+
+        list_in_state = getattr(gw, "list_project_tickets_in_state", None)
+        list_projects = getattr(gw, "list_projects", None)
+        if list_in_state is None or list_projects is None:
+            return
+
+        # 1. Same-project pass.
+        next_ref: str | None = None
+        chosen_via: str = "project_next"
+        chosen_project_id: str = current_project_id
+        try:
+            candidates = await list_in_state(
+                project_id=current_project_id,
+                linear_state_name="Backlog",
+                limit=10,
+            )
+        except Exception as exc:  # noqa: BLE001 — best-effort
+            logger.debug(
+                "project_next: list_in_state(current) failed ws=%s project=%s err=%s",
+                workspace_id, current_project_id, exc,
+            )
+            candidates = []
+        # Filter out the just-merged ticket defensively (shouldn't appear
+        # in Backlog state after the Done transition, but cache lag is
+        # cheap to guard against).
+        candidates = [
+            c for c in candidates if c.get("identifier") != merged_ref
+        ]
+        if candidates:
+            next_ref = str(candidates[0].get("identifier") or "")
+
+        # 2. Next-project pass (only if same-project came up empty).
+        if not next_ref:
+            for probe_state in ("started", "planned"):
+                try:
+                    projects = await list_projects(
+                        state=probe_state, limit=50
+                    )
+                except Exception as exc:  # noqa: BLE001 — best-effort
+                    logger.debug(
+                        "next_epic: list_projects(%s) failed ws=%s err=%s",
+                        probe_state, workspace_id, exc,
+                    )
+                    continue
+                # Skip current; ``list_projects`` orders by ``updatedAt``
+                # desc — most recently touched project wins, mirroring
+                # Linear's own UI sort.
+                for prj in projects:
+                    pid = str(prj.get("id") or "")
+                    if not pid or pid == current_project_id:
+                        continue
+                    try:
+                        prj_candidates = await list_in_state(
+                            project_id=pid,
+                            linear_state_name="Backlog",
+                            limit=5,
+                        )
+                    except Exception as exc:  # noqa: BLE001
+                        logger.debug(
+                            "next_epic: list_in_state(%s) failed ws=%s err=%s",
+                            pid, workspace_id, exc,
+                        )
+                        continue
+                    if prj_candidates:
+                        next_ref = str(
+                            prj_candidates[0].get("identifier") or ""
+                        )
+                        chosen_via = "next_epic"
+                        chosen_project_id = pid
+                        break
+                if next_ref:
+                    break
+
+        # 3. Queue empty — record + return.
+        if not next_ref:
+            session.add(
+                AuditLog(
+                    workspace_id=workspace_id,
+                    actor_user_id=None,
+                    actor_token_id=None,
+                    action="dispatch.queue_idle",
+                    target_kind="ticket",
+                    target_id=merged_ref,
+                    payload={
+                        "tracker_kind": resolved.kind,
+                        "current_project_id": current_project_id,
+                        "reason": "no_backlog_tickets",
+                    },
+                )
+            )
+            logger.info(
+                "queue idle after merge ws=%s ticket=%s project=%s",
+                workspace_id, merged_ref, current_project_id,
+            )
+            return
+
+        # 4. Move next ticket into entry state + dispatch. Transition
+        # is idempotent: a no-op if the ticket is already at "planning"
+        # because Linear webhook order happens to land its own
+        # state-change first. We pass ``from_state=None`` so the
+        # adapter falls back to adding ``stage:planning`` as the
+        # breadcrumb (the entry stage has no predecessor to retire).
+        next_ref_obj = _TR(
+            kind=resolved.kind, workspace_hint=None, id=next_ref
+        )
+        try:
+            await gw.transition(
+                next_ref_obj, to_state="planning", from_state=None
+            )
+        except Exception as exc:  # noqa: BLE001 — log + try dispatch anyway
+            logger.warning(
+                "project_next transition failed ws=%s ticket=%s err=%s",
+                workspace_id, next_ref, exc,
+            )
+
+        try:
+            result = await maybe_dispatch(
+                session,
+                workspace_id=workspace_id,
+                ticket_ref=next_ref,
+                trigger_kind=chosen_via,
+                fsm_stage="planning",
+                settings=settings,
+            )
+        except Exception as exc:  # noqa: BLE001 — best-effort
+            logger.warning(
+                "project_next maybe_dispatch failed ws=%s ticket=%s err=%s",
+                workspace_id, next_ref, exc,
+            )
+            return
+
+        session.add(
+            AuditLog(
+                workspace_id=workspace_id,
+                actor_user_id=None,
+                actor_token_id=None,
+                action="dispatch.queue_advance",
+                target_kind="ticket",
+                target_id=next_ref,
+                payload={
+                    "tracker_kind": resolved.kind,
+                    "via": chosen_via,
+                    "merged_ticket": merged_ref,
+                    "merged_project_id": current_project_id,
+                    "next_project_id": chosen_project_id,
+                    "maybe_dispatch_fired": result.fired,
+                    "maybe_dispatch_reason": result.reason,
+                },
+            )
+        )
+        logger.info(
+            "queue advance ws=%s merged=%s -> next=%s via=%s fired=%s reason=%s",
+            workspace_id, merged_ref, next_ref,
+            chosen_via, result.fired, result.reason,
+        )
+    except Exception as exc:  # noqa: BLE001 — never fail the webhook ack
+        logger.debug(
+            "project_next dispatch failed ws=%s pr_title=%s err=%s",
             workspace_id, pr_title, exc,
         )
 

--- a/apps/backend/tests/test_phase3_dispatch_next_in_project.py
+++ b/apps/backend/tests/test_phase3_dispatch_next_in_project.py
@@ -1,0 +1,277 @@
+"""Phase 3 of the FSM event-driven rearchitecture — after PR merge,
+walk the workspace's work queue automatically.
+
+The PR-merge handler in ``github_app.py`` calls
+``_dispatch_next_eligible_ticket``. It must:
+
+1. Pick the first Backlog ticket in the same Linear project as the
+   just-merged ticket, transition it to entry-stage ``planning``,
+   and fire ``maybe_dispatch`` with ``trigger_kind="project_next"``.
+2. Fall back to the next Linear project (state ``started`` →
+   ``planned``) when the current project has no Backlog tickets left.
+3. Write ``dispatch.queue_idle`` and stop firing dispatches when no
+   candidate exists in any project. NO cron, NO human touch required
+   to recover — the queue stays idle until something genuinely
+   enqueues new work.
+
+Pinned by per-scenario unit tests against a recording fake gateway
+that captures every ``transition`` + ``maybe_dispatch`` call.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from backend.app.api.v1.routes.github_app import (
+    _dispatch_next_eligible_ticket,
+)
+
+
+class _FakeGateway:
+    """Recording gateway stand-in — captures everything the helper calls."""
+
+    def __init__(self) -> None:
+        self.transitions: list[tuple[str, str]] = []  # (ticket_id, to_state)
+        self.project_tickets: dict[tuple[str, str], list[dict[str, Any]]] = {}
+        self.projects_by_state: dict[str, list[dict[str, Any]]] = {}
+        self.snapshots: dict[str, dict[str, Any]] = {}
+
+    async def get_ticket_snapshot(self, ref):
+        return self.snapshots.get(ref.id)
+
+    async def list_project_tickets_in_state(
+        self, *, project_id: str, linear_state_name: str, limit: int = 100
+    ) -> list[dict[str, Any]]:
+        return list(
+            self.project_tickets.get((project_id, linear_state_name), [])
+        )[: limit]
+
+    async def list_projects(
+        self, *, limit: int = 50, state: str | None = None, query=None
+    ) -> list[dict[str, Any]]:
+        return list(self.projects_by_state.get(state or "", []))[:limit]
+
+    async def transition(self, ref, *, to_state: str, from_state=None) -> None:
+        self.transitions.append((ref.id, to_state))
+
+
+def _build_resolved(gateway: _FakeGateway):
+    obj = AsyncMock()
+    obj.kind = "linear"
+    obj.gateway = gateway
+    return obj
+
+
+@pytest.fixture
+def workspace_id() -> uuid.UUID:
+    return uuid.uuid4()
+
+
+@pytest.fixture
+def session():
+    s = AsyncMock()
+    # capture rows passed to session.add for audit assertions
+    s.added = []
+    s.add = lambda row: s.added.append(row)
+    return s
+
+
+def _resolve_patch(gw: _FakeGateway):
+    """Patch resolve_for_workspace to return our recording gateway.
+
+    The helper imports resolve_for_workspace lazily inside its body
+    (``from backend.app.services.tracker_resolver import resolve_for_workspace``)
+    so we patch at the source module — the import inside the helper
+    binds to our mocked symbol every call.
+    """
+    return patch(
+        "backend.app.services.tracker_resolver.resolve_for_workspace",
+        new=AsyncMock(return_value=_build_resolved(gw)),
+    )
+
+
+def _dispatch_patch(captured: list, fired: bool = True, reason: str = "fired"):
+    """Patch maybe_dispatch + return a list to capture call kwargs."""
+    async def _fn(session, **kwargs):
+        captured.append(kwargs)
+        result = AsyncMock()
+        result.fired = fired
+        result.reason = reason
+        return result
+
+    return patch(
+        "backend.app.services.dispatcher.maybe_dispatch",
+        new=_fn,
+    )
+
+
+@pytest.mark.asyncio
+async def test_same_project_pick_when_backlog_has_siblings(workspace_id, session):
+    gw = _FakeGateway()
+    gw.snapshots["ELS-200"] = {"project_id": "proj-A"}
+    gw.project_tickets[("proj-A", "Backlog")] = [
+        {"identifier": "ELS-201", "title": "next one"},
+        {"identifier": "ELS-202", "title": "after that"},
+    ]
+    captured: list = []
+    with _resolve_patch(gw), _dispatch_patch(captured):
+        await _dispatch_next_eligible_ticket(
+            session, workspace_id=workspace_id, pr_title="fix(ELS-200): done",
+        )
+    # Pick the first Backlog ticket; transition it; dispatch.
+    assert gw.transitions == [("ELS-201", "planning")]
+    assert len(captured) == 1
+    call = captured[0]
+    assert call["ticket_ref"] == "ELS-201"
+    assert call["trigger_kind"] == "project_next"
+    assert call["fsm_stage"] == "planning"
+    # Audit row records the advance.
+    actions = [getattr(r, "action", None) for r in session.added]
+    assert "dispatch.queue_advance" in actions
+
+
+@pytest.mark.asyncio
+async def test_next_epic_pick_when_current_project_empty(workspace_id, session):
+    gw = _FakeGateway()
+    gw.snapshots["ELS-200"] = {"project_id": "proj-A"}
+    # Same project Backlog is empty (e.g., just-merged ticket was the
+    # only one). Fall back to the next project — list_projects returns
+    # newest first per Linear adapter contract.
+    gw.project_tickets[("proj-A", "Backlog")] = []
+    gw.projects_by_state["started"] = [
+        {"id": "proj-A", "name": "current — should be skipped"},
+        {"id": "proj-B", "name": "next epic"},
+    ]
+    gw.project_tickets[("proj-B", "Backlog")] = [
+        {"identifier": "PAC-9", "title": "first of next epic"},
+    ]
+    captured: list = []
+    with _resolve_patch(gw), _dispatch_patch(captured):
+        await _dispatch_next_eligible_ticket(
+            session, workspace_id=workspace_id, pr_title="fix(ELS-200): last",
+        )
+    assert gw.transitions == [("PAC-9", "planning")]
+    assert captured[0]["ticket_ref"] == "PAC-9"
+    assert captured[0]["trigger_kind"] == "next_epic"
+    # Advance audit captures the cross-project hop.
+    advance_rows = [
+        r for r in session.added
+        if getattr(r, "action", None) == "dispatch.queue_advance"
+    ]
+    assert len(advance_rows) == 1
+    payload = advance_rows[0].payload
+    assert payload["via"] == "next_epic"
+    assert payload["merged_project_id"] == "proj-A"
+    assert payload["next_project_id"] == "proj-B"
+
+
+@pytest.mark.asyncio
+async def test_started_then_planned_fallback(workspace_id, session):
+    gw = _FakeGateway()
+    gw.snapshots["ELS-200"] = {"project_id": "proj-A"}
+    gw.project_tickets[("proj-A", "Backlog")] = []
+    # Active queue is empty; pull from the planned bucket — common when
+    # the operator drafted a project but hasn't started it yet.
+    gw.projects_by_state["started"] = [
+        {"id": "proj-A", "name": "current, no Backlog"},
+    ]
+    gw.projects_by_state["planned"] = [
+        {"id": "proj-Z", "name": "next planned epic"},
+    ]
+    gw.project_tickets[("proj-Z", "Backlog")] = [
+        {"identifier": "PAC-50", "title": "first task"},
+    ]
+    captured: list = []
+    with _resolve_patch(gw), _dispatch_patch(captured):
+        await _dispatch_next_eligible_ticket(
+            session, workspace_id=workspace_id, pr_title="fix(ELS-200): x",
+        )
+    assert captured[0]["ticket_ref"] == "PAC-50"
+    assert captured[0]["trigger_kind"] == "next_epic"
+
+
+@pytest.mark.asyncio
+async def test_queue_idle_when_nothing_to_dispatch(workspace_id, session):
+    gw = _FakeGateway()
+    gw.snapshots["ELS-200"] = {"project_id": "proj-A"}
+    # No Backlog in current; no projects in started/planned; nothing
+    # to do. Helper must NOT silently exit — it must write
+    # dispatch.queue_idle so the operator can see "we truly have no
+    # work" instead of suspecting a missed event.
+    gw.project_tickets[("proj-A", "Backlog")] = []
+    gw.projects_by_state["started"] = []
+    gw.projects_by_state["planned"] = []
+    captured: list = []
+    with _resolve_patch(gw), _dispatch_patch(captured):
+        await _dispatch_next_eligible_ticket(
+            session, workspace_id=workspace_id, pr_title="fix(ELS-200): last",
+        )
+    assert captured == []  # zero dispatches
+    assert gw.transitions == []
+    actions = [getattr(r, "action", None) for r in session.added]
+    assert "dispatch.queue_idle" in actions
+    # Idle row carries enough context to diagnose later
+    idle = [
+        r for r in session.added
+        if getattr(r, "action", None) == "dispatch.queue_idle"
+    ][0]
+    assert idle.payload["current_project_id"] == "proj-A"
+    assert idle.payload["reason"] == "no_backlog_tickets"
+
+
+@pytest.mark.asyncio
+async def test_same_project_pick_ignores_self_loop(workspace_id, session):
+    # Defensive: the just-merged ticket might still appear in the
+    # Backlog list result if the Linear adapter / replica hasn't caught
+    # up with the Done transition we wrote a millisecond ago. The helper
+    # must NOT re-dispatch the same ticket — that would yo-yo the chain
+    # back into planning right after it finished auto-merge.
+    gw = _FakeGateway()
+    gw.snapshots["ELS-200"] = {"project_id": "proj-A"}
+    gw.project_tickets[("proj-A", "Backlog")] = [
+        {"identifier": "ELS-200", "title": "the one we just merged"},
+        {"identifier": "ELS-201", "title": "the real next one"},
+    ]
+    captured: list = []
+    with _resolve_patch(gw), _dispatch_patch(captured):
+        await _dispatch_next_eligible_ticket(
+            session, workspace_id=workspace_id, pr_title="fix(ELS-200): done",
+        )
+    assert captured[0]["ticket_ref"] == "ELS-201"
+    assert ("ELS-200", "planning") not in gw.transitions
+
+
+@pytest.mark.asyncio
+async def test_unparseable_pr_title_is_silent_noop(workspace_id, session):
+    gw = _FakeGateway()
+    captured: list = []
+    with _resolve_patch(gw), _dispatch_patch(captured):
+        await _dispatch_next_eligible_ticket(
+            session, workspace_id=workspace_id, pr_title="chore: bump deps",
+        )
+    # No ticket ref → no project to look in → nothing to do. Don't write
+    # an audit row for this case; it's not "queue empty", it's "merge
+    # wasn't ticket-linked".
+    assert captured == []
+    assert gw.transitions == []
+    assert session.added == []
+
+
+@pytest.mark.asyncio
+async def test_orphan_ticket_without_project_is_silent_noop(workspace_id, session):
+    # Ticket exists but has no Linear project assigned. Phase 3 has no
+    # "same epic" concept here, so it skips. (Orphans are also filtered
+    # out by the picker upstream — this is just defense in depth.)
+    gw = _FakeGateway()
+    gw.snapshots["ELS-200"] = {"project_id": None}
+    captured: list = []
+    with _resolve_patch(gw), _dispatch_patch(captured):
+        await _dispatch_next_eligible_ticket(
+            session, workspace_id=workspace_id, pr_title="fix(ELS-200): x",
+        )
+    assert captured == []
+    assert session.added == []


### PR DESCRIPTION
## Phase 3 of the event-driven FSM rearchitecture

Plan: `documentation/internal/planning/2026-05-28-fsm-event-driven-rearchitecture.md` (gitignored — internal).

Phase 1 (PR #341) and Phase 2 (PR #342) made the cascade walk a single ticket end-to-end without crons. On ELS-141 the system shipped a PR in **23 minutes** with zero operator input mid-flight. The piece that still required a manual touch: kicking the **next** ticket once the current one merged.

## What this changes

When a PR merge triggers `_transition_linked_tickets_on_merge`, the handler now also calls a new `_dispatch_next_eligible_ticket`:

1. **Same project pass** — list Backlog tickets in the merged ticket's Linear project (sorted by `createdAt` asc, matching Linear's UI). Take the first non-self.
2. **Next epic fallback** — `list_projects(state="started")` then `state="planned"`, skip current. First project with a Backlog ticket wins.
3. Chosen ticket: `gateway.transition(ref, to_state="planning")` then `maybe_dispatch(trigger_kind="project_next" | "next_epic", fsm_stage="planning")`. Same cascade as the operator-initiated flow that walked ELS-141.
4. Genuine "queue empty" → write `dispatch.queue_idle` once and stop. No cron will pick this up.

## Audit events

| Event | When |
|---|---|
| `dispatch.queue_advance` | Successful pick. Payload: `via`, `merged_ticket`, `next_project_id`, `maybe_dispatch_reason` |
| `dispatch.queue_idle` | No candidate found in any project. Payload: `current_project_id`, `reason=no_backlog_tickets` |

## Defense

- Skip the just-merged ticket if it shows up in the Backlog list (Linear replica lag).
- Silent no-op when PR title lacks a parseable ticket ref or the ticket has no project (orphans are filtered upstream).
- Tracker errors logged + swallowed; the webhook must ack GitHub on time.

## NOT in this PR (deferred per plan)

- `epics.queue_position` column. `list_projects(updatedAt desc)` already gives "most recently touched epic is next" without a new schema.
- Replace `project_lock` with `ticket.in_progress` — existing per-project lock already gives "one in flight per epic" (ELS-141 proved it end-to-end).
- Navigator drag/drop + `/start` button → Phase 6.

## Test plan

- [x] `pytest -q` — 1451 passed, 12 pre-existing `test_symbol_parser.py` failures (unrelated)
- [x] `py_compile` + import smoke
- [x] 7 unit-test scenarios on a recording fake gateway: same-project pick, next-epic fallback, started→planned fallback, queue-idle, self-loop guard, unparseable PR title, orphan ticket
- [ ] After rollout: merge a Ship-on-Ship PR with a ticket ref, watch `audit_log` for `dispatch.queue_advance` + the next ticket's planning dispatch