### PR TITLE
feat(fsm): autostart bootstrap epic after install PR merges (Phase 5)

### DIFF
--- a/apps/backend/app/api/v1/routes/github_app.py
+++ b/apps/backend/app/api/v1/routes/github_app.py
@@ -976,6 +976,188 @@ async def _apply_pull_request_event(
                 exc,
             )
 
+        # Phase 5 of the FSM event-driven rearchitecture (2026-05-29).
+        # The seed PR is what wires Ship into the repo — workflow file
+        # lands, run-token rotates, the dispatcher can fire. The very
+        # next thing the operator wants is dev/test/prod + CI/CD up,
+        # not a docs link saying "press this button to start". Hand the
+        # repo to bootstrap-intelligence here, then dispatch the first
+        # infra ticket so Phase 3 walks the rest autonomously through
+        # to merge. Operator can walk away from the wizard and come
+        # back to a configured workspace.
+        await _autostart_bootstrap_on_install_merge(
+            session,
+            workspace_id=repo_row.workspace_id,
+            repo_row=repo_row,
+        )
+
+
+async def _autostart_bootstrap_on_install_merge(
+    session: AsyncSession,
+    *,
+    workspace_id: uuid.UUID,
+    repo_row: Any,
+) -> None:
+    """Phase 5 — run bootstrap-intelligence + dispatch its first ticket
+    after the seed PR merges.
+
+    Pipes the standard ``run_bootstrap_for_repo`` (BS3 endpoint + Inbox
+    decision action share this entry point) into an automatic call
+    inside the install-PR-merge webhook, then immediately fires
+    ``maybe_dispatch`` for the first infra ticket so Phase 3's
+    auto-advance walks the rest of the epic to merge without an
+    operator touch. Audit events bracket every outcome:
+
+    - ``wizard.bootstrap_skipped`` — readiness probe came back
+      ``skipped_no_blueprint`` / ``skipped_already_ready`` /
+      ``skipped_no_gaps``. Workspace stays as-is; operator can press
+      "Generate bootstrap tickets" from the inbox card if they
+      disagree.
+    - ``wizard.bootstrap_epic_generated`` — readiness produced a plan,
+      epic minted (or reused) in Linear. Payload carries
+      ``project_url`` + ``ticket_count`` + ``first_ticket_ref``.
+    - ``wizard.bootstrap_first_dispatch`` — dispatch outcome for the
+      first ticket. ``fired=true / reason=fired`` is the happy path;
+      anything else (``project_busy``, ``no_repo``, …) surfaces here
+      so the operator can diagnose without reading the cascade chain.
+
+    Best-effort: any exception in the chain is logged + swallowed; the
+    seed PR-merge webhook must still ack GitHub on time. Idempotent on
+    re-delivery of the same install-PR-merge event because
+    ``generate_bootstrap_plan`` reuses an existing OPEN epic with the
+    same deterministic name.
+    """
+    try:
+        from backend.app.core.config import get_settings as _gs
+        from backend.app.services.bootstrap_plan import run_bootstrap_for_repo
+        from backend.app.services.dispatcher import maybe_dispatch
+        from backend.app.services.tracker_resolver import (
+            resolve_for_workspace as _resolve,
+        )
+
+        settings = _gs()
+        resolved = await _resolve(
+            session=session, settings=settings, workspace_id=workspace_id,
+        )
+        if resolved is None:
+            # Workspace has no tracker bound yet — nothing to anchor
+            # the bootstrap epic against. Operator wires the tracker
+            # later, then clicks "Generate bootstrap tickets" by hand.
+            return
+
+        try:
+            result = await run_bootstrap_for_repo(
+                session=session,
+                repo=repo_row,
+                tracker=resolved.gateway,
+                settings=settings,
+            )
+        except Exception as exc:  # noqa: BLE001 — best-effort
+            logger.warning(
+                "phase5 run_bootstrap_for_repo failed ws=%s repo=%s err=%s",
+                workspace_id, getattr(repo_row, "id", None), exc,
+            )
+            return
+
+        outcome = str(result.get("result") or "")
+        if outcome != "bootstrap_generated":
+            session.add(
+                AuditLog(
+                    workspace_id=workspace_id,
+                    actor_user_id=None,
+                    actor_token_id=None,
+                    action="wizard.bootstrap_skipped",
+                    target_kind="repo",
+                    target_id=str(getattr(repo_row, "id", "")),
+                    payload={
+                        "reason": outcome or "unknown",
+                        "detail": result.get("detail"),
+                    },
+                )
+            )
+            logger.info(
+                "phase5 bootstrap skipped ws=%s repo=%s reason=%s",
+                workspace_id, getattr(repo_row, "id", None), outcome,
+            )
+            return
+
+        session.add(
+            AuditLog(
+                workspace_id=workspace_id,
+                actor_user_id=None,
+                actor_token_id=None,
+                action="wizard.bootstrap_epic_generated",
+                target_kind="project",
+                target_id=str(result.get("project_native_id") or ""),
+                payload={
+                    "repo_id": str(getattr(repo_row, "id", "")),
+                    "project_url": result.get("project_url"),
+                    "ticket_count": result.get("ticket_count"),
+                    "first_ticket_ref": result.get("first_ticket_ref"),
+                    "tracker_kind": resolved.kind,
+                },
+            )
+        )
+
+        first_ticket = result.get("first_ticket_ref")
+        if not first_ticket:
+            # Idempotent reuse path — epic existed already, no new
+            # tickets minted. Don't second-guess the operator: if they
+            # asked for re-run and the existing epic has live work,
+            # Phase 3's PR-merge cascade picks the next ticket
+            # whenever the current one merges.
+            logger.info(
+                "phase5 bootstrap reused existing epic; no first_ticket "
+                "to dispatch ws=%s repo=%s",
+                workspace_id, getattr(repo_row, "id", None),
+            )
+            return
+
+        try:
+            dispatch_result = await maybe_dispatch(
+                session,
+                workspace_id=workspace_id,
+                ticket_ref=str(first_ticket),
+                trigger_kind="wizard_bootstrap",
+                fsm_stage="planning",
+                settings=settings,
+            )
+        except Exception as exc:  # noqa: BLE001 — best-effort
+            logger.warning(
+                "phase5 maybe_dispatch failed ws=%s ticket=%s err=%s",
+                workspace_id, first_ticket, exc,
+            )
+            return
+
+        session.add(
+            AuditLog(
+                workspace_id=workspace_id,
+                actor_user_id=None,
+                actor_token_id=None,
+                action="wizard.bootstrap_first_dispatch",
+                target_kind="ticket",
+                target_id=str(first_ticket),
+                payload={
+                    "project_native_id": result.get("project_native_id"),
+                    "tracker_kind": resolved.kind,
+                    "fired": dispatch_result.fired,
+                    "reason": dispatch_result.reason,
+                },
+            )
+        )
+        logger.info(
+            "phase5 bootstrap autostart ws=%s repo=%s epic=%s "
+            "first_ticket=%s fired=%s reason=%s",
+            workspace_id, getattr(repo_row, "id", None),
+            result.get("project_native_id"), first_ticket,
+            dispatch_result.fired, dispatch_result.reason,
+        )
+    except Exception as exc:  # noqa: BLE001 — never fail the webhook ack
+        logger.warning(
+            "phase5 autostart crashed ws=%s repo=%s err=%s",
+            workspace_id, getattr(repo_row, "id", None), exc,
+        )
+
 
 # Pull a ``ELS-99`` / ``ENG-12`` / ``ABCD-1234`` style ticket id out of
 # an agent-PR title. Agent PRs follow ``agent: <role> · <stage> ELS-99``

