### PR TITLE
fix(deploy): canonicalize route globs in the DigitalOcean adapter

### DIFF
--- a/apps/backend/app/services/deploy/providers/digitalocean.py
+++ b/apps/backend/app/services/deploy/providers/digitalocean.py
@@ -180,6 +180,30 @@ def _root_relative_dockerfile(source_dir: str | None, dockerfile_path: str) -> s
     return f"{sd}/{df}"
 
 
+def _normalize_route_path(path: str | None) -> str:
+    """Canonicalize a plan route into a DigitalOcean ingress path PREFIX.
+
+    DO route paths are literal prefixes; globs are NOT supported. An LLM
+    planner may emit ``/*`` (informally "everything"), but DO then matches no
+    request and the app 404s on ``/`` (confirmed live: ``/*`` → 404, ``/`` →
+    200). Strip a trailing wildcard so ``/*`` → ``/`` and ``/api/*`` →
+    ``/api``; plain prefixes pass through unchanged. Provider-specific (other
+    targets, e.g. AWS ALB, accept globs), so it lives in the adapter next to
+    ``_root_relative_dockerfile`` — not in the planner or the provider-neutral
+    plan.
+    """
+    p = (path or "/").strip() or "/"
+    if not p.startswith("/"):
+        p = "/" + p
+    if p.endswith("/*"):
+        p = p[:-2] or "/"
+    elif p.endswith("*"):
+        p = p[:-1] or "/"
+    if p != "/":
+        p = "/" + p.strip("/")
+    return p
+
+
 def _build_service(
     comp,
     *,
@@ -208,7 +232,7 @@ def _build_service(
     if comp.http_port:
         svc["http_port"] = comp.http_port
     routes = comp.routes or ["/"]
-    svc["routes"] = [{"path": r} for r in routes]
+    svc["routes"] = [{"path": _normalize_route_path(r)} for r in routes]
     hc = _build_health_check(comp)
     if hc:
         svc["health_check"] = hc
@@ -235,7 +259,7 @@ def _build_static_site(
     if comp.output_dir:
         site["output_dir"] = comp.output_dir
     routes = comp.routes or ["/"]
-    site["routes"] = [{"path": r} for r in routes]
+    site["routes"] = [{"path": _normalize_route_path(r)} for r in routes]
     envs = _build_envs(comp.env, operator)
     if envs:
         site["envs"] = envs

--- a/apps/backend/tests/test_deploy_do_route_glob.py
+++ b/apps/backend/tests/test_deploy_do_route_glob.py
@@ -1,0 +1,70 @@
+"""Regression: the DigitalOcean adapter must canonicalize route globs.
+
+A DO ingress route ``path`` is a literal PREFIX — globs are not supported.
+When the LLM planner emits ``routes: ["/*"]`` (informally meaning
+"everything"), the adapter previously passed it through verbatim, so DO
+stored a route prefix of ``/*`` which matches no request — the app then
+404s on ``/`` (confirmed live: ``/*`` → HTTP 404, ``/`` → HTTP 200).
+
+Other providers (e.g. AWS ALB/CloudFront) accept globs, so this lives in
+the DO adapter, next to ``_root_relative_dockerfile`` — it's a
+provider-specific encoding detail, not a planner/IR concern.
+"""
+
+from __future__ import annotations
+
+from backend.app.services.deploy.plan import DeployComponent
+from backend.app.services.deploy.providers import digitalocean as do_adapter
+
+
+def _static(routes: list[str]) -> DeployComponent:
+    return DeployComponent(
+        name="frontend",
+        kind="static_site",
+        runtime="node-js",
+        source_dir="/",
+        output_dir="dist",
+        build_command="npm install && npm run build",
+        routes=routes,
+    )
+
+
+def _service(routes: list[str]) -> DeployComponent:
+    return DeployComponent(
+        name="api",
+        kind="service",
+        runtime="node-js",
+        source_dir="/",
+        http_port=8080,
+        routes=routes,
+        health_check_path="/healthz",
+    )
+
+
+def _build_static(routes: list[str]) -> dict:
+    return do_adapter._build_static_site(
+        _static(routes), source_key="github", source_dict={}, operator={}
+    )
+
+
+def _build_svc(routes: list[str]) -> dict:
+    return do_adapter._build_service(
+        _service(routes), source_key="github", source_dict={}, operator={}
+    )
+
+
+def test_static_site_root_glob_becomes_root_prefix() -> None:
+    assert _build_static(["/*"])["routes"] == [{"path": "/"}]
+
+
+def test_static_site_subpath_glob_drops_wildcard() -> None:
+    assert _build_static(["/api/*"])["routes"] == [{"path": "/api"}]
+
+
+def test_service_root_glob_becomes_root_prefix() -> None:
+    assert _build_svc(["/*"])["routes"] == [{"path": "/"}]
+
+
+def test_plain_prefixes_are_unchanged() -> None:
+    assert _build_static(["/"])["routes"] == [{"path": "/"}]
+    assert _build_svc(["/api"])["routes"] == [{"path": "/api"}]


### PR DESCRIPTION
## Problem

A no-manual-key (GitHub Actions) deploy of `frontend-only-janky` reached **ACTIVE** with a live URL, but the site **404'd on `/`** — it didn't actually serve.

Root cause: the planner LLM emitted `routes: ["/*"]`. A DigitalOcean ingress route `path` is a **literal prefix** — globs are not supported — so DO stored a `/*` prefix that matches *no* request, and every path (including `/`) 404'd. The adapter ([`_build_static_site`/`_build_service`](apps/backend/app/services/deploy/providers/digitalocean.py)) passed the route through verbatim.

The manual-key deploys of the same repo worked only because their LLM happened to emit `/` — same planner, just non-deterministic output.

### Confirmed live

- `curl https://…ondigitalocean.app/` with route `/*` → **HTTP 404** (`x-do-orig-status: 404`, empty body).
- Edited the DO route `/* → /` → redeploy → **HTTP 200**, `content-type: text/html`, serving the real `index.html`.

## Fix

Add `_normalize_route_path` and apply it in both DO builders:
- `/*` → `/`
- `/api/*` → `/api`
- plain prefixes (`/`, `/api`) unchanged

### Why the adapter, not the prompt or the plan

Route-path encoding is **provider-specific**: DO uses literal prefixes (no globs), while AWS ALB/CloudFront *do* accept `/*`. So normalizing belongs in the DO adapter next to `_root_relative_dockerfile` — not in the planner prompt (LLM output can't be guaranteed) and not in the provider-neutral `DeployPlan` (a glob may be valid for a future provider).

## Test

New regression test drives the builders directly: **fails** on the verbatim pass-through (`/*`, `/api/*`), **passes** with the normalization. Full deploy suite (13 tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)