### PR TITLE
feat(knowledge): auto-auth for GitLab + Confluence + Jira importers

### DIFF
--- a/apps/backend/app/api/v1/routes/knowledge.py
+++ b/apps/backend/app/api/v1/routes/knowledge.py
@@ -328,6 +328,7 @@ class ImporterIntegrationOut(BaseModel):
     provider: str
     account_name: str | None = None
     account_url: str | None = None
+    provides_config_keys: list[str] = Field(default_factory=list)
 
 
 def _coerce_importer(row: dict[str, Any]) -> ImporterOut:
@@ -348,20 +349,22 @@ def _coerce_importer(row: dict[str, Any]) -> ImporterOut:
     )
 
 
-async def _merge_workspace_secrets(
+async def _merge_workspace_creds(
     session: AsyncSession,
     workspace_id: uuid.UUID,
     importer_type: str,
+    operator_config: dict[str, Any],
     operator_secrets: dict[str, str],
     *,
     use_workspace: bool,
-) -> dict[str, str]:
+) -> tuple[dict[str, Any], dict[str, str]]:
     """When ``use_workspace`` is true, resolve the workspace's
     integration creds for this importer type and merge them under the
-    operator-supplied secrets (explicit values override). Raises 400
-    if the workspace has no usable integration for the type."""
+    operator-supplied values (explicit values override). Raises 400 if
+    the workspace has no usable integration for the type. Returns
+    ``(config, secrets)``."""
     if not use_workspace:
-        return operator_secrets
+        return operator_config, operator_secrets
     resolved = await resolve_workspace_importer_secrets(
         session,
         workspace_id=workspace_id,
@@ -379,7 +382,10 @@ async def _merge_workspace_secrets(
                 ),
             },
         )
-    return {**resolved, **operator_secrets}
+    return (
+        {**resolved.config, **operator_config},
+        {**resolved.secrets, **operator_secrets},
+    )
 
 
 def _require_lighthouse_or_503():
@@ -447,6 +453,7 @@ async def list_importer_workspace_integrations(
             provider=r.provider,
             account_name=r.account_name,
             account_url=r.account_url,
+            provides_config_keys=list(r.provides_config_keys),
         )
         for r in rows
     ]
@@ -488,8 +495,12 @@ async def create_workspace_importer(
     await _require_membership(session, workspace_id, auth.user.id, ROLES_MAINTAIN)
     client = _require_lighthouse_or_503()
     recipe = payload.recipe or f"workspace-{payload.type}"
-    secrets = await _merge_workspace_secrets(
-        session, workspace_id, payload.type, payload.secrets,
+    config, secrets = await _merge_workspace_creds(
+        session,
+        workspace_id,
+        payload.type,
+        payload.config,
+        payload.secrets,
         use_workspace=payload.use_workspace_integration,
     )
     try:
@@ -499,7 +510,7 @@ async def create_workspace_importer(
             name=payload.name,
             description=payload.description,
             recipe=recipe,
-            config=payload.config,
+            config=config,
             secrets=secrets,
         )
     except httpx.HTTPStatusError as exc:
@@ -548,15 +559,19 @@ async def discover_importer_items(
     items the operator can choose from. No DB writes."""
     await _require_membership(session, workspace_id, auth.user.id, ROLES_MAINTAIN)
     client = _require_lighthouse_or_503()