--- a/apps/backend/app/services/bootstrap_plan.py
+++ b/apps/backend/app/services/bootstrap_plan.py
@@ -379,11 +379,21 @@ async def run_bootstrap_for_repo(
         report=rdy.report,
         actor_user_id=actor_user_id,
     )
+    # Phase 5 (2026-05-29): surface the first ticket so the install-PR
+    # merge handler can fire ``maybe_dispatch`` for it directly,
+    # without re-querying Linear for the project's contents. ``None``
+    # on the idempotent-reuse path (existing project — no new tickets
+    # minted; caller decides whether to also walk the existing
+    # backlog).
+    first_ticket_ref = (
+        plan.tickets[0].display_id if plan.tickets else None
+    )
     return {
         "result": "bootstrap_generated",
         "project_url": plan.project_url,
         "project_native_id": plan.project_native_id,
         "ticket_count": len(plan.tickets),
+        "first_ticket_ref": first_ticket_ref,
     }
 
 

--- a/apps/backend/tests/test_phase5_bootstrap_autostart.py
+++ b/apps/backend/tests/test_phase5_bootstrap_autostart.py
@@ -1,0 +1,253 @@
+"""Phase 5 of the FSM event-driven rearchitecture — after the seed PR
+merges, automatically run bootstrap-intelligence + dispatch the first
+infra ticket so the cascade walks setup autonomously to merge.
+
+These tests pin the helper's decision tree against fakes:
+
+1. No tracker bound — silent return (no audit, no dispatch).
+2. Bootstrap probe says ``skipped_no_blueprint`` → audit
+   ``wizard.bootstrap_skipped`` + no dispatch.
+3. Same for ``skipped_already_ready`` and ``skipped_no_gaps`` (one
+   parametrised test).
+4. ``bootstrap_generated`` with tickets → epic-generated audit + first
+   ticket dispatched via ``maybe_dispatch(trigger_kind="wizard_bootstrap")``
+   + first-dispatch audit row.
+5. ``bootstrap_generated`` with empty tickets (idempotent reuse path)
+   → epic-generated audit only; NO dispatch (no first_ticket_ref).
+6. ``run_bootstrap_for_repo`` raises → swallow + log + no audit/dispatch.
+7. ``maybe_dispatch`` raises → epic-generated audit fired earlier, but
+   first-dispatch audit NOT written (we trust the log + audit history
+   to surface the gap).
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from backend.app.api.v1.routes.github_app import (
+    _autostart_bootstrap_on_install_merge,
+)
+
+
+class _FakeRepo:
+    """``WorkspaceRepo``-shaped enough for the helper. The helper only
+    reads ``id`` (audit telemetry); ``full_name`` is touched by the
+    fakes only when ``run_bootstrap_for_repo`` is called for real,
+    which we patch out in every test."""
+
+    def __init__(self) -> None:
+        self.id = uuid.uuid4()
+        self.full_name = "acme/widget"
+        self.workspace_id = uuid.uuid4()
+
+
+class _RecordingSession:
+    """Captures every ``add()`` so tests can read back audit rows."""
+
+    def __init__(self) -> None:
+        self.added: list[Any] = []
+
+    def add(self, row: Any) -> None:
+        self.added.append(row)
+
+
+def _resolved_or_none(kind: str | None = "linear"):
+    if kind is None:
+        return None
+    resolved = MagicMock()
+    resolved.kind = kind
+    resolved.gateway = MagicMock()
+    return resolved
+
+
+def _patches(*, resolved, bootstrap_result, dispatch_fired=True,
+             dispatch_reason="fired", dispatch_raises=False):
+    """Stack of patches that mock the helper's external surface."""
+    resolve_patch = patch(
+        "backend.app.services.tracker_resolver.resolve_for_workspace",
+        new=AsyncMock(return_value=resolved),
+    )
+    if isinstance(bootstrap_result, Exception):
+        bootstrap_mock = AsyncMock(side_effect=bootstrap_result)
+    else:
+        bootstrap_mock = AsyncMock(return_value=bootstrap_result)
+    bootstrap_patch = patch(
+        "backend.app.services.bootstrap_plan.run_bootstrap_for_repo",
+        new=bootstrap_mock,
+    )
+    if dispatch_raises:
+        dispatch_mock = AsyncMock(side_effect=RuntimeError("dispatch crashed"))
+    else:
+        dispatch_result = MagicMock()
+        dispatch_result.fired = dispatch_fired
+        dispatch_result.reason = dispatch_reason
+        dispatch_mock = AsyncMock(return_value=dispatch_result)
+    dispatch_patch = patch(
+        "backend.app.services.dispatcher.maybe_dispatch",
+        new=dispatch_mock,
+    )
+    return resolve_patch, bootstrap_patch, dispatch_patch, dispatch_mock
+
+
+@pytest.mark.asyncio
+async def test_silent_noop_when_no_tracker_bound():
+    session = _RecordingSession()
+    repo = _FakeRepo()
+    rp, bp, dp, dm = _patches(
+        resolved=None, bootstrap_result={"result": "ignored"},
+    )
+    with rp, bp, dp:
+        await _autostart_bootstrap_on_install_merge(
+            session, workspace_id=repo.workspace_id, repo_row=repo,
+        )
+    # The workspace hasn't wired its tracker yet — Phase 5 has no place
+    # to anchor the epic. The wizard sets the tracker, this code path
+    # only runs after install PR merge, so this is a defensive guard.
+    assert session.added == []
+    dm.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "skip_reason",
+    ("skipped_no_blueprint", "skipped_already_ready", "skipped_no_gaps"),
+)
+@pytest.mark.asyncio
+async def test_bootstrap_skip_paths_audit_and_no_dispatch(skip_reason):
+    session = _RecordingSession()
+    repo = _FakeRepo()
+    rp, bp, dp, dm = _patches(
+        resolved=_resolved_or_none(),
+        bootstrap_result={"result": skip_reason, "detail": "no scaffolding to do"},
+    )
+    with rp, bp, dp:
+        await _autostart_bootstrap_on_install_merge(
+            session, workspace_id=repo.workspace_id, repo_row=repo,
+        )
+    actions = [getattr(r, "action", None) for r in session.added]
+    assert actions == ["wizard.bootstrap_skipped"]
+    row = session.added[0]
+    assert row.payload["reason"] == skip_reason
+    assert row.payload["detail"] == "no scaffolding to do"
+    dm.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_generated_with_first_ticket_dispatches():
+    session = _RecordingSession()
+    repo = _FakeRepo()
+    rp, bp, dp, dm = _patches(
+        resolved=_resolved_or_none(),
+        bootstrap_result={
+            "result": "bootstrap_generated",
+            "project_url": "https://linear.app/acme/project/bootstrap",
+            "project_native_id": "proj-9",
+            "ticket_count": 4,
+            "first_ticket_ref": "ACME-101",
+        },
+    )
+    with rp, bp, dp:
+        await _autostart_bootstrap_on_install_merge(
+            session, workspace_id=repo.workspace_id, repo_row=repo,
+        )
+    actions = [getattr(r, "action", None) for r in session.added]
+    assert actions == [
+        "wizard.bootstrap_epic_generated",
+        "wizard.bootstrap_first_dispatch",
+    ]
+    epic = session.added[0]
+    assert epic.payload["project_url"] == "https://linear.app/acme/project/bootstrap"
+    assert epic.payload["ticket_count"] == 4
+    assert epic.payload["first_ticket_ref"] == "ACME-101"
+    dispatch = session.added[1]
+    assert dispatch.target_id == "ACME-101"
+    assert dispatch.payload["fired"] is True
+    assert dispatch.payload["reason"] == "fired"
+    # Direct check: maybe_dispatch called with our trigger_kind +
+    # fsm_stage so future audit consumers can filter Phase 5 dispatches
+    # off the cascade chain.
+    call = dm.await_args
+    assert call.kwargs["ticket_ref"] == "ACME-101"
+    assert call.kwargs["trigger_kind"] == "wizard_bootstrap"
+    assert call.kwargs["fsm_stage"] == "planning"
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_generated_idempotent_reuse_skips_dispatch():
+    # Re-running bootstrap on a repo that already has an OPEN epic
+    # reuses the project (no fresh tickets minted). The helper records
+    # the epic-generated audit but does NOT dispatch — there's no
+    # ``first_ticket_ref`` to hand to maybe_dispatch, and we don't want
+    # to second-guess what the operator is already working on.
+    session = _RecordingSession()
+    repo = _FakeRepo()
+    rp, bp, dp, dm = _patches(
+        resolved=_resolved_or_none(),
+        bootstrap_result={
+            "result": "bootstrap_generated",
+            "project_url": "https://linear.app/acme/project/bootstrap",
+            "project_native_id": "proj-9",
+            "ticket_count": 0,
+            "first_ticket_ref": None,
+        },
+    )
+    with rp, bp, dp:
+        await _autostart_bootstrap_on_install_merge(
+            session, workspace_id=repo.workspace_id, repo_row=repo,
+        )
+    actions = [getattr(r, "action", None) for r in session.added]
+    assert actions == ["wizard.bootstrap_epic_generated"]
+    dm.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_run_bootstrap_for_repo_raising_is_swallowed():
+    # A tracker hiccup mid-bootstrap must not fail the webhook ack.
+    # We log it, write nothing to audit_log, and let the operator
+    # retry by hand (or wait for the next install PR redelivery —
+    # GH retries failed webhooks for 8 hours).
+    session = _RecordingSession()
+    repo = _FakeRepo()
+    rp, bp, dp, dm = _patches(
+        resolved=_resolved_or_none(),
+        bootstrap_result=RuntimeError("tracker 500"),
+    )
+    with rp, bp, dp:
+        await _autostart_bootstrap_on_install_merge(
+            session, workspace_id=repo.workspace_id, repo_row=repo,
+        )
+    assert session.added == []
+    dm.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_maybe_dispatch_raising_still_records_epic_audit():
+    # The epic exists in Linear by the time dispatch is attempted —
+    # ``generate_bootstrap_plan`` already wrote the project + tickets.
+    # If dispatch crashes (cap exceeded race, transient lock contention),
+    # the epic audit row stays so the operator can see what was minted
+    # before the failure. The dispatch row only fires on success — its
+    # absence is the diagnostic.
+    session = _RecordingSession()
+    repo = _FakeRepo()
+    rp, bp, dp, dm = _patches(
+        resolved=_resolved_or_none(),
+        bootstrap_result={
+            "result": "bootstrap_generated",
+            "project_url": "https://linear.app/acme/project/bootstrap",
+            "project_native_id": "proj-9",
+            "ticket_count": 4,
+            "first_ticket_ref": "ACME-101",
+        },
+        dispatch_raises=True,
+    )
+    with rp, bp, dp:
+        await _autostart_bootstrap_on_install_merge(
+            session, workspace_id=repo.workspace_id, repo_row=repo,
+        )
+    actions = [getattr(r, "action", None) for r in session.added]
+    assert actions == ["wizard.bootstrap_epic_generated"]
+    # The dispatch crash is in the logs; no first_dispatch audit row.


