### PR TITLE
feat(knowledge): importers auto-pickup workspace integrations

### DIFF
--- a/apps/backend/app/api/v1/routes/knowledge.py
+++ b/apps/backend/app/api/v1/routes/knowledge.py
@@ -28,6 +28,10 @@ from backend.app.db.models.integrations import GitHubInstallation, WorkspaceRepo
 from backend.app.db.models.tenancy import Workspace
 from backend.app.db.session import get_session
 from backend.app.integrations.lighthouse import build_lighthouse_client
+from backend.app.integrations.lighthouse.secrets_resolver import (
+    list_workspace_importer_integrations,
+    resolve_workspace_importer_secrets,
+)
 from backend.app.services.knowledge_search import (
     EmbeddingsUnavailable,
     KnowledgeSearchHit,
@@ -311,6 +315,19 @@ class ImporterCreateIn(BaseModel):
     recipe: str | None = Field(default=None, min_length=1, max_length=200)
     config: dict[str, Any] = Field(default_factory=dict)
     secrets: dict[str, str] = Field(default_factory=dict)
+    # When true, Ship resolves the importer's secrets from the
+    # workspace's own integration (GitHub App, Notion / Linear OAuth)
+    # server-side. The browser never sees the token. Explicit values in
+    # ``secrets`` still override the resolved ones, so operators can
+    # mix.
+    use_workspace_integration: bool = False
+
+
+class ImporterIntegrationOut(BaseModel):
+    importer_type: str
+    provider: str
+    account_name: str | None = None
+    account_url: str | None = None
 
 
 def _coerce_importer(row: dict[str, Any]) -> ImporterOut:
@@ -329,6 +346,40 @@ def _coerce_importer(row: dict[str, Any]) -> ImporterOut:
         created_at=row.get("created_at"),
         updated_at=row.get("updated_at"),
     )
+
+
+async def _merge_workspace_secrets(
+    session: AsyncSession,
+    workspace_id: uuid.UUID,
+    importer_type: str,
+    operator_secrets: dict[str, str],
+    *,
+    use_workspace: bool,
+) -> dict[str, str]:
+    """When ``use_workspace`` is true, resolve the workspace's
+    integration creds for this importer type and merge them under the
+    operator-supplied secrets (explicit values override). Raises 400
+    if the workspace has no usable integration for the type."""
+    if not use_workspace:
+        return operator_secrets
+    resolved = await resolve_workspace_importer_secrets(
+        session,
+        workspace_id=workspace_id,
+        importer_type=importer_type,
+        settings=get_settings(),
+    )
+    if resolved is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "code": "no_workspace_integration",
+                "message": (
+                    f"No workspace integration for importer type "
+                    f"'{importer_type}'."
+                ),
+            },
+        )
+    return {**resolved, **operator_secrets}
 
 
 def _require_lighthouse_or_503():
@@ -375,6 +426,32 @@ async def list_importer_types(
     ]
 
 