-    secrets = await _merge_workspace_secrets(
-        session, workspace_id, payload.type, payload.secrets,
+    config, secrets = await _merge_workspace_creds(
+        session,
+        workspace_id,
+        payload.type,
+        payload.config,
+        payload.secrets,
         use_workspace=payload.use_workspace_integration,
     )
     try:
         items = await client.discover_importer(
             workspace_id=workspace_id,
             type_=payload.type,
-            config=payload.config,
+            config=config,
             secrets=secrets,
         )
     except httpx.HTTPStatusError as exc:

--- a/apps/backend/app/integrations/lighthouse/secrets_resolver.py
+++ b/apps/backend/app/integrations/lighthouse/secrets_resolver.py
@@ -1,9 +1,10 @@
-"""Resolve Lighthouse importer secrets from Ship's own integrations.
+"""Resolve Lighthouse importer credentials from Ship's own integrations.
 
 When the operator picks an importer type Ship already has an integration
-for (GitHub App, Notion OAuth, Linear OAuth, …), we can fill the
-secrets dict server-side instead of asking the operator to paste a
-token. The token never crosses the wire to the browser.
+for (GitHub App, Notion / Linear OAuth, GitLab PAT, Atlassian site), we
+can fill the secrets — and any config the integration already knows
+(``base_url``, account email, ...) — server-side instead of asking the
+operator to paste them. Tokens never cross the wire to the browser.
 
 The mapping is intentionally narrow — only the importer types where
 Ship has a first-party native installation in
@@ -15,7 +16,8 @@ from __future__ import annotations
 
 import logging
 import uuid
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from typing import Any
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -33,13 +35,40 @@ logger = logging.getLogger(__name__)
 
 
 @dataclass(slots=True)
+class ResolvedImporterCreds:
+    """Credentials + config the integration can pre-fill on the
+    importer create request. ``config`` lands under the operator's
+    explicit values (operator wins), ``secrets`` merges the same way."""
+
+    secrets: dict[str, str]
+    config: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
 class WorkspaceImporterIntegration:
-    """One importer type the workspace has auto-resolvable credentials for."""
+    """One importer type the workspace has auto-resolvable credentials for.
+
+    ``provides_config_keys`` lists ``config_schema`` properties the
+    integration will fill server-side (in addition to the importer's
+    ``secret_keys``). The Console hides these inputs when the operator
+    opts into the workspace integration.
+    """
 
     importer_type: str
     provider: str
     account_name: str | None
     account_url: str | None
+    provides_config_keys: tuple[str, ...] = ()
+
+
+# Config-schema keys each integration pre-fills server-side. Used by
+# the Console form to hide those inputs when the workspace integration
+# is selected.
+_PROVIDED_CONFIG_KEYS: dict[str, tuple[str, ...]] = {
+    "gitlab": ("base_url",),
+    "confluence": ("base_url", "user_name"),
+    "jira": ("server_url", "email"),
+}
 
 
 # Importer types we know how to resolve credentials for.
@@ -49,6 +78,9 @@ SUPPORTED_TYPES: frozenset[str] = frozenset(
         "github_releases",
         "notion",
         "linear",
+        "gitlab",
+        "confluence",
+        "jira",
     }
 )
 
@@ -59,10 +91,10 @@ async def list_workspace_importer_integrations(
 ) -> list[WorkspaceImporterIntegration]:
     """Return the importer types the workspace can auto-authorize.
 
-    One entry per importer type that has a working Ship integration —
-    so ``github_repo`` and ``github_releases`` each appear separately
-    when the GitHub App is installed, even though they share one
-    installation row.
+    One entry per importer type — so ``github_repo`` and
+    ``github_releases`` each appear separately when the GitHub App is
+    installed; ``confluence`` + ``jira`` each appear when an Atlassian
+    site is connected.
     """
     out: list[WorkspaceImporterIntegration] = []
 
@@ -90,13 +122,15 @@ async def list_workspace_importer_integrations(
                         if github.account_login
                         else None
                     ),
+                    provides_config_keys=_PROVIDED_CONFIG_KEYS.get(itype, ()),
                 )
             )
 
-    # ── Native OAuth installations (Notion, Linear) ──
-    native_pairs = (
+    # ── Native installations (Notion / Linear / GitLab) ──
+    native_pairs: tuple[tuple[str, str], ...] = (
         (NativeIntegrationProvider.NOTION, "notion"),
         (NativeIntegrationProvider.LINEAR, "linear"),
+        (NativeIntegrationProvider.GITLAB, "gitlab"),
     )
     for provider, importer_type in native_pairs:
         install = await _latest_ready_install(session, workspace_id, provider)
@@ -108,8 +142,25 @@ async def list_workspace_importer_integrations(
                 provider=provider,
                 account_name=install.external_account_name,
                 account_url=install.external_account_url,
+                provides_config_keys=_PROVIDED_CONFIG_KEYS.get(importer_type, ()),
             )
         )
+
+    # ── Atlassian site → confluence + jira ──
+    atlassian = await _latest_ready_install(
+        session, workspace_id, NativeIntegrationProvider.ATLASSIAN
+    )
+    if atlassian is not None:
+        for itype in ("confluence", "jira"):
+            out.append(
+                WorkspaceImporterIntegration(
+                    importer_type=itype,
+                    provider="atlassian",
+                    account_name=atlassian.external_account_name,
+                    account_url=atlassian.external_account_url,
+                    provides_config_keys=_PROVIDED_CONFIG_KEYS.get(itype, ()),
+                )
+            )
 
     return out
 
@@ -120,34 +171,50 @@ async def resolve_workspace_importer_secrets(
     workspace_id: uuid.UUID,
     importer_type: str,
     settings: Settings,
-) -> dict[str, str] | None:
-    """Return the secret dict to inject into a Lighthouse importer
-    request, or ``None`` when the workspace has no usable integration
-    for this importer type."""
+) -> ResolvedImporterCreds | None:
+    """Return creds (+ optional config patch) for the importer, or
+    ``None`` when the workspace has no usable integration for it."""
     if importer_type not in SUPPORTED_TYPES:
         return None
 
     if importer_type in ("github_repo", "github_releases"):
