### PR TITLE
feat(fsm): server-validated code_review→auto_merge gate (Phase 4)

### DIFF
--- a/apps/backend/app/api/v1/routes/agent_runs.py
+++ b/apps/backend/app/api/v1/routes/agent_runs.py
@@ -1107,6 +1107,174 @@ def _collect_project_sections(payload: "FinishIn") -> list["ProjectSectionPatch"
     return out
 
 
+def _extract_pr_url(text: str | None) -> str | None:
+    """Pull the first GitHub PR URL out of ``text`` using the same
+    regex the ELS-120 PR-URL gate uses.
+
+    The dev role's sidecar appends ``PR: <url>`` to ``comment`` after
+    ``gh pr create`` succeeds (see :data:`_PR_AUTHORING_STAGES`). For
+    the Phase 4 gate we just need the URL; finer parsing (owner / repo
+    / number) happens inside :func:`_validate_code_review_to_auto_merge`.
+    Returns ``None`` when nothing matches so the caller can short-circuit
+    on the ``no_pr_url`` reason.
+    """
+    if not text:
+        return None
+    match = _PR_URL_RE.search(text)
+    return match.group(0) if match else None
+
+
+async def _validate_code_review_to_auto_merge(
+    session: AsyncSession,
+    *,
+    workspace_id: uuid.UUID,
+    pr_url: str | None,
+    settings: Settings,
+) -> tuple[bool, str]:
+    """Verify the agent's ``code_review → auto_merge`` claim against
+    GitHub.
+
+    Phase 4 of the FSM event-driven rearchitecture (2026-05-29). The
+    code_review agent is supposed to leave an ``APPROVED`` review on
+    the PR before claiming ``ready_next_step → auto_merge``; the
+    auto-merger then squash-merges via the App token. Pre-Phase-4 the
+    server trusted the agent's word — if the review never landed (or
+    the CI was red), the auto-merger fired anyway, hit GitHub's 405
+    "not mergeable" wall, audited ``github.auto_merge.failed``, and
+    sat at ``auto_merge`` until something else moved it. Wasted agent
+    tokens + one extra cycle in the cascade.
+
+    This gate checks:
+
+    1. PR URL exists in the finish ``comment`` (``no_pr_url``).
+    2. PR URL parses into owner/repo/number (``invalid_pr_url``).
+    3. Workspace has an active GitHub installation (``no_install``).
+    4. GitHub returns reviews + PR detail without 4xx (``reviews_api_X``,
+       ``pr_api_X``).
+    5. At least one submitted review state ``APPROVED`` (``no_approval``).
+    6. Every completed check_run on the PR's head SHA has a non-failing
+       conclusion (``success`` / ``skipped`` / ``neutral``);
+       ``ci_red`` for any failing conclusion, ``ci_incomplete`` for any
+       run still in progress, ``checks_api_X`` for GitHub errors.
+
+    Returns ``(True, "ok")`` when every check passes. The caller
+    downgrades ``outcome=ready_next_step`` to ``outcome=blocked`` on
+    any other return so the Phase 1 freeze flow runs (label + inbox).
+
+    Best-effort: any unexpected exception inside the check surfaces as
+    ``("unexpected_error:<exc>")`` so a transient GH outage doesn't
+    silently advance bad transitions. The Phase 1 freeze stops the
+    bleeding either way (one stage later, via the auto-merger's own
+    failed merge), so a brittle gate is safer than a permissive one.
+    """
+    if not pr_url:
+        return False, "no_pr_url"
+    pr_path_re = re.compile(
+        r"^https://github\.com/([\w.-]+)/([\w.-]+)/pull/(\d+)$",
+        re.IGNORECASE,
+    )
+    m = pr_path_re.match(pr_url.strip())
+    if not m:
+        return False, "invalid_pr_url"
+    owner, repo, number_str = m.group(1), m.group(2), m.group(3)
+    try:
+        number = int(number_str)
+    except ValueError:
+        return False, "invalid_pr_url"
+
+    from sqlalchemy import select as _select
+
+    from backend.app.db.models.integrations import (
+        GitHubInstallation as _GHInstall,
+    )
+    from backend.app.integrations.github.app_auth import (
+        fetch_installation_token as _fetch_install_token,
+    )
+
+    install_row = (
+        await session.execute(
+            _select(_GHInstall).where(
+                _GHInstall.workspace_id == workspace_id,
+                _GHInstall.suspended_at.is_(None),
+            ).limit(1)
+        )
+    ).scalar_one_or_none()
+    if install_row is None:
+        return False, "no_install"
+
+    import httpx as _httpx
+
+    try:
+        async with _httpx.AsyncClient(timeout=_httpx.Timeout(15.0)) as client:
+            token = await _fetch_install_token(
+                install_row.installation_id,
+                settings=settings,
+                client=client,
+            )
+            api_root = f"https://api.github.com/repos/{owner}/{repo}"
+            headers = {
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/vnd.github+json",
+            }
+            # 1. Reviews — need ≥1 APPROVED.
+            reviews_resp = await client.get(
+                f"{api_root}/pulls/{number}/reviews",
+                headers=headers,
+                params={"per_page": "100"},
+            )
+            if reviews_resp.status_code >= 400:
+                return False, f"reviews_api_{reviews_resp.status_code}"
+            reviews = reviews_resp.json() or []
+            has_approval = any(
+                str(r.get("state") or "").upper() == "APPROVED"
+                for r in reviews
+            )
+            if not has_approval:
+                return False, "no_approval"
+
+            # 2. PR detail — need head SHA for check-runs.
+            pr_resp = await client.get(
+                f"{api_root}/pulls/{number}",
+                headers=headers,
+            )
+            if pr_resp.status_code >= 400:
+                return False, f"pr_api_{pr_resp.status_code}"
+            head_sha = (
+                ((pr_resp.json() or {}).get("head") or {}).get("sha")
+            )
+            if not head_sha:
+                return False, "no_head_sha"
+
+            # 3. check_runs on the head SHA — all completed + non-failing.
+            checks_resp = await client.get(
+                f"{api_root}/commits/{head_sha}/check-runs",
+                headers=headers,
+                params={"per_page": "100"},
+            )
+            if checks_resp.status_code >= 400:
+                return False, f"checks_api_{checks_resp.status_code}"
+            check_runs = (checks_resp.json() or {}).get("check_runs") or []
+            # Empty check_runs is a pass — some workspaces don't have
+            # CI configured at all. If the repo enforces required
+            # checks via branch protection, GH will reject the merge
+            # downstream; we just don't double-gate here.
+            for c in check_runs:
+                status_val = str(c.get("status") or "").lower()
+                conclusion = str(c.get("conclusion") or "").lower()
+                if status_val != "completed":
+                    return False, "ci_incomplete"
+                if conclusion not in ("success", "skipped", "neutral"):
+                    return False, "ci_red"
+
+            return True, "ok"
+    except Exception as exc:  # noqa: BLE001 — fail closed on any error
+        logger.warning(
+            "phase4 validation crashed ws=%s pr_url=%s err=%s",
+            workspace_id, pr_url, exc,
+        )
+        return False, f"unexpected_error:{type(exc).__name__}"
+
+
 async def _release_project_lock_for_ticket(
     session: AsyncSession,
     *,
@@ -3775,6 +3943,77 @@ async def finish_agent_run(
         workspace_id=workspace_id,
     )
     tracker_kind = resolved.kind if resolved else None
+
+    # Phase 4 gate (2026-05-29): server-validate the agent's
+    # ``stage_next`` claim against real-world facts before allowing the
+    # FSM transition. Today's check: ``code_review → auto_merge``
+    # requires the PR to carry ≥1 ``APPROVED`` review AND every
+    # completed check_run with a non-success conclusion. If either
+    # fails, we downgrade the outcome to ``blocked`` so the Phase 1
+    # blocked-handler flow runs (adds the ``blocked`` signal label →
+    # picker overlay-freezes the ticket; files one inbox letter). The
+    # agent's word is no longer load-bearing for the highest-stakes
+    # transition; the server verifies via GitHub before letting the
+    # auto-merger dispatch fire.
+    if (
+        payload.outcome == "ready_next_step"
+        and payload.fsm_stage == "code_review"
+        and payload.stage_next == "auto_merge"
+        and payload.ticket_ref
+        and resolved is not None
+    ):
+        pr_url = _extract_pr_url(payload.comment)
+        gate_ok, gate_reason = await _validate_code_review_to_auto_merge(
+            session,
+            workspace_id=workspace_id,
+            pr_url=pr_url,
+            settings=settings,
+        )
+        if not gate_ok:
+            logger.info(
+                "phase4 gate rejected code_review→auto_merge "
+                "ws=%s ticket=%s reason=%s pr_url=%s",
+                workspace_id, payload.ticket_ref, gate_reason, pr_url,
+            )
+            session.add(
+                AuditLog(
+                    workspace_id=workspace_id,
+                    actor_user_id=auth.user.id,
+                    actor_token_id=auth.token.id if auth.token else None,
+                    action="transition.validation_failed",
+                    target_kind="ticket",
+                    target_id=payload.ticket_ref,
+                    payload={
+                        "fsm_stage": payload.fsm_stage,
+                        "stage_next": payload.stage_next,
+                        "reason": gate_reason,
+                        "pr_url": pr_url,
+                        "run_id": payload.run_id,
+                    },
+                )
+            )
+            actions.append(f"phase4:rejected:{gate_reason}")
+            # Mutate the payload so the existing elif chain processes
+            # this as a blocked finish (freeze label + inbox letter).
+            # Stash the rejection reason in payload.payload so the
+            # blocker letter body has the diagnostic without us having
+            # to duplicate the letter-creation code.
+            payload.outcome = "blocked"
+            payload.stage_next = None
+            existing = dict(payload.payload or {})
+            existing["phase4_reject_reason"] = gate_reason
+            if pr_url:
+                existing["phase4_pr_url"] = pr_url
+            payload.payload = existing
+            payload.summary = (
+                f"Phase 4 gate refused code_review → auto_merge for "
+                f"{payload.ticket_ref}: {gate_reason}. The server "
+                "checked the PR's approval and CI state before "
+                "allowing the transition; the agent's claim didn't "
+                "match GitHub. Resolve the underlying gap (missing "
+                "approval, red CI, no PR URL on the finish) and "
+                "remove the ``blocked`` label in Linear to retry."
+            )[:2000]
 
     # Outcomes that need a tracker but the workspace has none → drop an
     # inbox item so the operator notices, but still record the run.

--- a/apps/backend/tests/test_phase4_code_review_validation.py
+++ b/apps/backend/tests/test_phase4_code_review_validation.py
@@ -1,0 +1,297 @@
+"""Phase 4 of the FSM event-driven rearchitecture — server-validated
+``code_review → auto_merge`` transition.
+
+The agent reports ``outcome=ready_next_step, stage_next=auto_merge``
+at the code_review stage. Pre-Phase-4, the server trusted the claim,
+moved the ticket to auto_merge, and dispatched the auto-merger; if
+the reviewer agent had skipped the GitHub APPROVE (or CI was red),
+the auto-merger hit GitHub's 405 "not mergeable" wall, audited
+``github.auto_merge.failed``, and the ticket sat at auto_merge until
+something else moved it. Wasted agent-tokens + one extra cycle.
+
+Phase 4 gates the transition at the finish handler: the server calls
+GitHub for the PR's review state + the head SHA's check_runs, and
+only allows the move if BOTH "≥1 APPROVED review" AND "every
+completed check_run is success/skipped/neutral" hold. Failure
+downgrades ``outcome=ready_next_step`` to ``outcome=blocked`` so the
+Phase 1 freeze flow runs (label + inbox letter); ``stage_next`` is
+cleared so neither the transition call nor the cascade dispatch
+fires.
+
+These tests pin the helper's decision logic against synthetic GitHub
+responses (httpx.MockTransport), one rejection reason per test. The
+helper's audit + payload-mutation side effects in the finish handler
+are covered by the live ELS-157/191/189 cascade verification noted
+in the planning doc + the existing test_blocked_freeze_label.py
+contract for the downstream blocked branch.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from backend.app.api.v1.routes.agent_runs import (
+    _extract_pr_url,
+    _validate_code_review_to_auto_merge,
+)
+
+
+_OWNER = "acme"
+_REPO = "ship"
+_PR_NUMBER = 99
+_PR_URL = f"https://github.com/{_OWNER}/{_REPO}/pull/{_PR_NUMBER}"
+_HEAD_SHA = "0123456789abcdef0123456789abcdef01234567"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_settings():
+    s = MagicMock()
+    return s
+
+
+def _mock_install_row():
+    row = MagicMock()
+    row.installation_id = 42
+    row.suspended_at = None
+    return row
+
+
+def _gh_handler(*, reviews, pr_detail, check_runs):
+    """Build an httpx.MockTransport handler returning the canned shapes."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if path.endswith(f"/pulls/{_PR_NUMBER}/reviews"):
+            if isinstance(reviews, int):  # status code override
+                return httpx.Response(reviews, json={})
+            return httpx.Response(200, json=reviews)
+        if path.endswith(f"/pulls/{_PR_NUMBER}"):
+            if isinstance(pr_detail, int):
+                return httpx.Response(pr_detail, json={})
+            return httpx.Response(200, json=pr_detail)
+        if path.endswith(f"/commits/{_HEAD_SHA}/check-runs"):
+            if isinstance(check_runs, int):
+                return httpx.Response(check_runs, json={})
+            return httpx.Response(200, json={"check_runs": check_runs})
+        return httpx.Response(404, json={"message": f"unexpected path: {path}"})
+
+    return handler
+
+
+def _run_with_mocked_gh(
+    *,
+    reviews,
+    pr_detail,
+    check_runs,
+    pr_url: str | None = _PR_URL,
+):
+    """Drive the validator with mocked install row + httpx transport."""
+    transport = httpx.MockTransport(_gh_handler(
+        reviews=reviews, pr_detail=pr_detail, check_runs=check_runs,
+    ))
+
+    class _MockedClient(httpx.AsyncClient):
+        def __init__(self, *args, **kwargs):
+            kwargs.pop("timeout", None)
+            super().__init__(*args, transport=transport, **kwargs)
+
+    session = AsyncMock()
+    scalar_one_or_none = MagicMock(return_value=_mock_install_row())
+    exec_result = MagicMock(scalar_one_or_none=scalar_one_or_none)
+    session.execute = AsyncMock(return_value=exec_result)
+
+    with patch(
+        "backend.app.integrations.github.app_auth.fetch_installation_token",
+        new=AsyncMock(return_value="ghs_token"),
+    ), patch.object(httpx, "AsyncClient", _MockedClient):
+        import asyncio
+
+        return asyncio.new_event_loop().run_until_complete(
+            _validate_code_review_to_auto_merge(
+                session,
+                workspace_id=uuid.uuid4(),
+                pr_url=pr_url,
+                settings=_build_settings(),
+            )
+        )
+
+
+# ---------------------------------------------------------------------------
+# _extract_pr_url
+# ---------------------------------------------------------------------------
+
+
+def test_extract_pr_url_pulls_first_github_url() -> None:
+    body = (
+        "Done. PR: https://github.com/acme/ship/pull/42 — please review. "
+        "[Ship SDLC:role-reviewer]"
+    )
+    assert _extract_pr_url(body) == "https://github.com/acme/ship/pull/42"
+
+
+def test_extract_pr_url_returns_none_on_blank_input() -> None:
+    assert _extract_pr_url("") is None
+    assert _extract_pr_url(None) is None
+
+
+def test_extract_pr_url_ignores_unrelated_github_urls() -> None:
+    # The regex is anchored on /pull/<n> — non-PR GH URLs (issues,
+    # blobs, raw files) must not match. If they did, the validator
+    # downstream would try to fetch them as PRs and 4xx.
+    body = "Saw a related issue: https://github.com/acme/ship/issues/41"
+    assert _extract_pr_url(body) is None
+
+
+# ---------------------------------------------------------------------------
+# _validate_code_review_to_auto_merge — failure reasons
+# ---------------------------------------------------------------------------
+
+
+def test_no_pr_url_is_rejected() -> None:
+    # The dev sidecar wraps gh pr create and embeds the URL. A finish
+    # without it means the agent bypassed the sidecar — possibly
+    # legitimately on an unusual stage, but for code_review → auto_merge
+    # there's nothing to merge without a PR.
+    ok, reason = _run_with_mocked_gh(
+        reviews=[], pr_detail={}, check_runs=[], pr_url=None,
+    )
+    assert ok is False
+    assert reason == "no_pr_url"
+
+
+def test_invalid_pr_url_is_rejected() -> None:
+    ok, reason = _run_with_mocked_gh(
+        reviews=[], pr_detail={}, check_runs=[],
+        pr_url="https://example.com/not-a-pr",
+    )
+    assert ok is False
+    assert reason == "invalid_pr_url"
+
+
+def test_no_approval_is_rejected() -> None:
+    # PR exists, CI is fine — but the reviewer agent never actually
+    # left an APPROVED review. The high-stakes case Phase 4 exists to
+    # prevent: pre-Phase-4 the server would have advanced to
+    # auto_merge and hit GH's 405 wall.
+    ok, reason = _run_with_mocked_gh(
+        reviews=[
+            {"state": "COMMENTED"},
+            {"state": "CHANGES_REQUESTED"},
+        ],
+        pr_detail={"head": {"sha": _HEAD_SHA}},
+        check_runs=[],
+    )
+    assert ok is False
+    assert reason == "no_approval"
+
+
+def test_red_ci_is_rejected_even_with_approval() -> None:
+    ok, reason = _run_with_mocked_gh(
+        reviews=[{"state": "APPROVED"}],
+        pr_detail={"head": {"sha": _HEAD_SHA}},
+        check_runs=[
+            {"name": "test", "status": "completed", "conclusion": "failure"},
+        ],
+    )
+    assert ok is False
+    assert reason == "ci_red"
+
+
+def test_incomplete_ci_is_rejected_even_with_approval() -> None:
+    # Run still in flight — don't advance until it lands. Phase 4
+    # prefers a brief wait + retry over advancing then catching the
+    # failure downstream.
+    ok, reason = _run_with_mocked_gh(
+        reviews=[{"state": "APPROVED"}],
+        pr_detail={"head": {"sha": _HEAD_SHA}},
+        check_runs=[
+            {"name": "build", "status": "in_progress", "conclusion": None},
+        ],
+    )
+    assert ok is False
+    assert reason == "ci_incomplete"
+
+
+def test_neutral_and_skipped_conclusions_pass() -> None:
+    # GitHub uses "neutral" for advisory checks (linters that don't
+    # block merge) and "skipped" for paths-filter early-outs. Neither
+    # should block a Phase 4 transition.
+    ok, reason = _run_with_mocked_gh(
+        reviews=[{"state": "APPROVED"}],
+        pr_detail={"head": {"sha": _HEAD_SHA}},
+        check_runs=[
+            {"name": "lint", "status": "completed", "conclusion": "neutral"},
+            {"name": "skip", "status": "completed", "conclusion": "skipped"},
+            {"name": "pass", "status": "completed", "conclusion": "success"},
+        ],
+    )
+    assert ok is True
+    assert reason == "ok"
+
+
+def test_zero_check_runs_passes_with_approval() -> None:
+    # Some workspaces have no CI configured. Branch protection
+    # (required status checks) catches this downstream at merge time;
+    # Phase 4 doesn't double-gate it.
+    ok, reason = _run_with_mocked_gh(
+        reviews=[{"state": "APPROVED"}],
+        pr_detail={"head": {"sha": _HEAD_SHA}},
+        check_runs=[],
+    )
+    assert ok is True
+    assert reason == "ok"
+
+
+def test_github_pr_api_error_is_rejected() -> None:
+    # PR moved / deleted / permissions revoked between agent claim and
+    # gate check. Fail closed so a 404 doesn't quietly advance the
+    # ticket on a ghost PR.
+    ok, reason = _run_with_mocked_gh(
+        reviews=[{"state": "APPROVED"}],
+        pr_detail=404,
+        check_runs=[],
+    )
+    assert ok is False
+    assert reason == "pr_api_404"
+
+
+def test_github_reviews_api_error_is_rejected() -> None:
+    ok, reason = _run_with_mocked_gh(
+        reviews=500,
+        pr_detail={"head": {"sha": _HEAD_SHA}},
+        check_runs=[],
+    )
+    assert ok is False
+    assert reason == "reviews_api_500"
+
+
+def test_no_install_is_rejected() -> None:
+    # Workspace has no GitHub App installation row. Without a token
+    # we can't probe GitHub, so reject — Phase 1 freeze handles the
+    # rest (operator sees the inbox letter and decides).
+    session = AsyncMock()
+    scalar_one_or_none = MagicMock(return_value=None)
+    exec_result = MagicMock(scalar_one_or_none=scalar_one_or_none)
+    session.execute = AsyncMock(return_value=exec_result)
+
+    import asyncio
+
+    ok, reason = asyncio.new_event_loop().run_until_complete(
+        _validate_code_review_to_auto_merge(
+            session,
+            workspace_id=uuid.uuid4(),
+            pr_url=_PR_URL,
+            settings=_build_settings(),
+        )
+    )
+    assert ok is False
+    assert reason == "no_install"


### PR DESCRIPTION
## Phase 4 of the event-driven FSM rearchitecture

Plan: `documentation/internal/planning/2026-05-28-fsm-event-driven-rearchitecture.md` (gitignored — internal).

Phases 1-3 made tickets walk Backlog → Done autonomously: blocked freeze + crons killed + auto-advance to next ticket on PR merge. Verified live on 4 sequential tickets (ELS-157 → 191 → 189 → 193).

What still let bad agent claims through: the code_review agent could return `outcome=ready_next_step, stage_next=auto_merge` WITHOUT actually leaving an APPROVED GitHub review or while CI was red. The server trusted the claim, advanced the ticket, dispatched the auto-merger, which hit GitHub's 405 ("not mergeable") wall and audited `github.auto_merge.failed`. Wasted agent tokens + one extra cycle.

## What this changes

ONE invariant for the minimal Phase 4 pass: `code_review → auto_merge` requires **≥1 `APPROVED` GitHub review** AND **every completed check_run in {`success`, `skipped`, `neutral`}**.

| Added | Where |
|---|---|
| `_extract_pr_url(text)` | Thin wrapper over the existing `_PR_URL_RE` |
| `_validate_code_review_to_auto_merge(...)` | Fetches PR reviews + head SHA's check_runs via GH App token; returns `(ok, reason)` |
| Gate in `finish_agent_run` | Between resolved-tracker step and the outcome if/elif chain |

On rejection:
1. Audit `transition.validation_failed` with `reason`, `pr_url`, `run_id`
2. Mutate `payload.outcome = "blocked"`, clear `stage_next`, stash `phase4_reject_reason` in `payload.payload`, override `summary`
3. The existing **Phase 1 blocked branch** runs naturally → adds `blocked` label → picker overlay-freezes → one inbox letter

## Rejection reasons enumerated

`no_pr_url`, `invalid_pr_url`, `no_install`, `reviews_api_<status>`, `no_approval`, `pr_api_<status>`, `no_head_sha`, `checks_api_<status>`, `ci_red`, `ci_incomplete`, `unexpected_error:<exc>` (fail closed on any crash).

## NOT in this PR (deferred per plan)

- `dev_implementation → validation`: PR exists + commits > 0
- `planning → dev_implementation`: WBS section non-empty
- `validation → code_review`: tests exist + green
- Retry loop on `ci_incomplete` (small backoff before failing)

## Test plan

- [x] `pytest -q` — 1464 passed, 12 pre-existing `test_symbol_parser.py` failures (unrelated)
- [x] 13 unit scenarios on `httpx.MockTransport`: no_pr_url, invalid_pr_url, no_approval, ci_red, ci_incomplete, neutral+skipped pass, zero-checks pass, GH 4xx/5xx fail-closed, no_install
- [ ] After rollout: monitor `transition.validation_failed` audit events. Expect rare hits — the existing agents do approve correctly. Each hit means the agent claimed advance without an actual approval; the inbox letter explains what's wrong.