+@router.get(
+    "/importers/integrations",
+    response_model=list[ImporterIntegrationOut],
+)
+async def list_importer_workspace_integrations(
+    workspace_id: uuid.UUID,
+    auth: AuthContext = Depends(get_current_auth),
+    session: AsyncSession = Depends(get_session),
+) -> list[ImporterIntegrationOut]:
+    """List importer types that the workspace can auto-authorize via
+    its existing Ship integration (GitHub App, Notion / Linear OAuth).
+    The Console uses this to surface the "Use workspace integration"
+    checkbox on the Add form."""
+    await _require_membership(session, workspace_id, auth.user.id, ROLES_READ)
+    rows = await list_workspace_importer_integrations(session, workspace_id)
+    return [
+        ImporterIntegrationOut(
+            importer_type=r.importer_type,
+            provider=r.provider,
+            account_name=r.account_name,
+            account_url=r.account_url,
+        )
+        for r in rows
+    ]
+
+
 @router.get("/importers", response_model=list[ImporterOut])
 async def list_workspace_importers(
     workspace_id: uuid.UUID,
@@ -411,6 +488,10 @@ async def create_workspace_importer(
     await _require_membership(session, workspace_id, auth.user.id, ROLES_MAINTAIN)
     client = _require_lighthouse_or_503()
     recipe = payload.recipe or f"workspace-{payload.type}"
+    secrets = await _merge_workspace_secrets(
+        session, workspace_id, payload.type, payload.secrets,
+        use_workspace=payload.use_workspace_integration,
+    )
     try:
         row = await client.create_importer(
             workspace_id=workspace_id,
@@ -419,7 +500,7 @@ async def create_workspace_importer(
             description=payload.description,
             recipe=recipe,
             config=payload.config,
-            secrets=payload.secrets,
+            secrets=secrets,
         )
     except httpx.HTTPStatusError as exc:
         body = exc.response.text
@@ -442,6 +523,7 @@ class ImporterDiscoverIn(BaseModel):
     type: str = Field(min_length=1, max_length=120)
     config: dict[str, Any] = Field(default_factory=dict)
     secrets: dict[str, str] = Field(default_factory=dict)
+    use_workspace_integration: bool = False
 
 
 class ImporterDiscoveredItem(BaseModel):
@@ -466,12 +548,16 @@ async def discover_importer_items(
     items the operator can choose from. No DB writes."""
     await _require_membership(session, workspace_id, auth.user.id, ROLES_MAINTAIN)
     client = _require_lighthouse_or_503()
+    secrets = await _merge_workspace_secrets(
+        session, workspace_id, payload.type, payload.secrets,
+        use_workspace=payload.use_workspace_integration,
+    )
     try:
         items = await client.discover_importer(
             workspace_id=workspace_id,
             type_=payload.type,
             config=payload.config,
-            secrets=payload.secrets,
+            secrets=secrets,
         )
     except httpx.HTTPStatusError as exc:
         raise HTTPException(

--- a/apps/backend/app/integrations/lighthouse/secrets_resolver.py
+++ b/apps/backend/app/integrations/lighthouse/secrets_resolver.py
@@ -1,0 +1,242 @@
+"""Resolve Lighthouse importer secrets from Ship's own integrations.
+
+When the operator picks an importer type Ship already has an integration
+for (GitHub App, Notion OAuth, Linear OAuth, …), we can fill the
+secrets dict server-side instead of asking the operator to paste a
+token. The token never crosses the wire to the browser.
+
+The mapping is intentionally narrow — only the importer types where
+Ship has a first-party native installation in
+``NativeIntegrationInstallation`` (or a ``GitHubInstallation`` for the
+App flow). Bitbucket / Asana / Trello / Slack stay manual.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from dataclasses import dataclass
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.app.core.config import Settings
+from backend.app.db.models.integrations import (
+    GitHubInstallation,
+    NativeIntegrationInstallation,
+    NativeIntegrationCredential,
+    NativeIntegrationProvider,
+    NativeIntegrationStatus,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class WorkspaceImporterIntegration:
+    """One importer type the workspace has auto-resolvable credentials for."""
+
+    importer_type: str
+    provider: str
+    account_name: str | None
+    account_url: str | None
+
+
+# Importer types we know how to resolve credentials for.
+SUPPORTED_TYPES: frozenset[str] = frozenset(
+    {
+        "github_repo",
+        "github_releases",
+        "notion",
+        "linear",
+    }
+)
+
+
+async def list_workspace_importer_integrations(
+    session: AsyncSession,
+    workspace_id: uuid.UUID,
+) -> list[WorkspaceImporterIntegration]:
+    """Return the importer types the workspace can auto-authorize.
+
+    One entry per importer type that has a working Ship integration —
+    so ``github_repo`` and ``github_releases`` each appear separately
+    when the GitHub App is installed, even though they share one
+    installation row.
+    """
+    out: list[WorkspaceImporterIntegration] = []
+
+    # ── GitHub App (mint installation tokens JIT) ──
+    github = (
+        await session.execute(
+            select(GitHubInstallation)
+            .where(
+                GitHubInstallation.workspace_id == workspace_id,
+                GitHubInstallation.suspended_at.is_(None),
+            )
+            .order_by(GitHubInstallation.installed_at.desc())
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+    if github is not None:
+        for itype in ("github_repo", "github_releases"):
+            out.append(
+                WorkspaceImporterIntegration(
+                    importer_type=itype,
+                    provider="github",
+                    account_name=github.account_login,
+                    account_url=(
+                        f"https://github.com/{github.account_login}"
+                        if github.account_login
+                        else None
+                    ),
+                )
+            )
+
+    # ── Native OAuth installations (Notion, Linear) ──
+    native_pairs = (
+        (NativeIntegrationProvider.NOTION, "notion"),
+        (NativeIntegrationProvider.LINEAR, "linear"),
+    )
+    for provider, importer_type in native_pairs:
+        install = await _latest_ready_install(session, workspace_id, provider)
+        if install is None:
+            continue
+        out.append(
+            WorkspaceImporterIntegration(
+                importer_type=importer_type,
+                provider=provider,
+                account_name=install.external_account_name,
+                account_url=install.external_account_url,
+            )
+        )
+
+    return out
+
+
+async def resolve_workspace_importer_secrets(
+    session: AsyncSession,
+    *,
+    workspace_id: uuid.UUID,
+    importer_type: str,
+    settings: Settings,
+) -> dict[str, str] | None:
+    """Return the secret dict to inject into a Lighthouse importer
+    request, or ``None`` when the workspace has no usable integration
+    for this importer type."""
+    if importer_type not in SUPPORTED_TYPES:
+        return None
+
+    if importer_type in ("github_repo", "github_releases"):
+        return await _resolve_github(session, workspace_id, settings)
+    if importer_type == "notion":
+        token = await _resolve_native_access_token(
+            session, workspace_id, NativeIntegrationProvider.NOTION
+        )
+        return {"integration_token": token} if token else None
+    if importer_type == "linear":
+        token = await _resolve_native_access_token(
+            session, workspace_id, NativeIntegrationProvider.LINEAR
+        )
+        return {"api_key": token} if token else None
+
+    return None
+
+
+async def _resolve_github(
+    session: AsyncSession,
+    workspace_id: uuid.UUID,
+    settings: Settings,
+) -> dict[str, str] | None:
+    install = (
+        await session.execute(
+            select(GitHubInstallation)
+            .where(
+                GitHubInstallation.workspace_id == workspace_id,
+                GitHubInstallation.suspended_at.is_(None),
+            )
+            .order_by(GitHubInstallation.installed_at.desc())
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+    if install is None:
+        return None
+
+    # Lazy import to avoid pulling jose / private-key paths in unrelated
+    # codepaths (and to keep import time fast).
+    from backend.app.integrations.github.app_auth import (
+        fetch_installation_token,
+    )
+
+    try:
+        token = await fetch_installation_token(
+            install.installation_id, settings=settings
+        )
+    except Exception:
+        logger.warning(
+            "github installation token mint failed for ws=%s install=%s",
+            workspace_id,
+            install.installation_id,
+            exc_info=True,
+        )
+        return None
+    return {"github_token": token}
+
+
+async def _resolve_native_access_token(
+    session: AsyncSession,
+    workspace_id: uuid.UUID,
+    provider: str,
+) -> str | None:
+    install = await _latest_ready_install(session, workspace_id, provider)
+    if install is None:
+        return None
+
+    cred = (
+        await session.execute(
+            select(NativeIntegrationCredential)
+            .where(
+                NativeIntegrationCredential.installation_id == install.id,
+                NativeIntegrationCredential.kind == "access_token",
+                NativeIntegrationCredential.revoked_at.is_(None),
+            )
+            .order_by(NativeIntegrationCredential.created_at.desc())
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+    if cred is None:
+        return None
+
+    # Lazy import for the same reason as github.
+    from backend.app.security.encryption import decrypt
+
+    try:
+        return decrypt(cred.secret_ciphertext)
+    except Exception:
+        logger.warning(
+            "credential decrypt failed for ws=%s provider=%s",
+            workspace_id,
+            provider,
+            exc_info=True,
+        )
+        return None
+
+
+async def _latest_ready_install(
+    session: AsyncSession,
+    workspace_id: uuid.UUID,
+    provider: str,
+) -> NativeIntegrationInstallation | None:
+    return (
+        await session.execute(
+            select(NativeIntegrationInstallation)
+            .where(
+                NativeIntegrationInstallation.workspace_id == workspace_id,
+                NativeIntegrationInstallation.provider == provider,
+                NativeIntegrationInstallation.status == NativeIntegrationStatus.READY,
+                NativeIntegrationInstallation.disabled_at.is_(None),
+            )
+            .order_by(NativeIntegrationInstallation.connected_at.desc())
+            .limit(1)
+        )
+    ).scalar_one_or_none()

--- a/apps/console/src/app/(authed)/knowledge/actions.ts
+++ b/apps/console/src/app/(authed)/knowledge/actions.ts
@@ -82,6 +82,7 @@ export async function discoverItemsAction(input: {
   type: string;
   config: Record<string, unknown>;
   secrets?: Record<string, string>;
+  use_workspace_integration?: boolean;
 }): Promise<DiscoverItemsResult> {
   if (!input.type?.trim()) return { ok: false, message: "Type is required." };
 

--- a/apps/console/src/app/(authed)/knowledge/importers-panel.tsx
+++ b/apps/console/src/app/(authed)/knowledge/importers-panel.tsx
@@ -18,6 +18,7 @@ import type {
   ApiImporterDiscoveredItem,
   ApiImporterType,
   ApiWorkspaceImporter,
+  ApiWorkspaceImporterIntegration,
 } from "@/lib/api/client";
 
 import {
@@ -35,10 +36,15 @@ const HIDDEN_TYPES = new Set(["local_files"]);
 type Props = {
   importers: ApiWorkspaceImporter[];
   importerTypes: ApiImporterType[];
+  integrations: ApiWorkspaceImporterIntegration[];
 };
 
 
-export function ImportersPanel({ importers, importerTypes }: Props) {
+export function ImportersPanel({
+  importers,
+  importerTypes,
+  integrations,
+}: Props) {
   const [adding, setAdding] = useState(false);
   const visibleTypes = useMemo(
     () => importerTypes.filter((t) => !HIDDEN_TYPES.has(t.type)),
@@ -77,6 +83,7 @@ export function ImportersPanel({ importers, importerTypes }: Props) {
       {adding && (
         <AddImporterForm
           types={visibleTypes}
+          integrations={integrations}
           onDone={() => setAdding(false)}
         />
       )}
@@ -154,15 +161,21 @@ function ImporterRow({ importer }: { importer: ApiWorkspaceImporter }) {
 
 function AddImporterForm({
   types,
+  integrations,
   onDone,
 }: {
   types: ApiImporterType[];
+  integrations: ApiWorkspaceImporterIntegration[];
   onDone: () => void;
 }) {
   const [typeKey, setTypeKey] = useState<string>(types[0]?.type ?? "");
   const [name, setName] = useState("");
   const [configValues, setConfigValues] = useState<Record<string, string>>({});
   const [secrets, setSecrets] = useState<Record<string, string>>({});
+  // Default ON whenever the selected type has a workspace integration —
+  // the typical case is "user installed GitHub once, wants to import
+  // any repo without re-pasting a token".
+  const [useWorkspaceIntegration, setUseWorkspaceIntegration] = useState(true);
   const [error, setError] = useState<string | null>(null);
   // Discovery state: items returned by the engine + the operator's
   // picks. Active only when the selected type ``supports_discovery``.
@@ -176,6 +189,11 @@ function AddImporterForm({
     () => types.find((t) => t.type === typeKey) ?? null,
     [types, typeKey],
   );
+  const integration = useMemo(
+    () => integrations.find((i) => i.importer_type === typeKey) ?? null,
+    [integrations, typeKey],
+  );
+  const useIntegration = !!integration && useWorkspaceIntegration;
   const needsDiscovery = !!selected?.supports_discovery;
   // Once discovery has surfaced items, we hide the config fields and
   // show only the picker — operators expect the form to advance.
@@ -195,6 +213,7 @@ function AddImporterForm({
     setName("");
     setDiscovered(null);
     setPicked(new Set());
+    setUseWorkspaceIntegration(true);
     setError(null);
   }
 
@@ -220,13 +239,15 @@ function AddImporterForm({
         message: `Missing required field(s): ${missing.join(", ")}.`,
       };
     }
-    const missingSecrets = selected.secret_keys.filter((k) => !secrets[k]);
-    if (missingSecrets.length > 0) {
-      return {
-        ok: false,
-        config,
-        message: `Missing required secret(s): ${missingSecrets.join(", ")}.`,
-      };
+    if (!useIntegration) {
+      const missingSecrets = selected.secret_keys.filter((k) => !secrets[k]);
+      if (missingSecrets.length > 0) {
+        return {
+          ok: false,
+          config,
+          message: `Missing required secret(s): ${missingSecrets.join(", ")}.`,
+        };
+      }
     }
     return { ok: true, config };
   }
@@ -242,7 +263,11 @@ function AddImporterForm({
       const result = await discoverItemsAction({
         type: selected!.type,
         config: check.config,
-        secrets: Object.keys(secrets).length > 0 ? secrets : undefined,
+        secrets:
+          !useIntegration && Object.keys(secrets).length > 0
+            ? secrets
+            : undefined,
+        use_workspace_integration: useIntegration ? true : undefined,
       });
       if (!result.ok) {
         setError(result.message);
@@ -287,7 +312,11 @@ function AddImporterForm({
         type: selected.type,
         name: name.trim(),
         config,
-        secrets: Object.keys(secrets).length > 0 ? secrets : undefined,
+        secrets:
+          !useIntegration && Object.keys(secrets).length > 0
+            ? secrets
+            : undefined,
+        use_workspace_integration: useIntegration ? true : undefined,
       });
       if (!result.ok) {
         setError(result.message);
@@ -338,8 +367,34 @@ function AddImporterForm({
           {selected.description && (
             <p className="text-xs text-white/55">{selected.description}</p>
           )}
-          {Object.entries(selected.config_schema?.properties ?? {}).map(
-            ([key, prop]) => (
+          {integration && (
+            <label className="flex items-start gap-2 rounded border border-aqua/20 bg-aqua/[0.05] p-2 text-xs">
+              <input
+                type="checkbox"
+                checked={useWorkspaceIntegration}
+                onChange={(e) =>
+                  setUseWorkspaceIntegration(e.target.checked)
+                }
+                className="mt-0.5"
+              />
+              <span className="text-white/75">
+                Use workspace{" "}
+                <span className="text-aqua">{integration.provider}</span>
+                {" "}integration
+                {integration.account_name
+                  ? ` (${integration.account_name})`
+                  : ""}
+                . Ship resolves the token server-side — the secret never
+                leaves the backend.
+              </span>
+            </label>
+          )}
+          {Object.entries(selected.config_schema?.properties ?? {})
+            // Hide schema entries that match a secret key — those are
+            // rendered as dedicated password inputs below (or skipped
+            // entirely when the workspace integration fills them).
+            .filter(([key]) => !selected.secret_keys.includes(key))
+            .map(([key, prop]) => (
               <SchemaField
                 key={key}
                 name={key}
@@ -348,20 +403,20 @@ function AddImporterForm({
                 value={configValues[key] ?? ""}
                 onChange={(v) => setConfig(key, v)}
               />
-            ),
-          )}
-          {selected.secret_keys.map((key) => (
-            <label key={key} className="block space-y-1 text-xs">
-              <span className="text-white/60">{key} (secret)</span>
-              <input
-                type="password"
-                value={secrets[key] ?? ""}
-                onChange={(e) => setSecret(key, e.target.value)}
-                autoComplete="off"
-                className="w-full rounded border border-white/10 bg-white/[0.04] px-2 py-1.5 text-sm text-white outline-none focus:border-aqua/60"
-              />
-            </label>
-          ))}
+            ))}
+          {!useIntegration &&
+            selected.secret_keys.map((key) => (
+              <label key={key} className="block space-y-1 text-xs">
+                <span className="text-white/60">{key} (secret)</span>
+                <input
+                  type="password"
+                  value={secrets[key] ?? ""}
+                  onChange={(e) => setSecret(key, e.target.value)}
+                  autoComplete="off"
+                  className="w-full rounded border border-white/10 bg-white/[0.04] px-2 py-1.5 text-sm text-white outline-none focus:border-aqua/60"
+                />
+              </label>
+            ))}
           {needsDiscovery && (
             <p className="text-[11px] text-white/45">
               Click <span className="text-white/70">Preview items</span> to

--- a/apps/console/src/app/(authed)/knowledge/knowledge-control-center.tsx
+++ b/apps/console/src/app/(authed)/knowledge/knowledge-control-center.tsx
@@ -24,6 +24,7 @@ import type {
   ApiKnowledgeSearchHit,
   ApiKnowledgeSearchResponse,
   ApiWorkspaceImporter,
+  ApiWorkspaceImporterIntegration,
 } from "@/lib/api/client";
 
 import { ImportersPanel } from "./importers-panel";
@@ -34,6 +35,7 @@ type Props = {
   corpus: ApiKnowledgeCorpus | null;
   importers: ApiWorkspaceImporter[];
   importerTypes: ApiImporterType[];
+  importerIntegrations: ApiWorkspaceImporterIntegration[];
 };
 
 
@@ -42,6 +44,7 @@ export function KnowledgeControlCenter({
   corpus,
   importers,
   importerTypes,
+  importerIntegrations,
 }: Props) {
   const [query, setQuery] = useState("");
   const [searchHits, setSearchHits] = useState<ApiKnowledgeSearchHit[] | null>(null);
@@ -112,6 +115,7 @@ export function KnowledgeControlCenter({
       <ImportersPanel
         importers={importers}
         importerTypes={importerTypes}
+        integrations={importerIntegrations}
       />
 
       {pending && <p className="text-xs text-white/45">Searching…</p>}

--- a/apps/console/src/app/(authed)/knowledge/page.tsx
+++ b/apps/console/src/app/(authed)/knowledge/page.tsx
@@ -8,10 +8,12 @@ import {
   type ApiImporterType,
   type ApiKnowledgeCorpus,
   type ApiWorkspaceImporter,
+  type ApiWorkspaceImporterIntegration,
   ApiHttpError,
   getWorkspaceCorpus,
   listActivatedRepos,
   listImporterTypes,
+  listWorkspaceImporterIntegrations,
   listWorkspaceImporters,
 } from "@/lib/api/client";
 import {
@@ -32,6 +34,7 @@ type LiveData = {
   corpus: ApiKnowledgeCorpus | null;
   importers: ApiWorkspaceImporter[];
   importerTypes: ApiImporterType[];
+  importerIntegrations: ApiWorkspaceImporterIntegration[];
   me: Awaited<ReturnType<typeof getCachedMe>>;
 };
 
@@ -55,7 +58,14 @@ async function load(
   const workspace = pickWorkspace(workspaceRows, resolved);
 
   try {
-    const [repos, me, corpus, importers, importerTypes] = await Promise.all([
+    const [
+      repos,
+      me,
+      corpus,
+      importers,
+      importerTypes,
+      importerIntegrations,
+    ] = await Promise.all([
       listActivatedRepos(workspace.id, token).catch(() => [] as ApiActivatedRepo[]),
       getCachedMe(),
       getWorkspaceCorpus(workspace.id, token).catch(
@@ -67,6 +77,10 @@ async function load(
       ),
       listImporterTypes(workspace.id, token).catch(
         () => [] as ApiImporterType[],
+      ),
+      // Auto-resolvable workspace integrations (GitHub App, Notion / Linear).
+      listWorkspaceImporterIntegrations(workspace.id, token).catch(
+        () => [] as ApiWorkspaceImporterIntegration[],
       ),
     ]);
 
@@ -82,6 +96,7 @@ async function load(
         corpus,
         importers,
         importerTypes,
+        importerIntegrations,
         me,
       },
     };
@@ -114,7 +129,15 @@ export default async function KnowledgeIndexPage({
     );
   }
 
-  const { workspace, repos, corpus, importers, importerTypes, me } = result.data;
+  const {
+    workspace,
+    repos,
+    corpus,
+    importers,
+    importerTypes,
+    importerIntegrations,
+    me,
+  } = result.data;
 
   const scopePill = (
     <ScopePill
@@ -144,6 +167,7 @@ export default async function KnowledgeIndexPage({
           corpus={corpus}
           importers={importers}
           importerTypes={importerTypes}
+          importerIntegrations={importerIntegrations}
         />
       </PageBody>
     </>

--- a/apps/console/src/lib/api/client.ts
+++ b/apps/console/src/lib/api/client.ts
@@ -3230,7 +3230,25 @@ export type ApiImporterCreateBody = {
   recipe?: string;
   config: Record<string, unknown>;
   secrets?: Record<string, string>;
+  use_workspace_integration?: boolean;
 };
+
+export type ApiWorkspaceImporterIntegration = {
+  importer_type: string;
+  provider: string;
+  account_name: string | null;
+  account_url: string | null;
+};
+
+export async function listWorkspaceImporterIntegrations(
+  workspaceId: string,
+  token?: string,
+): Promise<ApiWorkspaceImporterIntegration[]> {
+  return apiFetch<ApiWorkspaceImporterIntegration[]>(
+    `/v1/workspaces/${workspaceId}/knowledge/importers/integrations`,
+    { token },
+  );
+}
 
 export async function listImporterTypes(
   workspaceId: string,
@@ -3277,6 +3295,7 @@ export async function discoverImporterItems(
     type: string;
     config: Record<string, unknown>;
     secrets?: Record<string, string>;
+    use_workspace_integration?: boolean;
   },
   token?: string,
 ): Promise<ApiImporterDiscoveredItem[]> {


### PR DESCRIPTION
## Summary
For importer types that map to a Ship integration the workspace already has wired (GitHub App, Notion OAuth, Linear OAuth), the operator no longer pastes a token. Ship resolves the secret server-side and forwards to Lighthouse — the browser never sees it.

### Mapping today
| Importer type | Source |
|---|---|
| `github_repo`, `github_releases` | GitHub App installation token (minted JIT via `fetch_installation_token`) |
| `notion` | Notion OAuth `access_token` (decrypted from `NativeIntegrationCredential`) |
| `linear` | Linear OAuth `access_token` (decrypted from `NativeIntegrationCredential`) |

Extends naturally — add a branch in `secrets_resolver.py::resolve_workspace_importer_secrets` per new provider.

### Backend
- New `integrations/lighthouse/secrets_resolver.py` with `list_workspace_importer_integrations` + `resolve_workspace_importer_secrets`.
- `GET /v1/workspaces/{ws}/knowledge/importers/integrations` surfaces what's auto-resolvable.
- `ImporterCreateIn` + `ImporterDiscoverIn` accept `use_workspace_integration: bool`. When true, Ship merges resolved secrets under operator-supplied ones (explicit values still override). 400 `no_workspace_integration` if there's nothing to resolve.

### Console
- Page fetches integrations alongside types/importers/corpus.
- `AddImporterForm`: when the selected type has an available integration, shows a checkbox **"Use workspace `<provider>` integration (`<account>`)"** (default ON), hides the secret inputs, submits with `use_workspace_integration: true`. Unchecking falls back to manual token entry.
- Side fix: secret keys are now filtered out of the config-schema rendering — they were rendering twice (once as text, once as password) for types like `asana`/`trello`.

## Test plan
- [x] `tsc --noEmit` clean, `vitest run` 47 passed
- [x] Backend lighthouse/knowledge pytest — 15 passed
- [x] ruff clean on touched backend files
- [ ] Browser: pick `github_repo` — checkbox appears with current account; click Preview → repo list comes back without typing a token; pick + submit → importer created and run queued
- [ ] Browser: uncheck the integration checkbox → secret inputs return; manual flow unchanged