### PR TITLE
feat(onboarding): wizard UX sweep — tracker save, roles gate, seed er…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 site/
 .cursor/
 .playwright-cli/
+.playwright-mcp/
 .venv-docs/
 .venv/
 node_modules/

--- a/apps/backend/app/api/v1/routes/repos.py
+++ b/apps/backend/app/api/v1/routes/repos.py
@@ -1381,6 +1381,13 @@ async def wizard_seed(
             return_url=return_url,
         )
     except WorkflowDispatchError as exc:
+        logger.exception(
+            "wizard_seed: commit_bundle_pr failed for repo=%s install=%s status=%s body=%s",
+            repo_row.full_name,
+            install_row.installation_id,
+            exc.status_code,
+            exc.message[:512],
+        )
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
             detail={

--- a/apps/console/package-lock.json
+++ b/apps/console/package-lock.json
@@ -1,14 +1,16 @@
 {
   "name": "ship-console",
-  "version": "0.16.30",
+  "version": "0.16.35",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ship-console",
-      "version": "0.16.30",
+      "version": "0.16.35",
       "dependencies": {
         "@auth0/nextjs-auth0": "^4.18.0",
+        "@emnapi/core": "^1.10.0",
+        "@emnapi/runtime": "^1.10.0",
         "@sentry/nextjs": "^10.49.0",
         "jszip": "^3.10.1",
         "luxon": "^3.7.2",
@@ -157,6 +159,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -504,6 +507,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -552,6 +556,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -569,9 +574,8 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
       "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
+      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
@@ -582,7 +586,7 @@
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
       "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "license": "MIT",
-      "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -591,9 +595,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
       "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1428,7 +1430,6 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
       "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25"
@@ -1660,6 +1661,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -1681,6 +1683,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.0.tgz",
       "integrity": "sha512-DT12SXVwV2eoJrGf4nnsvZojxxeQo+LlNAsoYGRRObPWTeN6APiqZ2+nqDCQDvQX40eLi1AePONS0onoASp3yQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -2103,6 +2106,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.7.0.tgz",
       "integrity": "sha512-Yg9zEXJB50DLVLpsKPk7NmNqlPlS+OvqhJGh0A8oawIOTPOwlm4eXs9BMJV7L79lvEwI+dWtAj+YjTyddV336A==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.7.0",
         "@opentelemetry/resources": "2.7.0",
@@ -2120,6 +2124,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
       "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -2578,6 +2583,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3427,7 +3433,6 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -3448,7 +3453,6 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -3524,8 +3528,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -3631,7 +3634,6 @@
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -3642,7 +3644,6 @@
       "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
       "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint": "*",
         "@types/estree": "*"
@@ -3750,6 +3751,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3760,6 +3762,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3830,6 +3833,7 @@
       "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.2",
         "@typescript-eslint/types": "8.58.2",
@@ -4374,6 +4378,7 @@
       "integrity": "sha512-36l628fQ/9a/8ihy97eOtEnvWQEdqULQOJtcaxtoNq0G1w3Mxd4szSahOaMM9/NGyZ+hyKcMtIW/WIxq0XQViQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.6",
@@ -4527,7 +4532,6 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
       "integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/helper-numbers": "1.13.2",
         "@webassemblyjs/helper-wasm-bytecode": "1.13.2"
@@ -4537,29 +4541,25 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
       "integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-api-error": {
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
       "integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-buffer": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
       "integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-numbers": {
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.13.2.tgz",
       "integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/floating-point-hex-parser": "1.13.2",
         "@webassemblyjs/helper-api-error": "1.13.2",
@@ -4570,15 +4570,13 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
       "integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-wasm-section": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.14.1.tgz",
       "integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-buffer": "1.14.1",
@@ -4591,7 +4589,6 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.13.2.tgz",
       "integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@xtuc/ieee754": "^1.2.0"
       }
@@ -4601,7 +4598,6 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.13.2.tgz",
       "integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@xtuc/long": "4.2.2"
       }
@@ -4610,15 +4606,13 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
       "integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/wasm-edit": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.14.1.tgz",
       "integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-buffer": "1.14.1",
@@ -4635,7 +4629,6 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.14.1.tgz",
       "integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
@@ -4649,7 +4642,6 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz",
       "integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-buffer": "1.14.1",
@@ -4662,7 +4654,6 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz",
       "integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-api-error": "1.13.2",
@@ -4677,7 +4668,6 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.14.1.tgz",
       "integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@xtuc/long": "4.2.2"
@@ -4687,21 +4677,20 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
       "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/@xtuc/long": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4723,7 +4712,6 @@
       "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
       "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.13.0"
       },
@@ -4775,7 +4763,6 @@
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ajv": "^8.0.0"
       },
@@ -4793,7 +4780,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -4809,8 +4795,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
@@ -4818,7 +4803,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -5268,6 +5252,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -5286,8 +5271,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/call-bind": {
       "version": "1.0.9",
@@ -5499,7 +5483,6 @@
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
       "integrity": "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.0"
       }
@@ -6029,8 +6012,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dotenv": {
       "version": "16.6.1",
@@ -6077,7 +6059,6 @@
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
       "integrity": "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.4",
         "tapable": "^2.3.0"
@@ -6320,6 +6301,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6493,6 +6475,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6746,7 +6729,6 @@
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.8.x"
       }
@@ -6831,8 +6813,7 @@
           "url": "https://opencollective.com/fastify"
         }
       ],
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
       "version": "1.20.1",
@@ -7121,8 +7102,7 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
-      "license": "BSD-2-Clause",
-      "peer": true
+      "license": "BSD-2-Clause"
     },
     "node_modules/glob/node_modules/balanced-match": {
       "version": "4.0.4",
@@ -7207,8 +7187,7 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",
@@ -8062,7 +8041,6 @@
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
       "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "merge-stream": "^2.0.0",
@@ -8077,7 +8055,6 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
       "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -8094,6 +8071,7 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -8628,7 +8606,6 @@
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.1.tgz",
       "integrity": "sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.11.5"
       },
@@ -8706,7 +8683,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -9061,8 +9037,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -9656,7 +9631,6 @@
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -9772,14 +9746,14 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/next": {
       "version": "15.5.15",
       "resolved": "https://registry.npmjs.org/next/-/next-15.5.15.tgz",
       "integrity": "sha512-VSqCrJwtLVGwAVE0Sb/yikrQfkwkZW9p+lL/J4+xe+G3ZA+QnWPqgcfH1tDUEuk9y+pthzzVFp4L/U8JerMfMQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@next/env": "15.5.15",
         "@swc/helpers": "0.5.15",
@@ -10367,6 +10341,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -10587,7 +10562,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -10603,7 +10577,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -10616,8 +10589,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
@@ -10698,6 +10670,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10707,6 +10680,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -10718,7 +10692,8 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
@@ -10752,6 +10727,7 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -10862,7 +10838,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -11112,6 +11089,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
       "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -11260,7 +11238,6 @@
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
       "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "ajv": "^8.9.0",
@@ -11297,7 +11274,6 @@
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
       "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3"
       },