### PR DESCRIPTION
## Phase 5 of the event-driven FSM rearchitecture

Plan: `documentation/internal/planning/2026-05-28-fsm-event-driven-rearchitecture.md` (gitignored — internal).

Phases 1-4 made tickets walk Backlog → Done autonomously: blocked freeze, crons killed, PR-merge auto-advance, server-validated `code_review → auto_merge`. The one piece still requiring a human touch was the **START**: after the wizard's seed PR merged, the operator had to manually open the "Generate bootstrap tickets" inbox card to get dev/test/prod + CI/CD scaffolding moving.

## What this changes

After `ship/install-*` (seed PR) merges:

1. `run_bootstrap_for_repo()` runs against the now-configured repo
2. On `bootstrap_generated` → audit `wizard.bootstrap_epic_generated` (`project_url`, `ticket_count`, `first_ticket_ref`)
3. `maybe_dispatch(first_ticket, trigger_kind="wizard_bootstrap", fsm_stage="planning")` fires the first infra ticket
4. **Phase 3 auto-advances** the rest of the epic as each PR merges
5. `wizard.bootstrap_first_dispatch` records the dispatch outcome

Skip paths (`skipped_no_blueprint` / `skipped_already_ready` / `skipped_no_gaps`) write `wizard.bootstrap_skipped` and stop — no scaffolding to do, workspace stays as-is.