-        return await _resolve_github(session, workspace_id, settings)
+        token = await _resolve_github_token(session, workspace_id, settings)
+        return (
+            ResolvedImporterCreds(secrets={"github_token": token})
+            if token
+            else None
+        )
     if importer_type == "notion":
         token = await _resolve_native_access_token(
             session, workspace_id, NativeIntegrationProvider.NOTION
         )
-        return {"integration_token": token} if token else None
+        return (
+            ResolvedImporterCreds(secrets={"integration_token": token})
+            if token
+            else None
+        )
     if importer_type == "linear":
         token = await _resolve_native_access_token(
             session, workspace_id, NativeIntegrationProvider.LINEAR
         )
-        return {"api_key": token} if token else None
+        return (
+            ResolvedImporterCreds(secrets={"api_key": token}) if token else None
+        )
+    if importer_type == "gitlab":
+        return await _resolve_gitlab(session, workspace_id)
+    if importer_type == "confluence":
+        return await _resolve_atlassian(session, workspace_id, target="confluence")
+    if importer_type == "jira":
+        return await _resolve_atlassian(session, workspace_id, target="jira")
 
     return None
 
 
-async def _resolve_github(
+async def _resolve_github_token(
     session: AsyncSession,
     workspace_id: uuid.UUID,
     settings: Settings,
-) -> dict[str, str] | None:
+) -> str | None:
     install = (
         await session.execute(
             select(GitHubInstallation)
@@ -162,14 +229,12 @@ async def _resolve_github(
     if install is None:
         return None
 
-    # Lazy import to avoid pulling jose / private-key paths in unrelated
-    # codepaths (and to keep import time fast).
     from backend.app.integrations.github.app_auth import (
         fetch_installation_token,
     )
 
     try:
-        token = await fetch_installation_token(
+        return await fetch_installation_token(
             install.installation_id, settings=settings
         )
     except Exception:
@@ -180,13 +245,24 @@ async def _resolve_github(
             exc_info=True,
         )
         return None
-    return {"github_token": token}
 
 
 async def _resolve_native_access_token(
     session: AsyncSession,
     workspace_id: uuid.UUID,
     provider: str,
+) -> str | None:
+    return await _resolve_native_credential(
+        session, workspace_id, provider, kind="access_token"
+    )
+
+
+async def _resolve_native_credential(
+    session: AsyncSession,
+    workspace_id: uuid.UUID,
+    provider: str,
+    *,
+    kind: str,
 ) -> str | None:
     install = await _latest_ready_install(session, workspace_id, provider)
     if install is None:
@@ -197,7 +273,7 @@ async def _resolve_native_access_token(
             select(NativeIntegrationCredential)
             .where(
                 NativeIntegrationCredential.installation_id == install.id,
-                NativeIntegrationCredential.kind == "access_token",
+                NativeIntegrationCredential.kind == kind,
                 NativeIntegrationCredential.revoked_at.is_(None),
             )
             .order_by(NativeIntegrationCredential.created_at.desc())
@@ -207,19 +283,88 @@ async def _resolve_native_access_token(
     if cred is None:
         return None
 
-    # Lazy import for the same reason as github.
     from backend.app.security.encryption import decrypt
 
     try:
         return decrypt(cred.secret_ciphertext)
     except Exception:
         logger.warning(
-            "credential decrypt failed for ws=%s provider=%s",
+            "credential decrypt failed for ws=%s provider=%s kind=%s",
             workspace_id,
             provider,
+            kind,
             exc_info=True,
         )
         return None
+
+
+async def _resolve_gitlab(
+    session: AsyncSession,
+    workspace_id: uuid.UUID,
+) -> ResolvedImporterCreds | None:
+    install = await _latest_ready_install(
+        session, workspace_id, NativeIntegrationProvider.GITLAB
+    )
+    if install is None:
+        return None
+    token = await _resolve_native_credential(
+        session, workspace_id, NativeIntegrationProvider.GITLAB, kind="pat"
+    )
+    if not token:
+        return None
+    config: dict[str, Any] = {}
+    base_url = (install.config or {}).get("base_url")
+    if isinstance(base_url, str) and base_url:
+        config["base_url"] = base_url
+    return ResolvedImporterCreds(
+        secrets={"private_token": token}, config=config
+    )
+
+
+async def _resolve_atlassian(
+    session: AsyncSession,
+    workspace_id: uuid.UUID,
+    *,
+    target: str,
+) -> ResolvedImporterCreds | None:
+    install = await _latest_ready_install(
+        session, workspace_id, NativeIntegrationProvider.ATLASSIAN
+    )
+    if install is None:
+        return None
+    token = await _resolve_native_credential(
+        session,
+        workspace_id,
+        NativeIntegrationProvider.ATLASSIAN,
+        kind="api_token",
+    )
+    if not token:
+        return None
+    cfg = install.config or {}
+    site_url = str(cfg.get("site_url") or "").rstrip("/")
+    email = str(cfg.get("email") or "")
+    if not site_url or not email:
+        # The atlassian install is missing the metadata the importer
+        # needs — operator should reconnect (or fill manually).
+        return None
+
+    if target == "confluence":
+        # Confluence's REST endpoint sits under /wiki on Atlassian Cloud.
+        return ResolvedImporterCreds(
+            secrets={"api_token": token},
+            config={
+                "base_url": f"{site_url}/wiki",
+                "user_name": email,
+            },
+        )
+    # jira
+    return ResolvedImporterCreds(
+        secrets={"api_token": token},
+        config={
+            "server_url": site_url,
+            "email": email,
+        },
+    )
 
 
 async def _latest_ready_install(

--- a/apps/console/src/app/(authed)/knowledge/importers-panel.tsx
+++ b/apps/console/src/app/(authed)/knowledge/importers-panel.tsx
@@ -231,7 +231,13 @@ function AddImporterForm({
     if (!name.trim()) return { ok: false, config: {}, message: "Name is required." };
     const config = coerceConfig(selected, configValues);
     const required = selected.config_schema?.required ?? [];
-    const missing = required.filter((k) => isBlank(config[k]));
+    // Skip required-check for fields the workspace integration fills.
+    const filledByIntegration = useIntegration
+      ? new Set(integration?.provides_config_keys ?? [])
+      : new Set<string>();
+    const missing = required.filter(
+      (k) => isBlank(config[k]) && !filledByIntegration.has(k),
+    );
     if (missing.length > 0) {
       return {
         ok: false,
@@ -393,7 +399,13 @@ function AddImporterForm({
             // Hide schema entries that match a secret key — those are
             // rendered as dedicated password inputs below (or skipped
             // entirely when the workspace integration fills them).
-            .filter(([key]) => !selected.secret_keys.includes(key))
+            // Also hide config keys the chosen integration will fill
+            // server-side (e.g. base_url + email for atlassian).
+            .filter(
+              ([key]) =>
+                !selected.secret_keys.includes(key) &&
+                !(useIntegration && (integration?.provides_config_keys ?? []).includes(key)),
+            )
             .map(([key, prop]) => (
               <SchemaField
                 key={key}

--- a/apps/console/src/lib/api/client.ts
+++ b/apps/console/src/lib/api/client.ts
@@ -3267,6 +3267,7 @@ export type ApiWorkspaceImporterIntegration = {
   provider: string;
   account_name: string | null;
   account_url: string | null;
+  provides_config_keys: string[];
 };
 
 export async function listWorkspaceImporterIntegrations(


### PR DESCRIPTION
## Summary
Extends the workspace-integration auto-auth from #346 to the two remaining first-party Ship providers — **GitLab PAT installations** and **Atlassian sites**. The same checkbox now appears for these importer types when the workspace has them connected; the operator doesn't paste a token, and for Atlassian the form also auto-fills the site URL + email it already knows.

### Mapping
| Importer | Resolves |
|---|---|
| `gitlab` | secret `private_token` (NativeIntegrationCredential `kind=pat`) + config `base_url` (from install.config) |
| `confluence` | secret `api_token` + config `base_url` (= `site_url + /wiki`) + `user_name` (= email) |
| `jira` | secret `api_token` + config `server_url` (= `site_url`) + `email` |

Resolver now returns `ResolvedImporterCreds(secrets, config)` so the route merges **both** under operator-supplied values (operator wins). 400 `no_workspace_integration` still fires when nothing's connected.

### UX
- `WorkspaceImporterIntegration.provides_config_keys` advertises which config-schema keys the integration will fill, so the Console hides them from the form. Without this, atlassian/jira would show `base_url`/`email` as required + blank when the integration checkbox is on.
- Required-field check skips the same keys.

After this PR the auto-auth covers **all 6 native providers** Ship has wired (GitHub, Notion, Linear, GitLab, Atlassian → confluence+jira). Bitbucket / Asana / Trello / Slack stay manual (no first-party Ship integration to draw from).

## Test plan
- [x] `tsc --noEmit` + `vitest run` (47 passed) on console
- [x] Backend lighthouse/knowledge pytest — 15 passed
- [x] ruff clean
- [ ] Browser: pick `confluence` with the workspace's Atlassian connected → checkbox shows "Use workspace atlassian integration (<site>)"; `base_url` + Email inputs hidden; submit just needs `space_key` → importer created with all 3 fields filled from the install
- [ ] Browser: pick `gitlab` → same flow, only `project_id` left to fill