@@ -11309,8 +11285,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.7.4",
@@ -11536,7 +11511,6 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11555,7 +11529,6 @@
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -11995,7 +11968,6 @@
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.2.tgz",
       "integrity": "sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       },
@@ -12009,7 +11981,6 @@
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.1.tgz",
       "integrity": "sha512-vzCjQO/rgUuK9sf8VJZvjqiqiHFaZLnOiimmUuOKODxWL8mm/xua7viT7aqX7dgPY60otQjUotzFMmCB4VdmqQ==",
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",
@@ -12028,7 +11999,6 @@
       "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.4.0.tgz",
       "integrity": "sha512-Bn5vxm48flOIfkdl5CaD2+1CiUVbonWQ3KQPyP7/EuIl9Gbzq/gQFOzaMFUEgVjB1396tcK0SG8XcNJ/2kDH8g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.25",
         "jest-worker": "^27.4.5",
@@ -12061,8 +12031,7 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/thenify": {
       "version": "3.3.1",
@@ -12151,6 +12120,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12385,6 +12355,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12661,6 +12632,7 @@
       "integrity": "sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -12752,6 +12724,7 @@
       "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.6",
         "@vitest/mocker": "4.1.6",
@@ -12867,7 +12840,6 @@
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",
       "integrity": "sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
@@ -12887,7 +12859,6 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.106.2.tgz",
       "integrity": "sha512-wGN3qcrBQIFmQ/c0AiOAQBvrZ5lmY8vbbMv4Mxfgzqd/B6+9pXtLo73WuS1dSGXM5QYY3hZnIbvx+K1xxe6FyA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -12935,7 +12906,6 @@
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.4.tgz",
       "integrity": "sha512-7tP1PdV4vF+lYPnkMR0jMY5/la2ub5Fc/8VQrrU+lXkiM6C4TjVfGw7iKfyhnTQOsD+6Q/iKw0eFciziRgD58Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.13.0"
       }
@@ -12945,7 +12915,6 @@
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
       "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
@@ -12959,7 +12928,6 @@
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "license": "BSD-2-Clause",
-      "peer": true,
       "engines": {
         "node": ">=4.0"
       }