## Changes

- `apps/backend/app/services/bootstrap_plan.py` — `run_bootstrap_for_repo()` result now includes `first_ticket_ref`. Backwards-compatible (added key).
- `apps/backend/app/api/v1/routes/github_app.py` — new `_autostart_bootstrap_on_install_merge` helper + call site after the existing `auto_dispatch_knowledge_routines` block.
- `apps/backend/tests/test_phase5_bootstrap_autostart.py` — 8 unit scenarios.

## Defense

- Every external call wrapped + logged. The webhook ack stays fast; a bootstrap hiccup never fails the PR-merge handler.
- Idempotent re-delivery: `generate_bootstrap_plan` reuses an existing OPEN epic with the same deterministic name. Replayed install PR webhook doesn't mint duplicate tickets (returns `bootstrap_generated` with `first_ticket_ref=None` on reuse path → no dispatch).
- No tracker bound → silent return (no audit, no dispatch).

## NOT in this PR (deferred per plan)

- `enqueue_harvest()` after seed PR merges so readiness probe has fresh `repo_intel` data
- Operator-facing UI surface: "Setting up your repo…" spinner on Wizard Done + Inbox progress card
- Navigator-driven chat-style setup → Phase 6

## Test plan

- [x] `pytest -q` — 1480 passed, 12 pre-existing `test_symbol_parser.py` failures (unrelated)
- [x] 8 unit scenarios: no_tracker, 3× skip reasons (parametrised), generated+dispatch, idempotent reuse no-dispatch, bootstrap-raises swallowed, dispatch-raises preserves epic audit
- [ ] After rollout: install a fresh repo via wizard, watch `audit_log` for the three event chain. First infra ticket should start `planning` within seconds of install PR merge.