--- a/apps/console/package.json
+++ b/apps/console/package.json
@@ -14,6 +14,8 @@
   },
   "dependencies": {
     "@auth0/nextjs-auth0": "^4.18.0",
+    "@emnapi/core": "^1.10.0",
+    "@emnapi/runtime": "^1.10.0",
     "@sentry/nextjs": "^10.49.0",
     "jszip": "^3.10.1",
     "luxon": "^3.7.2",

--- a/apps/console/src/app/(authed)/settings/_shell/settings-shell.tsx
+++ b/apps/console/src/app/(authed)/settings/_shell/settings-shell.tsx
@@ -21,6 +21,7 @@ import {
 } from "@/components/integrations-workspace-body";
 import { WorkspaceMembersPanelLoader } from "@/components/workspace-members-panel";
 import { AgentRolesList } from "../agent-roles/agent-roles-list";
+import { WorkspaceNameField } from "./workspace-name-field";
 import {
   Badge,
   Card,
@@ -366,7 +367,7 @@ export async function SettingsShell({
               <Card>
                 <CardHeader title="General" subtitle="Workspace identity" />
                 <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-                  <Field label="Workspace name" value={workspace.name} readOnly />
+                  <WorkspaceNameField workspace={workspace} />
                   <Field label="Slug (URL handle)" value={workspace.slug} mono readOnly />
                   <Field label="Workspace ID" value={workspace.id} mono readOnly />
                   <Field
@@ -1185,42 +1186,6 @@ function WorkspacesPanel({
   const peers = memberships.filter((w) => w.id !== current.id);
   return (
     <div className="space-y-6">
-      <Card>
-        <CardHeader
-          title="Rename this workspace"
-          subtitle="Name is for humans (sidebar header, audit, invites). The slug is the URL handle and can't change after create."
-        />
-        <form
-          action="/api/settings/workspace/rename"
-          method="POST"
-          className="grid grid-cols-1 gap-4 md:grid-cols-[1fr_auto]"
-        >
-          <input type="hidden" name="ws" value={current.id} suppressHydrationWarning />
-          <label className="block">
-            <div className="mb-1 text-[10px] font-bold uppercase tracking-widest text-white/45">
-              Workspace name
-            </div>
-            <input
-              name="name"
-              defaultValue={current.name}
-              required
-              maxLength={200}
-              className="w-full rounded-lg border border-white/10 bg-white/[0.06] px-3 py-2 text-sm text-white outline-none focus:border-aqua/40"
-              suppressHydrationWarning
-            />
-            <div className="mt-1 text-[11px] text-white/45">
-              Slug: <code className="font-mono">{current.slug}</code> · ID:{" "}
-              <code className="font-mono">{current.id}</code>
-            </div>
-          </label>
-          <div className="flex items-end">
-            <button type="submit" className="btn-primary">
-              Save
-            </button>
-          </div>
-        </form>
-      </Card>
-
       <Card>
         <CardHeader
           title="Your workspaces"

--- a/apps/console/src/app/(authed)/settings/_shell/workspace-name-field.tsx
+++ b/apps/console/src/app/(authed)/settings/_shell/workspace-name-field.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useRef, useState } from "react";
+
+import type { ApiWorkspace } from "@/lib/api/types";
+
+export function WorkspaceNameField({ workspace }: { workspace: ApiWorkspace }) {
+  const [editing, setEditing] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  return (
+    <div className="block">
+      <div className="mb-1 text-[10px] font-bold uppercase tracking-widest text-white/45">
+        Workspace name
+      </div>
+
+      {editing ? (
+        <form
+          action="/api/settings/workspace/rename"
+          method="POST"
+          className="flex items-center gap-2"
+        >
+          <input type="hidden" name="ws" value={workspace.id} />
+          <input
+            ref={inputRef}
+            name="name"
+            defaultValue={workspace.name}
+            required
+            maxLength={200}
+            autoFocus
+            className="flex-1 rounded-lg border border-aqua/40 bg-white/[0.06] px-3 py-2 text-sm text-white outline-none focus:border-aqua/60"
+          />
+          <button
+            type="submit"
+            className="rounded-md bg-aqua/15 px-3 py-2 text-xs font-semibold text-aqua transition hover:bg-aqua/25"
+          >
+            Save
+          </button>
+          <button
+            type="button"
+            onClick={() => setEditing(false)}
+            className="rounded-md px-3 py-2 text-xs font-semibold text-white/45 transition hover:text-white"
+          >
+            Cancel
+          </button>
+        </form>
+      ) : (
+        <div className="flex items-center gap-2">
+          <div className="flex-1 rounded-lg border border-white/10 bg-white/[0.02] px-3 py-2 text-sm text-white/75">
+            {workspace.name}
+          </div>
+          <button
+            type="button"
+            aria-label="Rename workspace"
+            onClick={() => setEditing(true)}
+            className="rounded-md p-2 text-white/35 transition hover:bg-white/[0.06] hover:text-white/80"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
+              <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
+            </svg>
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/console/src/app/api/onboard/tracker-install/route.ts
+++ b/apps/console/src/app/api/onboard/tracker-install/route.ts
@@ -28,7 +28,9 @@ import {
   isApiConfigured,
   startLinearInstall,
   startNotionInstall,
+  upsertIntegration,
 } from "@/lib/api/client";
+import { getSessionToken } from "@/lib/api/session";
 import { resolveOrigin } from "@/lib/api/origin";
 
 export async function POST(request: Request) {
@@ -41,7 +43,24 @@ export async function POST(request: Request) {
     return NextResponse.redirect(new URL("/onboarding", origin), 303);
   }
 
-  if (kind === "skip" || kind === "github") {
+  if (kind === "skip") {
+    return forward(origin, wsId);
+  }
+
+  if (kind === "github") {
+    // GitHub Issues rides on the App installation token — no OAuth needed.
+    // But we still need to persist an Integration row (kind=github,
+    // repo_id=NULL) so wizard-seed's workspace_tracker_required check
+    // finds it. Without this the selection is never saved to the DB.
+    if (isApiConfigured()) {
+      try {
+        const token = await getSessionToken();
+        await upsertIntegration(wsId, "github", { config: {} }, token ?? undefined);
+      } catch {
+        // Best-effort — if the upsert fails the user still proceeds;
+        // wizard-seed will surface workspace_tracker_required if needed.
+      }
+    }
     return forward(origin, wsId);
   }
 

--- a/apps/console/src/app/api/onboard/wizard-seed/route.ts
+++ b/apps/console/src/app/api/onboard/wizard-seed/route.ts
@@ -77,7 +77,14 @@ function relayError(err: unknown) {
       return json({ error: code }, 412);
     }
     if (err.status === 422) return json({ error: "bad_body" }, 422);
-    if (err.status === 502) return json({ error: "github_api_error" }, 502);
+    if (err.status === 502) {
+      const detail = err.detail as { code?: string; message?: string; upstream_status?: number } | null;
+      return json({
+        error: "github_api_error",
+        detail: detail?.message ?? null,
+        upstream_status: detail?.upstream_status ?? null,
+      }, 502);
+    }
     return json({ error: `http_${err.status}` }, err.status);
   }
   return json({ error: "unknown" }, 500);

--- a/apps/console/src/app/api/settings/workspace/rename/route.ts
+++ b/apps/console/src/app/api/settings/workspace/rename/route.ts
@@ -41,14 +41,13 @@ export async function POST(request: Request) {
     return back(origin, wsId, "unknown");
   }
 
-  const url = new URL("/settings/workspaces", origin);
+  const url = new URL("/settings", origin);
   url.searchParams.set("ws", wsId);
-  url.searchParams.set("renamed", "1");
   return NextResponse.redirect(url, 303);
 }
 
 function back(origin: string, wsId: string, code: string) {
-  const url = new URL("/settings/workspaces", origin);
+  const url = new URL("/settings", origin);
   if (wsId) url.searchParams.set("ws", wsId);
   url.searchParams.set("error", code);
   return NextResponse.redirect(url, 303);

--- a/apps/console/src/app/onboarding/page.tsx
+++ b/apps/console/src/app/onboarding/page.tsx
@@ -480,9 +480,27 @@ export default async function OnboardingPage({
   // the per-repo reads with ``Promise.all`` — they're independent.
   let confirmCards: RepoCardInitial[] | null = null;
   let confirmLoadError: string | null = null;
+  let rolesComplete =
+    rolesInitial !== null &&
+    rolesInitial.currentTrackerKind !== null &&
+    rolesInitial.currentAgentProfile !== null;
   if (step === "confirm" && wsId && apiConfigured) {
     try {
-      const activated = await listActivatedRepos(wsId, sessionToken ?? undefined);
+      const [activated, wsListForRoles, integrationsForRoles] = await Promise.all([
+        listActivatedRepos(wsId, sessionToken ?? undefined),
+        listWorkspaces(sessionToken ?? undefined).catch(() => [] as Awaited<ReturnType<typeof listWorkspaces>>),
+        listIntegrations(wsId, sessionToken ?? undefined).catch(() => [] as Awaited<ReturnType<typeof listIntegrations>>),
+      ]);
+      // Compute roles completion for the stepper checkmark — the roles
+      // data isn't loaded on the confirm step normally, so we fetch it
+      // here to avoid showing "4" instead of ✓ when arriving from step 4.
+      const wsForRoles = wsListForRoles.find((w) => w.id === wsId);
+      const hasTracker =
+        integrationsForRoles.some(
+          (i) => (i.kind === "linear" || i.kind === "jira") && i.has_secret,
+        ) || githubAppInstalled;
+      const defaultAgentProfile = wsForRoles?.default_agent_profile ?? null;
+      rolesComplete = hasTracker && defaultAgentProfile != null;
       if (activated.length === 0) {
         // No repos → bounce to the picker. Soft redirect via URL
         // param so the banner explains what happened.
@@ -492,7 +510,7 @@ export default async function OnboardingPage({
       }
       confirmCards = await Promise.all(
         activated.map((r) =>
-          loadRepoCardInitial(wsId, r, sessionToken ?? undefined),
+          loadRepoCardInitial(wsId, r, sessionToken ?? undefined, defaultAgentProfile),
         ),
       );
     } catch (err) {
@@ -589,10 +607,7 @@ export default async function OnboardingPage({
                 // rendered (otherwise we don't pay for the workspace
                 // + integrations fetch on every step). On other
                 // steps the cell shows the step number, not a ✓.
-                roles:
-                  rolesInitial !== null &&
-                  rolesInitial.currentTrackerKind !== null &&
-                  rolesInitial.currentAgentProfile !== null,
+                roles: rolesComplete,
                 confirm: false /* never auto-checks; confirm is the action */,
               }}
             />
@@ -1485,10 +1500,26 @@ function TrackerStep({
  * instead of a generic "reload" banner. The full message is logged
  * server-side for ops to triage.
  */
+/** Maps a workspace ``default_agent_profile`` to the agent catalog slug
+ *  whose secret becomes required on the confirm step. Abstract profiles
+ *  (auto/main/cheaper) default to claude-md — the canonical Ship agent.
+ *  Profiles that need no vendor key (local_cli, ship_cloud_agent) return
+ *  null so no agent is marked required. */
+const PROFILE_TO_REQUIRED_SLUG: Record<string, string | null> = {
+  cursor_agent: "cursor-cloud",
+  codex_cli: "codex",
+  main: "claude-md",
+  auto: "claude-md",
+  cheaper: "claude-md",
+  ship_cloud_agent: null,
+  local_cli: null,
+};
+
 async function loadRepoCardInitial(
   wsId: string,
   repo: ApiActivatedRepo,
   token: string | undefined,
+  defaultAgentProfile: string | null = null,
 ): Promise<RepoCardInitial> {
   const [trackerRes, secretsRes] = await Promise.allSettled([
     getRepoTrackerBinding(wsId, repo.id, token),
@@ -1531,6 +1562,18 @@ async function loadRepoCardInitial(
     // open a seed PR. The card surfaces ``probe_errors.agents`` so
     // they know the secret check is stale.
     agents = [];
+  }
+
+  // Mark the agent matching the workspace's chosen profile as required
+  // so the "Open seed PR" button stays blocked until that key is set.
+  const requiredSlug =
+    defaultAgentProfile != null
+      ? (PROFILE_TO_REQUIRED_SLUG[defaultAgentProfile] ?? null)
+      : null;
+  if (requiredSlug !== null) {
+    agents = agents.map((a) =>
+      a.slug === requiredSlug ? { ...a, required: true } : a,
+    );
   }
 
   return {

--- a/apps/console/src/app/onboarding/repo-card.tsx
+++ b/apps/console/src/app/onboarding/repo-card.tsx
@@ -128,7 +128,9 @@ export function RepoCard({
 
   const [seedSaving, setSeedSaving] = useState(false);
   const [seedError, setSeedError] = useState<string | null>(null);
+  const [trackerRequired, setTrackerRequired] = useState(false);
   const seedButtonRef = useRef<HTMLButtonElement | null>(null);
+  const trackerRef = useRef<HTMLFieldSetElement | null>(null);
   // Post-seed modal state. Pre-fix the seed POST navigated straight
   // to ``/done`` and silently dropped the operator on a screen that
   // told them "open the PR on GitHub and merge it" — ~30% of pilot
@@ -280,10 +282,15 @@ export function RepoCard({
       )}
 
       {/* ── Tracker binding ────────────────────────────────────── */}
-      <fieldset className="mt-5">
+      <fieldset ref={trackerRef} className="mt-5">
         <legend className="text-[11px] font-bold uppercase tracking-widest text-white/55">
           Tracker
         </legend>
+        {trackerRequired && (
+          <p className="mt-1 text-[11px] font-semibold text-coral">
+            Pick a tracker before opening the seed PR.
+          </p>
+        )}
         {initial.probe_errors?.tracker && (
           <p className="mt-2 rounded border border-amber-500/30 bg-amber-500/10 px-2.5 py-1.5 text-[11px] leading-snug text-amber-200">
             Couldn&apos;t read the current tracker binding:{" "}
@@ -319,12 +326,13 @@ export function RepoCard({
                     ? "Connect Linear OAuth at the workspace level first"
                     : undefined
                 }
-                onClick={() =>
+                onClick={() => {
                   setTrackerDraft((d) => ({
                     ...d,
                     kind: selected ? "" : k,
-                  }))
-                }
+                  }));
+                  if (!selected) setTrackerRequired(false);
+                }}
                 className={`${baseClass} ${stateClass}`}
               >
                 {k}
@@ -423,6 +431,10 @@ export function RepoCard({
                 binding: ApiTrackerBinding;
               };
               setTracker(body.binding);
+              setTrackerRequired(false);
+              setSeedError((prev) =>
+                prev === "workspace_tracker_required" ? null : prev,
+              );
             }}
             className="rounded-full border border-aqua/40 bg-aqua/[0.08] px-3 py-1 text-[11px] font-semibold text-aqua transition hover:bg-aqua/[0.16] disabled:opacity-40"
           >
@@ -474,7 +486,7 @@ export function RepoCard({
           summary. */}
       <details
         className="mt-5 group/agents"
-        open={missingRequiredSecrets.length > 0 || secretsFailed.length > 0}
+        open
       >
         <summary className="cursor-pointer list-none [&::-webkit-details-marker]:hidden">
           <span className="inline-flex items-center gap-2">
@@ -684,10 +696,9 @@ export function RepoCard({
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div className="min-w-0 text-[11px] leading-snug text-white/55">
             {!readyToSeed ? (
-              <>
-                <strong className="text-white/80">Not ready.</strong>{" "}
-                {missingBlockers(missingRequiredSecrets)}
-              </>
+              <span className="font-semibold text-coral">
+                Not ready. {missingBlockers(missingRequiredSecrets)}
+              </span>
             ) : seedState === "update_available" ? (
               <>
                 Re-seed updates Ship&apos;s workflow and config files to{" "}
@@ -722,7 +733,16 @@ export function RepoCard({
               if (!resp.ok) {
                 setSeedSaving(false);
                 const p = await resp.json().catch(() => ({}));
-                setSeedError(p?.error ?? "unknown");
+                const errCode = p?.error ?? "unknown";
+                const errDetail = p?.detail ? ` — ${p.detail}` : "";
+                setSeedError(errCode + errDetail);
+                if (errCode === "workspace_tracker_required") {
+                  setTrackerRequired(true);
+                  trackerRef.current?.scrollIntoView({
+                    behavior: "smooth",
+                    block: "center",
+                  });
+                }
                 return;
               }
               const body = (await resp.json()) as {
@@ -749,11 +769,17 @@ export function RepoCard({
             }}
             className="inline-flex items-center justify-center gap-1.5 rounded-full bg-gradient-to-r from-coral via-lilac to-aqua px-5 py-2 text-sm font-semibold text-ink shadow-glow transition hover:brightness-110 active:scale-[0.99] disabled:cursor-default disabled:bg-none disabled:bg-white/[0.05] disabled:text-white/45 disabled:shadow-none"
           >
-            {seedSaving
-              ? "Opening PR..."
-              : seedState === "update_available"
-                ? "Open re-seed PR"
-                : "Open seed PR"}
+            {seedSaving ? (
+              <span className="inline-flex items-center gap-2">
+                <svg className="animate-spin h-3.5 w-3.5" viewBox="0 0 24 24" fill="none">
+                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"/>
+                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"/>
+                </svg>
+                Opening PR…
+              </span>
+            ) : seedState === "update_available"
+              ? "Open re-seed PR"
+              : "Open seed PR"}
           </button>
         </div>
         {seedError && (

--- a/apps/console/src/app/onboarding/roles-step.tsx
+++ b/apps/console/src/app/onboarding/roles-step.tsx
@@ -33,6 +33,7 @@
 "use client";
 
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { useState } from "react";
 
 import { Badge } from "@/components/ui";
@@ -101,6 +102,9 @@ export function RolesStep({ initial }: { initial: RolesStepInitial }) {
   const [agentError, setAgentError] = useState<string | null>(null);
   const [trackerSaving, setTrackerSaving] = useState(false);
   const [trackerError, setTrackerError] = useState<string | null>(null);
+  const [submitted, setSubmitted] = useState(false);
+  const [continuing, setContinuing] = useState(false);
+  const router = useRouter();
 
   const trackerOptions = initial.trackerCandidates;
   const trackerReady = tracker !== "";
@@ -153,52 +157,64 @@ export function RolesStep({ initial }: { initial: RolesStepInitial }) {
             </p>
           ) : (
             <div className="flex flex-wrap items-center gap-3">
-              <select
-                value={tracker}
-                disabled={trackerSaving}
-                onChange={async (e) => {
-                  const next = e.target.value as TrackerKind | "";
-                  if (!next || next === tracker) return;
-                  setTrackerSaving(true);
-                  setTrackerError(null);
-                  // ``tracker-install`` is form-encoded by design, so
-                  // we use a transient form to fire the request.
-                  // Browser-side fetch with form-data also works and
-                  // skips the page redirect.
-                  try {
-                    const fd = new FormData();
-                    fd.set("ws", initial.workspaceId);
-                    fd.set("kind", next);
-                    const resp = await fetch(
-                      "/api/onboard/tracker-install",
-                      { method: "POST", body: fd, redirect: "manual" },
-                    );
-                    // The handler 303-redirects on success; with
-                    // ``redirect: "manual"`` fetch returns an opaque
-                    // response and ``resp.ok`` is false. Treat any
-                    // non-error type as success — the action itself
-                    // is fire-and-forget.
-                    if (resp.type !== "opaqueredirect" && !resp.ok) {
-                      throw new Error(`HTTP ${resp.status}`);
+              <div className="relative">
+                <select
+                  value={tracker}
+                  disabled={trackerSaving}
+                  onChange={async (e) => {
+                    const next = e.target.value as TrackerKind | "";
+                    if (!next || next === tracker) return;
+                    setTrackerSaving(true);
+                    setTrackerError(null);
+                    // ``tracker-install`` is form-encoded by design, so
+                    // we use a transient form to fire the request.
+                    // Browser-side fetch with form-data also works and
+                    // skips the page redirect.
+                    try {
+                      const fd = new FormData();
+                      fd.set("ws", initial.workspaceId);
+                      fd.set("kind", next);
+                      const resp = await fetch(
+                        "/api/onboard/tracker-install",
+                        { method: "POST", body: fd, redirect: "manual" },
+                      );
+                      // The handler 303-redirects on success; with
+                      // ``redirect: "manual"`` fetch returns an opaque
+                      // response and ``resp.ok`` is false. Treat any
+                      // non-error type as success — the action itself
+                      // is fire-and-forget.
+                      if (resp.type !== "opaqueredirect" && !resp.ok) {
+                        throw new Error(`HTTP ${resp.status}`);
+                      }
+                      setTracker(next);
+                    } catch (err) {
+                      setTrackerError(
+                        err instanceof Error ? err.message : "save failed",
+                      );
+                    } finally {
+                      setTrackerSaving(false);
                     }
-                    setTracker(next);
-                  } catch (err) {
-                    setTrackerError(
-                      err instanceof Error ? err.message : "save failed",
-                    );
-                  } finally {
-                    setTrackerSaving(false);
+                  }}
+                  className={
+                    "appearance-none rounded-lg border px-3 py-2 pr-8 text-xs text-white bg-white/[0.04] " +
+                    (submitted && !trackerReady
+                      ? "border-coral/70 bg-coral/[0.06]"
+                      : "border-white/[0.08]")
                   }
-                }}
-                className="rounded-lg border border-white/[0.08] bg-white/[0.04] px-3 py-1.5 text-xs text-white"
-              >
-                <option value="">— pick a tracker —</option>
-                {trackerOptions.map((kind) => (
-                  <option key={kind} value={kind}>
-                    {TRACKER_LABEL[kind]}
-                  </option>
-                ))}
-              </select>
+                >
+                  <option value="">— pick a tracker —</option>
+                  {trackerOptions.map((kind) => (
+                    <option key={kind} value={kind}>
+                      {TRACKER_LABEL[kind]}
+                    </option>
+                  ))}
+                </select>
+                <span className="pointer-events-none absolute inset-y-0 right-2.5 flex items-center text-white/45">
+                  <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+                    <path d="M3 4.5L6 7.5L9 4.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+                  </svg>
+                </span>
+              </div>
               {trackerSaving && (
                 <span className="text-[11px] text-white/55">Saving…</span>
               )}
@@ -216,6 +232,7 @@ export function RolesStep({ initial }: { initial: RolesStepInitial }) {
           label="Documentation"
           description="Where curated knowledge buckets live."
           ready={initial.docsCandidates.length > 0}
+          hideBadge
         >
           {initial.docsCandidates.length === 0 ? (
             <p className="text-[11px] text-white/55">
@@ -251,52 +268,64 @@ export function RolesStep({ initial }: { initial: RolesStepInitial }) {
           ready={agentReady}
         >
           <div className="flex flex-wrap items-center gap-3">
-            <select
-              value={agent}
-              disabled={agentSaving}
-              onChange={async (e) => {
-                const next = e.target.value;
-                if (!next || next === agent) return;
-                setAgentSaving(true);
-                setAgentError(null);
-                try {
-                  const resp = await fetch(
-                    "/api/onboard/workspace-defaults",
-                    {
-                      method: "PATCH",
-                      headers: { "content-type": "application/json" },
-                      body: JSON.stringify({
-                        workspace_id: initial.workspaceId,
-                        default_agent_profile: next,
-                      }),
-                    },
-                  );
-                  if (!resp.ok) {
-                    const payload = await resp.json().catch(() => ({}));
-                    throw new Error(
-                      typeof payload?.error === "string"
-                        ? payload.error
-                        : `HTTP ${resp.status}`,
+            <div className="relative">
+              <select
+                value={agent}
+                disabled={agentSaving}
+                onChange={async (e) => {
+                  const next = e.target.value;
+                  if (!next || next === agent) return;
+                  setAgentSaving(true);
+                  setAgentError(null);
+                  try {
+                    const resp = await fetch(
+                      "/api/onboard/workspace-defaults",
+                      {
+                        method: "PATCH",
+                        headers: { "content-type": "application/json" },
+                        body: JSON.stringify({
+                          workspace_id: initial.workspaceId,
+                          default_agent_profile: next,
+                        }),
+                      },
                     );
+                    if (!resp.ok) {
+                      const payload = await resp.json().catch(() => ({}));
+                      throw new Error(
+                        typeof payload?.error === "string"
+                          ? payload.error
+                          : `HTTP ${resp.status}`,
+                      );
+                    }
+                    setAgent(next);
+                  } catch (err) {
+                    setAgentError(
+                      err instanceof Error ? err.message : "save failed",
+                    );
+                  } finally {
+                    setAgentSaving(false);
                   }
-                  setAgent(next);
-                } catch (err) {
-                  setAgentError(
-                    err instanceof Error ? err.message : "save failed",
-                  );
-                } finally {
-                  setAgentSaving(false);
+                }}
+                className={
+                  "appearance-none rounded-lg border px-3 py-2 pr-8 text-xs text-white bg-white/[0.04] " +
+                  (submitted && !agentReady
+                    ? "border-coral/70 bg-coral/[0.06]"
+                    : "border-white/[0.08]")
                 }
-              }}
-              className="rounded-lg border border-white/[0.08] bg-white/[0.04] px-3 py-1.5 text-xs text-white"
-            >
-              <option value="">— pick a default agent —</option>
-              {AGENT_PROFILES.map((p) => (
-                <option key={p.value} value={p.value}>
-                  {p.label}
-                </option>
-              ))}
-            </select>
+              >
+                <option value="">— pick a default agent —</option>
+                {AGENT_PROFILES.map((p) => (
+                  <option key={p.value} value={p.value}>
+                    {p.label}
+                  </option>
+                ))}
+              </select>
+              <span className="pointer-events-none absolute inset-y-0 right-2.5 flex items-center text-white/45">
+                <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+                  <path d="M3 4.5L6 7.5L9 4.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+                </svg>
+              </span>
+            </div>
             {agentSaving && (
               <span className="text-[11px] text-white/55">Saving…</span>
             )}
@@ -337,19 +366,60 @@ export function RolesStep({ initial }: { initial: RolesStepInitial }) {
           >
             ← Integrations
           </Link>
-          <Link
-            href={`/onboarding?step=confirm&ws=${encodeURIComponent(
-              initial.workspaceId,
-            )}`}
+          <button
+            type="button"
             data-testid="onboarding-roles-continue"
-            className={`rounded-md px-3 py-1.5 text-sm font-semibold transition ${
-              allReady
-                ? "bg-aqua/15 text-aqua hover:bg-aqua/25"
-                : "bg-white/[0.02] text-white/40 pointer-events-none"
-            }`}
+            disabled={continuing}
+            onClick={async () => {
+              if (!allReady) {
+                setSubmitted(true);
+                return;
+              }
+              setContinuing(true);
+              // Ensure the workspace-level tracker Integration row exists
+              // before navigating. tracker-install with kind=github creates
+              // the row if it's missing — this covers the case where the
+              // user arrived with github pre-selected but never changed the
+              // dropdown (so the onChange fetch never fired).
+              if (tracker) {
+                try {
+                  const fd = new FormData();
+                  fd.set("ws", initial.workspaceId);
+                  fd.set("kind", tracker);
+                  await fetch("/api/onboard/tracker-install", {
+                    method: "POST",
+                    body: fd,
+                    redirect: "manual",
+                  });
+                } catch {
+                  // best-effort
+                }
+              }
+              router.push(
+                `/onboarding?step=confirm&ws=${encodeURIComponent(initial.workspaceId)}`,
+              );
+            }}
+            className={
+              "rounded-md px-3 py-1.5 text-sm font-semibold transition " +
+              (continuing
+                ? "cursor-not-allowed bg-white/[0.04] text-white/30"
+                : allReady
+                  ? "bg-aqua/15 text-aqua hover:bg-aqua/25"
+                  : "bg-white/[0.02] text-white/40 hover:bg-white/[0.05] hover:text-white/60")
+            }
           >
-            Continue →
-          </Link>
+            {continuing ? (
+              <span className="inline-flex items-center gap-2">
+                <svg className="animate-spin h-3.5 w-3.5" viewBox="0 0 24 24" fill="none">
+                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"/>
+                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"/>
+                </svg>
+                Saving…
+              </span>
+            ) : (
+              "Continue →"
+            )}
+          </button>
         </div>
       </div>
     </section>
@@ -360,11 +430,13 @@ function RoleRow({
   label,
   description,
   ready,
+  hideBadge,
   children,
 }: {
   label: string;
   description: string;
   ready: boolean;
+  hideBadge?: boolean;
   children: React.ReactNode;
 }) {
   return (
@@ -373,9 +445,11 @@ function RoleRow({
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2">
             <span className="text-sm font-semibold text-white">{label}</span>
-            <Badge tone={ready ? "ok" : "warn"}>
-              {ready ? "ready" : "needed"}
-            </Badge>
+            {!hideBadge && (
+              <Badge tone={ready ? "ok" : "warn"}>
+                {ready ? "ready" : "needed"}
+              </Badge>
+            )}
           </div>
           <p className="mt-0.5 text-[11px] text-white/60">{description}</p>
         </div>

--- a/apps/console/src/app/page.tsx
+++ b/apps/console/src/app/page.tsx
@@ -22,6 +22,7 @@ import {
   isApiConfigured,
   listActivatedRepos,
   listInboxItems,
+  listIntegrations,
   listWorkspaces,
 } from "@/lib/api/client";
 import {
@@ -129,11 +130,19 @@ export default async function CloudHomePage({
   return renderWorkspaceHome(result, { opsWindow, skipWizard });
 }
 
+export type SetupResume = {
+  step: "tracker" | "roles" | "confirm";
+  label: string;
+  href: string;
+};
+
 type LiveContext = {
   workspace: ApiWorkspace;
   allWorkspaces: ApiWorkspace[];
   data: ApiOpsDashboard;
   repos: ApiActivatedRepo[];
+  /** Earliest incomplete onboarding step, or null if setup is done. */
+  setupResume: SetupResume | null;
   /** Inbox preview for "What needs you" — top items + counts. Best-effort:
    *  if the call fails we degrade to empty arrays so the rest of the
    *  dashboard still renders. */
@@ -170,6 +179,8 @@ function isGreenfieldWorkspace(ctx: LiveContext): boolean {
   );
 }
 
+const TRACKER_KINDS = new Set(["github", "linear", "notion", "jira", "azure_devops", "gitlab"]);
+
 async function loadLiveContext(
   token: string,
   list: ApiWorkspace[],
@@ -178,12 +189,13 @@ async function loadLiveContext(
 ): Promise<LiveContext | "unauthorized" | "down"> {
   const workspace = pickWorkspace(list, wsParam);
   try {
-    const [data, repos, inboxItems, inboxCounts, priorities, liveSystem] =
+    const [data, repos, integrations, inboxItems, inboxCounts, priorities, liveSystem] =
       await Promise.all([
         getOpsDashboard(workspace.id, token, { window: opsWindow }),
         listActivatedRepos(workspace.id, token).catch(
           () => [] as ApiActivatedRepo[],
         ),
+        listIntegrations(workspace.id, token).catch(() => []),
         listInboxItems(
           workspace.id,
           {
@@ -204,11 +216,15 @@ async function loadLiveContext(
           () => null as ApiLiveSystem | null,
         ),
       ]);
+
+    const setupResume = resolveSetupResume(workspace, repos, integrations);
+
     return {
       workspace,
       allWorkspaces: list,
       data,
       repos,
+      setupResume,
       inboxItems,
       inboxCounts,
       priorities,
@@ -219,6 +235,33 @@ async function loadLiveContext(
     if (err instanceof ApiUnavailableError) return "down";
     return "down";
   }
+}
+
+function resolveSetupResume(
+  workspace: ApiWorkspace,
+  repos: ApiActivatedRepo[],
+  integrations: Awaited<ReturnType<typeof listIntegrations>>,
+): SetupResume | null {
+  if (repos.length === 0) return null;
+
+  const wsId = workspace.id;
+  const base = `/onboarding`;
+
+  const hasTracker = integrations.some((i) => TRACKER_KINDS.has(i.kind));
+  if (!hasTracker) {
+    return { step: "tracker", label: "Connect a tracker", href: `${base}?step=tracker&ws=${wsId}` };
+  }
+
+  if (workspace.default_agent_profile === null) {
+    return { step: "roles", label: "Pick an agent role", href: `${base}?step=roles&ws=${wsId}` };
+  }
+
+  const allUnseeded = repos.every((r) => r.installed_bundle_version === null);
+  if (allUnseeded) {
+    return { step: "confirm", label: "Open your seed PR", href: `${base}?step=confirm&ws=${wsId}` };
+  }
+
+  return null;
 }
 
 function renderWorkspaceHome(
@@ -255,6 +298,7 @@ function renderWorkspaceHome(
         liveSystem={ctx.liveSystem}
         opsWindow={opsWindow}
         skipWizard={skipWizard}
+        setupResume={skipWizard ? null : ctx.setupResume}
       />
     </AppShell>
   );
@@ -300,11 +344,6 @@ function renderGreenfieldWelcome(ctx: LiveContext) {
       kicker={workspace.slug}
       workspace={{ id: workspace.id, name: workspace.name, slug: workspace.slug }}
       allWorkspaces={toAppShellWorkspaces(allWorkspaces)}
-      actions={
-        <ButtonPrimary>
-          <Link href={onboardingHref}>Continue setup →</Link>
-        </ButtonPrimary>
-      }
     >
       <div className="mx-auto max-w-3xl space-y-10">
         <header className="space-y-3">
@@ -333,6 +372,11 @@ function renderGreenfieldWelcome(ctx: LiveContext) {
             </li>
           ))}
         </ol>
+        <div>
+          <ButtonPrimary>
+            <Link href={onboardingHref}>Continue setup →</Link>
+          </ButtonPrimary>
+        </div>
       </div>
     </AppShell>
   );

--- a/apps/console/src/components/workspace-home.tsx
+++ b/apps/console/src/components/workspace-home.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 
 import { DashboardPrioritizer } from "@/components/dashboard/prioritizer";
 import { TemplateUpdateAlert } from "@/components/template-update-alert";
+import type { SetupResume } from "@/app/page";
 import type {
   ApiActivatedRepo,
   ApiLiveSystem,
@@ -61,6 +62,7 @@ export type WorkspaceHomeProps = {
   liveSystem: ApiLiveSystem | null;
   opsWindow: OpsReportWindow;
   skipWizard: boolean;
+  setupResume?: SetupResume | null;
 };
 
 export function WorkspaceHome({
@@ -74,6 +76,7 @@ export function WorkspaceHome({
   liveSystem,
   opsWindow,
   skipWizard,
+  setupResume = null,
 }: WorkspaceHomeProps) {
   const reposNeedingUpdate = repos.filter(needsShipTemplateUpdate);
   const decisions = (inboxItems?.items ?? []).slice(0, 5);
@@ -94,6 +97,24 @@ export function WorkspaceHome({
 
   return (
     <div className="mx-auto w-full max-w-[1600px] space-y-10">
+      {setupResume && (
+        <div className="flex items-center justify-between gap-4 rounded-2xl border border-sun/30 bg-sun/[0.06] px-5 py-4">
+          <div className="min-w-0">
+            <p className="text-sm font-semibold text-sun">Setup not finished</p>
+            <p className="mt-0.5 text-xs text-white/55">
+              {setupResume.step === "tracker" && "Connect a tracker so Ship can link work to issues."}
+              {setupResume.step === "roles" && "Pick an agent role so Ship knows which AI to use."}
+              {setupResume.step === "confirm" && "Open the seed PR to wire Ship into your repo."}
+            </p>
+          </div>
+          <Link
+            href={setupResume.href}
+            className="shrink-0 rounded-full bg-sun/15 px-4 py-2 text-xs font-semibold text-sun transition-colors hover:bg-sun/25"
+          >
+            Continue setup →
+          </Link>
+        </div>
+      )}
       {(reposNeedingUpdate.length > 0 || summary.blockers.length > 0) && (
         <StatusAlerts
           blockers={summary.blockers}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,6 +85,7 @@ services:
     build:
       context: .
       dockerfile: infra/deploy/backend/Dockerfile
+    command: ["uvicorn", "backend.app.main:app", "--host", "0.0.0.0", "--port", "8100", "--log-level", "info"]
     restart: unless-stopped
     depends_on:
       postgres:
@@ -92,8 +93,8 @@ services:
       minio:
         condition: service_healthy
     environment:
-      DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER:-ship}:${POSTGRES_PASSWORD:-ship}@postgres:5432/${POSTGRES_DB:-ship}
-      ALEMBIC_DATABASE_URL: postgresql+psycopg://${POSTGRES_USER:-ship}:${POSTGRES_PASSWORD:-ship}@postgres:5432/${POSTGRES_DB:-ship}
+      DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER:-ship}:${POSTGRES_PASSWORD:-ship}@postgres:5432/${POSTGRES_DB:-ship}?sslmode=disable
+      ALEMBIC_DATABASE_URL: postgresql+psycopg://${POSTGRES_USER:-ship}:${POSTGRES_PASSWORD:-ship}@postgres:5432/${POSTGRES_DB:-ship}?sslmode=disable
       S3_ENDPOINT_URL: http://minio:9000
       S3_BUCKET: ${S3_BUCKET:-ship-documents}
       S3_ACCESS_KEY: ${S3_ACCESS_KEY:-shipminio}
@@ -104,6 +105,9 @@ services:
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       OPENAI_EMBED_MODEL: ${OPENAI_EMBED_MODEL:-text-embedding-3-small}
       GITHUB_TOKEN: ${GITHUB_TOKEN:-}
+      GITHUB_APP_ID: ${GITHUB_APP_ID:-}
+      GITHUB_APP_PRIVATE_KEY: ${GITHUB_APP_PRIVATE_KEY:-}
+      GITHUB_APP_WEBHOOK_SECRET: ${GITHUB_APP_WEBHOOK_SECRET:-}
       SHIP_FEEDBACK_REPO: ${SHIP_FEEDBACK_REPO:-ElMundiUA/ship}
       SHIP_AUTH_MODE: ${SHIP_AUTH_MODE:-local}
       SHIP_ALLOW_LOCAL_AUTH0_CALLBACKS: ${SHIP_ALLOW_LOCAL_AUTH0_CALLBACKS:-}
@@ -135,60 +139,61 @@ services:
       retries: 6
       start_period: 30s
 
-  console:
-    # Operator console (Next.js). The marketing landing is intentionally NOT
-    # in compose — it stays on the public web and reads like any other site.
-    # This service ships only the in-app operator UI.
-    build:
-      context: .
-      dockerfile: infra/deploy/console/Dockerfile
-    restart: unless-stopped
-    depends_on:
-      ship-server:
-        # Wait for migrations + DB before serving — otherwise the first SSR
-        # request lands on a half-booted backend and the page falls back to
-        # the mock banner for no good reason.
-        condition: service_healthy
-    environment:
-      # Console talks to ship-server over the internal compose network.
-      # next.config.ts proxies /api/* -> ${SHIP_API_URL}/v1/* when set.
-      SHIP_API_URL: http://ship-server:8100
-      PORT: "3001"
-      SHIP_AUTH_MODE: ${SHIP_AUTH_MODE:-local}
-      # Auth0 (used when SHIP_AUTH_MODE=auth0). The SDK reads these from
-      # the standard env names; APP_BASE_URL is the public URL the user
-      # hits in their browser.
-      AUTH0_DOMAIN: ${AUTH0_DOMAIN:-}
-      AUTH0_CLIENT_ID: ${AUTH0_CLIENT_ID:-}
-      AUTH0_CLIENT_SECRET: ${AUTH0_CLIENT_SECRET:-}
-      AUTH0_AUDIENCE: ${AUTH0_AUDIENCE:-}
-      AUTH0_SESSION_SECRET: ${AUTH0_SESSION_SECRET:-}
-      APP_BASE_URL: ${APP_BASE_URL:-http://localhost:3001}
-      # Sentry — empty DSN means "off". The console reads NEXT_PUBLIC_*
-      # variants in the browser bundle and the unprefixed ones server-side.
-      SENTRY_DSN: ${SENTRY_DSN:-}
-      SENTRY_ENVIRONMENT: ${SENTRY_ENVIRONMENT:-local}
-      SENTRY_TRACES_SAMPLE_RATE: ${SENTRY_TRACES_SAMPLE_RATE:-0.0}
-      NEXT_PUBLIC_SENTRY_DSN: ${NEXT_PUBLIC_SENTRY_DSN:-${SENTRY_DSN:-}}
-      NEXT_PUBLIC_SENTRY_ENVIRONMENT: ${NEXT_PUBLIC_SENTRY_ENVIRONMENT:-${SENTRY_ENVIRONMENT:-local}}
-      NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE: ${NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE:-${SENTRY_TRACES_SAMPLE_RATE:-0.0}}
-      SHIP_VERSION: ${SHIP_VERSION:-}
-    ports:
-      - "${SHIP_CONSOLE_PORT:-3001}:3001"
-    healthcheck:
-      # node:alpine doesn't ship curl/wget — use node itself so we don't
-      # have to bloat the runner image. /login is a server component that
-      # renders without DB hits, so it's a good liveness target.
-      test:
-        - CMD-SHELL
-        - >
-          node -e "require('http').get('http://localhost:3001/login',
-          r => process.exit(r.statusCode < 500 ? 0 : 1))
-          .on('error', () => process.exit(1))"
-      interval: 15s
-      timeout: 5s
-      retries: 5
-      start_period: 20s
+  # console:
+  #   # Commented out — run the frontend locally with `npm run dev` in apps/console.
+  #   # Operator console (Next.js). The marketing landing is intentionally NOT
+  #   # in compose — it stays on the public web and reads like any other site.
+  #   # This service ships only the in-app operator UI.
+  #   build:
+  #     context: .
+  #     dockerfile: infra/deploy/console/Dockerfile
+  #   restart: unless-stopped
+  #   depends_on:
+  #     ship-server:
+  #       # Wait for migrations + DB before serving — otherwise the first SSR
+  #       # request lands on a half-booted backend and the page falls back to
+  #       # the mock banner for no good reason.
+  #       condition: service_healthy
+  #   environment:
+  #     # Console talks to ship-server over the internal compose network.
+  #     # next.config.ts proxies /api/* -> ${SHIP_API_URL}/v1/* when set.
+  #     SHIP_API_URL: http://ship-server:8100
+  #     PORT: "3001"
+  #     SHIP_AUTH_MODE: ${SHIP_AUTH_MODE:-local}
+  #     # Auth0 (used when SHIP_AUTH_MODE=auth0). The SDK reads these from
+  #     # the standard env names; APP_BASE_URL is the public URL the user
+  #     # hits in their browser.
+  #     AUTH0_DOMAIN: ${AUTH0_DOMAIN:-}
+  #     AUTH0_CLIENT_ID: ${AUTH0_CLIENT_ID:-}
+  #     AUTH0_CLIENT_SECRET: ${AUTH0_CLIENT_SECRET:-}
+  #     AUTH0_AUDIENCE: ${AUTH0_AUDIENCE:-}
+  #     AUTH0_SESSION_SECRET: ${AUTH0_SESSION_SECRET:-}
+  #     APP_BASE_URL: ${APP_BASE_URL:-http://localhost:3001}
+  #     # Sentry — empty DSN means "off". The console reads NEXT_PUBLIC_*
+  #     # variants in the browser bundle and the unprefixed ones server-side.
+  #     SENTRY_DSN: ${SENTRY_DSN:-}
+  #     SENTRY_ENVIRONMENT: ${SENTRY_ENVIRONMENT:-local}
+  #     SENTRY_TRACES_SAMPLE_RATE: ${SENTRY_TRACES_SAMPLE_RATE:-0.0}
+  #     NEXT_PUBLIC_SENTRY_DSN: ${NEXT_PUBLIC_SENTRY_DSN:-${SENTRY_DSN:-}}
+  #     NEXT_PUBLIC_SENTRY_ENVIRONMENT: ${NEXT_PUBLIC_SENTRY_ENVIRONMENT:-${SENTRY_ENVIRONMENT:-local}}
+  #     NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE: ${NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE:-${SENTRY_TRACES_SAMPLE_RATE:-0.0}}
+  #     SHIP_VERSION: ${SHIP_VERSION:-}
+  #   ports:
+  #     - "${SHIP_CONSOLE_PORT:-3001}:3001"
+  #   healthcheck:
+  #     # node:alpine doesn't ship curl/wget — use node itself so we don't
+  #     # have to bloat the runner image. /login is a server component that
+  #     # renders without DB hits, so it's a good liveness target.
+  #     test:
+  #       - CMD-SHELL
+  #       - >
+  #         node -e "require('http').get('http://localhost:3001/login',
+  #         r => process.exit(r.statusCode < 500 ? 0 : 1))
+  #         .on('error', () => process.exit(1))"
+  #     interval: 15s
+  #     timeout: 5s
+  #     retries: 5
+  #     start_period: 20s
 
   ship-worker:
     # The worker is opt-in via `docker compose --profile worker up`. Cloud
@@ -217,7 +222,7 @@ services:
     environment:
       # Server runs migrations; worker should not race on them.
       SHIP_SKIP_MIGRATIONS: "1"
-      DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER:-ship}:${POSTGRES_PASSWORD:-ship}@postgres:5432/${POSTGRES_DB:-ship}
+      DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER:-ship}:${POSTGRES_PASSWORD:-ship}@postgres:5432/${POSTGRES_DB:-ship}?sslmode=disable
       REDIS_URL: redis://redis:6379/0
       S3_ENDPOINT_URL: http://minio:9000
       S3_BUCKET: ${S3_BUCKET:-ship-documents}


### PR DESCRIPTION
…ror detail, dashboard resume banner

Onboarding wizard:
- roles-step: always upsert Integration row on Continue so workspace_tracker_required is satisfied on next wizard_seed; custom SVG chevron on selects; spinner on Continue
- repo-card: surface github_api_error detail message; coral "Not ready" + scroll-to tracker on workspace_tracker_required; AGENTS section open by default; spinner on Open seed PR
- confirm step: fetch integrations + workspace on load so Roles stepper shows checkmark; post-process agent secrets to mark required slug based on default_agent_profile
- wizard-seed route: relay 502 github_api_error detail + upstream_status to client
- tracker-install route: upsert github Integration row so wizard_seed check passes

Dashboard:
- resolve earliest incomplete onboarding step (tracker → roles → confirm) from activated repos + integrations + installed_bundle_version; show Setup not finished banner with Continue setup link; hidden when skipWizard=1

repos.py: log WorkflowDispatchError from commit_bundle_pr via logger.exception
docker-compose: comment out console service (run locally); log-level info
.gitignore: ignore .playwright-mcp/