### PR TITLE
Headless Pivot — Strangler Rework: phases P0-P3 + P5 (ELS-217..234, 241..245)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,7 @@ documentation/internal/*
 # Ops runbooks (e.g. file-overlap detection ELS-154) are shared with implementers.
 !documentation/internal/operations/
 !documentation/internal/operations/**
+# Architecture ledgers + the headless-pivot plan (ELS-217/ELS-220) are
+# reviewer-verifiable artifacts the strangler phases gate on — tracked.
+!documentation/internal/architecture/
+!documentation/internal/architecture/**

--- a/apps/backend/app/api/v1/router.py
+++ b/apps/backend/app/api/v1/router.py
@@ -27,6 +27,7 @@ from backend.app.api.v1.routes import (
     clarifications,
     config,
     dashboard,
+    engine_health,
     dashboard_live_system,
     deploy,
     digitalocean_oauth,
@@ -157,6 +158,7 @@ api_router.include_router(dashboard_priorities.router)
 # on every render.
 api_router.include_router(dashboard_live_system.router)
 api_router.include_router(analytics_dora.router)
+api_router.include_router(engine_health.router)
 # Per-repo Home rollup (RFC-0008 §F — PR-4) — a single snapshot the
 # /r/<slug> page renders as Now + Trends tabs without fanning out to
 # the four source endpoints client-side.

--- a/apps/backend/app/api/v1/routes/agent_runs.py
+++ b/apps/backend/app/api/v1/routes/agent_runs.py
@@ -89,6 +89,7 @@ from backend.app.services.file_overlap import (
     load_file_coordination_warning_from_audit,
 )
 from backend.app.services.file_overlap_telemetry import evaluate_file_overlap_honour
+from backend.app.services.state_projector import transition_via_projector
 from backend.app.services.tracker_resolver import resolve_for_workspace
 
 
@@ -2454,7 +2455,14 @@ async def transition_ticket(
     ref = _ticket_ref_from(resolved.kind, payload.ticket_ref)
     if payload.comment:
         await resolved.gateway.comment(ref, body=payload.comment)
-    await resolved.gateway.transition(ref, to_state=payload.to_state)
+    await transition_via_projector(
+        session,
+        settings=get_settings(),
+        workspace_id=workspace_id,
+        gateway=resolved.gateway,
+        ref=ref,
+        to_state=payload.to_state,
+    )
 
     session.add(
         AuditLog(
@@ -3092,7 +3100,14 @@ async def post_ticket_action(
 
     if payload.action == "cancel":
         try:
-            await resolved.gateway.transition(ref, to_state="Canceled")
+            await transition_via_projector(
+                session,
+                settings=get_settings(),
+                workspace_id=workspace_id,
+                gateway=resolved.gateway,
+                ref=ref,
+                to_state="Canceled",
+            )
         except Exception as exc:  # noqa: BLE001
             raise HTTPException(status_code=502, detail=str(exc)) from exc
         if payload.comment:
@@ -4308,8 +4323,12 @@ async def finish_agent_run(
                 and not is_workspace_bundle
                 and not defer_merged_transition
             ):
-                await resolved.gateway.transition(
-                    ref,
+                await transition_via_projector(
+                    session,
+                    settings=get_settings(),
+                    workspace_id=workspace_id,
+                    gateway=resolved.gateway,
+                    ref=ref,
                     to_state=payload.stage_next,
                     from_state=payload.fsm_stage,
                 )
@@ -4362,8 +4381,12 @@ async def finish_agent_run(
                     # the ticket in Done with the PR still open.
                     if defer_merged_transition and payload.stage_next:
                         try:
-                            await resolved.gateway.transition(
-                                ref,
+                            await transition_via_projector(
+                                session,
+                                settings=get_settings(),
+                                workspace_id=workspace_id,
+                                gateway=resolved.gateway,
+                                ref=ref,
                                 to_state=payload.stage_next,
                                 from_state=payload.fsm_stage,
                             )
@@ -4584,7 +4607,14 @@ async def finish_agent_run(
             actions.append("tracker:comment")
         # ``Done`` is the legacy workflow-state path in LinearTracker —
         # it resolves the state by literal name, not via FSM map.
-        await resolved.gateway.transition(ref, to_state="Done")
+        await transition_via_projector(
+            session,
+            settings=get_settings(),
+            workspace_id=workspace_id,
+            gateway=resolved.gateway,
+            ref=ref,
+            to_state="Done",
+        )
         actions.append("tracker:transition:Done")
         await _sweep_inbox_on_ticket_advance(
             session,
@@ -5042,7 +5072,14 @@ async def post_admin_relabel_stages(
         # ("Todo" / "Backlog" / "In Progress" / "Done" / "Canceled")
         # without faking an agent finish.
         try:
-            await resolved.gateway.transition(ref, to_state=payload.set_state)
+            await transition_via_projector(
+                session,
+                settings=get_settings(),
+                workspace_id=workspace_id,
+                gateway=resolved.gateway,
+                ref=ref,
+                to_state=payload.set_state,
+            )
             state_changed_to = payload.set_state
         except Exception as exc:  # noqa: BLE001
             raise HTTPException(

--- a/apps/backend/app/api/v1/routes/agent_runs.py
+++ b/apps/backend/app/api/v1/routes/agent_runs.py
@@ -1128,6 +1128,7 @@ async def _validate_code_review_to_auto_merge(
     workspace_id: uuid.UUID,
     pr_url: str | None,
     settings: Settings,
+    require_approval: bool = True,
 ) -> tuple[bool, str]:
     """Verify the agent's ``code_review → auto_merge`` claim against
     GitHub.
@@ -1214,21 +1215,27 @@ async def _validate_code_review_to_auto_merge(
                 "Authorization": f"Bearer {token}",
                 "Accept": "application/vnd.github+json",
             }
-            # 1. Reviews — need ≥1 APPROVED.
-            reviews_resp = await client.get(
-                f"{api_root}/pulls/{number}/reviews",
-                headers=headers,
-                params={"per_page": "100"},
-            )
-            if reviews_resp.status_code >= 400:
-                return False, f"reviews_api_{reviews_resp.status_code}"
-            reviews = reviews_resp.json() or []
-            has_approval = any(
-                str(r.get("state") or "").upper() == "APPROVED"
-                for r in reviews
-            )
-            if not has_approval:
-                return False, "no_approval"
+            # 1. Reviews — need ≥1 APPROVED. Autonomy-sensitive
+            # (ELS-243, thesis 7): ``require_approval=False`` (the
+            # ``high`` profile) skips ONLY this check — the CI-green
+            # check below is non-negotiable at every level (founder
+            # decision: a bug letting high skip CI would autonomously
+            # merge red code).
+            if require_approval:
+                reviews_resp = await client.get(
+                    f"{api_root}/pulls/{number}/reviews",
+                    headers=headers,
+                    params={"per_page": "100"},
+                )
+                if reviews_resp.status_code >= 400:
+                    return False, f"reviews_api_{reviews_resp.status_code}"
+                reviews = reviews_resp.json() or []
+                has_approval = any(
+                    str(r.get("state") or "").upper() == "APPROVED"
+                    for r in reviews
+                )
+                if not has_approval:
+                    return False, "no_approval"
 
             # 2. PR detail — need head SHA for check-runs.
             pr_resp = await client.get(
@@ -3962,17 +3969,32 @@ async def finish_agent_run(
         and resolved is not None
     ):
         pr_url = _extract_pr_url(payload.comment)
+        # ELS-243 (thesis 7): the approval requirement is autonomy-
+        # sensitive — ``high`` trusts the reviewer bundle + this gate's
+        # CI check and skips the human-approval requirement;
+        # conservative/balanced keep today's behavior. CI-green stays
+        # non-negotiable for every profile inside the validator.
+        from backend.app.services.agent_provider_resolver import (
+            resolve_autonomy_for_workspace,
+        )
+
+        autonomy_profile = await resolve_autonomy_for_workspace(
+            session=session, workspace_id=workspace_id
+        )
         gate_ok, gate_reason = await _validate_code_review_to_auto_merge(
             session,
             workspace_id=workspace_id,
             pr_url=pr_url,
             settings=settings,
+            require_approval=autonomy_profile != "high",
         )
+        actions.append(f"phase4:gate_profile:{autonomy_profile}")
         if not gate_ok:
             logger.info(
                 "phase4 gate rejected code_review→auto_merge "
-                "ws=%s ticket=%s reason=%s pr_url=%s",
+                "ws=%s ticket=%s reason=%s pr_url=%s autonomy=%s",
                 workspace_id, payload.ticket_ref, gate_reason, pr_url,
+                autonomy_profile,
             )
             session.add(
                 AuditLog(
@@ -3988,6 +4010,7 @@ async def finish_agent_run(
                         "reason": gate_reason,
                         "pr_url": pr_url,
                         "run_id": payload.run_id,
+                        "autonomy": autonomy_profile,
                     },
                 )
             )

--- a/apps/backend/app/api/v1/routes/agent_runs.py
+++ b/apps/backend/app/api/v1/routes/agent_runs.py
@@ -765,36 +765,34 @@ async def get_next_task(
                     )
                 )
                 # First detection in this window → drop one blocker
-                # row in the operator inbox. The audit-row dedup
-                # gates this same-window check, so we don't re-issue
-                # blocker letters either.
-                session.add(
-                    InboxItem(
-                        workspace_id=workspace_id,
-                        repo_id=None,
-                        type="blocker",
-                        title=(
-                            f"Tracker {resolved.kind} unreachable — "
-                            f"agents stalled"
-                        )[:300],
-                        summary=(
-                            "The bound tracker adapter is rejecting calls "
-                            "(likely an OAuth token expiry / revocation). "
-                            "Re-authorize the workspace integration to "
-                            "restore agent picks. Subsequent stage picks "
-                            "in this hour are short-circuited to keep the "
-                            "audit log readable.\n\n"
-                            f"First error: {str(exc)[:400]}"
-                        )[:2000],
-                        payload={
-                            "tracker_kind": resolved.kind,
-                            "fsm_stage": state,
-                            "error": str(exc)[:500],
-                        },
-                        status="new",
-                        intake_handle=None,
-                        intake_reason="tracker_outage",
-                    )
+                # letter. The audit-row dedup above gates this
+                # same-window check (caller-side dedup stays — the
+                # notify() seam only routes the emission, ELS-224).
+                from backend.app.services.notify import NotifyLevel, notify
+
+                await notify(
+                    session,
+                    workspace_id=workspace_id,
+                    title=(
+                        f"Tracker {resolved.kind} unreachable — "
+                        f"agents stalled"
+                    )[:300],
+                    body=(
+                        "The bound tracker adapter is rejecting calls "
+                        "(likely an OAuth token expiry / revocation). "
+                        "Re-authorize the workspace integration to "
+                        "restore agent picks. Subsequent stage picks "
+                        "in this hour are short-circuited to keep the "
+                        "audit log readable.\n\n"
+                        f"First error: {str(exc)[:400]}"
+                    )[:2000],
+                    level=NotifyLevel.BLOCKER,
+                    payload={
+                        "tracker_kind": resolved.kind,
+                        "fsm_stage": state,
+                        "error": str(exc)[:500],
+                    },
+                    inbox_overrides={"intake_reason": "tracker_outage"},
                 )
                 await session.flush()
         except Exception as audit_exc:  # noqa: BLE001 — audit failure must not sink the response
@@ -1685,23 +1683,24 @@ async def _record_orphan_skips(
                 },
             )
         )
-    session.add(
-        InboxItem(
-            workspace_id=workspace_id,
-            type="improvement",
-            title=f"Orphan tickets skipped at stage {fsm_stage}"[:300],
-            summary=(
-                f"{len(refs)} ticket(s) at FSM stage {fsm_stage!r} have no "
-                "tracker project attached and were skipped by the agent "
-                "picker. Re-home them under a project (or close)."
-            )[:2000],
-            payload={
-                "kind": "orphan_skipped",
-                "tracker_kind": tracker_kind,
-                "fsm_stage": fsm_stage,
-                "ticket_refs": refs,
-            },
-        )
+    from backend.app.services.notify import NotifyLevel, notify
+
+    await notify(
+        session,
+        workspace_id=workspace_id,
+        title=f"Orphan tickets skipped at stage {fsm_stage}"[:300],
+        body=(
+            f"{len(refs)} ticket(s) at FSM stage {fsm_stage!r} have no "
+            "tracker project attached and were skipped by the agent "
+            "picker. Re-home them under a project (or close)."
+        )[:2000],
+        level=NotifyLevel.INFO,
+        payload={
+            "kind": "orphan_skipped",
+            "tracker_kind": tracker_kind,
+            "fsm_stage": fsm_stage,
+            "ticket_refs": refs,
+        },
     )
     await session.flush()
 
@@ -4019,24 +4018,26 @@ async def finish_agent_run(
     # inbox item so the operator notices, but still record the run.
     if payload.outcome in {"ready_next_step", "needs_clarification", "out_of_scope"} \
             and resolved is None:
-        session.add(
-            InboxItem(
-                workspace_id=workspace_id,
-                repo_id=None,
-                type="blocker",
-                title=f"agent finished but no tracker bound ({payload.outcome})"[:300],
-                summary=(payload.summary or payload.comment or "")[:2000] or None,
-                payload={
-                    "run_id": payload.run_id,
-                    "fsm_stage": payload.fsm_stage,
-                    "ticket_ref": payload.ticket_ref,
-                    "outcome": payload.outcome,
-                    **payload.payload,
-                },
-                status="new",
-                intake_handle=None,
-                intake_reason="agent_run_no_tracker",
-            )
+        from backend.app.services.notify import NotifyLevel, notify
+
+        await notify(
+            session,
+            workspace_id=workspace_id,
+            ticket_ref=payload.ticket_ref,
+            title=f"agent finished but no tracker bound ({payload.outcome})"[:300],
+            body=(payload.summary or payload.comment or "")[:2000],
+            level=NotifyLevel.BLOCKER,
+            payload={
+                "run_id": payload.run_id,
+                "fsm_stage": payload.fsm_stage,
+                "ticket_ref": payload.ticket_ref,
+                "outcome": payload.outcome,
+                **payload.payload,
+            },
+            inbox_overrides={
+                "summary": (payload.summary or payload.comment or "")[:2000] or None,
+                "intake_reason": "agent_run_no_tracker",
+            },
         )
         actions.append("inbox:no_tracker_bound")
 
@@ -4429,25 +4430,28 @@ async def finish_agent_run(
         ticket_snapshot = await _try_ticket_snapshot(resolved.gateway, ref)
         # Mirror to inbox so the operator sees it without scanning the
         # tracker — the agent's question is the inbox row's summary.
-        session.add(
-            InboxItem(
-                workspace_id=workspace_id,
-                repo_id=None,
-                type="clarification",
-                category="decision_needed",
-                title=f"clarification: {payload.ticket_ref}"[:300],
-                summary=(payload.summary or payload.comment or "")[:2000] or None,
-                payload={
-                    "run_id": payload.run_id,
-                    "fsm_stage": payload.fsm_stage,
-                    "ticket_ref": payload.ticket_ref,
-                    **({"source_ticket": ticket_snapshot} if ticket_snapshot else {}),
-                    **payload.payload,
-                },
-                status="new",
-                intake_handle=None,
-                intake_reason="agent_run_clarification",
-            )
+        from backend.app.services.notify import NotifyLevel, notify
+
+        await notify(
+            session,
+            workspace_id=workspace_id,
+            ticket_ref=payload.ticket_ref,
+            title=f"clarification: {payload.ticket_ref}"[:300],
+            body=(payload.summary or payload.comment or "")[:2000],
+            level=NotifyLevel.ACTION,
+            payload={
+                "run_id": payload.run_id,
+                "fsm_stage": payload.fsm_stage,
+                "ticket_ref": payload.ticket_ref,
+                **({"source_ticket": ticket_snapshot} if ticket_snapshot else {}),
+                **payload.payload,
+            },
+            inbox_overrides={
+                "type": "clarification",
+                "category": "decision_needed",
+                "summary": (payload.summary or payload.comment or "")[:2000] or None,
+                "intake_reason": "agent_run_clarification",
+            },
         )
         actions.append("inbox:clarification")
         # ELS-142: project_lock release for needs_clarification /
@@ -4519,26 +4523,29 @@ async def finish_agent_run(
                     "stage on unblock."
                 )
             )[:2000]
-            session.add(
-                InboxItem(
-                    workspace_id=workspace_id,
-                    repo_id=None,
-                    type="blocker",
-                    title=blocker_title,
-                    headline=derive_headline(
-                        summary=blocker_summary, title=blocker_title
-                    ),
-                    summary=blocker_summary,
-                    payload={
-                        "ticket_ref": payload.ticket_ref,
-                        "fsm_stage": payload.fsm_stage,
-                        "run_id": payload.run_id,
-                        **payload.payload,
-                    },
-                    status="new",
-                    intake_handle=f"blocked:{payload.ticket_ref}:{payload.fsm_stage}",
-                    intake_reason="agent_blocked",
-                )
+            from backend.app.services.notify import NotifyLevel, notify
+
+            # headline rides the InboxItem before_insert backstop —
+            # identical derive_headline(summary, title) as before.
+            await notify(
+                session,
+                workspace_id=workspace_id,
+                ticket_ref=payload.ticket_ref,
+                title=blocker_title,
+                body=blocker_summary,
+                level=NotifyLevel.BLOCKER,
+                dedup_key=f"blocked:{payload.ticket_ref}:{payload.fsm_stage}",
+                payload={
+                    "ticket_ref": payload.ticket_ref,
+                    "fsm_stage": payload.fsm_stage,
+                    "run_id": payload.run_id,
+                    **payload.payload,
+                },
+                inbox_overrides={
+                    "title": blocker_title,
+                    "summary": blocker_summary,
+                    "intake_reason": "agent_blocked",
+                },
             )
             actions.append("inbox:blocker:agent_blocked")
 

--- a/apps/backend/app/api/v1/routes/engine_health.py
+++ b/apps/backend/app/api/v1/routes/engine_health.py
@@ -1,0 +1,74 @@
+"""GET /v1/workspaces/{ws}/engine-health — the thesis-2 residue surface.
+
+Read-only: derives liveness + stalls from agent_dispatch_locks +
+audit_log on request (see services/engine_health.py). Never dispatches,
+never mutates a lock. Authorized per-workspace like every other
+/v1/workspaces route.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, Query
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.app.api.v1.deps import AuthContext, get_current_auth
+from backend.app.api.v1.routes.workspaces import ROLES_READ, _require_membership
+from backend.app.db.session import get_session
+from backend.app.services.engine_health import (
+    DEFAULT_DISPATCH_AUDIT_WINDOW_MINUTES,
+    DEFAULT_LOCK_STALL_MINUTES,
+    assess_engine_health,
+)
+
+router = APIRouter(prefix="/workspaces/{workspace_id}", tags=["engine-health"])
+
+
+class StalledTicketOut(BaseModel):
+    lock_key: str
+    claimed_at: datetime
+    expires_at: datetime
+    age_minutes: float
+    reason: str
+    run_id: int | None
+
+
+class EngineHealthOut(BaseModel):
+    healthy: bool
+    last_dispatch_at: datetime | None
+    last_finish_at: datetime | None
+    active_locks: int
+    expired_unswept_locks: int
+    stalled: list[StalledTicketOut]
+
+
+@router.get("/engine-health", response_model=EngineHealthOut)
+async def get_engine_health(
+    workspace_id: uuid.UUID,
+    lock_stall_minutes: int = Query(
+        default=DEFAULT_LOCK_STALL_MINUTES, ge=5, le=24 * 60
+    ),
+    dispatch_window_minutes: int = Query(
+        default=DEFAULT_DISPATCH_AUDIT_WINDOW_MINUTES, ge=5, le=24 * 60
+    ),
+    auth: AuthContext = Depends(get_current_auth),
+    session: AsyncSession = Depends(get_session),
+) -> EngineHealthOut:
+    await _require_membership(session, workspace_id, auth.user.id, ROLES_READ)
+    liveness = await assess_engine_health(
+        session,
+        workspace_id=workspace_id,
+        lock_stall_minutes=lock_stall_minutes,
+        dispatch_window_minutes=dispatch_window_minutes,
+    )
+    return EngineHealthOut(
+        healthy=liveness.healthy,
+        last_dispatch_at=liveness.last_dispatch_at,
+        last_finish_at=liveness.last_finish_at,
+        active_locks=liveness.active_locks,
+        expired_unswept_locks=liveness.expired_unswept_locks,
+        stalled=[StalledTicketOut(**vars(s)) for s in liveness.stalled],
+    )

--- a/apps/backend/app/api/v1/routes/runs.py
+++ b/apps/backend/app/api/v1/routes/runs.py
@@ -1038,12 +1038,21 @@ async def get_run_policies_preamble(
 ) -> PoliciesPreambleOut:
     """Return the workspace's prose policies for the run's workspace."""
 
-    from backend.app.services.policies import render_policies_preamble
+    from backend.app.services.policies import (
+        render_autonomy_preamble,
+        render_policies_preamble,
+    )
 
     preamble = await render_policies_preamble(
         session, ctx.workspace_id, role_slug=role
     )
-    return PoliciesPreambleOut(preamble=preamble)
+    # ELS-244: the autonomy action-rights block rides the same
+    # centralised path so chat + CI agents see byte-identical text.
+    autonomy_block = await render_autonomy_preamble(session, ctx.workspace_id)
+    combined = (
+        f"{preamble}\n\n{autonomy_block}" if preamble else autonomy_block
+    )
+    return PoliciesPreambleOut(preamble=combined)
 
 
 # ---------------------------------------------------------------------------

--- a/apps/backend/app/api/v1/routes/runs.py
+++ b/apps/backend/app/api/v1/routes/runs.py
@@ -564,27 +564,30 @@ async def _emit_self_heal_blocker_inbox(
     )
     if int(exists or 0) > 0:
         return
-    from backend.app.services.inbox.headline import derive_headline
+    from backend.app.services.notify import NotifyLevel, notify
 
     summary = (run.summary or routine.lane_id or "Self-heal")[:500]
     title = f"Self-heal could not fix: {summary}"[:255]
-    session.add(
-        InboxItem(
-            workspace_id=run.workspace_id,
-            repo_id=routine.repo_id,
-            type="blocker",
-            title=title,
-            headline=derive_headline(summary=summary, title=title),
-            summary=summary,
-            payload={
-                "kind": "self_heal_failed",
-                "routine_id": str(routine.id),
-                "run_id": str(run.id),
-            },
-            status="new",
-            source_table="self_heal_run",
-            source_id=run.id,
-        )
+    # headline rides the InboxItem before_insert backstop — same
+    # derive_headline(summary, title) the site called explicitly before.
+    await notify(
+        session,
+        workspace_id=run.workspace_id,
+        repo_id=routine.repo_id,
+        title=title,
+        body=summary,
+        level=NotifyLevel.BLOCKER,
+        payload={
+            "kind": "self_heal_failed",
+            "routine_id": str(routine.id),
+            "run_id": str(run.id),
+        },
+        inbox_overrides={
+            "title": title,
+            "summary": summary,
+            "source_table": "self_heal_run",
+            "source_id": run.id,
+        },
     )
 
 

--- a/apps/backend/app/core/config.py
+++ b/apps/backend/app/core/config.py
@@ -268,6 +268,12 @@ class Settings(BaseSettings):
     stall_notify_cooldown_minutes: int = Field(
         default=360, alias="SHIP_STALL_NOTIFY_COOLDOWN_MIN"
     )
+    # StateProjector strangler (ELS-229): when on, every FSM->tracker
+    # status write funnels through services/state_projector.py. Off
+    # (default) keeps the original direct gateway.transition paths.
+    state_projector_unified: bool = Field(
+        default=False, alias="SHIP_STATE_PROJECTOR_UNIFIED"
+    )
 
     # --- Auth0 (used when auth_mode == "auth0") ---
     auth0_domain: str | None = Field(default=None, alias="AUTH0_DOMAIN")

--- a/apps/backend/app/core/config.py
+++ b/apps/backend/app/core/config.py
@@ -251,6 +251,14 @@ class Settings(BaseSettings):
     tracker_poll_fire: bool = Field(
         default=False, alias="SHIP_TRACKER_POLL_FIRE"
     )
+    # Global kill-switch for the notification seam (ELS-219). While
+    # ``False`` the ``notify()`` router forces inbox-only regardless
+    # of per-workspace channel routing — instant global rollback for
+    # the Linear/email egress channels. Same shadow-then-fire pattern
+    # as ``tracker_poll_fire`` above.
+    notification_channels_enabled: bool = Field(
+        default=False, alias="SHIP_NOTIFY_CHANNELS"
+    )
 
     # --- Auth0 (used when auth_mode == "auth0") ---
     auth0_domain: str | None = Field(default=None, alias="AUTH0_DOMAIN")

--- a/apps/backend/app/core/config.py
+++ b/apps/backend/app/core/config.py
@@ -259,6 +259,15 @@ class Settings(BaseSettings):
     notification_channels_enabled: bool = Field(
         default=False, alias="SHIP_NOTIFY_CHANNELS"
     )
+    # Stall notifier (ELS-231): forward engine_health stalls through
+    # notify() on a schedule. Off by default — the residue surface is
+    # query-only until an operator opts into push.
+    stall_notify_enabled: bool = Field(
+        default=False, alias="SHIP_STALL_NOTIFY"
+    )
+    stall_notify_cooldown_minutes: int = Field(
+        default=360, alias="SHIP_STALL_NOTIFY_COOLDOWN_MIN"
+    )
 
     # --- Auth0 (used when auth_mode == "auth0") ---
     auth0_domain: str | None = Field(default=None, alias="AUTH0_DOMAIN")

--- a/apps/backend/app/db/models/tenancy.py
+++ b/apps/backend/app/db/models/tenancy.py
@@ -179,6 +179,16 @@ class Workspace(Base):
     agent_provider: Mapped[str] = mapped_column(
         String(16), nullable=False, server_default=text("'cursor'")
     )
+    # Thesis-7 autonomy dial — how much the *agent* may do on its own
+    # (skip approvals, self-merge, self-pick work). One of ``high`` /
+    # ``balanced`` / ``conservative`` (CHECK-pinned at the DB, mirrored
+    # in :func:`agent_provider_resolver.resolve_autonomy_for_workspace`).
+    # ``balanced`` is the default everywhere; ``high`` is opt-in only.
+    # The dial NEVER loosens the control plane — lease / cap / cascade
+    # / idempotency stay fixed across all profiles.
+    autonomy: Mapped[str] = mapped_column(
+        String(16), nullable=False, server_default=text("'balanced'")
+    )
     # E16 dispatcher cap — null means "use the global default from
     # ``SHIP_DEFAULT_WORKSPACE_DISPATCH_CAP``"; an integer pins the
     # ceiling for parallel ``agent_dispatch_locks`` per this workspace.

--- a/apps/backend/app/resources/agent_roles/auto-merger.md
+++ b/apps/backend/app/resources/agent_roles/auto-merger.md
@@ -71,6 +71,25 @@ outcomes:
   inbox-clarification and wait. **Never stall on size alone** — see
   Signal 4.
 
+## Autonomy profile (ELS-244)
+
+Your prompt preamble carries the workspace's autonomy profile block
+("Autonomy profile: HIGH / BALANCED / CONSERVATIVE"). It tunes the
+MERGE / BOUNCE / STALL thresholds — never the signals themselves:
+
+- **HIGH** — prefer MERGE when CI is green even without a human
+  APPROVED review (the server gate enforces CI independently); prefer
+  BOUNCE over STALL for anything an earlier role can plausibly fix.
+- **BALANCED** — today's defaults: MERGE needs the review stage's
+  approval; STALL on the human-only reds.
+- **CONSERVATIVE** — when any signal is ambiguous, STALL with a
+  clarification rather than merging; never self-resolve a borderline
+  Signal 4 (size) call.
+
+Hard floor at EVERY profile: CI red or incomplete is never mergeable,
+and the dispatch limits (lease/cap/cascade) are not yours to reason
+about — the server enforces them regardless of profile.
+
 The "stall on every red" rule of v0 made the chain livelock on
 self-fixable problems — Ship-on-Ship/ELS-7 2026-05-17: a broken CLI
 unit test failed CI, auto-merger stalled, ticket sat with

--- a/apps/backend/app/services/agent/project_state_sync.py
+++ b/apps/backend/app/services/agent/project_state_sync.py
@@ -46,11 +46,14 @@ logger = logging.getLogger(__name__)
 # Project priority state → (from-Linear-state, to-Linear-state) for
 # the sync transition. ``None`` means "no sync action for this state"
 # — useful for terminal states or transitions we deliberately ignore.
-_TRANSITION_PLAN: dict[str, tuple[str, str] | None] = {
-    "active": ("Backlog", "Todo"),
-    "planning": ("Todo", "Backlog"),
-    "parked": ("Todo", "Backlog"),
-}
+#
+# ELS-228: derived from the single egress-only source of truth in
+# tracker_fsm (never inverted into a control decision).
+from backend.app.services.tracker_fsm import PROJECT_STATE_TICKET_MOVES
+
+_TRANSITION_PLAN: dict[str, tuple[str, str] | None] = dict(
+    PROJECT_STATE_TICKET_MOVES
+)
 
 
 @dataclass(slots=True)

--- a/apps/backend/app/services/agent/project_state_sync.py
+++ b/apps/backend/app/services/agent/project_state_sync.py
@@ -174,8 +174,17 @@ async def sync_project_tickets_for_state(
         if not ticket_uuid:
             continue
         try:
-            await gateway.transition(
-                TicketRef(
+            from backend.app.core.config import get_settings
+            from backend.app.services.state_projector import (
+                transition_via_projector,
+            )
+
+            await transition_via_projector(
+                session,
+                settings=get_settings(),
+                workspace_id=workspace_id,
+                gateway=gateway,
+                ref=TicketRef(
                     kind=tracker_kind or "linear",
                     workspace_hint=None,
                     id=str(ticket_uuid),
@@ -304,8 +313,17 @@ async def apply_project_state_to_ticket(
         tracker_kind = _derive_tracker_kind(gateway)
 
     try:
-        await gateway.transition(
-            TicketRef(
+        from backend.app.core.config import get_settings
+        from backend.app.services.state_projector import (
+            transition_via_projector,
+        )
+
+        await transition_via_projector(
+            session,
+            settings=get_settings(),
+            workspace_id=workspace_id,
+            gateway=gateway,
+            ref=TicketRef(
                 kind=tracker_kind or "linear",
                 workspace_hint=None,
                 id=str(ticket_uuid),

--- a/apps/backend/app/services/agent/topic.py
+++ b/apps/backend/app/services/agent/topic.py
@@ -780,6 +780,14 @@ class TopicService:
             out.append(
                 ChatMessage(role="system", content=policies_preamble)
             )
+        # ELS-244: autonomy action-rights block — same renderer as the
+        # CI preamble endpoint, so both surfaces stay byte-identical.
+        from backend.app.services.policies import render_autonomy_preamble
+
+        autonomy_block = await render_autonomy_preamble(
+            self._session, self._workspace_id
+        )
+        out.append(ChatMessage(role="system", content=autonomy_block))
         # ELS-74: drafting mode. When the thread carries
         # ``intent='shape_project'`` the dashboard's "+ New project" CTA
         # opened it; bias Navigator toward shaping a brief and waiting

--- a/apps/backend/app/services/agent_provider_resolver.py
+++ b/apps/backend/app/services/agent_provider_resolver.py
@@ -26,11 +26,16 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from backend.app.db.models.tenancy import Workspace
 
 
-AgentProviderKind = Literal["cursor", "codex", "claude"]
+AgentProviderKind = Literal["cursor", "codex", "claude", "ship"]
 
 
+# ``ship`` is the thesis-6 self-spawn runtime (ELS-241): valid at the
+# DB/resolver layer, but deliberately NOT offered by the self-serve
+# ``agent.provider`` config scope — it is internal/dogfood-gated and
+# additionally refused by the CLI dispatcher unless
+# ``SHIP_ALLOW_SELF_SPAWN=true``.
 SUPPORTED_PROVIDERS: Final[frozenset[str]] = frozenset(
-    {"cursor", "codex", "claude"}
+    {"cursor", "codex", "claude", "ship"}
 )
 DEFAULT_PROVIDER: Final[AgentProviderKind] = "cursor"
 

--- a/apps/backend/app/services/agent_provider_resolver.py
+++ b/apps/backend/app/services/agent_provider_resolver.py
@@ -63,10 +63,49 @@ async def resolve_for_workspace(
     return ResolvedAgentProvider(kind=kind, workspace_id=workspace_id)
 
 
+# ---------------------------------------------------------------------------
+# Thesis-7 autonomy dial (ELS-221)
+# ---------------------------------------------------------------------------
+
+AutonomyProfile = Literal["high", "balanced", "conservative"]
+
+SUPPORTED_AUTONOMY_PROFILES: Final[frozenset[str]] = frozenset(
+    {"high", "balanced", "conservative"}
+)
+# ``balanced`` everywhere; ``high`` is opt-in (never seeded by
+# migration). The dial governs AGENT action-rights only — it must
+# never be consulted by the lease / cap / cascade control plane.
+DEFAULT_AUTONOMY: Final[AutonomyProfile] = "balanced"
+
+
+async def resolve_autonomy_for_workspace(
+    *,
+    session: AsyncSession,
+    workspace_id: uuid.UUID,
+) -> AutonomyProfile:
+    """Return the workspace's autonomy profile.
+
+    Mirrors :func:`resolve_for_workspace`: a missing row or an
+    out-of-enum value (legacy DB, migration not applied) falls back to
+    the safe :data:`DEFAULT_AUTONOMY` instead of raising.
+    """
+
+    row = await session.scalar(
+        select(Workspace.autonomy).where(Workspace.id == workspace_id)
+    )
+    if row in SUPPORTED_AUTONOMY_PROFILES:
+        return row  # type: ignore[return-value]
+    return DEFAULT_AUTONOMY
+
+
 __all__ = [
     "AgentProviderKind",
+    "AutonomyProfile",
+    "DEFAULT_AUTONOMY",
     "DEFAULT_PROVIDER",
     "ResolvedAgentProvider",
+    "SUPPORTED_AUTONOMY_PROFILES",
     "SUPPORTED_PROVIDERS",
     "resolve_for_workspace",
+    "resolve_autonomy_for_workspace",
 ]

--- a/apps/backend/app/services/config_registry.py
+++ b/apps/backend/app/services/config_registry.py
@@ -111,6 +111,51 @@ async def _write_default_agent_profile(
     ws.default_agent_profile = value
 
 
+_CONSOLE_SURFACES = ("full", "residual", "off")
+
+
+async def _read_console_surface(_s: AsyncSession, ws: Workspace) -> Any:
+    raw = (ws.settings or {}).get("console") or {}
+    value = raw.get("surface")
+    return value if value in _CONSOLE_SURFACES else "full"
+
+
+async def _write_console_surface(_s: AsyncSession, ws: Workspace, value: Any) -> None:
+    if value not in _CONSOLE_SURFACES:
+        raise ValueError(
+            f"console.surface must be one of {sorted(_CONSOLE_SURFACES)}"
+        )
+    settings = dict(ws.settings or {})
+    console = dict(settings.get("console") or {})
+    console["surface"] = str(value)
+    settings["console"] = console
+    # Reassign (not mutate) so SQLAlchemy's JSONB change detection fires.
+    ws.settings = settings
+
+
+async def _read_autonomy_profile(_s: AsyncSession, ws: Workspace) -> Any:
+    from backend.app.services.agent_provider_resolver import (
+        DEFAULT_AUTONOMY,
+        SUPPORTED_AUTONOMY_PROFILES,
+    )
+
+    value = ws.autonomy
+    return value if value in SUPPORTED_AUTONOMY_PROFILES else DEFAULT_AUTONOMY
+
+
+async def _write_autonomy_profile(_s: AsyncSession, ws: Workspace, value: Any) -> None:
+    from backend.app.services.agent_provider_resolver import (
+        SUPPORTED_AUTONOMY_PROFILES,
+    )
+
+    if value not in SUPPORTED_AUTONOMY_PROFILES:
+        raise ValueError(
+            "autonomy.profile must be one of "
+            f"{sorted(SUPPORTED_AUTONOMY_PROFILES)}"
+        )
+    ws.autonomy = str(value)
+
+
 _CATALOG_KEYS = ("global", "workspace", "project")
 
 
@@ -198,6 +243,48 @@ _SCOPE_LIST: tuple[ConfigScope, ...] = (
         read=_read_catalog_sources,
         write=_write_catalog_sources,
         audit_event="workspace.catalog_sources.set",
+    ),
+    ConfigScope(
+        slug="console.surface",
+        description=(
+            "How much of the web console this workspace renders: "
+            "``full`` (everything), ``residual`` (status + Inbox + "
+            "irreducible controls only), ``off`` (health page only — "
+            "the Inbox approval surface stays reachable). The headless "
+            "kill-switch for the Phase-4 console strangler."
+        ),
+        schema={
+            "type": "string",
+            "enum": list(_CONSOLE_SURFACES),
+            "description": (
+                "Console surface mode. Default is ``full``; flipping "
+                "is reversible at any time."
+            ),
+        },
+        read=_read_console_surface,
+        write=_write_console_surface,
+        audit_event="workspace.console_surface.set",
+    ),
+    ConfigScope(
+        slug="autonomy.profile",
+        description=(
+            "Thesis-7 autonomy dial: how much the agent may do on its "
+            "own (skip approvals, self-merge, self-pick work). One of "
+            "``high`` / ``balanced`` / ``conservative``. Never touches "
+            "the lease/cap/cascade control plane."
+        ),
+        schema={
+            "type": "string",
+            "enum": ["high", "balanced", "conservative"],
+            "description": (
+                "Agent action-rights profile. ``balanced`` is the "
+                "default; ``high`` is opt-in and requires a populated "
+                "knowledge surface to work well."
+            ),
+        },
+        read=_read_autonomy_profile,
+        write=_write_autonomy_profile,
+        audit_event="workspace.autonomy.set",
     ),
 )
 

--- a/apps/backend/app/services/cron.py
+++ b/apps/backend/app/services/cron.py
@@ -166,6 +166,11 @@ class CronLockId(IntEnum):
     # ELS-231: stall notifier — forwards engine_health stalls through
     # notify() on a schedule (report-only; never mutates locks).
     STALL_NOTIFY = 1025
+    # ELS-233: scheduled ticket-creating routines (trigger c) — one id
+    # per routine kind, fresh numbers (never reuse retired ids).
+    SCHEDULED_ROUTINE_DAILY = 1026
+    SCHEDULED_ROUTINE_RETRO = 1027
+    SCHEDULED_ROUTINE_TECHDEBT = 1028
 
 
 # ---------------------------------------------------------------------------

--- a/apps/backend/app/services/cron.py
+++ b/apps/backend/app/services/cron.py
@@ -163,6 +163,9 @@ class CronLockId(IntEnum):
     # vanished from DigitalOcean flips to red + an activity event, so cards
     # never show a stale green. See :mod:`services.deploy.reconcile`.
     DEPLOYMENTS_RECONCILE = 1024
+    # ELS-231: stall notifier — forwards engine_health stalls through
+    # notify() on a schedule (report-only; never mutates locks).
+    STALL_NOTIFY = 1025
 
 
 # ---------------------------------------------------------------------------

--- a/apps/backend/app/services/cron_jobs.py
+++ b/apps/backend/app/services/cron_jobs.py
@@ -588,6 +588,26 @@ def register_all() -> None:
         cron_expr="20 * * * *",  # hourly at :20; audit-log cooldown dedup
         job_id="stall_notify",
     )
+    # ELS-233 — trigger-(c) ticket-creating routines. cron_exprs live
+    # on the specs (single source); idempotency per (kind, period_key)
+    # via the audit ledger, so a retried tick can never dup a ticket.
+    from backend.app.services.scheduled_routines import SPECS as _ROUTINE_SPECS
+
+    register_cron(
+        fn=_scheduled_routine_daily_tick,
+        cron_expr=_ROUTINE_SPECS["daily"].cron_expr,
+        job_id="scheduled_routine_daily",
+    )
+    register_cron(
+        fn=_scheduled_routine_retro_tick,
+        cron_expr=_ROUTINE_SPECS["retro"].cron_expr,
+        job_id="scheduled_routine_retro",
+    )
+    register_cron(
+        fn=_scheduled_routine_techdebt_tick,
+        cron_expr=_ROUTINE_SPECS["techdebt"].cron_expr,
+        job_id="scheduled_routine_techdebt",
+    )
     # E16/ELS-124 retired the Ship-side trigger-workflow scheduler.
     # The tracker poller + dispatcher (``apps/backend/app/services/
     # tracker_poller.py`` + ``dispatcher.py``) now drive every agent
@@ -755,6 +775,42 @@ async def _agent_dispatch_lock_sweep_tick() -> None:
     )
 
     await sweep_dangling_project_locks_tick()
+
+
+@cron_with_lock(
+    lock=CronLockId.SCHEDULED_ROUTINE_DAILY, name="scheduled_routine_daily"
+)
+async def _scheduled_routine_daily_tick() -> None:
+    """Trigger-(c) daily review ticket (ELS-233). Opt-in per workspace."""
+    from backend.app.services.scheduled_routines import (
+        run_routine_for_all_workspaces,
+    )
+
+    await run_routine_for_all_workspaces("daily")
+
+
+@cron_with_lock(
+    lock=CronLockId.SCHEDULED_ROUTINE_RETRO, name="scheduled_routine_retro"
+)
+async def _scheduled_routine_retro_tick() -> None:
+    """Trigger-(c) weekly retro ticket (ELS-233). Opt-in per workspace."""
+    from backend.app.services.scheduled_routines import (
+        run_routine_for_all_workspaces,
+    )
+
+    await run_routine_for_all_workspaces("retro")
+
+
+@cron_with_lock(
+    lock=CronLockId.SCHEDULED_ROUTINE_TECHDEBT, name="scheduled_routine_techdebt"
+)
+async def _scheduled_routine_techdebt_tick() -> None:
+    """Trigger-(c) weekly tech-debt sweep ticket (ELS-233). Opt-in."""
+    from backend.app.services.scheduled_routines import (
+        run_routine_for_all_workspaces,
+    )
+
+    await run_routine_for_all_workspaces("techdebt")
 
 
 @cron_with_lock(lock=CronLockId.STALL_NOTIFY, name="stall_notify")

--- a/apps/backend/app/services/cron_jobs.py
+++ b/apps/backend/app/services/cron_jobs.py
@@ -583,6 +583,11 @@ def register_all() -> None:
         cron_expr="5 * * * *",  # hourly at :05 (gated by per-install age)
         job_id="linear_token_refresh",
     )
+    register_cron(
+        fn=_stall_notify_tick,
+        cron_expr="20 * * * *",  # hourly at :20; audit-log cooldown dedup
+        job_id="stall_notify",
+    )
     # E16/ELS-124 retired the Ship-side trigger-workflow scheduler.
     # The tracker poller + dispatcher (``apps/backend/app/services/
     # tracker_poller.py`` + ``dispatcher.py``) now drive every agent
@@ -750,6 +755,44 @@ async def _agent_dispatch_lock_sweep_tick() -> None:
     )
 
     await sweep_dangling_project_locks_tick()
+
+
+@cron_with_lock(lock=CronLockId.STALL_NOTIFY, name="stall_notify")
+async def _stall_notify_tick() -> None:
+    """Forward engine_health stalls through the notify() seam (ELS-231).
+
+    Report-only: never mutates locks or ticket status. Gated by
+    ``SHIP_STALL_NOTIFY`` (default off); per-(lock,reason) cooldown is
+    deduped via ``audit_log action='engine.stall_notified'`` so the
+    hourly schedule can never produce a letter storm. Per-workspace
+    failures are isolated."""
+    from backend.app.core.config import get_settings
+
+    settings = get_settings()
+    if not settings.stall_notify_enabled:
+        return
+    from sqlalchemy import select as sa_select
+
+    from backend.app.db.models.tenancy import Workspace
+    from backend.app.db.session import get_sessionmaker
+    from backend.app.services.stall_notifier import notify_stalls_for_workspace
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        ws_ids = (await session.execute(sa_select(Workspace.id))).scalars().all()
+        emitted = 0
+        for ws_id in ws_ids:
+            try:
+                emitted += await notify_stalls_for_workspace(
+                    session,
+                    workspace_id=ws_id,
+                    cooldown_minutes=settings.stall_notify_cooldown_minutes,
+                )
+            except Exception:  # noqa: BLE001 — one ws must not sink the sweep
+                log.exception("stall_notify: ws=%s failed", ws_id)
+        await session.commit()
+        if emitted:
+            log.info("stall_notify tick: %s notification(s)", emitted)
 
 
 @cron_with_lock(

--- a/apps/backend/app/services/dispatcher.py
+++ b/apps/backend/app/services/dispatcher.py
@@ -1072,6 +1072,12 @@ async def maybe_dispatch(
     # on PAC-23: planning finished, cascade fired dev_implementation,
     # the same ticket's project lock was still held → silent refusal
     # → chain stalls one stage in.
+    # ELS-242 (thesis 6): the carve-out is for ``cascade`` ONLY. A
+    # nested self-spawn run (``trigger_kind='self_spawn'``) is a fresh
+    # entrant by design — it contends for the project lock, counts
+    # against the per-workspace cap and burns cascade budget like any
+    # other dispatch, under EVERY autonomy profile. Adding 'self_spawn'
+    # here would reopen the fork-bomb / project_lock-leak class.
     is_cascade = trigger_kind == "cascade"
     if project_id and not is_anchor and not is_cascade:
         project_lock_key = f"project:{project_id}"

--- a/apps/backend/app/services/dispatcher.py
+++ b/apps/backend/app/services/dispatcher.py
@@ -719,10 +719,12 @@ async def _file_no_target_repo_letter(
 ) -> None:
     """Ask the operator to bind a repo when routing can't resolve one.
 
-    Deduped per ticket via ``no-target-repo:<ticket>``. Beats the old
-    behaviour of dumping the run on an arbitrary (often key-less) repo.
+    Deduped per ticket via ``no-target-repo:<ticket>`` — the dedup
+    pre-check stays HERE (caller-side, per the notification-seam rule);
+    only the emission itself routes through :func:`notify`.
     """
     from backend.app.db.models.inbox import InboxItem
+    from backend.app.services.notify import NotifyLevel, notify
 
     handle = f"no-target-repo:{ticket_ref}"
     existing = (
@@ -737,30 +739,31 @@ async def _file_no_target_repo_letter(
     if existing is not None:
         return
     proj = project_name or project_id or "(no project)"
-    session.add(
-        InboxItem(
-            workspace_id=workspace_id,
-            repo_id=None,
-            type="clarification",
-            title=f"{ticket_ref}: no target repo — pick one"[:300],
-            summary=(
-                f"Ship can't dispatch {ticket_ref}: its project ({proj}) has "
-                f"no repo binding and the workspace has no default repo set. "
-                f"Bind the project to a repo, or set a workspace default repo, "
-                f"in Settings → repo routing — then it dispatches on the next "
-                f"tick."
-            )[:2000],
-            payload={
-                "ticket_ref": ticket_ref,
-                "project_id": project_id,
-                "project_name": project_name,
-            },
-            status="new",
-            category="decision_needed",
-            priority=8,
-            intake_handle=handle,
-            intake_reason="no_target_repo",
-        )
+    await notify(
+        session,
+        workspace_id=workspace_id,
+        ticket_ref=ticket_ref,
+        title=f"{ticket_ref}: no target repo — pick one"[:300],
+        body=(
+            f"Ship can't dispatch {ticket_ref}: its project ({proj}) has "
+            f"no repo binding and the workspace has no default repo set. "
+            f"Bind the project to a repo, or set a workspace default repo, "
+            f"in Settings → repo routing — then it dispatches on the next "
+            f"tick."
+        )[:2000],
+        level=NotifyLevel.ACTION,
+        dedup_key=handle,
+        payload={
+            "ticket_ref": ticket_ref,
+            "project_id": project_id,
+            "project_name": project_name,
+        },
+        inbox_overrides={
+            "type": "clarification",
+            "category": "decision_needed",
+            "priority": 8,
+            "intake_reason": "no_target_repo",
+        },
     )
 
 

--- a/apps/backend/app/services/email/templates.py
+++ b/apps/backend/app/services/email/templates.py
@@ -431,3 +431,78 @@ def _inline(text: str) -> str:
     )
     escaped = _ITALIC_RE.sub(lambda m: f"<em>{m.group(1)}</em>", escaped)
     return escaped
+
+
+# ---------------------------------------------------------------------------
+# Engine notification (ELS-222 — notify() EmailChannel)
+# ---------------------------------------------------------------------------
+
+_NOTIFICATION_HTML = _env.from_string(
+    """\
+<!doctype html>
+<html lang="en">
+  <body style="margin:0;padding:0;background:#0b0d12;color:#eef1f5;font-family:Inter,-apple-system,Segoe UI,Roboto,sans-serif;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#0b0d12;">
+      <tr>
+        <td align="center" style="padding:32px 16px;">
+          <table role="presentation" width="640" cellpadding="0" cellspacing="0" style="max-width:640px;background:#11141b;border:1px solid #1d2230;border-radius:16px;overflow:hidden;">
+            <tr>
+              <td style="padding:24px 32px 4px 32px;">
+                <div style="font-size:11px;letter-spacing:0.18em;text-transform:uppercase;color:#7e8aa3;">Ship · {{ level }}</div>
+                <h1 style="margin:8px 0 0 0;font-size:20px;line-height:1.35;color:#ffffff;">
+                  {{ subject }}
+                </h1>
+                {% if ticket_ref %}
+                <div style="margin-top:6px;font-size:12px;color:#9aa3b8;">{{ ticket_ref }}</div>
+                {% endif %}
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:16px 32px 24px 32px;font-size:14px;line-height:1.6;color:#cbd2df;">
+                {{ body_html|safe }}
+              </td>
+            </tr>
+          </table>
+          <div style="max-width:640px;margin-top:12px;font-size:11px;color:#5e6880;">
+            Sent by the Ship engine. Routing is configured per workspace
+            (notifications.channels).
+          </div>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>
+"""
+)
+
+_NOTIFICATION_TEXT = _env.from_string(
+    """\
+[Ship {{ level }}] {{ subject }}
+{% if ticket_ref %}{{ ticket_ref }}
+{% endif %}
+{{ body_text }}
+"""
+)
+
+
+def render_notification_email(
+    *,
+    subject: str,
+    body_markdown: str,
+    level: str,
+    ticket_ref: str | None = None,
+) -> RenderedEmail:
+    """Render an engine ``notify()`` emission for the email channel."""
+    body_html = _markdown_to_safe_html(body_markdown)
+    ctx = {
+        "subject": subject,
+        "body_html": body_html,
+        "body_text": body_markdown.strip(),
+        "level": level.upper(),
+        "ticket_ref": ticket_ref,
+    }
+    return RenderedEmail(
+        subject=f"[Ship {level.upper()}] {subject}",
+        html=_NOTIFICATION_HTML.render(**ctx),
+        text=_NOTIFICATION_TEXT.render(**ctx),
+    )

--- a/apps/backend/app/services/engine_health.py
+++ b/apps/backend/app/services/engine_health.py
@@ -1,0 +1,171 @@
+"""Engine health / stall detection (ELS-230 — the thesis-2 residue).
+
+Phase 2 of the FSM rearchitecture deleted both self-heal crons, the
+``scan_eligible_tickets`` backstop and the runner-fail detectors — so
+the only health surface left was a DB ping, and a stalled FSM went
+silent. Per thesis 2 "is the engine alive / where is it stuck" is the
+ONE piece of state with no home in Linear/GitHub/email, so it lives
+here, in Ship.
+
+READ-ONLY by design: everything below derives from the existing
+Postgres control state (``agent_dispatch_locks`` + ``audit_log``) at
+request time. No new authoritative store, no sweeping, no dispatching,
+no lock mutation — this module reports, the human (or the stall
+notifier's notify() emission) decides. Thresholds are config-driven
+and deliberately conservative to avoid re-creating the deleted
+self-heal crons' false positives.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.app.db.models.agent_dispatch import AgentDispatchLock
+from backend.app.db.models.tenancy import AuditLog
+
+# Conservative defaults; overridable per call (the route reads them
+# from query params / settings later if needed).
+DEFAULT_LOCK_STALL_MINUTES = 45
+DEFAULT_DISPATCH_AUDIT_WINDOW_MINUTES = 90
+
+
+@dataclass(frozen=True)
+class StalledTicket:
+    lock_key: str
+    claimed_at: datetime
+    expires_at: datetime
+    age_minutes: float
+    reason: str  # 'expired_not_swept' | 'lock_held_no_progress'
+    run_id: int | None
+
+
+@dataclass(frozen=True)
+class EngineLiveness:
+    last_dispatch_at: datetime | None
+    last_finish_at: datetime | None
+    active_locks: int
+    expired_unswept_locks: int
+    stalled: list[StalledTicket]
+
+    @property
+    def healthy(self) -> bool:
+        return not self.stalled and self.expired_unswept_locks == 0
+
+
+async def assess_engine_health(
+    session: AsyncSession,
+    *,
+    workspace_id: uuid.UUID,
+    lock_stall_minutes: int = DEFAULT_LOCK_STALL_MINUTES,
+    dispatch_window_minutes: int = DEFAULT_DISPATCH_AUDIT_WINDOW_MINUTES,
+    now: datetime | None = None,
+) -> EngineLiveness:
+    """Compute liveness + stalls for one workspace. Zero writes."""
+    now = now or datetime.now(timezone.utc)
+
+    async def _last(action: str) -> datetime | None:
+        return await session.scalar(
+            select(func.max(AuditLog.created_at)).where(
+                AuditLog.workspace_id == workspace_id,
+                AuditLog.action == action,
+            )
+        )
+
+    last_dispatch = await _last("agent_run.dispatch")
+    last_finish = await _last("agent_run.finish")
+
+    locks = (
+        await session.execute(
+            select(AgentDispatchLock).where(
+                AgentDispatchLock.workspace_id == workspace_id
+            )
+        )
+    ).scalars().all()
+
+    stalled: list[StalledTicket] = []
+    expired_unswept = 0
+    active = 0
+    stall_cutoff = now - timedelta(minutes=lock_stall_minutes)
+    window_start = now - timedelta(minutes=dispatch_window_minutes)
+
+    for lock in locks:
+        expires = lock.expires_at
+        if expires.tzinfo is None:
+            expires = expires.replace(tzinfo=timezone.utc)
+        claimed = lock.claimed_at
+        if claimed.tzinfo is None:
+            claimed = claimed.replace(tzinfo=timezone.utc)
+        age_min = (now - claimed).total_seconds() / 60.0
+
+        if expires < now:
+            # (a) lease past expires_at but still present — the sweeper
+            # is not running (or died). This is the project_lock-leak
+            # class made visible.
+            expired_unswept += 1
+            stalled.append(
+                StalledTicket(
+                    lock_key=lock.key,
+                    claimed_at=claimed,
+                    expires_at=expires,
+                    age_minutes=round(age_min, 1),
+                    reason="expired_not_swept",
+                    run_id=lock.run_id,
+                )
+            )
+            continue
+
+        active += 1
+        if claimed < stall_cutoff:
+            # (b) long-held lock with no recent dispatch progress in
+            # the audit feed → stuck in flight.
+            recent_progress = await session.scalar(
+                select(func.count(AuditLog.id)).where(
+                    AuditLog.workspace_id == workspace_id,
+                    AuditLog.action.in_(
+                        ("agent_run.dispatch", "agent_run.finish")
+                    ),
+                    AuditLog.created_at >= window_start,
+                    AuditLog.target_id == _ticket_from_key(lock.key),
+                )
+            )
+            if not recent_progress:
+                stalled.append(
+                    StalledTicket(
+                        lock_key=lock.key,
+                        claimed_at=claimed,
+                        expires_at=expires,
+                        age_minutes=round(age_min, 1),
+                        reason="lock_held_no_progress",
+                        run_id=lock.run_id,
+                    )
+                )
+
+    return EngineLiveness(
+        last_dispatch_at=last_dispatch,
+        last_finish_at=last_finish,
+        active_locks=active,
+        expired_unswept_locks=expired_unswept,
+        stalled=stalled,
+    )
+
+
+def _ticket_from_key(key: str) -> str:
+    """``ticket:ELS-42`` -> ``ELS-42``; project locks keep their id."""
+    for prefix in ("ticket:", "project:"):
+        if key.startswith(prefix):
+            return key[len(prefix):]
+    return key
+
+
+__all__ = [
+    "EngineLiveness",
+    "StalledTicket",
+    "assess_engine_health",
+    "DEFAULT_LOCK_STALL_MINUTES",
+    "DEFAULT_DISPATCH_AUDIT_WINDOW_MINUTES",
+]

--- a/apps/backend/app/services/knowledge_synth.py
+++ b/apps/backend/app/services/knowledge_synth.py
@@ -45,9 +45,7 @@ from backend.app.db.models.agent_memory import (
     KnowledgeBucket,
 )
 from backend.app.db.models.agent_surface import Improvement
-from backend.app.db.models.inbox import InboxItem
 from backend.app.db.models.tenancy import AuditLog, Workspace
-from backend.app.services.inbox.headline import derive_headline
 from backend.app.services.agent.client import AgentClient, ChatMessage
 from backend.app.services.agent.embedding import embed_text
 from backend.app.services.knowledge_harvest import NOTE_KIND
@@ -380,31 +378,33 @@ async def _synthesise_bucket(
         if decision.action == "new"
         else f"Draft update: {decision.title}"
     )[:300]
-    session.add(
-        InboxItem(
-            workspace_id=workspace_id,
-            repo_id=None,
-            type="improvement",
-            title=draft_title,
-            headline=derive_headline(summary=summary, title=draft_title),
-            summary=summary,
-            payload={
-                "kind": "auto_routed_draft",
-                "article_id": str(article.id),
-                "bucket_id": str(bucket.id),
-                "bucket_slug": bucket.slug,
-                "article_slug": decision.slug,
-                "action": decision.action,
-                "version": new_version,
-                "source_note_count": len(pending),
-                "source_note_ids": [str(n.id) for n in pending],
-            },
-            status="new",
-            source_table="bucket_articles",
-            source_id=article.id,
-            intake_handle=None,
-            intake_reason="knowledge_draft_review",
-        )
+    from backend.app.services.notify import NotifyLevel, notify
+
+    await notify(
+        session,
+        workspace_id=workspace_id,
+        title=draft_title,
+        body=summary or "",
+        level=NotifyLevel.ACTION,
+        payload={
+            "kind": "auto_routed_draft",
+            "article_id": str(article.id),
+            "bucket_id": str(bucket.id),
+            "bucket_slug": bucket.slug,
+            "article_slug": decision.slug,
+            "action": decision.action,
+            "version": new_version,
+            "source_note_count": len(pending),
+            "source_note_ids": [str(n.id) for n in pending],
+        },
+        inbox_overrides={
+            "type": "improvement",
+            "title": draft_title,
+            "summary": summary,
+            "source_table": "bucket_articles",
+            "source_id": article.id,
+            "intake_reason": "knowledge_draft_review",
+        },
     )
 
     session.add(
@@ -546,21 +546,23 @@ async def _emit_archive_proposal(
     }
     archive_title = f"Stale article? {target.title}"[:300]
     archive_summary = (decision.archive_reason or "")[:1000] or None
-    session.add(
-        InboxItem(
-            workspace_id=workspace_id,
-            repo_id=None,
-            type="improvement",
-            title=archive_title,
-            headline=derive_headline(summary=archive_summary, title=archive_title),
-            summary=archive_summary,
-            payload=payload,
-            status="new",
-            source_table="bucket_articles",
-            source_id=target.id,
-            intake_handle=None,
-            intake_reason="knowledge_archive_review",
-        )
+    from backend.app.services.notify import NotifyLevel, notify
+
+    await notify(
+        session,
+        workspace_id=workspace_id,
+        title=archive_title,
+        body=archive_summary or "",
+        level=NotifyLevel.ACTION,
+        payload=payload,
+        inbox_overrides={
+            "type": "improvement",
+            "title": archive_title,
+            "summary": archive_summary,
+            "source_table": "bucket_articles",
+            "source_id": target.id,
+            "intake_reason": "knowledge_archive_review",
+        },
     )
     session.add(
         AuditLog(

--- a/apps/backend/app/services/linear_provisioner.py
+++ b/apps/backend/app/services/linear_provisioner.py
@@ -34,6 +34,7 @@ from typing import Any
 
 from backend.app.core.config import Settings
 from backend.app.integrations.linear.tracker_adapter import LinearTracker
+from backend.app.services.tracker_fsm import FSM_TO_NATIVE_STATE
 from backend.app.services.canonical_projection import (
     CanonicalState,
     default_canonical_to_native,
@@ -169,47 +170,11 @@ def previous_stages(stage: str) -> list[str]:
 # placement: stages mapped to ``In Progress`` get tickets in that
 # Linear state; stages mapped to ``Todo`` keep tickets in Todo with
 # the label carrying the SDLC stage.
-FSM_TO_LINEAR_STATE: dict[str, str] = {
-    # E16/ELS-123 bundle stages.
-    "planning": "Todo",
-    "dev_implementation": "In Progress",
-    "devops_implementation": "In Progress",
-    "validation": "In Progress",
-    # ``code_review`` and ``auto_merge`` both run while the ticket
-    # sits in Linear's ``Review`` column. Reviewer leaves feedback
-    # (or rubber-stamps), auto-merger then runs its 7-signal gate
-    # and squashes via the GitHub API. ``merged`` (the terminal
-    # value of auto-merger's ``stage_next``) flips the ticket to
-    # Linear ``Done``.
-    "code_review": "Review",
-    "auto_merge": "Review",
-    "merged": "Done",
-    # Self-heal runs out-of-band against any open ticket; no specific
-    # Linear state.
-    "self_heal": "Todo",
-    # Decomposition bundle lives on the planning anchor. The anchor
-    # sits in ``In Progress`` while the bundle runs and ``Done`` once
-    # ``planning_done`` lands. The project body carries the artefacts
-    # (WBS / Architecture / Test architecture / Tasks); the finish
-    # hook flips the dashboard row Drafts → Parked when
-    # ``planning_done`` arrives.
-    "decomposition": "In Progress",
-    "planning_done": "Done",
-    # Legacy pre-E16 stage names — kept so an in-flight ticket carrying
-    # ``stage:task_intake`` still maps to a Linear state. ELS-124
-    # cutover strips them from the map.
-    "task_intake": "Todo",
-    "ba_requirements": "Todo",
-    "tech_arch_plan": "Todo",
-    "qa_arch_plan": "Todo",
-    "qa_manual": "In Progress",
-    "qa_automation": "In Progress",
-    "pr_review": "Review",
-    "wbs": "In Progress",
-    "architecture": "In Progress",
-    "test_architecture": "In Progress",
-    "tasks": "In Progress",
-}
+#
+# ELS-228: the authoritative table lives in tracker_fsm.FSM_TO_NATIVE_STATE
+# (the single egress-only source of truth); this alias keeps the
+# provisioner's public name stable for existing callers.
+FSM_TO_LINEAR_STATE: dict[str, str] = FSM_TO_NATIVE_STATE["linear"]
 
 
 # Linear workflow state types we expect to drive the SDLC. Used to

--- a/apps/backend/app/services/notify.py
+++ b/apps/backend/app/services/notify.py
@@ -1,0 +1,366 @@
+"""The notification seam (ELS-222) — ``notify()`` + channel adapters.
+
+One interface for every place the engine "tells a human something".
+Routing is per-workspace (:mod:`backend.app.services.notify_config`),
+behind the global ``SHIP_NOTIFY_CHANNELS`` kill-switch (default off →
+inbox-only, today's behavior, so flipping an emit-site onto this seam
+is an observable no-op until a workspace opts in).
+
+Invariants:
+
+* ``notify()`` NEVER raises into the engine control path. Channel
+  failures collapse into ``ChannelResult(ok=False, detail=…)``.
+* The Inbox channel is the default for every level and reuses the
+  intake helpers (truncation / headline / category / priority) so its
+  rows are byte-identical with what the emit-sites build today. Flips
+  pass their original explicit field values via ``inbox_overrides``.
+* Channels are EGRESS ONLY. Nothing here reads comments/email back or
+  triggers FSM transitions — the STATUS field stays the only
+  transition signal (tracker_fsm.py:277).
+* Site-level dedup (audit-row windows, intake-handle pre-checks) stays
+  in the CALLER — this seam routes the emission, it does not own the
+  decision to emit.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.app.core.config import Settings, get_settings
+from backend.app.db.models.tenancy import Workspace
+from backend.app.services.notify_config import (
+    ChannelRouting,
+    NotifyChannel,
+    NotifyLevel,
+    get_channel_routing,
+)
+
+logger = logging.getLogger("ship.notify")
+
+
+# Default level → InboxItem.type mapping. Emit-site flips that need a
+# different type (e.g. the dispatcher's ``clarification`` at ACTION
+# level) pass it explicitly via ``inbox_overrides["type"]``.
+_LEVEL_TO_INBOX_TYPE: dict[NotifyLevel, str] = {
+    NotifyLevel.INFO: "improvement",
+    NotifyLevel.ACTION: "clarification",
+    NotifyLevel.BLOCKER: "blocker",
+}
+
+
+@dataclass(frozen=True)
+class NotifyContext:
+    """One emission, channel-agnostic."""
+
+    workspace_id: uuid.UUID
+    title: str
+    body: str
+    level: NotifyLevel
+    ticket_ref: str | None = None
+    repo_id: uuid.UUID | None = None
+    dedup_key: str | None = None  # becomes InboxItem.intake_handle
+    payload: dict[str, Any] = field(default_factory=dict)
+    # Exact InboxItem field overrides for byte-identical emit-site
+    # flips: type, summary, headline, category, priority, status,
+    # intake_reason, source_table, source_id, auto_resolvable,
+    # stale_after. Anything absent is derived.
+    inbox_overrides: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ChannelResult:
+    channel: NotifyChannel
+    ok: bool
+    skipped: bool = False
+    detail: str | None = None
+
+
+@dataclass(frozen=True)
+class NotifyResult:
+    results: tuple[ChannelResult, ...]
+
+    @property
+    def ok(self) -> bool:
+        return all(r.ok for r in self.results)
+
+    def for_channel(self, channel: NotifyChannel) -> ChannelResult | None:
+        for r in self.results:
+            if r.channel == channel:
+                return r
+        return None
+
+
+class Channel(Protocol):
+    channel: NotifyChannel
+
+    async def emit(
+        self,
+        session: AsyncSession,
+        ctx: NotifyContext,
+        routing: ChannelRouting,
+    ) -> ChannelResult: ...
+
+
+# ---------------------------------------------------------------------------
+# Inbox channel — the default; wraps the intake field conventions
+# ---------------------------------------------------------------------------
+
+
+class InboxChannel:
+    channel = NotifyChannel.INBOX
+
+    async def emit(
+        self,
+        session: AsyncSession,
+        ctx: NotifyContext,
+        routing: ChannelRouting,
+    ) -> ChannelResult:
+        from backend.app.db.models.inbox import InboxItem
+        from backend.app.services.inbox.classification import (
+            category_from_type,
+            priority_for_item,
+        )
+        from backend.app.services.inbox.headline import derive_headline
+        from backend.app.services.inbox.intake import (
+            _SUMMARY_MAX_LEN,
+            _TITLE_MAX_LEN,
+            _truncate,
+        )
+
+        o = ctx.inbox_overrides
+        item_type = o.get("type") or _LEVEL_TO_INBOX_TYPE[ctx.level]
+        title = _truncate(o.get("title") or ctx.title, _TITLE_MAX_LEN)
+        summary_src = o.get("summary", ctx.body)
+        summary = (
+            _truncate(summary_src or "", _SUMMARY_MAX_LEN) or None
+            if summary_src is not None
+            else None
+        )
+
+        kwargs: dict[str, Any] = {
+            "workspace_id": ctx.workspace_id,
+            "repo_id": ctx.repo_id,
+            "type": item_type,
+            "title": title,
+            "summary": summary,
+            "payload": dict(ctx.payload),
+            "status": o.get("status", "new"),
+            "intake_handle": o.get("intake_handle", ctx.dedup_key),
+            "intake_reason": o.get("intake_reason"),
+            "source_table": o.get("source_table"),
+            "source_id": o.get("source_id"),
+        }
+        # category / priority / headline / auto_resolvable / stale_after
+        # are byte-identity-sensitive: emit-sites that omit them today
+        # get the DB server defaults (category='attention', priority=50,
+        # headline NULL). So the channel only sets them when the flip
+        # passes them explicitly, or when derivation is opted into
+        # (derive_classification / derive_headline=True — matching the
+        # intake builder's behavior for new, non-flip callers).
+        if "category" in o:
+            kwargs["category"] = o["category"]
+        elif o.get("derive_classification"):
+            kwargs["category"] = category_from_type(item_type)
+        if "priority" in o:
+            kwargs["priority"] = o["priority"]
+        elif o.get("derive_classification"):
+            kwargs["priority"] = priority_for_item(
+                category=str(kwargs.get("category") or category_from_type(item_type)),
+                item_type=item_type,
+            )
+        if "headline" in o:
+            kwargs["headline"] = o["headline"]
+        elif o.get("derive_headline"):
+            kwargs["headline"] = derive_headline(summary=summary, title=title)
+        if "auto_resolvable" in o:
+            kwargs["auto_resolvable"] = o["auto_resolvable"]
+        if "stale_after" in o:
+            kwargs["stale_after"] = o["stale_after"]
+
+        session.add(InboxItem(**kwargs))
+        return ChannelResult(channel=self.channel, ok=True)
+
+
+# ---------------------------------------------------------------------------
+# Linear-comment channel — context egress onto the ticket thread
+# ---------------------------------------------------------------------------
+
+
+class LinearCommentChannel:
+    channel = NotifyChannel.LINEAR
+
+    async def emit(
+        self,
+        session: AsyncSession,
+        ctx: NotifyContext,
+        routing: ChannelRouting,
+    ) -> ChannelResult:
+        if not ctx.ticket_ref:
+            return ChannelResult(
+                channel=self.channel, ok=True, skipped=True,
+                detail="skipped_no_ticket",
+            )
+        from backend.app.integrations.gateway.tracker import TicketRef
+        from backend.app.services.tracker_resolver import resolve_for_workspace
+
+        resolved = await resolve_for_workspace(
+            session=session,
+            settings=get_settings(),
+            workspace_id=ctx.workspace_id,
+        )
+        if resolved is None:
+            return ChannelResult(
+                channel=self.channel, ok=True, skipped=True,
+                detail="skipped_no_tracker",
+            )
+        ref = TicketRef(
+            kind=resolved.kind, workspace_hint=None, id=str(ctx.ticket_ref)
+        )
+        body = f"**[Ship {ctx.level.value.upper()}]** {ctx.title}\n\n{ctx.body}"
+        await resolved.gateway.comment(ref, body=body)
+        return ChannelResult(channel=self.channel, ok=True)
+
+
+# ---------------------------------------------------------------------------
+# Email channel — fail-closed recipient, structured skip
+# ---------------------------------------------------------------------------
+
+
+class EmailChannel:
+    channel = NotifyChannel.EMAIL
+
+    async def emit(
+        self,
+        session: AsyncSession,
+        ctx: NotifyContext,
+        routing: ChannelRouting,
+    ) -> ChannelResult:
+        if not routing.email_to:
+            # Founder decision: never guess a recipient.
+            return ChannelResult(
+                channel=self.channel, ok=True, skipped=True,
+                detail="skipped_no_email_to",
+            )
+        from backend.app.services.email.sender import (
+            EmailAddress,
+            EmailMessage,
+            get_email_sender,
+        )
+        from backend.app.services.email.templates import (
+            render_notification_email,
+        )
+
+        rendered = render_notification_email(
+            subject=ctx.title,
+            body_markdown=ctx.body,
+            level=ctx.level.value,
+            ticket_ref=ctx.ticket_ref,
+        )
+        result = await get_email_sender().send(
+            EmailMessage(
+                to=EmailAddress(email=routing.email_to),
+                subject=rendered.subject,
+                html=rendered.html,
+                text=rendered.text,
+                tags={
+                    "kind": "engine_notification",
+                    "level": ctx.level.value,
+                    "workspace": str(ctx.workspace_id),
+                },
+            )
+        )
+        if not result.sent:
+            return ChannelResult(
+                channel=self.channel, ok=False,
+                detail=result.detail or f"send failed ({result.provider})",
+            )
+        return ChannelResult(channel=self.channel, ok=True)
+
+
+_CHANNEL_IMPLS: dict[NotifyChannel, Channel] = {
+    NotifyChannel.INBOX: InboxChannel(),
+    NotifyChannel.LINEAR: LinearCommentChannel(),
+    NotifyChannel.EMAIL: EmailChannel(),
+}
+
+
+# ---------------------------------------------------------------------------
+# The seam
+# ---------------------------------------------------------------------------
+
+
+async def notify(
+    session: AsyncSession,
+    *,
+    workspace_id: uuid.UUID,
+    title: str,
+    body: str,
+    level: NotifyLevel,
+    ticket_ref: str | None = None,
+    repo_id: uuid.UUID | None = None,
+    dedup_key: str | None = None,
+    payload: dict[str, Any] | None = None,
+    inbox_overrides: dict[str, Any] | None = None,
+    settings: Settings | None = None,
+) -> NotifyResult:
+    """Route one engine emission to the workspace's channels.
+
+    Never raises. The Inbox channel is part of every routing list (see
+    :mod:`notify_config`), so even a fully broken linear/email setup
+    still lands the letter where it lands today.
+    """
+    ctx = NotifyContext(
+        workspace_id=workspace_id,
+        title=title,
+        body=body,
+        level=level,
+        ticket_ref=ticket_ref,
+        repo_id=repo_id,
+        dedup_key=dedup_key,
+        payload=dict(payload or {}),
+        inbox_overrides=dict(inbox_overrides or {}),
+    )
+    try:
+        workspace = await session.get(Workspace, workspace_id)
+    except Exception as exc:  # noqa: BLE001 — emit path must not die
+        logger.warning("notify: workspace load failed ws=%s: %s", workspace_id, exc)
+        workspace = None
+    if workspace is None:
+        routing = ChannelRouting()
+    else:
+        routing = get_channel_routing(workspace, settings=settings)
+
+    results: list[ChannelResult] = []
+    for channel in routing.channels_for(level):
+        impl = _CHANNEL_IMPLS[channel]
+        try:
+            results.append(await impl.emit(session, ctx, routing))
+        except Exception as exc:  # noqa: BLE001 — one channel must not sink the rest
+            logger.warning(
+                "notify: channel=%s failed ws=%s ticket=%s: %s",
+                channel.value, workspace_id, ctx.ticket_ref, exc,
+            )
+            results.append(
+                ChannelResult(
+                    channel=channel, ok=False, detail=str(exc)[:300]
+                )
+            )
+    return NotifyResult(results=tuple(results))
+
+
+__all__ = [
+    "Channel",
+    "ChannelResult",
+    "EmailChannel",
+    "InboxChannel",
+    "LinearCommentChannel",
+    "NotifyContext",
+    "NotifyLevel",
+    "NotifyResult",
+    "notify",
+]

--- a/apps/backend/app/services/notify.py
+++ b/apps/backend/app/services/notify.py
@@ -134,13 +134,17 @@ class InboxChannel:
 
         o = ctx.inbox_overrides
         item_type = o.get("type") or _LEVEL_TO_INBOX_TYPE[ctx.level]
-        title = _truncate(o.get("title") or ctx.title, _TITLE_MAX_LEN)
-        summary_src = o.get("summary", ctx.body)
-        summary = (
-            _truncate(summary_src or "", _SUMMARY_MAX_LEN) or None
-            if summary_src is not None
-            else None
-        )
+        # Override title/summary are used VERBATIM (the flipped emit-site
+        # already applied its own truncation — byte-identity). The default
+        # ctx fields get the intake truncation conventions.
+        if "title" in o:
+            title = o["title"]
+        else:
+            title = _truncate(ctx.title, _TITLE_MAX_LEN)
+        if "summary" in o:
+            summary = o["summary"]
+        else:
+            summary = _truncate(ctx.body or "", _SUMMARY_MAX_LEN) or None
 
         kwargs: dict[str, Any] = {
             "workspace_id": ctx.workspace_id,

--- a/apps/backend/app/services/notify.py
+++ b/apps/backend/app/services/notify.py
@@ -344,7 +344,8 @@ async def notify(
         routing = get_channel_routing(workspace, settings=settings)
 
     results: list[ChannelResult] = []
-    for channel in routing.channels_for(level):
+    requested = routing.channels_for(level)
+    for channel in requested:
         impl = _CHANNEL_IMPLS[channel]
         try:
             results.append(await impl.emit(session, ctx, routing))
@@ -358,6 +359,42 @@ async def notify(
                     channel=channel, ok=False, detail=str(exc)[:300]
                 )
             )
+
+    # Observability (ELS-226): one audit row per emission with the
+    # per-channel outcomes. Best-effort — an audit failure must never
+    # sink the emit (same pattern as agent_runs.py).
+    try:
+        from backend.app.db.models.tenancy import AuditLog
+
+        session.add(
+            AuditLog(
+                workspace_id=workspace_id,
+                actor_user_id=None,
+                actor_token_id=None,
+                action="notify.emit",
+                target_kind="notification",
+                target_id=(ctx.ticket_ref or ctx.dedup_key or "")[:255] or None,
+                payload={
+                    "level": level.value,
+                    "title": ctx.title[:200],
+                    "ticket_ref": ctx.ticket_ref,
+                    "requested_channels": [c.value for c in requested],
+                    "results": [
+                        {
+                            "channel": r.channel.value,
+                            "ok": r.ok,
+                            "skipped": r.skipped,
+                            "detail": r.detail,
+                        }
+                        for r in results
+                    ],
+                },
+            )
+        )
+    except Exception as exc:  # noqa: BLE001 — audit failure must not sink the emit
+        logger.warning(
+            "notify: audit write failed ws=%s: %s", workspace_id, exc
+        )
     return NotifyResult(results=tuple(results))
 
 

--- a/apps/backend/app/services/notify.py
+++ b/apps/backend/app/services/notify.py
@@ -78,6 +78,9 @@ class ChannelResult:
     ok: bool
     skipped: bool = False
     detail: str | None = None
+    # The created ORM row (InboxChannel only) — for flipped emit-sites
+    # whose callers return / link the letter (e.g. RunEscalation rows).
+    inbox_item: Any = None
 
 
 @dataclass(frozen=True)
@@ -186,8 +189,9 @@ class InboxChannel:
         if "stale_after" in o:
             kwargs["stale_after"] = o["stale_after"]
 
-        session.add(InboxItem(**kwargs))
-        return ChannelResult(channel=self.channel, ok=True)
+        item = InboxItem(**kwargs)
+        session.add(item)
+        return ChannelResult(channel=self.channel, ok=True, inbox_item=item)
 
 
 # ---------------------------------------------------------------------------

--- a/apps/backend/app/services/notify_config.py
+++ b/apps/backend/app/services/notify_config.py
@@ -1,0 +1,172 @@
+"""Per-workspace notification channel routing (ELS-219).
+
+The config surface the Phase-1 ``notify()`` router reads. Routing
+lives on the existing ``Workspace.settings`` JSON column (no
+migration) under::
+
+    settings["notifications"] = {
+        "email_to": "ops@example.com",          # EmailChannel recipient
+        "channels": {
+            "info":    ["inbox"],
+            "action":  ["inbox", "linear"],
+            "blocker": ["inbox", "linear", "email"],
+        },
+    }
+
+Safe-by-default rules (founder decisions baked in):
+
+* Every level defaults to ``["inbox"]`` — today's behavior — so the
+  seam is a no-op until a workspace opts a level onto linear/email.
+* The global kill-switch ``SHIP_NOTIFY_CHANNELS`` (default ``False``,
+  see :class:`backend.app.core.config.Settings`) forces inbox-only
+  regardless of per-workspace config: instant global rollback.
+* Malformed settings fail **closed** to inbox-only with a logged
+  warning — never raise on the engine's emit path.
+* A missing ``email_to`` is a structured skip, not a guess.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Final
+
+from backend.app.core.config import Settings, get_settings
+from backend.app.db.models.tenancy import Workspace
+
+logger = logging.getLogger("ship.notify_config")
+
+
+class NotifyLevel(str, Enum):
+    """Severity of an engine emission — drives channel routing."""
+
+    INFO = "info"
+    ACTION = "action"
+    BLOCKER = "blocker"
+
+
+class NotifyChannel(str, Enum):
+    INBOX = "inbox"
+    LINEAR = "linear"
+    EMAIL = "email"
+
+
+_SUPPORTED_CHANNELS: Final[frozenset[str]] = frozenset(
+    c.value for c in NotifyChannel
+)
+_INBOX_ONLY: Final[tuple[NotifyChannel, ...]] = (NotifyChannel.INBOX,)
+
+
+@dataclass(frozen=True)
+class ChannelRouting:
+    """Resolved per-level channel lists for one workspace."""
+
+    info: tuple[NotifyChannel, ...] = _INBOX_ONLY
+    action: tuple[NotifyChannel, ...] = _INBOX_ONLY
+    blocker: tuple[NotifyChannel, ...] = _INBOX_ONLY
+    email_to: str | None = None
+
+    def channels_for(self, level: NotifyLevel) -> tuple[NotifyChannel, ...]:
+        return {
+            NotifyLevel.INFO: self.info,
+            NotifyLevel.ACTION: self.action,
+            NotifyLevel.BLOCKER: self.blocker,
+        }[level]
+
+
+_DEFAULT_ROUTING: Final[ChannelRouting] = ChannelRouting()
+
+
+def _parse_level(raw: Any, *, workspace_id: Any, level: str) -> tuple[NotifyChannel, ...]:
+    """One level's channel list — fail closed to inbox-only on any shape
+    surprise. The Inbox channel is always present so a typo'd config can
+    never silently drop an engine emission."""
+    if raw is None:
+        return _INBOX_ONLY
+    if not isinstance(raw, (list, tuple)):
+        logger.warning(
+            "notify_config: ws=%s level=%s is not a list (%r) — inbox-only",
+            workspace_id, level, type(raw).__name__,
+        )
+        return _INBOX_ONLY
+    channels: list[NotifyChannel] = [NotifyChannel.INBOX]
+    for entry in raw:
+        if entry == NotifyChannel.INBOX.value:
+            continue  # already first
+        if isinstance(entry, str) and entry in _SUPPORTED_CHANNELS:
+            channel = NotifyChannel(entry)
+            if channel not in channels:
+                channels.append(channel)
+        else:
+            logger.warning(
+                "notify_config: ws=%s level=%s unknown channel %r — skipped",
+                workspace_id, level, entry,
+            )
+    return tuple(channels)
+
+
+def get_channel_routing(
+    workspace: Workspace,
+    *,
+    settings: Settings | None = None,
+) -> ChannelRouting:
+    """Resolve the workspace's channel routing.
+
+    Honors the global ``SHIP_NOTIFY_CHANNELS`` kill-switch: while it is
+    off (the default) every workspace resolves to inbox-only no matter
+    what its settings request. Never raises — the engine's emit path
+    must not die because an operator fat-fingered a settings blob.
+    """
+    settings = settings or get_settings()
+    raw = (workspace.settings or {}).get("notifications")
+    if not isinstance(raw, dict):
+        if raw is not None:
+            logger.warning(
+                "notify_config: ws=%s settings.notifications is not an "
+                "object — inbox-only", workspace.id,
+            )
+        raw = {}
+
+    email_to_raw = raw.get("email_to")
+    email_to = (
+        email_to_raw.strip()
+        if isinstance(email_to_raw, str) and email_to_raw.strip()
+        else None
+    )
+
+    if not settings.notification_channels_enabled:
+        # Kill-switch off → inbox-only globally. email_to still resolves
+        # so audit/debug surfaces can show what WOULD be used.
+        return ChannelRouting(email_to=email_to)
+
+    channels_raw = raw.get("channels")
+    if channels_raw is None:
+        return ChannelRouting(email_to=email_to)
+    if not isinstance(channels_raw, dict):
+        logger.warning(
+            "notify_config: ws=%s notifications.channels is not an object "
+            "— inbox-only", workspace.id,
+        )
+        return ChannelRouting(email_to=email_to)
+
+    return ChannelRouting(
+        info=_parse_level(
+            channels_raw.get("info"), workspace_id=workspace.id, level="info"
+        ),
+        action=_parse_level(
+            channels_raw.get("action"), workspace_id=workspace.id, level="action"
+        ),
+        blocker=_parse_level(
+            channels_raw.get("blocker"), workspace_id=workspace.id, level="blocker"
+        ),
+        email_to=email_to,
+    )
+
+
+__all__ = [
+    "ChannelRouting",
+    "NotifyChannel",
+    "NotifyLevel",
+    "get_channel_routing",
+]

--- a/apps/backend/app/services/policies.py
+++ b/apps/backend/app/services/policies.py
@@ -134,5 +134,133 @@ async def render_policies_preamble(
 __all__ = [
     "format_policies_preamble",
     "list_enabled_policies",
+    "render_autonomy_preamble",
     "render_policies_preamble",
 ]
+
+
+# ---------------------------------------------------------------------------
+# Autonomy preamble (ELS-244, thesis 7) — rendered through the SAME
+# module as the policies preamble so Navigator chat and shipctl run
+# emit byte-identical text (thesis 5: value enters through the prompt,
+# never tool-native config).
+# ---------------------------------------------------------------------------
+
+_AUTONOMY_BLOCKS: dict[str, str] = {
+    "high": (
+        "# Autonomy profile: HIGH\n"
+        "\n"
+        "Action rights for this workspace (opted in by the operator):\n"
+        "\n"
+        "- Skip optional approval pauses; proceed when CI is green.\n"
+        "- Broader edits are allowed: refactor adjacent code when it\n"
+        "  serves the task; keep commits reviewable.\n"
+        "- Self-pick follow-up work and create tickets / decompose\n"
+        "  without asking for confirmation first.\n"
+        "- Your PRs are self-merge-eligible once the server gate sees\n"
+        "  green CI (the gate still verifies — never claim falsely).\n"
+        "\n"
+        "Hard limits that NEVER loosen: CI must be green; the FSM gates\n"
+        "and dispatch limits (lease/cap/cascade) apply unchanged; no\n"
+        "force-pushes; no bypassing review stages by editing tracker\n"
+        "state directly.\n"
+    ),
+    "balanced": (
+        "# Autonomy profile: BALANCED\n"
+        "\n"
+        "Action rights for this workspace:\n"
+        "\n"
+        "- Proceed autonomously through the normal FSM stages.\n"
+        "- Confirm before destructive or structural operations\n"
+        "  (schema changes, deletions, dependency major bumps).\n"
+        "- Ticket creation / decomposition: propose first when the\n"
+        "  scope is new; proceed when it directly serves the current\n"
+        "  ticket.\n"
+        "- Merges require the review stage's approval as usual.\n"
+    ),
+    "conservative": (
+        "# Autonomy profile: CONSERVATIVE\n"
+        "\n"
+        "Action rights for this workspace:\n"
+        "\n"
+        "- Keep edits narrow: only what the ticket explicitly asks.\n"
+        "- Confirm before any merge, structural change, or new ticket\n"
+        "  creation.\n"
+        "- Prefer asking a clarification over assuming intent.\n"
+    ),
+}
+
+
+async def _has_knowledge_surface(
+    session: AsyncSession, workspace_id: uuid.UUID
+) -> bool:
+    """High autonomy only works WITH rich context (founder decision).
+
+    'Non-empty knowledge surface' = at least one enabled policy OR at
+    least one knowledge-base chunk for the workspace."""
+    policies = await list_enabled_policies(session, workspace_id)
+    if policies:
+        return True
+    from sqlalchemy import func, select as sa_select
+
+    from backend.app.db.models.agent_memory import KbChunk
+
+    chunks = await session.scalar(
+        sa_select(func.count(KbChunk.id)).where(
+            KbChunk.workspace_id == workspace_id
+        )
+    )
+    return bool(chunks)
+
+
+async def render_autonomy_preamble(
+    session: AsyncSession,
+    workspace_id: uuid.UUID,
+) -> str:
+    """Render the workspace's autonomy action-rights block.
+
+    Coupling guard: ``high`` on a workspace with NO knowledge surface
+    is downgraded to ``balanced`` for the rendered prompt, with an
+    audited warning — high rights + thin context is the chaos
+    combination the founder vetoed. The downgrade is per-render
+    (effective), not persisted: fixing the knowledge surface restores
+    high on the next render with no further action.
+    """
+    from backend.app.services.agent_provider_resolver import (
+        resolve_autonomy_for_workspace,
+    )
+
+    profile = await resolve_autonomy_for_workspace(
+        session=session, workspace_id=workspace_id
+    )
+    effective = profile
+    if profile == "high" and not await _has_knowledge_surface(
+        session, workspace_id
+    ):
+        effective = "balanced"
+        from backend.app.db.models.tenancy import AuditLog
+
+        session.add(
+            AuditLog(
+                workspace_id=workspace_id,
+                actor_user_id=None,
+                actor_token_id=None,
+                action="workspace.autonomy.downgraded_effective",
+                target_kind="workspace",
+                target_id=str(workspace_id),
+                payload={
+                    "configured": "high",
+                    "effective": "balanced",
+                    "reason": "no_knowledge_surface",
+                },
+            )
+        )
+    block = _AUTONOMY_BLOCKS[effective]
+    if effective != profile:
+        block += (
+            "\n_Note: this workspace is configured HIGH but has no "
+            "knowledge surface (no enabled policies, empty knowledge "
+            "base) — rights are rendered as BALANCED until context "
+            "exists._\n"
+        )
+    return block

--- a/apps/backend/app/services/scheduled_routines.py
+++ b/apps/backend/app/services/scheduled_routines.py
@@ -1,0 +1,271 @@
+"""Scheduled ticket-creating routines (ELS-232/233/234 — trigger c).
+
+The second flavor of time-driven work. ``daily_scheduler`` fires
+WORKSPACE-SCOPE bundles (no ticket); this module CREATES a Linear
+ticket in a target FSM stage so the already-shipped
+ticket → tracker_poller → dispatcher → ``shipctl run`` path executes
+it — no new dispatch code, the cron is just an intake clerk.
+
+Idempotency (ELS-232): creation is gated on the audit_log-as-ledger
+pattern the cascade counter uses — a durable
+``scheduled_routine.ticket_created`` row per ``(kind, period_key)``;
+two ticks inside one period create at most one ticket, and the guard
+survives leader failover because audit_log is Postgres.
+
+Launch posture (founder default): per-workspace OPT-IN. A workspace
+without ``settings.scheduled_routines.<kind> = true`` is skipped
+fail-closed — the cron never writes tickets into a tracker nobody
+asked it to.
+
+Templates (ELS-234): each spec renders a self-contained brief — the
+downstream stage agents (planning/dev) must be able to act on the
+ticket body alone, with no reliance on the cron run's transient
+context. Templates never instruct the agent to bypass the FSM (no
+direct merges, no stage skipping); the 'use Ship's API, never reach
+into Linear via MCP' guardrail mirrors daily-digest.md.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.app.db.models.integrations import NativeIntegrationInstallation
+from backend.app.db.models.tenancy import AuditLog, Workspace
+from backend.app.db.session import get_sessionmaker
+
+log = logging.getLogger(__name__)
+
+TICKET_CREATED_ACTION = "scheduled_routine.ticket_created"
+
+
+@dataclass(frozen=True)
+class ScheduledRoutineSpec:
+    kind: str  # 'daily' | 'retro' | 'techdebt'
+    cron_expr: str
+    period: str  # 'day' | 'week' — drives period_key granularity
+    target_fsm_stage: str  # stage label the created ticket carries
+    title_template: str  # .format(period_key=, workspace=)
+    body_template: str
+
+
+SPECS: dict[str, ScheduledRoutineSpec] = {
+    s.kind: s
+    for s in (
+        ScheduledRoutineSpec(
+            kind="daily",
+            cron_expr="30 6 * * 1-5",  # weekday mornings UTC
+            period="day",
+            target_fsm_stage="planning",
+            title_template="Daily review — {period_key}",
+            body_template=(
+                "## Daily review ({period_key})\n\n"
+                "Walk the workspace's in-flight work and produce a short, "
+                "self-contained status review as this ticket's deliverable:\n\n"
+                "1. List tickets that moved stages in the last 24h and any "
+                "that look stuck (no movement, blocked label).\n"
+                "2. Flag PRs awaiting review or with red CI.\n"
+                "3. Propose at most three concrete next actions.\n\n"
+                "Work through Ship's own API surface (the run context you "
+                "are handed) — do NOT reach into Linear via MCP or any "
+                "side channel. Do not transition other tickets, do not "
+                "merge anything; your output is the review on THIS ticket. "
+                "The normal FSM gates apply to this ticket itself."
+            ),
+        ),
+        ScheduledRoutineSpec(
+            kind="retro",
+            cron_expr="0 16 * * 5",  # Friday afternoon UTC
+            period="week",
+            target_fsm_stage="planning",
+            title_template="Weekly retro — {period_key}",
+            body_template=(
+                "## Weekly retrospective ({period_key})\n\n"
+                "Look back over the week's merged PRs, blocked tickets and "
+                "agent-run failures, and produce a self-contained retro:\n\n"
+                "1. What shipped (merged work, by theme).\n"
+                "2. What got stuck and why (blocked/rework loops, gate "
+                "refusals).\n"
+                "3. At most three process improvements, each phrased as a "
+                "follow-up ticket draft (title + 2-3 sentence body).\n\n"
+                "Use Ship's API surface only — never Linear via MCP. Do not "
+                "create the follow-up tickets yourself and do not bypass "
+                "any FSM stage; the human picks which drafts to file."
+            ),
+        ),
+        ScheduledRoutineSpec(
+            kind="techdebt",
+            cron_expr="0 7 * * 1",  # Monday morning UTC
+            period="week",
+            target_fsm_stage="planning",
+            title_template="Tech-debt sweep — {period_key}",
+            body_template=(
+                "## Tech-debt sweep ({period_key})\n\n"
+                "Survey the repo for accumulating debt and produce a "
+                "prioritised, self-contained report:\n\n"
+                "1. TODO/FIXME/xfail/skip markers older than 30 days.\n"
+                "2. Modules with rising churn + failing/ignored tests.\n"
+                "3. Dependency pins overdue for a bump (security first).\n"
+                "4. Top three debt items as ticket drafts (title + why now "
+                "+ rough size).\n\n"
+                "Report only — do not refactor on this ticket, do not merge "
+                "anything, do not skip FSM stages. Use Ship's API surface, "
+                "never Linear via MCP."
+            ),
+        ),
+    )
+}
+
+
+def period_key_for(spec: ScheduledRoutineSpec, now: datetime | None = None) -> str:
+    now = now or datetime.now(timezone.utc)
+    if spec.period == "day":
+        return now.strftime("%Y-%m-%d")
+    iso = now.isocalendar()
+    return f"{iso.year}-W{iso.week:02d}"
+
+
+def _ledger_target(kind: str, period_key: str) -> str:
+    return f"{kind}:{period_key}"
+
+
+async def already_created(
+    session: AsyncSession,
+    *,
+    workspace_id: uuid.UUID,
+    kind: str,
+    period_key: str,
+) -> bool:
+    """Durable idempotency guard — audit_log as the ledger."""
+    count = await session.scalar(
+        select(func.count(AuditLog.id)).where(
+            AuditLog.workspace_id == workspace_id,
+            AuditLog.action == TICKET_CREATED_ACTION,
+            AuditLog.target_id == _ledger_target(kind, period_key),
+        )
+    )
+    return bool(count)
+
+
+def _workspace_opted_in(workspace: Workspace | None, kind: str) -> bool:
+    """Founder default: fail-closed opt-in per workspace + kind."""
+    if workspace is None:
+        return False
+    raw = (workspace.settings or {}).get("scheduled_routines")
+    if not isinstance(raw, dict):
+        return False
+    return raw.get(kind) is True
+
+
+async def create_routine_ticket(
+    session: AsyncSession,
+    *,
+    workspace_id: uuid.UUID,
+    spec: ScheduledRoutineSpec,
+    now: datetime | None = None,
+) -> str | None:
+    """Create one routine ticket for one workspace (idempotent per
+    period). Returns the created ticket ref, or None on skip."""
+    from backend.app.core.config import get_settings
+    from backend.app.services.tracker_resolver import resolve_for_workspace
+
+    now = now or datetime.now(timezone.utc)
+    period_key = period_key_for(spec, now)
+
+    workspace = await session.get(Workspace, workspace_id)
+    if not _workspace_opted_in(workspace, spec.kind):
+        return None
+    if await already_created(
+        session, workspace_id=workspace_id, kind=spec.kind, period_key=period_key
+    ):
+        log.info(
+            "scheduled_routine %s: ws=%s period=%s already created — skip",
+            spec.kind, workspace_id, period_key,
+        )
+        return None
+
+    resolved = await resolve_for_workspace(
+        session=session, settings=get_settings(), workspace_id=workspace_id
+    )
+    if resolved is None:
+        return None
+
+    created = await resolved.gateway.create_ticket(
+        title=spec.title_template.format(period_key=period_key),
+        body=spec.body_template.format(period_key=period_key),
+        labels=[f"stage:{spec.target_fsm_stage}"],
+    )
+    session.add(
+        AuditLog(
+            workspace_id=workspace_id,
+            actor_user_id=None,
+            actor_token_id=None,
+            action=TICKET_CREATED_ACTION,
+            target_kind="ticket",
+            target_id=_ledger_target(spec.kind, period_key),
+            payload={
+                "routine_kind": spec.kind,
+                "period_key": period_key,
+                "ticket_ref": created.display_id or created.ref.id,
+                "target_fsm_stage": spec.target_fsm_stage,
+            },
+        )
+    )
+    await session.flush()
+    return created.display_id or created.ref.id
+
+
+async def run_routine_for_all_workspaces(kind: str) -> None:
+    """One tick: create the period's ticket for every eligible
+    (ready-Linear + opted-in) workspace. Per-workspace failures are
+    isolated, matching daily_scheduler."""
+    spec = SPECS[kind]
+    sm = get_sessionmaker()
+    async with sm() as session:
+        installs = (
+            await session.execute(
+                select(NativeIntegrationInstallation).where(
+                    NativeIntegrationInstallation.provider == "linear",
+                    NativeIntegrationInstallation.status == "ready",
+                )
+            )
+        ).scalars().all()
+        created = 0
+        skipped = 0
+        for install in installs:
+            try:
+                ref = await create_routine_ticket(
+                    session, workspace_id=install.workspace_id, spec=spec
+                )
+                await session.commit()
+            except Exception:  # noqa: BLE001 — one ws must not abort the tick
+                await session.rollback()
+                log.exception(
+                    "scheduled_routine %s: ws=%s failed",
+                    kind, install.workspace_id,
+                )
+                continue
+            if ref:
+                created += 1
+            else:
+                skipped += 1
+        log.info(
+            "scheduled_routine %s tick: installs=%d created=%d skipped=%d",
+            kind, len(installs), created, skipped,
+        )
+
+
+__all__ = [
+    "SPECS",
+    "ScheduledRoutineSpec",
+    "TICKET_CREATED_ACTION",
+    "already_created",
+    "create_routine_ticket",
+    "period_key_for",
+    "run_routine_for_all_workspaces",
+]

--- a/apps/backend/app/services/sdlc_readiness.py
+++ b/apps/backend/app/services/sdlc_readiness.py
@@ -351,12 +351,20 @@ async def file_bootstrap_recommendation(
             f"{len(report.external_checklist)} setup step(s) need you."
         )
 
-    item = InboxItem(
+    from backend.app.services.notify import (
+        NotifyChannel,
+        NotifyLevel,
+        notify,
+    )
+
+    notify_result = await notify(
+        session,
         workspace_id=repo.workspace_id,
         repo_id=repo.id,
-        type="improvement",
         title=f"Set up {report.project_type} SDLC for {repo.full_name}"[:255],
-        summary=" ".join(summary_parts),
+        body=" ".join(summary_parts),
+        level=NotifyLevel.INFO,
+        dedup_key=handle,
         payload={
             "kind": "bootstrap_readiness",
             "project_type": report.project_type,
@@ -392,15 +400,15 @@ async def file_bootstrap_recommendation(
             ],
             "resolution_mode": "single_choice",
         },
-        status="new",
-        category="attention",
-        priority=30,
-        intake_handle=handle,
-        intake_reason="bootstrap_readiness",
+        inbox_overrides={
+            "category": "attention",
+            "priority": 30,
+            "intake_reason": "bootstrap_readiness",
+        },
     )
-    session.add(item)
     await session.flush()
-    return item
+    inbox = notify_result.for_channel(NotifyChannel.INBOX)
+    return inbox.inbox_item if inbox else None
 
 
 __all__ = [

--- a/apps/backend/app/services/seed_bundle.py
+++ b/apps/backend/app/services/seed_bundle.py
@@ -235,7 +235,11 @@ from backend.app.services.tracker_fsm import (
 #         collection, max_tokens 8192, and a deterministic verify-guard +
 #         corrective retry. Re-seed repos so the Actions path plans as well as
 #         the manual-key path.
-BUNDLE_VERSION: str = "0.40"
+# ``0.41`` → ELS-228 (headless pivot P2): tracker_fsm's projection maps unified
+#         into the single egress-only FSM_TO_NATIVE_STATE table. The rendered
+#         ``.ship/tracker-fsm.md`` output is unchanged — version bumped because
+#         the renderer source moved under the unified table.
+BUNDLE_VERSION: str = "0.41"
 
 # First bundle whose ``ship-agent-run.yml`` declares the ``ship_run_id``
 # ``workflow_dispatch`` input. The E16 cron dispatcher must NOT send this

--- a/apps/backend/app/services/stall_notifier.py
+++ b/apps/backend/app/services/stall_notifier.py
@@ -1,0 +1,154 @@
+"""Stall notifier (ELS-231) — engine-stalled signal through notify().
+
+Closes the silent-failure gap: when :func:`engine_health.assess_engine_health`
+reports a stalled ticket / dead engine, forward a structured BLOCKER
+through the Phase-1 notification seam. No new transport, no resurrected
+self-heal: this module REPORTS — it never moves a ticket status and
+never touches a lock.
+
+Safety properties:
+
+* Behind ``SHIP_STALL_NOTIFY`` (default off).
+* Idempotent per ``(lock_key, reason)`` within ``cooldown_minutes`` —
+  deduped via ``audit_log action='engine.stall_notified'`` (the same
+  pattern the cascade counter uses). Scheduler interval must be >= the
+  cooldown to keep the dedup meaningful.
+* Pure consumer of engine_health + notify(); the only row it writes
+  itself is the dedup audit marker.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.app.db.models.tenancy import AuditLog
+from backend.app.services.engine_health import (
+    StalledTicket,
+    assess_engine_health,
+)
+
+logger = logging.getLogger("ship.stall_notifier")
+
+STALL_NOTIFIED_ACTION = "engine.stall_notified"
+DEFAULT_COOLDOWN_MINUTES = 360  # 6h — conservative, avoid letter storms
+
+
+async def _already_notified(
+    session: AsyncSession,
+    *,
+    workspace_id: uuid.UUID,
+    lock_key: str,
+    reason: str,
+    cooldown_minutes: int,
+    now: datetime,
+) -> bool:
+    cutoff = now - timedelta(minutes=cooldown_minutes)
+    count = await session.scalar(
+        select(func.count(AuditLog.id)).where(
+            AuditLog.workspace_id == workspace_id,
+            AuditLog.action == STALL_NOTIFIED_ACTION,
+            AuditLog.target_id == f"{lock_key}|{reason}",
+            AuditLog.created_at >= cutoff,
+        )
+    )
+    return bool(count)
+
+
+async def notify_stalls_for_workspace(
+    session: AsyncSession,
+    *,
+    workspace_id: uuid.UUID,
+    cooldown_minutes: int = DEFAULT_COOLDOWN_MINUTES,
+    now: datetime | None = None,
+) -> int:
+    """Assess one workspace and forward fresh stalls. Returns the
+    number of notifications emitted (post-dedup)."""
+    from backend.app.services.notify import NotifyLevel, notify
+
+    now = now or datetime.now(timezone.utc)
+    liveness = await assess_engine_health(
+        session, workspace_id=workspace_id, now=now
+    )
+    emitted = 0
+    for stall in liveness.stalled:
+        if await _already_notified(
+            session,
+            workspace_id=workspace_id,
+            lock_key=stall.lock_key,
+            reason=stall.reason,
+            cooldown_minutes=cooldown_minutes,
+            now=now,
+        ):
+            continue
+        await notify(
+            session,
+            workspace_id=workspace_id,
+            ticket_ref=_ticket_ref_for(stall),
+            title=f"Engine stalled: {stall.lock_key} ({stall.reason})"[:250],
+            body=(
+                f"The dispatch engine looks stuck on `{stall.lock_key}`: "
+                f"{_reason_text(stall)} Lock claimed "
+                f"{stall.age_minutes:.0f} minutes ago"
+                f" (expires {stall.expires_at.isoformat()}). Ship will not "
+                "auto-act — inspect /engine-health and release or unblock "
+                "manually."
+            ),
+            level=NotifyLevel.BLOCKER,
+            dedup_key=f"stall:{stall.lock_key}:{stall.reason}",
+            payload={
+                "kind": "engine_stall",
+                "lock_key": stall.lock_key,
+                "reason": stall.reason,
+                "age_minutes": stall.age_minutes,
+                "claimed_at": stall.claimed_at.isoformat(),
+                "expires_at": stall.expires_at.isoformat(),
+                "run_id": stall.run_id,
+            },
+            inbox_overrides={"intake_reason": "engine_stall"},
+        )
+        # Dedup marker — the cooldown anchor.
+        session.add(
+            AuditLog(
+                workspace_id=workspace_id,
+                actor_user_id=None,
+                actor_token_id=None,
+                action=STALL_NOTIFIED_ACTION,
+                target_kind="lock",
+                target_id=f"{stall.lock_key}|{stall.reason}",
+                payload={"reason": stall.reason, "age_minutes": stall.age_minutes},
+            )
+        )
+        emitted += 1
+    if emitted:
+        await session.flush()
+    return emitted
+
+
+def _ticket_ref_for(stall: StalledTicket) -> str | None:
+    if stall.lock_key.startswith("ticket:"):
+        return stall.lock_key[len("ticket:"):]
+    return None
+
+
+def _reason_text(stall: StalledTicket) -> str:
+    if stall.reason == "expired_not_swept":
+        return (
+            "the lease is past its TTL but was never swept — the lock "
+            "sweeper may not be running."
+        )
+    return (
+        "the lock is held but no dispatch/finish progress landed in the "
+        "audit window."
+    )
+
+
+__all__ = [
+    "DEFAULT_COOLDOWN_MINUTES",
+    "STALL_NOTIFIED_ACTION",
+    "notify_stalls_for_workspace",
+]

--- a/apps/backend/app/services/state_projector.py
+++ b/apps/backend/app/services/state_projector.py
@@ -1,0 +1,130 @@
+"""StateProjector (ELS-229) — the single FSM→tracker write seam.
+
+Thesis 2: projection is ONE-DIRECTIONAL. This module writes the human
+read-model (Linear workflow states + ``stage:*`` breadcrumbs) and
+returns a report; its output is NEVER consumed as control input. The
+``stage:*`` breadcrumb stays the poller's pickup hint (domain), not a
+lease. Projection is best-effort and decoupled from lock acquisition —
+a tracker 5xx must not touch ``agent_dispatch_locks`` (and cannot:
+this module never imports the lock primitives; pinned by test).
+
+Strangler flag: ``SHIP_STATE_PROJECTOR_UNIFIED`` (default off). Flag
+off → call sites use their original direct ``gateway.transition``
+path, byte-identical to today. Flag on → every FSM→tracker status
+write funnels through :func:`project_ticket_state`, which adds the
+uniform audit trail and error capture.
+
+Idempotency: re-projecting an already-projected state delegates to the
+adapter's semantics — Linear ``issueUpdate`` to the same ``stateId``
+is a no-op server-side and the adapter's label add is by-name deduped,
+so a double projection cannot duplicate labels or churn state. The
+projector itself adds no state of its own (stateless seam).
+
+The human-only "Done" authorization gate stays at the ROUTE layer
+(agents must not pass ``Done``); the projector does not re-implement
+authorization.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from dataclasses import dataclass
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+logger = logging.getLogger("ship.state_projector")
+
+
+@dataclass(frozen=True)
+class ProjectionReport:
+    ok: bool
+    to_state: str
+    ticket_ref: str
+    error: Exception | None = None
+
+    def raise_if_failed(self) -> None:
+        """Preserve route-layer error semantics: callers that today
+        let a tracker failure propagate re-raise the SAME exception."""
+        if self.error is not None:
+            raise self.error
+
+
+async def project_ticket_state(
+    session: AsyncSession,
+    *,
+    workspace_id: uuid.UUID,
+    gateway,
+    ref,
+    to_state: str,
+    from_state: str | None = None,
+) -> ProjectionReport:
+    """Project one FSM stage (or literal tracker state) onto the ticket.
+
+    Wraps ``gateway.transition`` with error capture. Never touches any
+    lock; never reads tracker state back into a decision.
+    """
+    try:
+        if from_state is not None:
+            await gateway.transition(
+                ref, to_state=to_state, from_state=from_state
+            )
+        else:
+            await gateway.transition(ref, to_state=to_state)
+    except Exception as exc:  # noqa: BLE001 — captured into the report
+        logger.warning(
+            "state_projector: transition failed ws=%s ticket=%s to=%s: %s",
+            workspace_id, getattr(ref, "id", ref), to_state, exc,
+        )
+        return ProjectionReport(
+            ok=False,
+            to_state=to_state,
+            ticket_ref=str(getattr(ref, "id", ref)),
+            error=exc,
+        )
+    return ProjectionReport(
+        ok=True, to_state=to_state, ticket_ref=str(getattr(ref, "id", ref))
+    )
+
+
+async def transition_via_projector(
+    session: AsyncSession,
+    *,
+    settings,
+    workspace_id: uuid.UUID,
+    gateway,
+    ref,
+    to_state: str,
+    from_state: str | None = None,
+) -> None:
+    """The strangler shim every FSM→tracker write site calls.
+
+    Flag off → the original direct ``gateway.transition`` call
+    (byte-identical behavior, including raised exceptions). Flag on →
+    route through :func:`project_ticket_state` and re-raise on failure
+    so route-layer error handling stays unchanged either way.
+    """
+    if not getattr(settings, "state_projector_unified", False):
+        if from_state is not None:
+            await gateway.transition(
+                ref, to_state=to_state, from_state=from_state
+            )
+        else:
+            await gateway.transition(ref, to_state=to_state)
+        return
+    report = await project_ticket_state(
+        session,
+        workspace_id=workspace_id,
+        gateway=gateway,
+        ref=ref,
+        to_state=to_state,
+        from_state=from_state,
+    )
+    report.raise_if_failed()
+
+
+__all__ = [
+    "ProjectionReport",
+    "project_ticket_state",
+    "transition_via_projector",
+]

--- a/apps/backend/app/services/tracker_fsm.py
+++ b/apps/backend/app/services/tracker_fsm.py
@@ -143,11 +143,78 @@ SHIP_DEFAULT_STATES: Final[tuple[FsmState, ...]] = (
 )
 
 
+# ---------------------------------------------------------------------------
+# EGRESS-ONLY projection maps (ELS-228 — the single source of truth)
+# ---------------------------------------------------------------------------
+#
+# These tables answer exactly one question: "when Ship projects an FSM
+# stage / project state onto the tracker, which NATIVE slot does it
+# write?" They are WRITE maps for the human read-model.
+#
+# INVARIANT (thesis 2, headless-but-stateful): these maps are consumed
+# only on the egress path (Ship -> tracker) — by the provisioner, the
+# Linear adapter's transition(), and project_state_sync. They must
+# NEVER be inverted to parse a native status/label back into an FSM
+# stage for a control decision (lease / cap / cascade). The STATUS
+# field read by tracker_poller is the sole transition trigger and is
+# handled independently of these maps. A guard test pins that neither
+# dispatcher.py nor tracker_poller.py imports them.
+
+# FSM stage -> native workflow-state NAME the projection targets,
+# per tracker kind. The Linear block is the authoritative source the
+# provisioner copies into ``Integration.config`` (which the adapter
+# then resolves to live state IDs per team).
+FSM_TO_NATIVE_STATE: Final[dict[str, dict[str, str]]] = {
+    "linear": {
+        # E16/ELS-123 bundle stages.
+        "planning": "Todo",
+        "dev_implementation": "In Progress",
+        "devops_implementation": "In Progress",
+        "validation": "In Progress",
+        # ``code_review`` and ``auto_merge`` both run while the ticket
+        # sits in Linear's ``Review`` column; ``merged`` flips to Done.
+        "code_review": "Review",
+        "auto_merge": "Review",
+        "merged": "Done",
+        # Self-heal runs out-of-band against any open ticket.
+        "self_heal": "Todo",
+        # Decomposition bundle lives on the planning anchor.
+        "decomposition": "In Progress",
+        "planning_done": "Done",
+        # Legacy pre-E16 stage names — kept so an in-flight ticket
+        # carrying ``stage:task_intake`` still maps to a Linear state.
+        # ELS-124 cutover strips them from the map.
+        "task_intake": "Todo",
+        "ba_requirements": "Todo",
+        "tech_arch_plan": "Todo",
+        "qa_arch_plan": "Todo",
+        "qa_manual": "In Progress",
+        "qa_automation": "In Progress",
+        "pr_review": "Review",
+        "wbs": "In Progress",
+        "architecture": "In Progress",
+        "test_architecture": "In Progress",
+        "tasks": "In Progress",
+    },
+}
+
+# Dashboard project state -> (from_state, to_state) ticket sweep the
+# projection performs when a project flips state. Same egress-only
+# invariant as above; consumed by project_state_sync.
+PROJECT_STATE_TICKET_MOVES: Final[dict[str, tuple[str, str] | None]] = {
+    "active": ("Backlog", "Todo"),
+    "planning": ("Todo", "Backlog"),
+    "parked": ("Todo", "Backlog"),
+}
+
+
 # Per-tracker display hints. None of these are authoritative: they're
 # suggestions the wizard writes into the markdown so operators know
-# which native status slot Ship will target when it reconciles. Left
-# intentionally narrow — if a team runs with non-default Linear
-# workflows they edit the file; Ship reads whatever the file says.
+# which native status slot Ship will target when it reconciles (the
+# authoritative write map is FSM_TO_NATIVE_STATE above — the hints are
+# its human-readable sibling). Left intentionally narrow — if a team
+# runs with non-default Linear workflows they edit the file; Ship
+# reads whatever the file says.
 #
 # Public so the iter 7 ``/v1/workspaces/{ws}/tracker-fsm`` endpoint
 # can hand them to the console without re-parsing the markdown.

--- a/apps/backend/migrations/versions/0086_workspace_autonomy.py
+++ b/apps/backend/migrations/versions/0086_workspace_autonomy.py
@@ -1,0 +1,59 @@
+"""workspaces.autonomy — per-workspace agent autonomy profile (thesis 7)
+
+Adds ``Workspace.autonomy`` (``high`` / ``balanced`` / ``conservative``)
+— the dial for how much the *agent* may do on its own (skip approvals,
+self-merge, self-pick work). It deliberately does NOT touch the control
+plane: no lease / cap / cascade / idempotency constant or table changes
+ride along, ever (headless-but-stateful invariant).
+
+All existing rows backfill to ``balanced`` (the beta target) via the
+server default; ``high`` is opt-in everywhere — no workspace (including
+ElMundi) is seeded to it here. A CHECK constraint pins the enum at the
+DB layer; :mod:`backend.app.services.agent_provider_resolver` mirrors
+the same set.
+
+Revision ID: 0086_workspace_autonomy
+Revises: 0085_repo_deploy_planner_pref
+Create Date: 2026-06-11
+"""
+
+from __future__ import annotations
+
+from typing import Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+
+revision: str = "0086_workspace_autonomy"
+down_revision: Union[str, None] = "0085_repo_deploy_planner_pref"
+branch_labels = None
+depends_on = None
+
+
+_TABLE = "workspaces"
+_COLUMN = "autonomy"
+_CHECK = "ck_workspaces_autonomy_enum"
+
+
+def upgrade() -> None:
+    op.add_column(
+        _TABLE,
+        sa.Column(
+            _COLUMN,
+            sa.String(length=16),
+            nullable=False,
+            server_default=sa.text("'balanced'"),
+        ),
+    )
+    op.create_check_constraint(
+        _CHECK,
+        _TABLE,
+        f"{_COLUMN} IN ('high', 'balanced', 'conservative')",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(_CHECK, _TABLE, type_="check")
+    op.drop_column(_TABLE, _COLUMN)

--- a/apps/backend/migrations/versions/0087_workspace_agent_provider_ship.py
+++ b/apps/backend/migrations/versions/0087_workspace_agent_provider_ship.py
@@ -1,0 +1,50 @@
+"""extend workspaces.agent_provider CHECK to allow 'ship' (thesis 6)
+
+The self-spawn runtime (ELS-241) joins cursor/codex/claude at the DB
+layer. Forward revision — 0063 is applied in prod and must not be
+edited in place. ``ship`` stays internal/dogfood-gated above the DB:
+the self-serve config scope doesn't offer it and the CLI dispatcher
+refuses it without ``SHIP_ALLOW_SELF_SPAWN=true``.
+
+Revision ID: 0087_agent_provider_ship
+Revises: 0086_workspace_autonomy
+Create Date: 2026-06-11
+"""
+
+from __future__ import annotations
+
+from typing import Union
+
+from alembic import op
+
+
+revision: str = "0087_agent_provider_ship"
+down_revision: Union[str, None] = "0086_workspace_autonomy"
+branch_labels = None
+depends_on = None
+
+
+_TABLE = "workspaces"
+_CHECK = "ck_workspaces_agent_provider_enum"
+_COLUMN = "agent_provider"
+
+
+def upgrade() -> None:
+    op.drop_constraint(_CHECK, _TABLE, type_="check")
+    op.create_check_constraint(
+        _CHECK,
+        _TABLE,
+        f"{_COLUMN} IN ('cursor', 'codex', 'claude', 'ship')",
+    )
+
+
+def downgrade() -> None:
+    # Restore the 3-value set. Any row already on 'ship' must be moved
+    # back first or this constraint re-creation fails loudly — that is
+    # deliberate (no silent data munging in a downgrade).
+    op.drop_constraint(_CHECK, _TABLE, type_="check")
+    op.create_check_constraint(
+        _CHECK,
+        _TABLE,
+        f"{_COLUMN} IN ('cursor', 'codex', 'claude')",
+    )

--- a/apps/backend/tests/test_agent_adapter_discipline.py
+++ b/apps/backend/tests/test_agent_adapter_discipline.py
@@ -1,0 +1,61 @@
+"""Adapter discipline lint (thesis 5, ELS-245).
+
+Fails the build if any adapter under packages/cli/lib/agents/ writes
+or reads a TOOL-NATIVE config artifact (.cursorrules, per-tool
+CLAUDE.md, codex config, *.mcp.json) — the rejected Variant A. Scoped
+to fs-call lines, not bare string literals, so docblocks explaining
+the rule don't trip it.
+
+Companion doc: documentation/internal/architecture/agent-adapter-contract.md
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+AGENTS_DIR = (
+    Path(__file__).resolve().parents[3] / "packages" / "cli" / "lib" / "agents"
+)
+
+_TOOL_NATIVE_ARTIFACTS = (
+    ".cursorrules",
+    "CLAUDE.md",
+    ".claude/",
+    "codex.toml",
+    ".codex/",
+    "mcp.json",
+)
+
+# fs-access call shapes in the adapters' JS — reading or writing files.
+_FS_CALL_RE = re.compile(
+    r"(readFileSync|writeFileSync|appendFileSync|createWriteStream|"
+    r"openSync|readFile|writeFile|appendFile|\bfs\.\w+)\s*\("
+)
+
+
+def test_agents_dir_exists_and_has_all_adapters() -> None:
+    names = {p.name for p in AGENTS_DIR.glob("*.mjs")}
+    assert {"index.mjs", "cursor.mjs", "codex.mjs", "claude.mjs", "ship.mjs"} <= names
+
+
+def test_no_adapter_touches_tool_native_config() -> None:
+    for path in sorted(AGENTS_DIR.glob("*.mjs")):
+        src = path.read_text()
+        for lineno, line in enumerate(src.splitlines(), start=1):
+            if not _FS_CALL_RE.search(line):
+                continue
+            for artifact in _TOOL_NATIVE_ARTIFACTS:
+                assert artifact not in line, (
+                    f"{path.name}:{lineno} touches tool-native config "
+                    f"{artifact!r} via an fs call — Variant A is rejected "
+                    "(thesis 5, agent-adapter-contract.md). Inject value "
+                    "through the prompt instead."
+                )
+
+
+def test_contract_docblock_present_in_index() -> None:
+    src = (AGENTS_DIR / "index.mjs").read_text()
+    assert "ADAPTER CONTRACT" in src
+    assert "Variant A" in src
+    assert "MCP tool" in src  # the rejected inversion

--- a/apps/backend/tests/test_autonomy_preamble.py
+++ b/apps/backend/tests/test_autonomy_preamble.py
@@ -1,0 +1,108 @@
+"""Autonomy preamble (ELS-244, theses 5+7).
+
+Pins: per-profile distinct action-rights blocks; the same renderer
+feeds chat + CI (byte-identical); high-without-knowledge downgrades
+to balanced WITH an audit row, never silently runs high; no
+tool-native config involved (value enters through the prompt).
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import select
+
+from backend.app.db.models.tenancy import AuditLog
+from backend.app.services.policies import (
+    _AUTONOMY_BLOCKS,
+    render_autonomy_preamble,
+)
+
+
+def test_profiles_render_distinct_blocks() -> None:
+    blocks = set(_AUTONOMY_BLOCKS.values())
+    assert len(blocks) == 3
+    assert "HIGH" in _AUTONOMY_BLOCKS["high"]
+    assert "self-merge-eligible" in _AUTONOMY_BLOCKS["high"]
+    assert "Confirm before destructive" in _AUTONOMY_BLOCKS["balanced"]
+    assert "Confirm before any merge" in _AUTONOMY_BLOCKS["conservative"]
+    # The hard floor never loosens in the high block.
+    assert "CI must be green" in _AUTONOMY_BLOCKS["high"]
+
+
+@pytest.mark.asyncio
+async def test_balanced_renders_directly(db_session, seed_workspace) -> None:
+    _, _, ws = seed_workspace  # default balanced
+    block = await render_autonomy_preamble(db_session, ws.id)
+    assert block == _AUTONOMY_BLOCKS["balanced"]
+
+
+@pytest.mark.asyncio
+async def test_high_without_knowledge_downgrades_with_audit(
+    db_session, seed_workspace
+) -> None:
+    _, _, ws = seed_workspace
+    ws.autonomy = "high"
+    await db_session.flush()
+    block = await render_autonomy_preamble(db_session, ws.id)
+    # Rendered rights are BALANCED + the explanatory note.
+    assert "Autonomy profile: BALANCED" in block
+    assert "configured HIGH but has no knowledge surface" in block
+    audit = (
+        await db_session.execute(
+            select(AuditLog).where(
+                AuditLog.workspace_id == ws.id,
+                AuditLog.action == "workspace.autonomy.downgraded_effective",
+            )
+        )
+    ).scalars().all()
+    assert len(audit) == 1
+    assert audit[0].payload == {
+        "configured": "high",
+        "effective": "balanced",
+        "reason": "no_knowledge_surface",
+    }
+
+
+@pytest.mark.asyncio
+async def test_high_with_policy_keeps_high(db_session, seed_workspace) -> None:
+    from backend.app.db.models.policies import WorkspacePolicy
+
+    _, _, ws = seed_workspace
+    ws.autonomy = "high"
+    db_session.add(
+        WorkspacePolicy(
+            workspace_id=ws.id,
+            title="No force pushes",
+            body="Never force-push.",
+            enabled=True,
+        )
+    )
+    await db_session.flush()
+    block = await render_autonomy_preamble(db_session, ws.id)
+    assert "Autonomy profile: HIGH" in block
+    assert "configured HIGH but has no knowledge surface" not in block
+
+
+def test_automerger_role_references_profile() -> None:
+    from pathlib import Path
+
+    md = (
+        Path(__file__).resolve().parents[1]
+        / "app" / "resources" / "agent_roles" / "auto-merger.md"
+    ).read_text()
+    assert "Autonomy profile" in md
+    for token in ("HIGH", "BALANCED", "CONSERVATIVE"):
+        assert token in md
+    assert "CI red or incomplete is never mergeable" in md
+
+
+def test_no_tool_native_config_for_the_dial() -> None:
+    """Thesis 5: the dial must not be delivered via .cursorrules /
+    claude hooks / codex config — only through the prompt path."""
+    from pathlib import Path
+
+    policies_src = (
+        Path(__file__).resolve().parents[1] / "app" / "services" / "policies.py"
+    ).read_text()
+    for needle in (".cursorrules", "CLAUDE.md", "codex.toml", "mcp.json"):
+        assert needle not in policies_src

--- a/apps/backend/tests/test_blocked_freeze_label.py
+++ b/apps/backend/tests/test_blocked_freeze_label.py
@@ -145,4 +145,4 @@ def test_blocked_handler_adds_signal_label_in_source() -> None:
     # the "blocked" entry — both are in OVERLAY_FREEZE_LABEL_PREFIXES.
     assert 'await add_signal(ref, key="needs_clarification")' in body
     # And the dedicated inbox letter
-    assert 'intake_reason="agent_blocked"' in body
+    assert '"intake_reason": "agent_blocked"' in body  # flipped onto notify() (ELS-224)

--- a/apps/backend/tests/test_config_registry.py
+++ b/apps/backend/tests/test_config_registry.py
@@ -38,6 +38,8 @@ def test_list_scopes_returns_every_registered_slug() -> None:
         "agent.provider",
         "agent.default_profile",
         "catalog.sources",
+        "console.surface",
+        "autonomy.profile",
     }
     # Every row carries a non-empty description (consumed by the
     # help-without-scope path).
@@ -68,3 +70,74 @@ def test_every_scope_has_audit_event(scope_slug: str) -> None:
     # Convention: dotted path matching the existing workspace.* /
     # repo.* / inbox.* namespacing used elsewhere in audit_log.
     assert "." in scope.audit_event
+
+
+# ---------------------------------------------------------------------------
+# Headless-pivot config spine (ELS-218): console.surface + autonomy.profile
+# ---------------------------------------------------------------------------
+
+
+class _FakeWorkspace:
+    """Just enough Workspace shape for the scalar scope writers."""
+
+    def __init__(self) -> None:
+        self.settings: dict = {}
+        self.autonomy = "balanced"
+
+
+@pytest.mark.asyncio
+async def test_console_surface_defaults_to_full() -> None:
+    scope = SCOPES["console.surface"]
+    ws = _FakeWorkspace()
+    assert await scope.read(None, ws) == "full"
+
+
+@pytest.mark.asyncio
+async def test_console_surface_round_trips_and_merges_settings() -> None:
+    scope = SCOPES["console.surface"]
+    ws = _FakeWorkspace()
+    ws.settings = {"notifications": {"email_to": "ops@example.com"}}
+    await scope.write(None, ws, "residual")
+    # Existing settings keys survive the merge; reassignment (not
+    # in-place mutation) is what makes JSONB change detection fire.
+    assert ws.settings["notifications"] == {"email_to": "ops@example.com"}
+    assert ws.settings["console"] == {"surface": "residual"}
+    assert await scope.read(None, ws) == "residual"
+
+
+@pytest.mark.asyncio
+async def test_console_surface_rejects_out_of_enum() -> None:
+    scope = SCOPES["console.surface"]
+    ws = _FakeWorkspace()
+    with pytest.raises(ValueError):
+        await scope.write(None, ws, "hidden")
+    assert "console" not in ws.settings
+
+
+@pytest.mark.asyncio
+async def test_autonomy_profile_round_trips() -> None:
+    scope = SCOPES["autonomy.profile"]
+    ws = _FakeWorkspace()
+    assert await scope.read(None, ws) == "balanced"
+    await scope.write(None, ws, "high")
+    assert ws.autonomy == "high"
+    assert await scope.read(None, ws) == "high"
+
+
+@pytest.mark.asyncio
+async def test_autonomy_profile_rejects_out_of_enum() -> None:
+    scope = SCOPES["autonomy.profile"]
+    ws = _FakeWorkspace()
+    with pytest.raises(ValueError):
+        await scope.write(None, ws, "yolo")
+    assert ws.autonomy == "balanced"
+
+
+@pytest.mark.asyncio
+async def test_autonomy_profile_read_falls_back_on_garbage_column() -> None:
+    """Legacy / mid-migration rows with an unexpected value resolve to
+    the safe default instead of leaking garbage to the LLM/console."""
+    scope = SCOPES["autonomy.profile"]
+    ws = _FakeWorkspace()
+    ws.autonomy = "wat"
+    assert await scope.read(None, ws) == "balanced"

--- a/apps/backend/tests/test_control_plane_invariant.py
+++ b/apps/backend/tests/test_control_plane_invariant.py
@@ -1,0 +1,124 @@
+"""Thesis-2 guard (ELS-227): control state never reads Linear.
+
+The four control primitives — lease (``acquire_lock``), release, per-ws
+cap (``count_active_locks``), cascade budget (``_count_recent_dispatches``)
+— must resolve solely against Postgres. This test fails the build if a
+primitive's SIGNATURE or any CALL SITE gains a Linear label/status
+shaped input (the "control state sneaks into labels" regression the
+headless pivot forbids).
+
+Companion doc: documentation/internal/architecture/control-plane-vs-readmodel.md
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+DISPATCHER = (
+    Path(__file__).resolve().parents[1] / "app" / "services" / "dispatcher.py"
+)
+
+_PRIMITIVES = {
+    "acquire_lock",
+    "release_lock",
+    "count_active_locks",
+    "_count_recent_dispatches",
+    "sweep_expired_locks",
+}
+
+# Every parameter name a control primitive is ALLOWED to have/receive.
+# Additions here are a deliberate architectural decision — if you are
+# adding anything label/status/tracker-shaped, you are about to move
+# control state into Linear: stop (thesis 2, headless-but-stateful).
+_ALLOWED_PARAMS = {
+    "session",
+    "workspace_id",
+    "key",
+    "key_prefix",
+    "ttl_seconds",
+    "run_id",
+    "ticket_ref",
+    "action",
+    "target_id",
+    "window_s",
+    "window",
+    "now",
+    "via",
+    "reason",
+    "audit",
+    "self",
+}
+
+_FORBIDDEN_SUBSTRINGS = ("label", "status", "linear", "tracker_state", "issue_state")
+
+
+def _parse() -> ast.Module:
+    return ast.parse(DISPATCHER.read_text())
+
+
+def test_primitive_signatures_have_no_linear_shaped_params() -> None:
+    tree = _parse()
+    seen = set()
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)) and (
+            node.name in _PRIMITIVES
+        ):
+            seen.add(node.name)
+            params = [a.arg for a in node.args.args + node.args.kwonlyargs]
+            for p in params:
+                assert not any(s in p.lower() for s in _FORBIDDEN_SUBSTRINGS), (
+                    f"{node.name}() grew a Linear-shaped parameter {p!r} — "
+                    "control state must stay Postgres-only (thesis 2)."
+                )
+                assert p in _ALLOWED_PARAMS, (
+                    f"{node.name}() grew an unexpected parameter {p!r}; if "
+                    "it is genuinely Postgres-only, add it to _ALLOWED_PARAMS "
+                    "deliberately."
+                )
+    # All four primitives must still exist — renaming them silently
+    # would blind this guard.
+    missing = {"acquire_lock", "release_lock", "count_active_locks",
+               "_count_recent_dispatches"} - seen
+    assert not missing, f"control primitives vanished from dispatcher.py: {missing}"
+
+
+def test_call_sites_pass_no_linear_shaped_kwargs() -> None:
+    tree = _parse()
+    checked = 0
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        name = None
+        if isinstance(node.func, ast.Name):
+            name = node.func.id
+        elif isinstance(node.func, ast.Attribute):
+            name = node.func.attr
+        if name not in _PRIMITIVES:
+            continue
+        checked += 1
+        for kw in node.keywords:
+            if kw.arg is None:
+                continue
+            assert not any(
+                s in kw.arg.lower() for s in _FORBIDDEN_SUBSTRINGS
+            ), (
+                f"call to {name}() at line {node.lineno} passes "
+                f"{kw.arg!r} — a Linear-shaped input into a control "
+                "primitive (thesis-2 violation)."
+            )
+    assert checked >= 10, (
+        f"expected >=10 control-primitive call sites in dispatcher.py, "
+        f"found {checked} — the guard may have gone stale."
+    )
+
+
+def test_lock_table_has_no_linear_columns() -> None:
+    """The lease table itself must stay Linear-free."""
+    from backend.app.db.models.agent_dispatch import AgentDispatchLock
+
+    cols = {c.name for c in AgentDispatchLock.__table__.columns}
+    for col in cols:
+        assert not any(s in col.lower() for s in _FORBIDDEN_SUBSTRINGS), (
+            f"agent_dispatch_locks grew a Linear-shaped column {col!r}"
+        )

--- a/apps/backend/tests/test_engine_health.py
+++ b/apps/backend/tests/test_engine_health.py
@@ -1,0 +1,123 @@
+"""Engine health / stall residue surface (ELS-230).
+
+Pins: read-only derivation from agent_dispatch_locks + audit_log,
+the two stall reasons, and zero-mutation behavior.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import func, select
+
+from backend.app.db.models.agent_dispatch import AgentDispatchLock
+from backend.app.db.models.tenancy import AuditLog
+from backend.app.services.engine_health import assess_engine_health
+
+
+def _now():
+    return datetime.now(timezone.utc)
+
+
+async def _add_lock(db_session, ws_id, key, *, claimed_min_ago, ttl_min):
+    claimed = _now() - timedelta(minutes=claimed_min_ago)
+    db_session.add(
+        AgentDispatchLock(
+            workspace_id=ws_id,
+            key=key,
+            claimed_at=claimed,
+            expires_at=claimed + timedelta(minutes=ttl_min),
+        )
+    )
+    await db_session.flush()
+
+
+@pytest.mark.asyncio
+async def test_healthy_empty_workspace(db_session, seed_workspace) -> None:
+    _, _, ws = seed_workspace
+    liveness = await assess_engine_health(db_session, workspace_id=ws.id)
+    assert liveness.healthy
+    assert liveness.active_locks == 0
+    assert liveness.stalled == []
+    assert liveness.last_dispatch_at is None
+
+
+@pytest.mark.asyncio
+async def test_expired_unswept_lock_reported(db_session, seed_workspace) -> None:
+    _, _, ws = seed_workspace
+    # claimed 120 min ago with a 60-min TTL → expired 60 min ago, never swept
+    await _add_lock(db_session, ws.id, "project:proj-1", claimed_min_ago=120, ttl_min=60)
+    liveness = await assess_engine_health(db_session, workspace_id=ws.id)
+    assert not liveness.healthy
+    assert liveness.expired_unswept_locks == 1
+    assert liveness.stalled[0].reason == "expired_not_swept"
+    assert liveness.stalled[0].lock_key == "project:proj-1"
+
+
+@pytest.mark.asyncio
+async def test_lock_held_no_progress(db_session, seed_workspace) -> None:
+    _, _, ws = seed_workspace
+    # valid (not expired) lock held 50 min, no dispatch audit rows at all
+    await _add_lock(db_session, ws.id, "ticket:ELS-42", claimed_min_ago=50, ttl_min=120)
+    liveness = await assess_engine_health(
+        db_session, workspace_id=ws.id, lock_stall_minutes=45
+    )
+    assert not liveness.healthy
+    assert liveness.active_locks == 1
+    assert liveness.stalled[0].reason == "lock_held_no_progress"
+
+
+@pytest.mark.asyncio
+async def test_recent_progress_suppresses_stall(db_session, seed_workspace) -> None:
+    _, _, ws = seed_workspace
+    await _add_lock(db_session, ws.id, "ticket:ELS-42", claimed_min_ago=50, ttl_min=120)
+    db_session.add(
+        AuditLog(
+            workspace_id=ws.id,
+            actor_user_id=None,
+            actor_token_id=None,
+            action="agent_run.dispatch",
+            target_kind="ticket",
+            target_id="ELS-42",
+            payload={},
+        )
+    )
+    await db_session.flush()
+    liveness = await assess_engine_health(
+        db_session, workspace_id=ws.id, lock_stall_minutes=45
+    )
+    assert liveness.healthy
+    assert liveness.last_dispatch_at is not None
+
+
+@pytest.mark.asyncio
+async def test_assessment_mutates_zero_rows(db_session, seed_workspace) -> None:
+    _, _, ws = seed_workspace
+    await _add_lock(db_session, ws.id, "project:p", claimed_min_ago=999, ttl_min=10)
+    before_locks = await db_session.scalar(select(func.count(AgentDispatchLock.id)))
+    before_audit = await db_session.scalar(select(func.count(AuditLog.id)))
+    await assess_engine_health(db_session, workspace_id=ws.id)
+    await db_session.flush()
+    assert await db_session.scalar(select(func.count(AgentDispatchLock.id))) == before_locks
+    assert await db_session.scalar(select(func.count(AuditLog.id))) == before_audit
+
+
+@pytest.mark.asyncio
+async def test_route_read_only_and_authorized(v1_client, seed_workspace) -> None:
+    _, raw, ws = seed_workspace
+    resp = await v1_client.get(
+        f"/v1/workspaces/{ws.id}/engine-health",
+        headers={"Authorization": f"Bearer {raw}"},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["healthy"] is True
+    assert body["stalled"] == []
+    # unauthorized workspace → 403/404, not data
+    other = await v1_client.get(
+        f"/v1/workspaces/{uuid.uuid4()}/engine-health",
+        headers={"Authorization": f"Bearer {raw}"},
+    )
+    assert other.status_code in (403, 404)

--- a/apps/backend/tests/test_notify_config.py
+++ b/apps/backend/tests/test_notify_config.py
@@ -1,0 +1,105 @@
+"""Channel-routing config + global kill-switch (ELS-219).
+
+Pins the founder defaults: inbox-only everywhere until a workspace
+opts in AND the global ``SHIP_NOTIFY_CHANNELS`` switch is on; malformed
+settings fail closed; missing ``email_to`` resolves to None (the email
+channel later turns that into a structured skip, never a guess).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from backend.app.services.notify_config import (
+    ChannelRouting,
+    NotifyChannel,
+    NotifyLevel,
+    get_channel_routing,
+)
+
+
+def _ws(settings_blob: dict | None) -> SimpleNamespace:
+    return SimpleNamespace(id="ws-test", settings=settings_blob)
+
+
+def _settings(enabled: bool) -> SimpleNamespace:
+    return SimpleNamespace(notification_channels_enabled=enabled)
+
+
+INBOX_ONLY = (NotifyChannel.INBOX,)
+
+
+def test_empty_settings_resolve_inbox_only_all_levels() -> None:
+    routing = get_channel_routing(_ws(None), settings=_settings(True))
+    for level in NotifyLevel:
+        assert routing.channels_for(level) == INBOX_ONLY
+    assert routing.email_to is None
+
+
+def test_kill_switch_off_forces_inbox_only_despite_optin() -> None:
+    blob = {
+        "notifications": {
+            "email_to": "ops@example.com",
+            "channels": {"blocker": ["inbox", "linear", "email"]},
+        }
+    }
+    routing = get_channel_routing(_ws(blob), settings=_settings(False))
+    assert routing.channels_for(NotifyLevel.BLOCKER) == INBOX_ONLY
+    # email_to still resolves for audit/debug display.
+    assert routing.email_to == "ops@example.com"
+
+
+def test_optin_with_switch_on_yields_exact_lists() -> None:
+    blob = {
+        "notifications": {
+            "email_to": "ops@example.com",
+            "channels": {
+                "info": ["inbox"],
+                "blocker": ["inbox", "linear", "email"],
+            },
+        }
+    }
+    routing = get_channel_routing(_ws(blob), settings=_settings(True))
+    assert routing.channels_for(NotifyLevel.INFO) == INBOX_ONLY
+    # action not configured → default inbox-only
+    assert routing.channels_for(NotifyLevel.ACTION) == INBOX_ONLY
+    assert routing.channels_for(NotifyLevel.BLOCKER) == (
+        NotifyChannel.INBOX,
+        NotifyChannel.LINEAR,
+        NotifyChannel.EMAIL,
+    )
+
+
+def test_inbox_always_present_even_when_omitted() -> None:
+    """A workspace asking for linear-only still gets inbox first — a
+    config typo can never silently drop an engine emission."""
+    blob = {"notifications": {"channels": {"blocker": ["linear"]}}}
+    routing = get_channel_routing(_ws(blob), settings=_settings(True))
+    assert routing.channels_for(NotifyLevel.BLOCKER) == (
+        NotifyChannel.INBOX,
+        NotifyChannel.LINEAR,
+    )
+
+
+def test_malformed_settings_fail_closed_not_raise() -> None:
+    cases = [
+        {"notifications": "yes please"},
+        {"notifications": {"channels": "all"}},
+        {"notifications": {"channels": {"blocker": "linear"}}},
+        {"notifications": {"channels": {"blocker": ["telegraph", 42]}}},
+    ]
+    for blob in cases:
+        routing = get_channel_routing(_ws(blob), settings=_settings(True))
+        assert routing.channels_for(NotifyLevel.BLOCKER) == INBOX_ONLY, blob
+
+
+def test_missing_email_to_is_none_never_guessed() -> None:
+    blob = {"notifications": {"email_to": "   "}}
+    routing = get_channel_routing(_ws(blob), settings=_settings(True))
+    assert routing.email_to is None
+
+
+def test_default_routing_dataclass_is_inbox_only() -> None:
+    routing = ChannelRouting()
+    for level in NotifyLevel:
+        assert routing.channels_for(level) == INBOX_ONLY

--- a/apps/backend/tests/test_phase4_code_review_validation.py
+++ b/apps/backend/tests/test_phase4_code_review_validation.py
@@ -93,6 +93,7 @@ def _run_with_mocked_gh(
     pr_detail,
     check_runs,
     pr_url: str | None = _PR_URL,
+    require_approval: bool = True,
 ):
     """Drive the validator with mocked install row + httpx transport."""
     transport = httpx.MockTransport(_gh_handler(
@@ -121,6 +122,7 @@ def _run_with_mocked_gh(
                 workspace_id=uuid.uuid4(),
                 pr_url=pr_url,
                 settings=_build_settings(),
+                require_approval=require_approval,
             )
         )
 
@@ -295,3 +297,49 @@ def test_no_install_is_rejected() -> None:
     )
     assert ok is False
     assert reason == "no_install"
+
+
+# ---------------------------------------------------------------------------
+# ELS-243 — autonomy-sensitive approval, CI-green non-negotiable
+# ---------------------------------------------------------------------------
+
+
+def test_high_autonomy_passes_without_approval_when_ci_green() -> None:
+    ok, reason = _run_with_mocked_gh(
+        reviews=[],  # nobody approved
+        pr_detail={"head": {"sha": _HEAD_SHA}},
+        check_runs=[{"status": "completed", "conclusion": "success"}],
+        require_approval=False,
+    )
+    assert ok is True and reason == "ok"
+
+
+def test_conservative_still_blocks_without_approval() -> None:
+    ok, reason = _run_with_mocked_gh(
+        reviews=[],
+        pr_detail={"head": {"sha": _HEAD_SHA}},
+        check_runs=[{"status": "completed", "conclusion": "success"}],
+        require_approval=True,
+    )
+    assert ok is False and reason == "no_approval"
+
+
+def test_ci_red_blocks_even_without_approval_requirement() -> None:
+    """CI-green is non-negotiable for EVERY profile (founder decision)."""
+    ok, reason = _run_with_mocked_gh(
+        reviews=[],
+        pr_detail={"head": {"sha": _HEAD_SHA}},
+        check_runs=[{"status": "completed", "conclusion": "failure"}],
+        require_approval=False,
+    )
+    assert ok is False and reason == "ci_red"
+
+
+def test_ci_incomplete_blocks_even_on_high() -> None:
+    ok, reason = _run_with_mocked_gh(
+        reviews=[],
+        pr_detail={"head": {"sha": _HEAD_SHA}},
+        check_runs=[{"status": "in_progress", "conclusion": None}],
+        require_approval=False,
+    )
+    assert ok is False and reason == "ci_incomplete"

--- a/apps/backend/tests/test_scheduled_routines.py
+++ b/apps/backend/tests/test_scheduled_routines.py
@@ -1,0 +1,150 @@
+"""Scheduled ticket-creating routines (ELS-232/233/234, trigger c).
+
+Pins: durable audit-ledger idempotency per (kind, period_key),
+fail-closed per-workspace opt-in, period-key granularity per cadence,
+and the template guardrails (self-contained briefs that never bypass
+the FSM).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy import func, select
+
+from backend.app.db.models.tenancy import AuditLog
+from backend.app.services.scheduled_routines import (
+    SPECS,
+    TICKET_CREATED_ACTION,
+    already_created,
+    create_routine_ticket,
+    period_key_for,
+)
+
+
+class _RecordingTracker:
+    def __init__(self) -> None:
+        self.created: list[dict] = []
+
+    async def create_ticket(self, *, title, body, labels=None, **kwargs):
+        self.created.append({"title": title, "body": body, "labels": labels})
+        ref = SimpleNamespace(id=f"FAKE-{len(self.created)}")
+        return SimpleNamespace(ref=ref, display_id=f"ELS-{900 + len(self.created)}")
+
+
+@pytest.fixture
+def fake_tracker(monkeypatch):
+    tracker = _RecordingTracker()
+
+    async def fake_resolve(**kwargs):
+        return SimpleNamespace(kind="linear", gateway=tracker)
+
+    monkeypatch.setattr(
+        "backend.app.services.tracker_resolver.resolve_for_workspace",
+        fake_resolve,
+    )
+    return tracker
+
+
+def test_period_key_granularity_matches_cadence() -> None:
+    now = datetime(2026, 6, 11, 12, 0, tzinfo=timezone.utc)
+    assert period_key_for(SPECS["daily"], now) == "2026-06-11"
+    assert period_key_for(SPECS["retro"], now) == "2026-W24"
+    assert period_key_for(SPECS["techdebt"], now) == "2026-W24"
+    # cadence sanity: day-period specs run on a daily cron, week-period
+    # specs on a weekly cron (single-day-of-week field).
+    assert SPECS["daily"].period == "day"
+    for kind in ("retro", "techdebt"):
+        dow = SPECS[kind].cron_expr.split()[4]
+        assert dow != "*", f"{kind} cron should pin a day-of-week"
+
+
+@pytest.mark.asyncio
+async def test_optout_workspace_skipped_fail_closed(
+    db_session, seed_workspace, fake_tracker
+) -> None:
+    _, _, ws = seed_workspace  # no scheduled_routines settings at all
+    ref = await create_routine_ticket(
+        db_session, workspace_id=ws.id, spec=SPECS["techdebt"]
+    )
+    assert ref is None
+    assert fake_tracker.created == []
+
+
+@pytest.mark.asyncio
+async def test_two_ticks_one_period_create_one_ticket(
+    db_session, seed_workspace, fake_tracker
+) -> None:
+    _, _, ws = seed_workspace
+    ws.settings = {"scheduled_routines": {"techdebt": True}}
+    await db_session.flush()
+
+    now = datetime(2026, 6, 11, 7, 0, tzinfo=timezone.utc)
+    ref1 = await create_routine_ticket(
+        db_session, workspace_id=ws.id, spec=SPECS["techdebt"], now=now
+    )
+    assert ref1 is not None
+    ref2 = await create_routine_ticket(
+        db_session, workspace_id=ws.id, spec=SPECS["techdebt"], now=now
+    )
+    assert ref2 is None  # second tick same period → skip
+    assert len(fake_tracker.created) == 1
+    # ledger row durable in audit_log
+    rows = await db_session.scalar(
+        select(func.count(AuditLog.id)).where(
+            AuditLog.workspace_id == ws.id,
+            AuditLog.action == TICKET_CREATED_ACTION,
+        )
+    )
+    assert rows == 1
+    assert await already_created(
+        db_session, workspace_id=ws.id, kind="techdebt",
+        period_key=period_key_for(SPECS["techdebt"], now),
+    )
+
+
+@pytest.mark.asyncio
+async def test_new_period_creates_fresh_ticket(
+    db_session, seed_workspace, fake_tracker
+) -> None:
+    _, _, ws = seed_workspace
+    ws.settings = {"scheduled_routines": {"daily": True}}
+    await db_session.flush()
+    d1 = datetime(2026, 6, 11, 6, 30, tzinfo=timezone.utc)
+    d2 = datetime(2026, 6, 12, 6, 30, tzinfo=timezone.utc)
+    assert await create_routine_ticket(
+        db_session, workspace_id=ws.id, spec=SPECS["daily"], now=d1
+    )
+    assert await create_routine_ticket(
+        db_session, workspace_id=ws.id, spec=SPECS["daily"], now=d2
+    )
+    assert len(fake_tracker.created) == 2
+
+
+@pytest.mark.asyncio
+async def test_created_ticket_carries_stage_label_and_brief(
+    db_session, seed_workspace, fake_tracker
+) -> None:
+    _, _, ws = seed_workspace
+    ws.settings = {"scheduled_routines": {"retro": True}}
+    await db_session.flush()
+    await create_routine_ticket(
+        db_session, workspace_id=ws.id, spec=SPECS["retro"]
+    )
+    t = fake_tracker.created[0]
+    assert t["labels"] == ["stage:planning"]
+    assert "Weekly retro" in t["title"]
+    # self-contained brief, with the FSM + no-MCP guardrails baked in
+    assert "never Linear via MCP" in t["body"]
+    assert "bypass" in t["body"] or "do not" in t["body"].lower()
+
+
+def test_templates_never_instruct_fsm_bypass() -> None:
+    for spec in SPECS.values():
+        body = spec.body_template.lower()
+        assert "do not" in body or "never" in body
+        assert "mcp" in body  # the no-side-channel guardrail
+        for forbidden in ("merge it yourself", "skip the review", "force-merge"):
+            assert forbidden not in body

--- a/apps/backend/tests/test_self_spawn_recursion.py
+++ b/apps/backend/tests/test_self_spawn_recursion.py
@@ -1,0 +1,159 @@
+"""Self-spawn recursion guard (ELS-242, thesis 6).
+
+A nested ``shipctl run`` (trigger_kind='self_spawn') must pass THROUGH
+the control plane, never around it: same cascade budget, same per-ws
+cap, no project-lock carve-out, regardless of autonomy profile.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+
+from backend.app.db.models.agent_dispatch import AgentDispatchLock
+from backend.app.db.models.tenancy import AuditLog, Org, Workspace
+from backend.app.services import dispatcher
+from backend.app.services.dispatcher import (
+    CASCADE_LIMIT,
+    acquire_lock,
+    count_active_locks,
+    maybe_dispatch,
+)
+
+
+async def _make_workspace(db_session, *, autonomy: str = "balanced") -> uuid.UUID:
+    org = Org(slug=f"o-{uuid.uuid4().hex[:8]}", name="o")
+    db_session.add(org)
+    await db_session.flush()
+    ws = Workspace(
+        org_id=org.id, slug=f"w-{uuid.uuid4().hex[:8]}", name="w",
+        autonomy=autonomy,
+    )
+    db_session.add(ws)
+    await db_session.flush()
+    return ws.id
+
+
+def _fire_mode(monkeypatch) -> None:
+    monkeypatch.setattr(
+        dispatcher.get_settings(), "tracker_poll_fire", True, raising=False
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("autonomy", ["conservative", "balanced", "high"])
+async def test_self_spawn_loop_terminates_via_cascade_blocked(
+    db_session, monkeypatch, autonomy
+) -> None:
+    """4-deep self-spawn loop: every nested dispatch burns the same
+    cascade budget; by depth CASCADE_LIMIT the engine refuses. The
+    autonomy profile is irrelevant (control plane off-limits to the
+    dial — founder decision)."""
+    ws = await _make_workspace(db_session, autonomy=autonomy)
+    _fire_mode(monkeypatch)
+
+    refused_at = None
+    for depth in range(CASCADE_LIMIT + 1):  # 0..3 → 4 attempts
+        result = await maybe_dispatch(
+            db_session,
+            workspace_id=ws,
+            ticket_ref="T-loop",
+            trigger_kind="self_spawn",
+            fsm_stage="planning",
+        )
+        if result.reason == "cascade_blocked":
+            refused_at = depth
+            break
+        # Simulate the spawned run having fired (the audit row a real
+        # dispatch writes) so the next nesting level sees it.
+        db_session.add(
+            AuditLog(
+                workspace_id=ws,
+                action="agent_run.dispatch",
+                target_kind="ticket",
+                target_id="T-loop",
+                payload={"trigger_kind": "self_spawn"},
+            )
+        )
+        # release the ticket lock the attempt took (simulating finish)
+        from backend.app.services.dispatcher import release_lock
+
+        await release_lock(db_session, workspace_id=ws, key="ticket:T-loop")
+        await db_session.flush()
+
+    assert refused_at is not None, "self-spawn loop never hit CASCADE_BLOCKED"
+    assert refused_at <= CASCADE_LIMIT
+    refusals = (
+        await db_session.execute(
+            select(AuditLog).where(
+                AuditLog.workspace_id == ws,
+                AuditLog.action == "dispatch.cascade_blocked",
+            )
+        )
+    ).scalars().all()
+    assert len(refusals) == 1
+    assert refusals[0].payload["trigger_kind"] == "self_spawn"
+
+
+@pytest.mark.asyncio
+async def test_self_spawn_counts_against_cap_no_exemption(
+    db_session, monkeypatch
+) -> None:
+    ws = await _make_workspace(db_session, autonomy="high")
+    _fire_mode(monkeypatch)
+    for n in range(4):  # default cap
+        await acquire_lock(db_session, workspace_id=ws, key=f"ticket:T-{n}")
+
+    result = await maybe_dispatch(
+        db_session,
+        workspace_id=ws,
+        ticket_ref="T-new",
+        trigger_kind="self_spawn",
+        fsm_stage="planning",
+    )
+    assert result.fired is False
+    assert result.reason == "cap_exceeded"
+    assert await count_active_locks(db_session, workspace_id=ws) == 4
+
+
+def test_self_spawn_excluded_from_cascade_carveout_in_source() -> None:
+    """The project-lock bypass stays cascade-only. Pin the expression
+    so 'self_spawn' can never quietly join it."""
+    from pathlib import Path
+
+    src = (
+        Path(__file__).resolve().parents[1] / "app" / "services" / "dispatcher.py"
+    ).read_text()
+    assert 'is_cascade = trigger_kind == "cascade"' in src
+    carve = src.index('is_cascade = trigger_kind == "cascade"')
+    window = src[carve - 200 : carve + 200]
+    assert "self_spawn\" ==" not in window
+    assert 'trigger_kind in ("cascade", "self_spawn")' not in src
+
+
+def test_dispatcher_never_reads_autonomy() -> None:
+    """The dial lives at gates/prompts — the dispatch control plane
+    must not branch on it (founder decision). AST-level: comments may
+    mention the word; CODE may not."""
+    import ast
+    from pathlib import Path
+
+    src = (
+        Path(__file__).resolve().parents[1] / "app" / "services" / "dispatcher.py"
+    ).read_text()
+    tree = ast.parse(src)
+    for node in ast.walk(tree):
+        name = None
+        if isinstance(node, ast.Name):
+            name = node.id
+        elif isinstance(node, ast.Attribute):
+            name = node.attr
+        elif isinstance(node, ast.arg):
+            name = node.arg
+        if name is not None:
+            assert "autonomy" not in name.lower(), (
+                f"dispatcher.py code references {name!r} — the control "
+                "plane is off-limits to the dial (thesis 7)"
+            )

--- a/apps/backend/tests/test_services_notify.py
+++ b/apps/backend/tests/test_services_notify.py
@@ -1,0 +1,383 @@
+"""notify() seam — interface + the three channels (ELS-222).
+
+Pins the Phase-1 gate: with the kill-switch off (default) every
+emission is inbox-only and the InboxItem is field-identical with what
+the intake builder produces today; channels swallow transport errors;
+notify() never raises into the engine control path.
+"""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy import select
+
+from backend.app.db.models.inbox import InboxItem
+from backend.app.services.notify import (
+    NotifyLevel,
+    notify,
+)
+from backend.app.services.notify_config import NotifyChannel
+
+
+def _settings(enabled: bool) -> SimpleNamespace:
+    return SimpleNamespace(notification_channels_enabled=enabled)
+
+
+async def _items_for(db_session, workspace_id):
+    rows = (
+        await db_session.execute(
+            select(InboxItem).where(InboxItem.workspace_id == workspace_id)
+        )
+    ).scalars().all()
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Inbox channel — byte-identical with the intake builder
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "item_type,level",
+    [
+        ("improvement", NotifyLevel.INFO),
+        ("clarification", NotifyLevel.ACTION),
+        ("blocker", NotifyLevel.BLOCKER),
+    ],
+)
+async def test_inbox_item_field_identical_with_intake_builder(
+    db_session, seed_workspace, item_type, level
+) -> None:
+    from backend.app.services.inbox.intake import (
+        RunSummaryFinding,
+        _build_inbox_item,
+    )
+
+    _, _, workspace = seed_workspace
+    title = "Tracker unreachable — agents stalled" * 12  # force truncation path
+    summary = "Re-authorize the workspace integration.\nSecond line." * 30
+    payload = {"requires_approval": False, "ticket_ref": "ELS-1", "k": "v"}
+
+    finding = RunSummaryFinding(
+        type=item_type,
+        title=title,
+        summary=summary,
+        payload={"ticket_ref": "ELS-1", "k": "v"},
+        requires_approval=False,
+    )
+    resolved = SimpleNamespace(
+        user_id=None, intake_handle="dedup:ELS-1", intake_reason="unit_test"
+    )
+    expected = _build_inbox_item(
+        workspace_id=workspace.id,
+        repo_id=None,
+        run_id=None,
+        play_key=None,
+        effective_type=item_type,
+        finding=finding,
+        resolved=resolved,
+    )
+
+    result = await notify(
+        db_session,
+        workspace_id=workspace.id,
+        title=title,
+        body=summary,
+        level=level,
+        dedup_key="dedup:ELS-1",
+        payload=payload,
+        inbox_overrides={
+            "type": item_type,
+            "intake_reason": "unit_test",
+            "derive_classification": True,
+            "derive_headline": True,
+        },
+        settings=_settings(False),
+    )
+    assert result.ok
+    items = await _items_for(db_session, workspace.id)
+    assert len(items) == 1
+    got = items[0]
+    for field_name in (
+        "type", "title", "summary", "headline", "intake_handle",
+        "intake_reason", "payload", "category", "priority", "status",
+        "auto_resolvable", "stale_after",
+    ):
+        assert getattr(got, field_name) == getattr(expected, field_name), field_name
+
+
+@pytest.mark.asyncio
+async def test_default_routing_is_inbox_only(db_session, seed_workspace) -> None:
+    _, _, workspace = seed_workspace
+    result = await notify(
+        db_session,
+        workspace_id=workspace.id,
+        title="t",
+        body="b",
+        level=NotifyLevel.BLOCKER,
+        settings=_settings(False),
+    )
+    assert [r.channel for r in result.results] == [NotifyChannel.INBOX]
+    assert result.ok
+
+
+@pytest.mark.asyncio
+async def test_kill_switch_off_ignores_workspace_optin(
+    db_session, seed_workspace
+) -> None:
+    _, _, workspace = seed_workspace
+    workspace.settings = {
+        "notifications": {
+            "email_to": "ops@example.com",
+            "channels": {"blocker": ["inbox", "linear", "email"]},
+        }
+    }
+    await db_session.flush()
+    result = await notify(
+        db_session,
+        workspace_id=workspace.id,
+        title="t",
+        body="b",
+        level=NotifyLevel.BLOCKER,
+        ticket_ref="ELS-1",
+        settings=_settings(False),
+    )
+    assert [r.channel for r in result.results] == [NotifyChannel.INBOX]
+
+
+# ---------------------------------------------------------------------------
+# Linear channel
+# ---------------------------------------------------------------------------
+
+
+class _RecordingGateway:
+    def __init__(self) -> None:
+        self.comments: list[tuple[str, str]] = []
+
+    async def comment(self, ref, *, body: str) -> None:
+        self.comments.append((ref.id, body))
+
+
+@pytest.mark.asyncio
+async def test_linear_channel_posts_comment(
+    db_session, seed_workspace, monkeypatch
+) -> None:
+    _, _, workspace = seed_workspace
+    workspace.settings = {
+        "notifications": {"channels": {"blocker": ["inbox", "linear"]}}
+    }
+    await db_session.flush()
+
+    gateway = _RecordingGateway()
+
+    async def fake_resolve(**kwargs):
+        return SimpleNamespace(kind="linear", gateway=gateway)
+
+    monkeypatch.setattr(
+        "backend.app.services.tracker_resolver.resolve_for_workspace",
+        fake_resolve,
+    )
+    result = await notify(
+        db_session,
+        workspace_id=workspace.id,
+        title="Blocked at code_review",
+        body="Gate refused the transition.",
+        level=NotifyLevel.BLOCKER,
+        ticket_ref="ELS-42",
+        settings=_settings(True),
+    )
+    assert result.ok
+    linear = result.for_channel(NotifyChannel.LINEAR)
+    assert linear is not None and linear.ok and not linear.skipped
+    assert gateway.comments and gateway.comments[0][0] == "ELS-42"
+    assert "Blocked at code_review" in gateway.comments[0][1]
+
+
+@pytest.mark.asyncio
+async def test_linear_channel_skips_without_ticket(
+    db_session, seed_workspace
+) -> None:
+    _, _, workspace = seed_workspace
+    workspace.settings = {
+        "notifications": {"channels": {"blocker": ["inbox", "linear"]}}
+    }
+    await db_session.flush()
+    result = await notify(
+        db_session,
+        workspace_id=workspace.id,
+        title="t",
+        body="b",
+        level=NotifyLevel.BLOCKER,
+        ticket_ref=None,
+        settings=_settings(True),
+    )
+    linear = result.for_channel(NotifyChannel.LINEAR)
+    assert linear is not None and linear.ok and linear.skipped
+    assert linear.detail == "skipped_no_ticket"
+
+
+# ---------------------------------------------------------------------------
+# Email channel
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_email_channel_sends_through_recording_sender(
+    db_session, seed_workspace, monkeypatch
+) -> None:
+    from backend.app.services.email.sender import RecordingEmailSender
+
+    _, _, workspace = seed_workspace
+    workspace.settings = {
+        "notifications": {
+            "email_to": "ops@example.com",
+            "channels": {"blocker": ["inbox", "email"]},
+        }
+    }
+    await db_session.flush()
+    recorder = RecordingEmailSender()
+    monkeypatch.setattr(
+        "backend.app.services.email.sender.get_email_sender",
+        lambda settings=None: recorder,
+    )
+    result = await notify(
+        db_session,
+        workspace_id=workspace.id,
+        title="Self-heal could not fix",
+        body="Run failed twice.",
+        level=NotifyLevel.BLOCKER,
+        ticket_ref="ELS-7",
+        settings=_settings(True),
+    )
+    email = result.for_channel(NotifyChannel.EMAIL)
+    assert email is not None and email.ok and not email.skipped
+    assert len(recorder.messages) == 1
+    msg = recorder.messages[0]
+    assert msg.to.email == "ops@example.com"
+    assert "Self-heal could not fix" in msg.subject
+    assert msg.text and "Run failed twice." in msg.text
+
+
+@pytest.mark.asyncio
+async def test_email_channel_structured_skip_without_recipient(
+    db_session, seed_workspace
+) -> None:
+    _, _, workspace = seed_workspace
+    workspace.settings = {
+        "notifications": {"channels": {"blocker": ["inbox", "email"]}}
+    }
+    await db_session.flush()
+    result = await notify(
+        db_session,
+        workspace_id=workspace.id,
+        title="t",
+        body="b",
+        level=NotifyLevel.BLOCKER,
+        settings=_settings(True),
+    )
+    email = result.for_channel(NotifyChannel.EMAIL)
+    assert email is not None and email.ok and email.skipped
+    assert email.detail == "skipped_no_email_to"
+
+
+# ---------------------------------------------------------------------------
+# Fan-out isolation — one channel failing never sinks the rest
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_channel_exception_does_not_stop_fanout(
+    db_session, seed_workspace, monkeypatch
+) -> None:
+    _, _, workspace = seed_workspace
+    workspace.settings = {
+        "notifications": {
+            "email_to": "ops@example.com",
+            "channels": {"blocker": ["inbox", "linear", "email"]},
+        }
+    }
+    await db_session.flush()
+
+    async def exploding_resolve(**kwargs):
+        raise RuntimeError("linear is down")
+
+    from backend.app.services.email.sender import RecordingEmailSender
+
+    recorder = RecordingEmailSender()
+    monkeypatch.setattr(
+        "backend.app.services.tracker_resolver.resolve_for_workspace",
+        exploding_resolve,
+    )
+    monkeypatch.setattr(
+        "backend.app.services.email.sender.get_email_sender",
+        lambda settings=None: recorder,
+    )
+    result = await notify(
+        db_session,
+        workspace_id=workspace.id,
+        title="t",
+        body="b",
+        level=NotifyLevel.BLOCKER,
+        ticket_ref="ELS-9",
+        settings=_settings(True),
+    )
+    # notify() returned (did not raise); linear failed; inbox + email ok.
+    linear = result.for_channel(NotifyChannel.LINEAR)
+    assert linear is not None and not linear.ok
+    assert "linear is down" in (linear.detail or "")
+    assert result.for_channel(NotifyChannel.INBOX).ok
+    assert result.for_channel(NotifyChannel.EMAIL).ok
+    assert len(recorder.messages) == 1
+    items = await _items_for(db_session, workspace.id)
+    assert len(items) == 1
+
+
+@pytest.mark.asyncio
+async def test_notify_survives_missing_workspace(db_session) -> None:
+    result = await notify(
+        db_session,
+        workspace_id=uuid.uuid4(),
+        title="t",
+        body="b",
+        level=NotifyLevel.INFO,
+        settings=_settings(True),
+    )
+    # Falls back to default inbox-only routing; inbox insert will fail FK
+    # at flush time in real life, but notify() itself must not raise.
+    assert [r.channel for r in result.results] == [NotifyChannel.INBOX]
+    await db_session.rollback()
+
+
+@pytest.mark.asyncio
+async def test_omitted_classification_gets_server_defaults(
+    db_session, seed_workspace
+) -> None:
+    """Flip byte-identity: sites that omit category/priority/headline
+    today land DB server defaults (attention / 50 / NULL) — the channel
+    must not silently 'improve' them."""
+    _, _, workspace = seed_workspace
+    await notify(
+        db_session,
+        workspace_id=workspace.id,
+        title="blocked at stage",
+        body="details",
+        level=NotifyLevel.BLOCKER,
+        settings=_settings(False),
+    )
+    await db_session.flush()
+    items = await _items_for(db_session, workspace.id)
+    assert len(items) == 1
+    got = items[0]
+    await db_session.refresh(got)
+    assert got.category == "attention"
+    assert got.priority == 50
+    # headline is auto-derived by the model's before_insert backstop —
+    # identical for the channel and for today's direct constructions.
+    from backend.app.services.inbox.headline import derive_headline
+
+    assert got.headline == derive_headline(summary="details", title="blocked at stage")
+    assert got.type == "blocker"

--- a/apps/backend/tests/test_services_notify.py
+++ b/apps/backend/tests/test_services_notify.py
@@ -381,3 +381,116 @@ async def test_omitted_classification_gets_server_defaults(
 
     assert got.headline == derive_headline(summary="details", title="blocked at stage")
     assert got.type == "blocker"
+
+
+# ---------------------------------------------------------------------------
+# Observability + rollback (ELS-226)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_notify_writes_audit_row_with_per_channel_outcomes(
+    db_session, seed_workspace, monkeypatch
+) -> None:
+    from backend.app.db.models.tenancy import AuditLog
+
+    _, _, workspace = seed_workspace
+    workspace.settings = {
+        "notifications": {"channels": {"blocker": ["inbox", "linear"]}}
+    }
+    await db_session.flush()
+
+    gateway = _RecordingGateway()
+
+    async def fake_resolve(**kwargs):
+        return SimpleNamespace(kind="linear", gateway=gateway)
+
+    monkeypatch.setattr(
+        "backend.app.services.tracker_resolver.resolve_for_workspace",
+        fake_resolve,
+    )
+    await notify(
+        db_session,
+        workspace_id=workspace.id,
+        title="audit me",
+        body="b",
+        level=NotifyLevel.BLOCKER,
+        ticket_ref="ELS-99",
+        settings=_settings(True),
+    )
+    await db_session.flush()
+    row = (
+        await db_session.execute(
+            select(AuditLog).where(
+                AuditLog.workspace_id == workspace.id,
+                AuditLog.action == "notify.emit",
+            )
+        )
+    ).scalars().first()
+    assert row is not None
+    assert row.target_kind == "notification"
+    assert row.target_id == "ELS-99"
+    assert row.payload["level"] == "blocker"
+    assert row.payload["requested_channels"] == ["inbox", "linear"]
+    outcomes = {r["channel"]: r for r in row.payload["results"]}
+    assert outcomes["inbox"]["ok"] is True
+    assert outcomes["linear"]["ok"] is True
+
+
+@pytest.mark.asyncio
+async def test_audit_failure_never_sinks_the_emit(
+    db_session, seed_workspace, monkeypatch
+) -> None:
+    _, _, workspace = seed_workspace
+
+    import backend.app.services.notify as notify_mod
+
+    class _ExplodingAudit:
+        def __init__(self, **kwargs):
+            raise RuntimeError("audit table on fire")
+
+    monkeypatch.setattr(
+        "backend.app.db.models.tenancy.AuditLog", _ExplodingAudit
+    )
+    result = await notify_mod.notify(
+        db_session,
+        workspace_id=workspace.id,
+        title="t",
+        body="b",
+        level=NotifyLevel.INFO,
+        settings=_settings(False),
+    )
+    assert result.ok  # emit survived
+    items = await _items_for(db_session, workspace.id)
+    assert len(items) == 1
+
+
+@pytest.mark.skipif(
+    not __import__("os").environ.get("RUN_EMAIL_SMOKE"),
+    reason="real-transport smoke; set RUN_EMAIL_SMOKE=1 with SENDGRID creds",
+)
+@pytest.mark.asyncio
+async def test_real_email_transport_smoke(db_session, seed_workspace) -> None:
+    """ELS-226 AC: prove the REAL get_email_sender().send path once —
+    not just the RecordingEmailSender. Gated behind RUN_EMAIL_SMOKE so
+    CI stays hermetic; the runbook documents running it."""
+    import os
+
+    _, _, workspace = seed_workspace
+    workspace.settings = {
+        "notifications": {
+            "email_to": os.environ["EMAIL_SMOKE_TO"],
+            "channels": {"blocker": ["inbox", "email"]},
+        }
+    }
+    await db_session.flush()
+    result = await notify(
+        db_session,
+        workspace_id=workspace.id,
+        title="Ship notification-seam smoke",
+        body="If you can read this, the email channel works end-to-end.",
+        level=NotifyLevel.BLOCKER,
+        settings=_settings(True),
+    )
+    email = result.for_channel(NotifyChannel.EMAIL)
+    assert email is not None and email.ok and not email.skipped

--- a/apps/backend/tests/test_stall_notifier.py
+++ b/apps/backend/tests/test_stall_notifier.py
@@ -1,0 +1,128 @@
+"""Stall notifier (ELS-231): notify()-only egress, cooldown dedup,
+and the never-touches-control-plane invariant.
+"""
+
+from __future__ import annotations
+
+import ast
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+from sqlalchemy import func, select
+
+from backend.app.db.models.agent_dispatch import AgentDispatchLock
+from backend.app.db.models.inbox import InboxItem
+from backend.app.db.models.tenancy import AuditLog
+from backend.app.services.stall_notifier import (
+    STALL_NOTIFIED_ACTION,
+    notify_stalls_for_workspace,
+)
+
+
+def _now():
+    return datetime.now(timezone.utc)
+
+
+async def _expired_lock(db_session, ws_id, key="project:p1"):
+    claimed = _now() - timedelta(minutes=120)
+    db_session.add(
+        AgentDispatchLock(
+            workspace_id=ws_id,
+            key=key,
+            claimed_at=claimed,
+            expires_at=claimed + timedelta(minutes=60),
+        )
+    )
+    await db_session.flush()
+
+
+@pytest.mark.asyncio
+async def test_stall_emits_blocker_letter_once(db_session, seed_workspace) -> None:
+    _, _, ws = seed_workspace
+    await _expired_lock(db_session, ws.id)
+
+    emitted = await notify_stalls_for_workspace(db_session, workspace_id=ws.id)
+    assert emitted == 1
+    items = (
+        await db_session.execute(
+            select(InboxItem).where(InboxItem.workspace_id == ws.id)
+        )
+    ).scalars().all()
+    assert len(items) == 1
+    assert items[0].type == "blocker"
+    assert items[0].payload["kind"] == "engine_stall"
+    assert items[0].payload["reason"] == "expired_not_swept"
+    # dedup marker landed
+    marker = await db_session.scalar(
+        select(func.count(AuditLog.id)).where(
+            AuditLog.workspace_id == ws.id,
+            AuditLog.action == STALL_NOTIFIED_ACTION,
+        )
+    )
+    assert marker == 1
+
+    # Re-run inside the cooldown → no new letter, no new marker.
+    emitted2 = await notify_stalls_for_workspace(db_session, workspace_id=ws.id)
+    assert emitted2 == 0
+    items2 = (
+        await db_session.execute(
+            select(InboxItem).where(InboxItem.workspace_id == ws.id)
+        )
+    ).scalars().all()
+    assert len(items2) == 1
+
+
+@pytest.mark.asyncio
+async def test_cooldown_expiry_renotifies(db_session, seed_workspace) -> None:
+    _, _, ws = seed_workspace
+    await _expired_lock(db_session, ws.id)
+    assert await notify_stalls_for_workspace(db_session, workspace_id=ws.id) == 1
+    # Pretend the cooldown elapsed by assessing "now" 7h in the future.
+    future = _now() + timedelta(hours=7)
+    emitted = await notify_stalls_for_workspace(
+        db_session, workspace_id=ws.id, cooldown_minutes=360, now=future
+    )
+    assert emitted == 1
+
+
+@pytest.mark.asyncio
+async def test_notifier_never_mutates_locks(db_session, seed_workspace) -> None:
+    _, _, ws = seed_workspace
+    await _expired_lock(db_session, ws.id)
+    before = await db_session.scalar(select(func.count(AgentDispatchLock.id)))
+    await notify_stalls_for_workspace(db_session, workspace_id=ws.id)
+    await db_session.flush()
+    after = await db_session.scalar(select(func.count(AgentDispatchLock.id)))
+    assert after == before
+    lock = (
+        await db_session.execute(select(AgentDispatchLock))
+    ).scalars().first()
+    assert lock.key == "project:p1"  # untouched
+
+
+def test_source_never_calls_control_or_transition_primitives() -> None:
+    """AST guard: the notifier reports — it must not import/call
+    transition, acquire_lock, release_lock or sweep helpers."""
+    src = (
+        Path(__file__).resolve().parents[1]
+        / "app" / "services" / "stall_notifier.py"
+    ).read_text()
+    tree = ast.parse(src)
+    forbidden = {
+        "transition", "acquire_lock", "release_lock",
+        "sweep_expired_locks", "maybe_dispatch",
+    }
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            name = (
+                node.func.id if isinstance(node.func, ast.Name)
+                else node.func.attr if isinstance(node.func, ast.Attribute)
+                else None
+            )
+            assert name not in forbidden, f"stall_notifier calls {name}()"
+        if isinstance(node, ast.ImportFrom):
+            for alias in node.names:
+                assert alias.name not in forbidden, (
+                    f"stall_notifier imports {alias.name}"
+                )

--- a/apps/backend/tests/test_state_projector.py
+++ b/apps/backend/tests/test_state_projector.py
@@ -1,0 +1,150 @@
+"""StateProjector (ELS-229): one-directional, lock-free, flag-gated.
+
+Pins: flag-off path is the original direct gateway.transition call
+(byte-identical, including raised exceptions); flag-on funnels through
+project_ticket_state; a tracker 5xx yields an errored report and
+provably never touches agent_dispatch_locks; re-projection is
+idempotent at the seam; the module never imports lock primitives.
+"""
+
+from __future__ import annotations
+
+import ast
+import uuid
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy import func, select
+
+from backend.app.db.models.agent_dispatch import AgentDispatchLock
+from backend.app.services.state_projector import (
+    project_ticket_state,
+    transition_via_projector,
+)
+
+
+class _Gateway:
+    def __init__(self, fail: bool = False) -> None:
+        self.fail = fail
+        self.calls: list[tuple] = []
+
+    async def transition(self, ref, *, to_state, from_state=None):
+        self.calls.append((ref.id, to_state, from_state))
+        if self.fail:
+            raise RuntimeError("tracker 502")
+
+
+def _ref():
+    return SimpleNamespace(id="ELS-42", kind="linear")
+
+
+def _settings(on: bool):
+    return SimpleNamespace(state_projector_unified=on)
+
+
+@pytest.mark.asyncio
+async def test_flag_off_calls_gateway_directly_and_raises(db_session) -> None:
+    gw = _Gateway(fail=True)
+    with pytest.raises(RuntimeError, match="tracker 502"):
+        await transition_via_projector(
+            db_session,
+            settings=_settings(False),
+            workspace_id=uuid.uuid4(),
+            gateway=gw,
+            ref=_ref(),
+            to_state="In Progress",
+        )
+    assert gw.calls == [("ELS-42", "In Progress", None)]
+
+
+@pytest.mark.asyncio
+async def test_flag_on_same_error_semantics(db_session) -> None:
+    """Routes keep their behavior: failures re-raise either way."""
+    gw = _Gateway(fail=True)
+    with pytest.raises(RuntimeError, match="tracker 502"):
+        await transition_via_projector(
+            db_session,
+            settings=_settings(True),
+            workspace_id=uuid.uuid4(),
+            gateway=gw,
+            ref=_ref(),
+            to_state="In Progress",
+            from_state="planning",
+        )
+    assert gw.calls == [("ELS-42", "In Progress", "planning")]
+
+
+@pytest.mark.asyncio
+async def test_tracker_5xx_errored_report_zero_lock_mutation(
+    db_session, seed_workspace
+) -> None:
+    _, _, ws = seed_workspace
+    before = await db_session.scalar(select(func.count(AgentDispatchLock.id)))
+    report = await project_ticket_state(
+        db_session,
+        workspace_id=ws.id,
+        gateway=_Gateway(fail=True),
+        ref=_ref(),
+        to_state="Review",
+    )
+    assert report.ok is False
+    assert isinstance(report.error, RuntimeError)
+    await db_session.flush()
+    after = await db_session.scalar(select(func.count(AgentDispatchLock.id)))
+    assert after == before == 0
+
+
+@pytest.mark.asyncio
+async def test_reprojection_is_idempotent_at_the_seam(db_session) -> None:
+    gw = _Gateway()
+    for _ in range(2):
+        report = await project_ticket_state(
+            db_session,
+            workspace_id=uuid.uuid4(),
+            gateway=gw,
+            ref=_ref(),
+            to_state="Review",
+        )
+        assert report.ok
+    # Same call twice — same args both times; no state accumulates in
+    # the projector (the adapter's same-state write is a no-op
+    # server-side; label adds are by-name deduped in the adapter).
+    assert gw.calls == [("ELS-42", "Review", None)] * 2
+
+
+def test_projector_never_imports_lock_primitives() -> None:
+    src = (
+        Path(__file__).resolve().parents[1]
+        / "app" / "services" / "state_projector.py"
+    ).read_text()
+    tree = ast.parse(src)
+    forbidden = {
+        "acquire_lock", "release_lock", "count_active_locks",
+        "sweep_expired_locks", "_count_recent_dispatches", "maybe_dispatch",
+    }
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            for alias in node.names:
+                assert alias.name not in forbidden
+        if isinstance(node, ast.Call):
+            name = (
+                node.func.id if isinstance(node.func, ast.Name)
+                else node.func.attr if isinstance(node.func, ast.Attribute)
+                else None
+            )
+            assert name not in forbidden, f"projector calls {name}()"
+
+
+def test_no_direct_gateway_transitions_left_in_routes() -> None:
+    """Every FSM→tracker write in agent_runs.py + project_state_sync
+    goes through the projector shim."""
+    base = Path(__file__).resolve().parents[1] / "app"
+    for rel in (
+        "api/v1/routes/agent_runs.py",
+        "services/agent/project_state_sync.py",
+    ):
+        src = (base / rel).read_text()
+        assert "gateway.transition(" not in src.replace(
+            "transition_via_projector", ""
+        ), f"{rel} still calls gateway.transition directly"

--- a/apps/backend/tests/test_topic_assemble_policies.py
+++ b/apps/backend/tests/test_topic_assemble_policies.py
@@ -56,12 +56,15 @@ async def test_assemble_no_policies(db_session, seed_workspace) -> None:
         recent_messages=[],
         new_user_message="hi",
     )
-    # system prompt + session-context frame + final user turn.
-    assert len(out) == 3
+    # system prompt + session-context frame + autonomy block (ELS-244)
+    # + final user turn.
+    assert len(out) == 4
     assert out[0].role == "system"
     assert "You are Ship" in out[0].content
     assert out[1].role == "system"
     assert "## Session context" in out[1].content
+    assert out[2].role == "system"
+    assert "Autonomy profile" in out[2].content
     assert out[-1].role == "user"
 
 
@@ -114,7 +117,8 @@ async def test_assemble_injects_enabled_policies(
     )
 
     # Layering: 0=system prompt, 1=session context (date + workspace),
-    # 2=policies preamble, 3=topic summary, then the live user turn.
+    # 2=policies preamble, 3=autonomy block (ELS-244), 4=topic summary,
+    # then the live user turn.
     assert out[0].role == "system" and "You are Ship" in out[0].content
     assert out[1].role == "system"
     assert "## Session context" in out[1].content
@@ -128,7 +132,10 @@ async def test_assemble_injects_enabled_policies(
     assert "Should not render." not in preamble
 
     assert out[3].role == "system"
-    assert "Running topic summary" in out[3].content
+    assert "Autonomy profile" in out[3].content
+
+    assert out[4].role == "system"
+    assert "Running topic summary" in out[4].content
 
     assert out[-1].role == "user"
     assert out[-1].content == "hi"

--- a/apps/backend/tests/test_tracker_fsm_projection.py
+++ b/apps/backend/tests/test_tracker_fsm_projection.py
@@ -1,0 +1,92 @@
+"""Egress-only projection maps (ELS-228).
+
+Pins (1) the unified source of truth: the provisioner's
+FSM_TO_LINEAR_STATE and project_state_sync's _TRANSITION_PLAN derive
+from tracker_fsm; (2) per-state equivalence with the pre-unification
+literals (guard against drift between display strings and live state
+names); (3) the egress-only invariant: neither dispatcher.py nor
+tracker_poller.py (the control/ingest paths) consumes the projection
+maps.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+APP = Path(__file__).resolve().parents[1] / "app"
+
+
+def test_provisioner_map_is_the_shared_table() -> None:
+    from backend.app.services.linear_provisioner import FSM_TO_LINEAR_STATE
+    from backend.app.services.tracker_fsm import FSM_TO_NATIVE_STATE
+
+    assert FSM_TO_LINEAR_STATE is FSM_TO_NATIVE_STATE["linear"]
+
+
+def test_project_state_plan_derives_from_shared_table() -> None:
+    from backend.app.services.agent.project_state_sync import _TRANSITION_PLAN
+    from backend.app.services.tracker_fsm import PROJECT_STATE_TICKET_MOVES
+
+    assert _TRANSITION_PLAN == dict(PROJECT_STATE_TICKET_MOVES)
+
+
+def test_linear_targets_equal_pre_unification_values() -> None:
+    """Per-state equivalence with the literals that lived in
+    linear_provisioner before ELS-228 — the unification must not move
+    any native target."""
+    from backend.app.services.tracker_fsm import FSM_TO_NATIVE_STATE
+
+    expected = {
+        "planning": "Todo",
+        "dev_implementation": "In Progress",
+        "devops_implementation": "In Progress",
+        "validation": "In Progress",
+        "code_review": "Review",
+        "auto_merge": "Review",
+        "merged": "Done",
+        "self_heal": "Todo",
+        "decomposition": "In Progress",
+        "planning_done": "Done",
+        "task_intake": "Todo",
+        "ba_requirements": "Todo",
+        "tech_arch_plan": "Todo",
+        "qa_arch_plan": "Todo",
+        "qa_manual": "In Progress",
+        "qa_automation": "In Progress",
+        "pr_review": "Review",
+        "wbs": "In Progress",
+        "architecture": "In Progress",
+        "test_architecture": "In Progress",
+        "tasks": "In Progress",
+    }
+    assert FSM_TO_NATIVE_STATE["linear"] == expected
+
+
+def test_project_moves_equal_pre_unification_values() -> None:
+    from backend.app.services.tracker_fsm import PROJECT_STATE_TICKET_MOVES
+
+    assert PROJECT_STATE_TICKET_MOVES == {
+        "active": ("Backlog", "Todo"),
+        "planning": ("Todo", "Backlog"),
+        "parked": ("Todo", "Backlog"),
+    }
+
+
+def test_control_and_ingest_paths_never_consume_projection_maps() -> None:
+    """Egress-only invariant: the maps are write maps for the human
+    read-model. The dispatch control path and the poller ingest path
+    must never import them (inverting projection into control)."""
+    forbidden = (
+        "FSM_TO_NATIVE_STATE",
+        "PROJECT_STATE_TICKET_MOVES",
+        "TRACKER_MAPPING_HINTS",
+        "FSM_TO_LINEAR_STATE",
+    )
+    for rel in ("services/dispatcher.py", "services/tracker_poller.py"):
+        src = (APP / rel).read_text()
+        for name in forbidden:
+            assert name not in src, (
+                f"{rel} references {name} — projection maps are "
+                "egress-only and must not feed control/ingest decisions "
+                "(thesis 2, ELS-228)."
+            )

--- a/apps/backend/tests/test_v1_agent_provider.py
+++ b/apps/backend/tests/test_v1_agent_provider.py
@@ -58,7 +58,7 @@ async def test_get_agent_provider_returns_default_and_supported(
     body = resp.json()
     assert body["workspace_id"] == str(workspace.id)
     assert body["kind"] == "cursor"
-    assert body["supported"] == ["claude", "codex", "cursor"]
+    assert body["supported"] == ["claude", "codex", "cursor", "ship"]  # ship: ELS-241 self-spawn (dogfood-gated)
 
 
 @pytest.mark.asyncio

--- a/apps/backend/tests/test_workspace_autonomy.py
+++ b/apps/backend/tests/test_workspace_autonomy.py
@@ -1,0 +1,68 @@
+"""Workspace autonomy dial (ELS-221, thesis 7).
+
+Covers the resolver default (``balanced``), reading an explicit
+profile, the CHECK constraint at the DB layer, and the fallback for
+out-of-enum values. The dial is agent action-rights only — the
+control-plane invariant test lives in Phase 2 (ELS-227).
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy.exc import DBAPIError, IntegrityError
+
+
+@pytest.mark.asyncio
+async def test_autonomy_defaults_to_balanced(db_session, seed_workspace) -> None:
+    from backend.app.services.agent_provider_resolver import (
+        DEFAULT_AUTONOMY,
+        resolve_autonomy_for_workspace,
+    )
+
+    _, _, workspace = seed_workspace
+    assert workspace.autonomy == "balanced"
+    profile = await resolve_autonomy_for_workspace(
+        session=db_session, workspace_id=workspace.id
+    )
+    assert profile == DEFAULT_AUTONOMY == "balanced"
+
+
+@pytest.mark.asyncio
+async def test_autonomy_reads_explicit_profile(db_session, seed_workspace) -> None:
+    from backend.app.services.agent_provider_resolver import (
+        resolve_autonomy_for_workspace,
+    )
+
+    _, _, workspace = seed_workspace
+    workspace.autonomy = "high"
+    await db_session.flush()
+
+    profile = await resolve_autonomy_for_workspace(
+        session=db_session, workspace_id=workspace.id
+    )
+    assert profile == "high"
+
+
+@pytest.mark.asyncio
+async def test_autonomy_missing_workspace_falls_back(db_session) -> None:
+    import uuid
+
+    from backend.app.services.agent_provider_resolver import (
+        resolve_autonomy_for_workspace,
+    )
+
+    profile = await resolve_autonomy_for_workspace(
+        session=db_session, workspace_id=uuid.uuid4()
+    )
+    assert profile == "balanced"
+
+
+@pytest.mark.asyncio
+async def test_autonomy_check_constraint_rejects_garbage(
+    db_session, seed_workspace
+) -> None:
+    _, _, workspace = seed_workspace
+    workspace.autonomy = "yolo"
+    with pytest.raises((IntegrityError, DBAPIError)):
+        await db_session.flush()
+    await db_session.rollback()

--- a/documentation/internal/architecture/agent-adapter-contract.md
+++ b/documentation/internal/architecture/agent-adapter-contract.md
@@ -1,0 +1,65 @@
+# Agent-adapter contract (thesis 5, ELS-245)
+
+Ship is a **superstructure over coding agents**: it spawns, controls
+and injects context. It never re-implements the agent — not the
+file-edit loop, not git, not the tool loop, not even locally.
+
+## The two-point coupling rule
+
+An adapter under `packages/cli/lib/agents/` may couple to its tool
+through **exactly two points**:
+
+1. **The non-interactive invocation contract** — the tool's binary +
+   the handful of headless flags, prompt in:
+   - `cursor-agent` (Cursor CLI)
+   - `claude --print --dangerously-skip-permissions --output-format stream-json`
+   - `codex exec --full-auto --skip-git-repo-check <prompt>`
+   - `shipctl run` (the thesis-6 self-spawn, which bottoms out in one
+     of the above)
+2. **"The agent commits to the branch Ship checked out"** — plus the
+   exit code. The runner owns checkout, push, and the PR.
+
+Everything Ship knows — agent-roles, policies, `.ship/knowledge`,
+Lighthouse retrieval, the autonomy preamble — enters **through the
+prompt/context**. The adapter is a dumb spawn.
+
+## Why: the maintenance math
+
+The headless CLI is the most stable surface each vendor has (their own
+CI depends on it). Coupling only to it means: a vendor change is a
+~30-LOC adapter fix, version-pinnable, isolated. Ship supports one
+entrypoint per tool — not "everything they do" — and rides every
+coding agent while betting on none. A new tool is a +30-LOC adapter.
+
+## The two rejected patterns (do not reintroduce)
+
+1. **Variant A — tool-native config.** Delivering Ship's value via
+   `.cursorrules`, per-tool `CLAUDE.md`, codex config files, hooks or
+   slash commands. That is N foreign roadmaps of maintenance, breaks
+   on every vendor format change, and — decisive — config cannot hold
+   the control plane (lease/cap/cascade live in Postgres, thesis 2).
+   The moment an adapter writes a tool-native config artifact, we have
+   slid into Variant A. The lint below fails the build for it.
+2. **The inversion — Ship as an MCP tool the agents call.** That flips
+   the control direction: the agent would drive Ship. Ship spawns the
+   agent as a subprocess; the agent never drives Ship.
+
+## Per-tool rationale snapshot (2026-06)
+
+| Tool | Invocation | Tool-specific tail we deliberately forgo |
+|---|---|---|
+| Cursor | `cursor-agent` headless | repo indexing, cloud agents |
+| Claude Code | `--print` + `stream-json` | MCP servers, subagents, hooks |
+| Codex | `codex exec --full-auto` | profiles, sandbox modes |
+| ship (self-spawn) | nested `shipctl run` | — (dogfood-gated, ELS-241/242) |
+
+Forgoing the per-tool bells is the trade: agent-agnosticism **is** the
+moat.
+
+## Enforcement
+
+- The CONTRACT docblock at the top of `packages/cli/lib/agents/index.mjs`
+  states the rule at the point of change.
+- `apps/backend/tests/test_agent_adapter_discipline.py` fails CI if any
+  adapter file references a tool-native config artifact in a
+  read/write context.

--- a/documentation/internal/architecture/console-route-classification.md
+++ b/documentation/internal/architecture/console-route-classification.md
@@ -1,0 +1,193 @@
+# Console-route classification ledger (ELS-220)
+
+> Drives every Phase-4 deletion. BINDING RULES that override any
+> contradictory per-row note below:
+>
+> 1. The pre-seeded EXCLUDED list is final: inbox page + inbox.py,
+>    agent_runs.py, runs.py public_router, all *_oauth.py / *_webhook.py /
+>    github_app.py, config.py, and **dashboard_priorities.py** (its
+>    WorkspaceProjectPriority model feeds project_state_sync,
+>    project_completion and the Navigator picker) are NEVER deleted —
+>    neither routes nor models.
+> 2. "DUPLICATE" applies to the FRONTEND page + its BFF proxy; the
+>    backend model/business logic survives unless the row explicitly
+>    tags the backend route itself.
+> 3. Default for any ambiguity discovered during deletion: re-tag
+>    HEADLESS-CANDIDATE and keep behind the console flag (per plan).
+> 4. The Phase-4 regression gate (ELS-240) re-verifies all of this
+>    with an OpenAPI diff before merge.
+
+# Ship Console Strangler — Route Classification Ledger
+
+**ELS-220 Artifact | Thoroughness: Very Thorough | Generated: 2026-06-11**
+
+## DUPLICATE Routes
+| Path | What It Is | External View It Duplicates | Non-Console Callers Checked | Notes |
+|------|-----------|----------------------------|------------------------------|-------|
+| (authed)/analytics/page.tsx | DORA metrics + live system dashboard | Linear/GitHub analytics (DORA exists in Linear UI + GH insights) | ✓ daily_scheduler.py: does NOT call analytics_dora; only calls dispatcher for bundle work | Duplicates native tracker analytics. DORA metrics historically sourced from GitHub API + tracker; this is console-only view |
+| (authed)/audit/page.tsx | Audit log table (filter + paginate) | Linear audit log (project activity + member actions) | ✓ No non-console calls found | Backend audit.py table stores mutations; the page is pure UI render. The TABLE stays (audit_log model consumed by services); page deleted |
+| (authed)/deployments/page.tsx | DigitalOcean App Platform deployment management | DigitalOcean web dashboard + GitHub Releases (deployment status views) | ✓ No non-console calls to deploy routes found; deploy.py is console-only | Engine writes Deployment rows; console pages over them. The ROUTES stay (engine uses deploy.py internally); page deleted |
+| (authed)/memory/page.tsx | Navigator chat memory browser (mem0 session dump) | Linear/tracker activity timeline (project memory) | ✓ navigator_memories.py only called by console routes; no CLI or service use | Pure UI surface. Backend route stays (mem0-backend integration); page deleted in Phase 4 |
+| (authed)/repos/[id]/secrets/page.tsx | GitHub Actions secrets editor per-repo | GitHub web UI (repo settings → secrets tab) | ✓ No non-console calls; repo_secrets.py is console-only routing | Plaintext secrets only transmitted on POST to GitHub; never persisted by Ship. Routes stay (wizard uses them); page deleted |
+| r/[owner]/[repo]/page.tsx | Per-repo home (Now/Trends activity tabs) | GitHub repo dashboard (insights + activity) | ✓ repo_home.py called only from console; services do not read it | Reads RoutineRun / WorkflowRun / AgentRequest; no business logic consumer outside console. DELETE both |
+| (authed)/process/page.tsx | Process (FSM) editor — template selection + config | Linear project settings / Jira workflow editor | ✓ processes.py is console-only; no service consumption | Agent consumes process_templates.py defaults (hardcoded in catalog), not the workspace-level editor. Page + routes deleted; defaults stay |
+| (authed)/process/[processId]/page.tsx | Process FSM detail editor (states, rules, triggers) | Jira workflow config UI | ✓ processes.py routes not called from services | DELETE |
+| (authed)/knowledge/page.tsx | Knowledge import wizard (Confluence / Notion / GitHub / Website) | Notion/Confluence/GitHub native import UIs | ✓ knowledge_import_sources.py routes only called by console | Importer setup + sync orchestration is console-facing; the knowledge model itself (knowledge.py) stays for agent reads. ROUTES deleted; knowledge.py stays |
+| (authed)/settings/config/page.tsx | Workspace .ship/config.yml editor (YAML syntax, validation) | GitHub editor (`.ship/config.yml` direct edit) | ✓ config.py is console-only; services read from repos not API | The YAML source lives in `.ship/config.yml` in the repo (canonical); console is optional editor. Routes & page deleted; services fetch from repo |
+| (authed)/settings/integrations/page.tsx | Integration OAuth bind/unbind UI (Linear, Notion, Telegram, etc.) | Native OAuth provider UIs (Linear.app, Notion.com, etc.) | ✓ integrations.py routes called ONLY by console and webhook handlers | DELETE pages; backend ROUTES stay (webhooks call integrations for sync) |
+| (authed)/settings/integrations/telegram/page.tsx | Telegram bot group binding UI | Telegram client (group settings → linked bots) | ✓ telegram.py routes: bind_preview/bind_confirm/list/delete only called by console | DELETE page; telegram.py routes stay (bot calls them for group lifecycle) |
+| (authed)/settings/general/page.tsx | Workspace name + slug editor | Linear workspace settings | ✓ workspaces.py rename route is console-only | DELETE |
+| (authed)/settings/members/page.tsx | Team member invite + role UI | Linear members page | ✓ members.py + invites.py routes console-only; no service consumers | DELETE |
+| (authed)/settings/policy/page.tsx | Free-text policy editor (standing agent rules) | Linear project description / Jira description fields | ✓ policies.py not consumed by non-console (services.policies renders on read; no external caller writes) | DELETE pages + policy routes; services.policies library for render stays |
+| (authed)/settings/policy/new/page.tsx | New policy form | (same as above) | ✓ Same as above | DELETE |
+| (authed)/settings/repositories/page.tsx | GitHub repo activation (picker + list) | GitHub App installations page | ✓ repos.py called only by console; services use WorkspaceRepo model not API | DELETE |
+| (authed)/settings/registries/page.tsx | Artifact registry configuration (ECR / Docker / npm) | AWS ECR web console / Docker Hub settings | ✓ artifact_repos.py is console-only | DELETE |
+| (authed)/settings/agent-roles/page.tsx | Agent role library (Ship defaults + workspace overrides) | Linear custom roles / GitHub team settings | ✓ agent_roles.public_router used by shipctl run (CLI reads defaults); workspace_router is console-only | KEEP public_router for CLI; DELETE workspace routes + page |
+| (authed)/settings/api-keys/page.tsx | API token mint/revoke UI | Linear API tokens page | ✓ tokens routes are console-only | DELETE |
+| (authed)/settings/workspaces/page.tsx | Workspace list + create/delete | Linear org settings | ✓ workspaces.py routes: create/delete are console-only | DELETE |
+| (authed)/chat/archived/page.tsx | Archived chat threads list | Linear issue history | ✓ chat routes only console-facing | DELETE |
+| (authed)/settings/page.tsx | Settings root (redirect to general) | N/A (meta-page) | N/A | DELETE |
+| e2e/inbox-mailbox/page.tsx | Test instrumentation (e2e inbox state dump) | N/A — internal test harness | ✓ N/A | DELETE — test-only |
+
+---
+
+## HEADLESS-CANDIDATE Routes
+| Path | What It Is | Keep Behind Console Flag | Non-Console Callers | Notes |
+|------|-----------|------------------------|----------------------|-------|
+| (authed)/chat/page.tsx | Navigator chat (agent interaction loop) | YES | ✓ distiller.py consumes chat buckets (Phase 6 artifact consolidation) | Phase 5 will expose chat as public API (ELS-230+); keep for now; mark as HEADLESS when API endpoint lands |
+| (authed)/local-tracker/page.tsx | Laptop-offline sandbox control panel (local agent runs) | YES (dev-only when SHIP_USE_MEMORY_ADAPTERS=true) | ✓ local_tracker.py returns 404 when disabled in prod | Keep for local development; schedule deletion from production console config |
+| api/onboard/* routes | Onboarding flow (GitHub install, tracker bind, etc.) | YES | ✓ No non-console consumers | Keep until headless onboarding endpoint lands (post-MVP); wrap flag |
+| api/knowledge/* routes | Knowledge import + search (Confluence / Notion / GitHub) | YES | ✓ knowledge_import_sources.py is console-only setup | Import setup is console-only; core knowledge.py is internal. DELETE import wizard page; keep core knowledge.py for agent consumption |
+| api/process/config-propose | Process FSM config proposal | YES | ✓ No non-console callers | DELETE page + routes once FSM is internal-only |
+| api/team/* | Team invite flow | YES | ✓ invites routes only called by console | DELETE page; keep invites.py for public accept endpoint (public invite token path) |
+| api/settings/config/* | Config scope editor (global vs. workspace level) | YES | ✓ config.py is EXCLUDED; services read from repos not API | DELETE page; wrap routes behind console flag |
+| api/settings/agent-provider | Default agent selection (OpenAI vs. Anthropic vs. custom) | YES | ✓ No non-console callers found | Workspace agents read from config; no API consumer. DELETE console page; keep config.py (EXCLUDED) |
+| api/settings/dispatch-routine | Cron schedule editor for routines | YES | ✓ No non-console; cron is defined in .ship/config.yml | DELETE |
+| api/settings/repositories/reseed | Repository tree refresh | YES | ✓ No non-console callers | DELETE |
+| api/integrations/native-* | Native integration (Atlassian, Azure DevOps, GitLab) probe + config | YES | ✓ native_integrations.py only called by console | DELETE console routes; keep public_router probe for discovery |
+| api/sdlc-readiness | SDLC audit readiness check (GitHub/Linear/Jira health) | YES | ✓ No non-console callers | DELETE |
+| api/members/specialists | Specialist user roles (QA, Security, Tech Lead) | YES | ✓ members.py specialist assignment only console | DELETE |
+| api/bootstrap-plan | Bootstrap intelligence (auto-recommend devops setup) | YES | ✓ No non-console callers found | DELETE page + routes after bootstrap phase ships |
+| api/dashboard/install-bundle | Bundle installation trigger | YES | ✓ No non-console callers | DELETE |
+
+---
+
+## RESIDUE Routes
+(Irreducible native surface — keep in all phases)
+
+| Path | What It Is | Non-Console Callers | Notes |
+|------|-----------|---------------------|-------|
+| page.tsx | Root workspace dashboard (home + priorities + live system) | ✓ None — pure UI landing page | Root status view; KEEP |
+| auth-error/page.tsx | Auth error fallback (session expired, access denied, etc.) | ✓ None — error boundary | Irreducible error surface; KEEP |
+| no-access/page.tsx | RBAC denial page (member attempting admin action) | ✓ None — error boundary | Irreducible error surface; KEEP |
+| complete-profile/page.tsx | First-login profile setup (name, email confirmation) | ✓ None — onboarding only | Irreducible UX gate; KEEP |
+| login/page.tsx | Login form (email + magic link or OAuth) | ✓ None — auth-only | Irreducible entry point; KEEP |
+| invite/page.tsx | Invite code input + workspace picker | ✓ None — open invite gate | Irreducible invite flow gate; KEEP |
+| invite/[token]/page.tsx | Invite token accept (creates workspace + team link) | ✓ None — public gate; invites.py invite_router processes; no other consumer | Irreducible invite acceptance; KEEP |
+| onboarding/page.tsx | Onboarding wizard (GitHub App install → tracker bind → first routine) | ✓ None — wizard-only UX | Irreducible first-run flow; KEEP |
+| integrations/telegram/bind/page.tsx | Telegram group bind deep-link target | ✓ telegram.py bind endpoints only console; no CLI caller | Irreducible bind gate (bot sends deep-link); KEEP |
+| (authed)/settings/danger/page.tsx | Destructive zone (workspace leave, integration revoke) | ✓ No non-console callers | Irreducible UX gate for destructive actions; KEEP (safe behind confirmation UI) |
+| logout/route.ts | Session revocation | ✓ None — auth-only | Irreducible auth endpoint; KEEP |
+| api/auth/* | OAuth callback handlers + login/signup | ✓ None — auth-only; public routes for OAuth provider redirects | Irreducible auth boundary; KEEP |
+| api/me | Current user profile | ✓ None — console render only | Irreducible auth context; KEEP |
+| api/deployments | List deployments for a workspace | ✓ No non-console callers (deploy.py routes stay for console polling) | Polling endpoint for deployment console UX; KEEP |
+| api/deployment | Deployment detail + log fetch | ✓ Same | KEEP |
+| api/deploy/* | Deployment trigger + event stream + provider discovery | ✓ Same | KEEP for console UX; internal engine (services) only uses models not API |
+| api/v1/[...path] | Proxy to backend `/v1` routes | ✓ All traffic flows through this | Irreducible routing layer; KEEP |
+
+---
+
+## EXCLUDED Routes
+(Engine/control-plane/CLI boundary — never delete)
+
+| Path | What It Is | Pre-Seeded Reason | Non-Console Callers |
+|------|-----------|-------------------|----------------------|
+| (authed)/inbox/page.tsx | Unified inbox UI (inbox_items + inbox_item_events) | EXCLUDED (per pre-seed) | ✓ agent_runs.py writes inbox mutations; services.inbox.routing consumes inbox models for auto-assignment |
+| api/inbox/* | Inbox CRUD (list, detail, disposition, reassign, snooze) | EXCLUDED (per pre-seed) | ✓ agent_runs.py + services.inbox.routing are internal; routes stay for console + internal orchestration |
+| agent_runs.py | Agent dispatch intake (shipctl run API) | EXCLUDED (per pre-seed) | ✓ packages/cli/ship/ calls this; engine uses it for ticket-driven dispatch; routes STAY |
+| runs.py + runs.public_router | Routine run tracking (dispatch + webhook result callback) | EXCLUDED (per pre-seed) | ✓ CLI dispatches routines; GitHub Actions workflows callback to public_router; routes STAY |
+| analytics_dora.py | DORA metrics aggregation endpoint | EXCLUDED (per pre-seed) | ✓ daily_scheduler.py checked: does NOT call analytics_dora; crons call dispatcher only. **Page is DUPLICATE; routes are EXCLUDED** |
+| dashboard_live_system.py | Live system aggregator (knowledge + routines + daily + specialist health) | EXCLUDED (per pre-seed) | ✓ No non-console callers; pure render endpoint. **Page is part of root (RESIDUE); routes are EXCLUDED** |
+| dashboard_priorities.py | Project priority list + autonomy pause toggle | EXCLUDED (per pre-seed) | ✓ WorkspaceProjectPriority model consumed by: agent_runs.py (ELS-80 gate), services.agent.tools (Navigator picker), services.agent.project_state_sync. **Routes are EXCLUDED because services read the MODEL not API** |
+| dashboard.py | Workspace dashboard summary (ops rollup: PRs, runs, routines) | EXCLUDED (per pre-seed) | ✓ Pure render endpoint; no business logic consumer. **Render endpoints are EXCLUDED; page is RESIDUE (home uses it)** |
+| inbox.py | Inbox item model + routing service | EXCLUDED (per pre-seed) | ✓ agent_runs.py creates items; services.inbox.routing auto-assigns; console reads. ROUTES STAY; page is UI only |
+| config.py | Workspace configuration (api keys, defaults, settings) | EXCLUDED (per pre-seed) | ✓ Used by agent initialization; services read it. ROUTES STAY |
+| *_oauth.py | OAuth callbacks (linear_oauth, notion_oauth, digitalocean_oauth) | EXCLUDED (per pre-seed) | ✓ OAuth provider redirects (public paths); routes STAY; pages are console-only UI |
+| *_webhook.py | Webhook ingestion (linear_webhook, github_app webhook path) | EXCLUDED (per pre-seed) | ✓ Tracker/platform providers call these; routes STAY; pages don't exist |
+| github_app.py | GitHub App install + webhook routing | EXCLUDED (per pre-seed) | ✓ GitHub platform calls this; routes STAY; pages are console-only UI |
+
+---
+
+## Summary Statistics
+
+| Tag | Count | Phase 4 Action |
+|-----|-------|----------------|
+| **DUPLICATE** | 24 | Delete frontend pages + BFF proxy routes; keep backend model/business logic |
+| **HEADLESS-CANDIDATE** | 14 | Wrap behind console feature flag; schedule Phase 5 headless endpoint |
+| **RESIDUE** | 19 | Keep all — irreducible user-facing surfaces |
+| **EXCLUDED** | 11 | Never delete — engine/control-plane/CLI boundary |
+| **TOTAL** | 68 | |
+
+---
+
+## Deletion Topo-Order (Phase 4 Implementation)
+
+**Batch 1: Settings pages (no service consumers)**
+- settings/policy/{page.tsx, new/page.tsx} + /api/policies/*
+- settings/agent-roles/page.tsx + /api/agent-roles/WORKSPACE ROUTES (keep public_router)
+- settings/general/page.tsx (workspaces.py stays)
+- settings/members/page.tsx + /api/members/* + /api/team/* 
+- settings/api-keys/page.tsx + /api/tokens/*
+- settings/repositories/page.tsx (repos.py stays for engine)
+- settings/registries/page.tsx + /api/settings/artifact-repos/*
+- settings/page.tsx (root settings redirect)
+
+**Batch 2: Data pages (pure render, no service use)**
+- analytics/page.tsx (analytics_dora.py routes are EXCLUDED)
+- audit/page.tsx (audit model stays)
+- deployments/page.tsx (deploy.py routes stay)
+- memory/page.tsx (navigator_memories.py stays)
+- knowledge/page.tsx + knowledge_import_sources.py (knowledge.py stays)
+- process/{page.tsx, [processId]/page.tsx} (process_templates.py stays)
+- r/[owner]/[repo]/page.tsx + /v1/repos/{id}/home (repo_home.py: pure render)
+- r/[owner]/[repo]/settings/page.tsx
+- repos/[id]/secrets/page.tsx (repo_secrets.py stays)
+- chat/archived/page.tsx (chat.py stays)
+
+**Batch 3: Onboarding/flow pages**
+- integrations/telegram/bind/page.tsx (telegram.py routes stay)
+- e2e/inbox-mailbox/page.tsx (test-only)
+
+**Batch 4: HEADLESS-CANDIDATE (wrap flag, Phase 5 planning)**
+- chat/page.tsx (wrap flag; distiller consumes buckets)
+- local-tracker/page.tsx (dev-only flag)
+- api/onboard/* routes
+- api/knowledge/* (import setup only; knowledge.py stays)
+- api/process/config-propose
+- api/settings/config/* routes
+- api/integrations/native-* (probe remains)
+- api/sdlc-readiness
+- api/bootstrap-plan
+- api/dashboard/install-bundle
+
+**NO-DELETE (RESIDUE + EXCLUDED):**
+- page.tsx (root), login/, onboarding/, auth-error/, no-access/, complete-profile/, invite/*, logout/
+- api/auth/*, api/me, api/v1/[...path], api/deploy/*, api/deployments
+- All agent_runs.py, runs.py, inbox.py, config.py, *_oauth.py, *_webhook.py, github_app.py
+- dashboard.py, dashboard_live_system.py, dashboard_priorities.py (routes are EXCLUDED)
+
+---
+
+## Critical Verification Notes
+
+1. **daily_scheduler.py**: Confirmed it calls `dispatcher.maybe_dispatch_workspace_bundle()`, NOT `analytics_dora.py` directly. Render endpoints are console-only.
+
+2. **WorkspaceProjectPriority**: Model read by agent_runs.py (ELS-80 gate), services.agent.tools (Navigator picker), services.project_state_sync. Services read the **model** not API. Dashboard_priorities.py routes are EXCLUDED; page + routes both deletable.
+
+3. **telegram.py**: Routes EXCLUDED (bot + console use); console page is DUPLICATE. Delete page, keep routes.
+
+4. **repo_home.py**: Pure render endpoint; no service consumer. Page + routes both deleted.
+
+5. **Chat SSE**: HEADLESS-CANDIDATE because distiller.py consumes buckets. Keep routes behind flag; page deletable pending Phase 5.
+
+6. **Config sourcing**: Services read .ship/config.yml from repos directly, not from config.py API. Page deletable; routes (config.py) are EXCLUDED for backward-compat.

--- a/documentation/internal/architecture/control-plane-vs-readmodel.md
+++ b/documentation/internal/architecture/control-plane-vs-readmodel.md
@@ -1,0 +1,54 @@
+# Control plane vs. read-model — Linear-read inventory (ELS-227)
+
+> Thesis 2 (headless-but-stateful): **domain** state (ticket lifecycle,
+> PR/approval/CI) lives in Linear/GitHub; **control** state (lease, cap,
+> cascade, idempotency) lives in Ship Postgres and may NEVER be derived
+> from Linear labels/status. This doc enumerates every place Ship reads
+> Linear state on the dispatch path and classifies it. The companion
+> guard test is `apps/backend/tests/test_control_plane_invariant.py`.
+
+## The four control primitives — Postgres-only (verified)
+
+| Primitive | Where | Resolves against | Linear input |
+|---|---|---|---|
+| Lease | `dispatcher.acquire_lock` (:235) — atomic `INSERT … ON CONFLICT DO NOTHING` on `agent_dispatch_locks` | Postgres | none |
+| Release / sweep | `dispatcher.release_lock` (:290), `sweep_expired_locks` (:433) | Postgres (`expires_at`) | none |
+| Per-ws cap | `dispatcher.count_active_locks` (:466) | Postgres row count | none |
+| Cascade budget | `dispatcher._count_recent_dispatches` (:517) — `COUNT(*)` on `audit_log` `action='agent_run.dispatch'` within `CASCADE_WINDOW_S` | Postgres | none (`ticket_ref` is an identifier key into audit_log, not Linear state) |
+
+Call sites audited (all kwargs Postgres-shaped): dispatcher.py
+:402 :858 :882 :920 :932 :1028 :1078 :1083 :1123 :1127 :1230 :1234
+:1373 :1384 :1390 :1408 :1440 and `agent_runs.py:4676` (finish-path
+release).
+
+## Legitimate Linear reads on the dispatch path — DOMAIN (pickup-gating)
+
+| Read | Where | Classification | Why it is domain, not control |
+|---|---|---|---|
+| Issue STATUS (workflow state) | `tracker_poller._poll_installation` (reads state, emits transition event) | **domain — the settled-correct sole transition trigger** (`tracker_fsm.py:277`) | The status field decides *what work exists*; the lease decides *who may run it*. The poller never touches locks. |
+| `stage:*` labels | `tracker_poller._extract_fsm_stage` (:122); dispatcher stage→routine mapping (:62) | **domain — routing breadcrumb** | Picks WHICH routine handles the ticket; does not gate concurrency. |
+| `planning:anchor` label | `dispatcher.maybe_dispatch` (`is_anchor`, :1066) | **domain — pickup/parallelism semantics** | Exempts the anchor from the project lock *acquisition decision*, but the lock itself is still acquired/checked purely in Postgres. The label never feeds `acquire_lock` arguments. |
+| Freeze-overlay labels (`OVERLAY_FREEZE_LABEL_PREFIXES`, e.g. `blocked`) | dispatcher pickup filter | **domain — pickup gate** | A frozen ticket is *not eligible work* (domain); the lease table is untouched. Removing the label re-eligibilizes — it does not release any lock. |
+| `needs_clarification` signal label | finish path (`add_signal_label`) | **domain — egress breadcrumb** | Write-only projection for the human; the clarification resolution flows back through the STATUS field / Inbox, not by reading this label into a lock decision. |
+| Ticket snapshot labels (`get_ticket_snapshot`) | dispatcher :979 (`ticket_labels`) | **domain** | Used for `is_anchor` / routing above. |
+
+## Violations found
+
+**None.** Every Linear read on the dispatch path gates *pickup/routing*
+(what + which), never *lease/cap/cascade* (whether/how-many). The
+control primitives' signatures and all call sites carry only
+Postgres-shaped arguments — now pinned by the guard test.
+
+## Rules for future changes
+
+1. A new parameter on `acquire_lock` / `count_active_locks` /
+   `_count_recent_dispatches` / `release_lock` must be added to the
+   guard test's `_ALLOWED_PARAMS` **deliberately** — if it is
+   label/status/tracker-shaped, the change is architecturally wrong.
+2. Projection (FSM → Linear status/labels) is **one-directional**
+   (egress). Nothing may invert a projected label back into a control
+   decision. (`TRACKER_MAPPING_HINTS` unification: ELS-228;
+   StateProjector: ELS-229.)
+3. New "is this ticket eligible?" reads of Linear are fine (domain);
+   new "may I run / how many are running?" reads of Linear are not
+   (control).

--- a/documentation/internal/architecture/headless-pivot-strangler-rework-plan.md
+++ b/documentation/internal/architecture/headless-pivot-strangler-rework-plan.md
@@ -1,0 +1,832 @@
+# Headless Pivot — Strangler Rework
+
+> Implementation plan generated 2026-06-11 via multi-agent planning workflows (analyze → synthesize → adversarial review), green-lit against the live codebase. Loaded into Ship Linear (team ELS).
+
+## Overview
+
+A strangler-fig in place behind feature flags (not a rewrite, not a new repo): 208 files keep importing backend.app.*, 86 migrations and the DB/CLI/secrets/CI stay shared, and the 48k-LOC test suite is the net for every in-place deletion. The plan is sequenced cheapest-and-most-reversible first and preserves the settled global order: config spine -> notification seam -> control guardrail -> scheduled trigger(c) -> console strangler -> superstructure(adapters/self-spawn/autonomy) -> local executor(a), then the two new workstreams as later phases: chat-edge/inbound (T4) and the deterministic workflow primitive (T8). The shape: a thin config-as-code spine lands first because notification routing, the console kill-switch, and the autonomy dial all read from it; the autonomy column migration is pulled FORWARD into Phase 0 (per the must-fix) so the local executor and autonomy gate are not serialized behind the entire console teardown. The notification seam is the single reversible egress interface, default inbox-only so every emit-site flip is an observable no-op until a workspace opts in; launch egress is inbox-only everywhere with Linear/email OPT-IN per workspace. Phase 2 pins the headless-but-stateful invariant (control state stays in Ship Postgres; STATUS is the only FSM transition signal) with an audit + guard test, unifies the runtime TRACKER_MAPPING_HINTS consumer plus the two hardcoded maps into one egress-only source of truth (corrected premise: it IS consulted at runtime, tracker_fsm.py:287), and rebuilds the deleted health/stall residue routing its stall signal through the Phase-1 seam. Phase 3 dogfoods scheduled ticket-creating routines over the shipped dispatch path. Phase 4 tears down the console leaf-first behind the suite, keeping the Inbox approval surface reachable in every console mode. Phase 5 codifies adapter discipline, adds the gated `ship` self-spawn provider forced through cascade+cap, and wires the autonomy dial at the FSM gate + agent-role prompts + auto-merger with CI-green pinned non-negotiable in ALL profiles and the control plane strictly off-limits to the dial. Phase 6 builds the net-new lease-free local executor (default-off everywhere, escalation suggested not forced). Phase 7 (chat-edge T4) makes human replies first-class conversational inbound without regressing the STATUS-only invariant, and hardens the Telegram control-adjacent surfaces (durable pending-action store, signed single-use callbacks, deep-link-not-commit approvals); it depends on the notification seam and the durable store. Phase 8 (workflow primitive T8) adds a deterministic bounded orchestrator distinct from the FSM, every leaf routed through a WorkflowDispatchGate that reuses lease/cap/cascade/idempotency; it depends on the Phase-5 self-spawn recursion guard. Founder decisions are baked into bodies: balanced backfill + balanced default for new workspaces, high is opt-in everywhere (even ElMundi), inbox-only launch egress, control plane never exempted by the dial, local executor default-off with E20-style suggestion, email_to from workspace.settings fail-closed, and all new migrations are 0086+ forward revisions off HEAD=0085.
+
+## Project description
+
+Convert Ship into a fully headless engine that acts THROUGH Linear+GitHub+email, executed as a strangler-fig in place behind feature flags (not a rewrite, not a repo lift-and-shift): 208 files keep importing backend.app.*, the DB/CLI/secrets/CI/migrations stay shared, and the 48k-LOC test suite is the net for every in-place deletion. Sequenced cheapest-and-most-reversible first: a config-as-code spine (channel routing + autonomy/console scopes) and the notification egress seam land early; the headless-but-stateful control-plane guardrail (control state stays in Ship Postgres, STATUS is the only FSM transition signal) is a cross-cutting invariant every phase respects; scheduled ticket-creating routines dogfood the shipped dispatch path; the console frontend + console-only API routes are deleted leaf-first behind the suite; superstructure (agent adapters, gated ship self-spawn, per-workspace autonomy dial) and the net-new lease-free local executor land next; then chat-edge inbound (human replies as conversational inbound without regressing the STATUS-only invariant) and the deterministic workflow primitive (a bounded orchestrator distinct from the FSM, every leaf routed through the control plane). Founder defaults baked in: balanced backfill + balanced default for new workspaces, high is opt-in everywhere (even ElMundi), inbox-only launch egress (Linear/email opt-in per workspace), control plane strictly off-limits to the autonomy dial, local executor default-off + suggest-escalation, email_to from workspace.settings fail-closed, and all new migrations are 0086+ forward revisions off HEAD=0085. Honors all eight settled theses; the test suite is the safety net for every deletion.
+
+## Phases & gates
+
+### Phase 0 — Config-as-code spine + inventories
+
+**Goal:** Land the shared config surface every later phase reads from, the two authoritative ledgers (emit-sites, console routes) that drive the strangler, and the autonomy column (pulled forward) — all zero-runtime-risk.
+
+**Exit gate:** config scopes round-trip via GET/PUT and .ship/config.yml; both ledgers checked in and reviewer-verifiable by re-running the grep; autonomy column migrates+downgrades cleanly with balanced backfill; no behavior change.
+
+### Phase 1 — Notification seam (reversible egress)
+
+**Goal:** Introduce the single notify(workspace,ticket,body,level) interface routing across Inbox/Linear/email, flip all engine emit-sites onto it behind a default-off flag (inbox-only launch egress), and prove a real sandbox email send end-to-end.
+
+**Exit gate:** SHIP_NOTIFY_CHANNELS=false forces inbox-only globally and all flipped sites produce byte-identical InboxItems vs today; rg 'InboxItem(' shows zero bucket-A sites remaining; audit_log records per-channel outcomes; a real sandbox email send is exercised end-to-end at least once.
+
+### Phase 2 — Control-plane guardrail + health residue
+
+**Goal:** Pin the thesis-2 invariant (control state stays in Postgres; STATUS is the only transition signal) with an audit+guard-test, unify the runtime TRACKER_MAPPING_HINTS consumer plus the two hardcoded maps into one egress-only source of truth, and rebuild the deleted is-alive/where-stuck surface routing its stall signal through the Phase-1 seam.
+
+**Exit gate:** guard test fails if any lock/cap/cascade primitive gains a Linear-label input; the unified mapping table targets the same native states as before (no drift); engine-health computes purely from agent_dispatch_locks+audit_log (zero writes asserted); stall-notify dedupes per (ticket,reason) and provably never touches a lock or transition.
+
+### Phase 3 — Scheduled ticket-creating routines (trigger c)
+
+**Goal:** Add the net-new (c) flavor: a cron that creates a Linear ticket in a target FSM stage so the already-shipped dispatch path executes it, idempotency-guarded against open duplicates.
+
+**Exit gate:** two ticks in one period_key create at most one ticket (durable audit_log dedup, survives failover); created ticket is picked up by existing tracker_poller->dispatcher with no new dispatch code; per-workspace failures isolated; egress-off/disabled workspaces skipped fail-closed.
+
+### Phase 4 — Console strangler / teardown
+
+**Goal:** Flag the console dark per-workspace, migrate mutable settings to config-as-code, then delete DUPLICATE routes leaf-first (pages->BFF->backend) behind the test suite, collapsing the frontend to a residual control panel while keeping the Inbox approval surface reachable in every mode.
+
+**Exit gate:** OpenAPI diff shows ONLY console-render routes removed, zero EXCLUDED routes touched; dashboard_priorities.py retained (control-plane-adjacent); full build+typecheck+Playwright+backend suite green; dispatch+install+webhook+Inbox+config e2e green; Inbox approval surface reachable in residual AND off modes.
+
+### Phase 5 — Superstructure: adapters, self-spawn, autonomy dial
+
+**Goal:** Codify adapter discipline (thesis 5), add the gated `ship` self-spawn provider forced through cascade+cap (thesis 6), and wire the autonomy dial at the FSM gate + agent-role prompt + auto-merger (thesis 7) with CI-green non-negotiable and the control plane off-limits to the dial.
+
+**Exit gate:** self-spawn 4-deep loop terminates via CASCADE_BLOCKED (test); CI-green invariant holds across all three autonomy profiles; high-autonomy-without-knowledge emits an audited warning/downgrade; adapter lint fails on any tool-native config write; no profile branch touches any lock/cap/cascade constant.
+
+### Phase 6 — Local synchronous executor (trigger a)
+
+**Goal:** Build the net-new lease-free, scratch-checkout, stop-before-push local executor as a distinct command, default-off everywhere, classifier-gated, escalating a->b only via create_issue (suggest, never hard-block).
+
+**Exit gate:** local command never calls /tracker/next, /agent-runs/finish, pushBranch, openPullRequest, or the dispatcher (grep + e2e leaving origin untouched); ESCALATE creates a ticket through the existing create_ticket adapter with no lease handoff; default-off everywhere including ElMundi; misclassified big-feature turn SUGGESTS escalation, never blocks.
+
+### Phase 7 — Chat-edge / inbound control (trigger a inbound, thesis 4)
+
+**Goal:** Make human replies (Linear comments + Telegram) first-class conversational inbound to the Navigator WITHOUT regressing the STATUS-only transition invariant, and harden the Telegram control-adjacent surfaces (durable pending-action store, signed single-use callbacks, deep-link-not-commit approvals). Control plane never commits through chat.
+
+**Exit gate:** comment ingestion adds exactly one Navigator turn per new human comment, calls no transition()/state write (asserted), and is idempotent; agent-vs-human classified by Linear author identity with marker fallback; keyboards survive a leader-failover via the durable store and never pollute the Console Inbox; callbacks are signed + single-use; actor-sensitive approvals render as deep-links, never commit from chat.
+
+### Phase 8 — Deterministic workflow primitive (thesis 8)
+
+**Goal:** Add a scripted bounded multi-agent orchestrator Ship INVOKES for one job and that COMPLETES — distinct from the reactive FSM — with every leaf routed through a WorkflowDispatchGate that reuses lease/cap/cascade/idempotency, fireable from all three triggers, complementary to (never merged with) the /process editor.
+
+**Exit gate:** loader rejects fork-bomb specs (fanout/depth) BEFORE any dispatch; runtime is structurally incapable of spawning except through the gate (AST/grep check); a workflow recursion is refused at CASCADE_LIMIT=3 reusing _count_recent_dispatches; (workflow_run_id,step_id,attempt) UNIQUE enforces idempotency; control plane not loosened by autonomy profile (no profile branch in gate.py); processes.py unmodified (diff check).
+
+## Critical path
+
+1. Inventory and tag every engine emit-site (notification seam audit)
+2. Add per-workspace notification channel-routing config + global kill-switch
+3. Define notify() interface + Inbox/Linear/email channel router
+4. Flip dispatcher + self-heal engine emit-sites onto notify()
+5. Flip agent_runs finish + pick-tick engine emit-sites onto notify()
+6. Wire notify() audit logging + sandbox email-transport check + rollback runbook
+7. Audit + guard test: prove no control state is read from Linear labels/status
+8. Add control-plane health/stall residue surface (is-alive / where-stuck)
+9. Stall-notification: emit engine-stalled signal through the notify() seam
+10. Classify every console page + backend render route (pre-tag dashboard_priorities.py EXCLUDED)
+11. Add SHIP_CONSOLE_MODE per-workspace flag gating the authed shell (Inbox reachable in every mode)
+12. Delete DUPLICATE analytics + dashboard render pages and their BFF proxies
+13. Delete orphaned dashboard/analytics/repo_home backend render routes (retain dashboard_priorities.py)
+14. Collapse root dashboard + repo pages to the residual status surface
+15. Strangler regression gate: headless egress + Inbox + CLI boundary survive teardown
+16. Add 'ship' self-spawn provider adapter + wire into runAgent behind a flag
+17. Force self-spawn recursion THROUGH cascade-depth + per-ws cap (recursion guard)
+18. W8.2 — WorkflowDispatchGate: route EVERY workflow-spawned agent through the control plane
+19. W8.3 — Workflow runtime executor: schedule the DAG, drive leaves through the gate, collect structured outputs
+20. W8.5 — Ticket/gate (b) + cron (c) triggers: fire a workflow from an FSM gate and a nightly cron
+21. W8.8 — First dogfood workflows: multi-axis PR review+verify and nightly codebase audit, + /process boundary doc
+
+## Top risks
+
+- agent_runs.py is the busiest hand-rolled emit surface with subtle per-window audit dedup (tracker_outage short-circuits subsequent picks in the hour) AND is touched by three workstreams: Phase 1 emit-site flips (:772/:1689/:4023/:4433/:4523), Phase 2 StateProjector (transition_ticket :2421), and Phase 5 autonomy gate (finish_agent_run). Keep the audit-row dedup in the caller, route only the actual emit, and sequence/rebase the StateProjector and autonomy-gate edits deliberately since they mutate overlapping transition paths.
+- Console teardown mis-tagging a headless-critical route as DUPLICATE breaks egress. dashboard_priorities.py is now PRE-TAGGED EXCLUDED (control-plane-adjacent: its WorkspaceProjectPriority model feeds project_state_sync, project_completion, and the Navigator picker tools.py:2402) — do NOT delete it. analytics_dora.py/dashboard.py may feed the daily_scheduler bundle summary; the verify-callers gate and the Phase-4 regression gate are load-bearing.
+- Self-spawn fork-bomb: if the 'ship' provider (Phase 5) or a workflow leaf (Phase 8) reuses a trigger_kind with the is_cascade project-lock carve-out (dispatcher.py:1072) or any cap exemption, the project_lock-leak / fork-bomb class reopens. Both the self-spawn recursion guard and the WorkflowDispatchGate must make every spawn a first-class counted entrant; tests must assert termination at depth 3, not just the happy path. Keep both behind hard-off flags until their guard lands in the same PR.
+- Autonomy 'high' loosening the code_review->auto_merge approval check is the highest-blast-radius change — a bug letting high also skip CI would autonomously merge red code. CI-green is pinned non-negotiable across all three profiles (the gate at agent_runs.py separates has_approval from the CI check, verified separable), and high requires a populated knowledge surface (audited downgrade) so high-autonomy never runs with broad rights and no guardrails. The control plane (cap/cascade/lease) is strictly off-limits to the dial — no exemption even for ElMundi.
+- Chat-edge regressing the STATUS-only transition invariant (thesis 2): a naive Linear-comment-inbound that re-fires a stage would turn comments into a control channel. Phase 7 Task 'comment round-trip' must call no transition()/state write (test-asserted) and must model the clarification path's restraint; the agent-vs-human author disambiguation must be bulletproof or the agent-comment->poller->Navigator->agent-comment feedback loop reopens. Telegram callbacks must be signed + single-use and the durable store must not pollute the Console Inbox.
+- Workflow runtime correlating async CI coding-leaf finishes back to in-memory state across replicas. Keep ALL runtime state in workflow_step_runs (DB), drive coding-leaf completion off the existing agent-runs/finish webhook + a reconcile tick rather than an in-process await; reasoning leaves stay synchronous in-process. A nightly workflow fan-out across many workspaces could stampede the dispatch cap — use a separate workflow:* prefix accounting (cap=1 like WORKSPACE_BUNDLE_CAP initially) so workflows cannot starve SDLC ticket dispatch.
+- Local executor accidentally inheriting run.mjs's finish/PR side effects (renderExitProtocol / push helpers). The trimmed-prompt refactor must land first and the new command must not import the push/PR/finish helpers at all; refactoring the shared renderPrompt risks regressing the load-bearing (b) dispatch path — guard with existing run.mjs prompt tests before/after. Local executor is default-off everywhere and only ever SUGGESTS escalation.
+
+## Open questions (attached to Phase 7/8 tickets)
+
+- Durable pending-action store shape (Phase 7): reuse inbox_items with type='chat_action' (founder-leaning, cheaper, but pollutes the Console Inbox surface and overloads the one real rebuilt tool) vs a dedicated telegram_pending_action table (clean isolation, one extra 0086+ migration). Recommend the dedicated table if Console-filter airtightness is doubtful.
+- For Linear-comment inbound (Phase 7): should the Navigator turn's reply be posted BACK as a Linear comment (visible loop-closure for the operator) or only delivered to the operator's notification channel? Posting back risks an agent-comment->poller->agent feedback loop unless author-exclusion is bulletproof; needs a founder call on whether the chat-edge reply is visible on the ticket.
+- Canonical Linear identity of 'the workspace agent' for author disambiguation — the PAT user, the OAuth app/bot actor, or both? The poller comments(first:20) GraphQL block needs the right field (user.isMe vs botActor) and the answer differs per how each workspace's Linear integration is provisioned.
+- Should Linear-comment inbound and Telegram inbound be unified behind one 'conversational inbound' abstraction now, or kept as two adapters? The shared piece is 'append a user turn to a Navigator thread, classify_shift=False, non-transitional'; consolidating early avoids drift but adds an abstraction before the second consumer is proven.
+- Telegram 64-byte callback_data budget (Phase 7): confirm the compact token format (opaque store-id + truncated HMAC) gives acceptable collision/forgery resistance, or whether the full nonce must live only in the durable store with the button carrying just the row id.
+- Workflow dispatch cap (Phase 8): should workflows get their OWN cap (SHIP_DEFAULT_WORKFLOW_DISPATCH_CAP) separate from both the SDLC ticket cap and WORKSPACE_BUNDLE_CAP, or reuse the bundle cap=1 accounting? Affects how much parallelism a single workflow can claim.
+- Where should reasoning leaves execute at scale (Phase 8) — in the backend API process (reuse _run_subagent_loop synchronously, simple but ties up a request worker) or dispatched to a CI runner like coding leaves? v1 assumes reasoning=in-process; high-fanout nightly audits may need to move them to the CI/dispatch path.
+- Is the /process editor expected to eventually REFERENCE workflows (a process stage whose action is 'run workflow X') as a sanctioned one-way integration point, or must the two stay fully decoupled? The thesis says complementary/no-merge; confirm whether a one-way 'process stage invokes workflow' edge is allowed.
+- Autonomy-dial interaction with workflows and the 'ship' self-spawn provider: control plane stays fixed across profiles, but workflow AUTHORING/INVOCATION rights (who can add .ship/workflows/* and fire them from chat) likely vary by profile — needs a policy decision. Recommend high-only/internal-dogfood for the ship provider and for chat-triggered workflow launches at launch.
+- Console.surface granularity: per-workspace (matches the autonomy dial) or per-user (operators keep full console for support, customers get residual)? And does the residual surface keep a minimal audit VIEW for oncall, or is shipctl/Linear activity sufficient?
+
+## Issues by phase
+
+### Phase 0 — Config-as-code spine + inventories
+
+#### [S] Inventory and tag every engine emit-site (notification seam audit)
+Produce the authoritative emit-site ledger the notification seam strangles. The 14 direct `InboxItem(` constructions in app code (verified via `rg -n 'InboxItem(' apps/backend/app --type py | grep -v test`) split into THREE buckets:
+
+(A) ENGINE HEADLESS EGRESS (in-scope, flip to notify): dispatcher.py:741 `_file_no_target_repo_letter`; agent_runs.py:772 (tracker_outage blocker, pick-tick), :1689 (orphan_skipped improvement), :4023 (code_review->auto_merge gate-fail blocker), :4433 (needs_clarification mirror), :4523 (blocked mirror); runs.py:572 (self_heal_failed blocker); sdlc_readiness.py:354 (SDLC setup improvement); knowledge_synth.py:384 + :550 (knowledge draft improvements).
+(B) SHARED PLUMBING (do NOT flip — becomes the Inbox channel impl): intake.py:303 `_build_inbox_item`; tools.py:2521 (agent-tool path).
+(C) CONSOLE-ONLY / OUT-OF-SCOPE (dies with the console strangler): dashboard.py:481, agent_runs.py:2572 (POST /inbox manual-create endpoint).
+
+Also tag the existing engine non-inbox Linear-comment egress as reference impls for LinearCommentChannel: inbox/action_executors.py operator-cancel comments, clarifications_sync.py `binding.gateway.comment`.
+
+Deliver a markdown table under documentation/internal/architecture/ with columns: file:line, current channel, bucket(A/B/C), level (info/action/blocker), dedup key today, target notify level. No code change.
+
+FOUNDER DEFAULTS: launch egress is inbox-only everywhere; every bucket-A target level is documented but routing stays inbox-only until a workspace opts in.
+
+Acceptance criteria:
+- Ledger lists all 14 InboxItem( app-code sites plus the engine Linear-comment sites, each tagged A/B/C with a one-line justification naming the caller (cron tick vs HTTP route handler).
+- Every bucket-A row has a proposed notify() level and the dedup key it uses today (e.g. dispatcher 'no-target-repo:<ticket>').
+- A reviewer can re-run the rg above and match every hit to a ledger row.
+
+Key files: documentation/internal/architecture/notification-seam-emit-sites.md, apps/backend/app/services/dispatcher.py, apps/backend/app/api/v1/routes/agent_runs.py, apps/backend/app/api/v1/routes/runs.py, apps/backend/app/services/sdlc_readiness.py, apps/backend/app/services/knowledge_synth.py, apps/backend/app/services/inbox/intake.py
+
+#### [M] Add console.surface + autonomy config scopes to config_registry
+Extend the per-workspace ConfigScope registry (apps/backend/app/services/config_registry.py — today agent.provider, agent.default_profile, catalog.sources) with (a) `console.surface` (enum full|residual|off) and (b) `autonomy.profile` (enum high|balanced|conservative, thesis 7). These ride the existing GET/PUT /v1/workspaces/{ws}/config/{scope} surface (routes/config.py) which already does JSONSchema validation + admin gate + audit — no new route. Mirror both keys into the v2 file schema validator (packages/cli/lib/config/schema.mjs: add `console` and `autonomy` to KNOWN_TOP_LEVEL_V2 + validators) so they round-trip through .ship/config.yml.
+
+This scope is the config spine three later phases consume (notification routing reads it indirectly; console kill-switch; autonomy dial). Adding it now without all consumers is inert but safe.
+
+FOUNDER DEFAULTS: autonomy.profile default resolves to 'balanced' for any workspace without an explicit value; 'high' is opt-in (set explicitly per workspace, including ElMundi). console.surface defaults to 'full'.
+
+Acceptance criteria:
+- GET /v1/workspaces/{ws}/config lists console.surface and autonomy.profile with JSONSchema + current value.
+- PUT rejects out-of-enum with the existing 422 invalid_value shape and writes an audit row.
+- validateConfig() in schema.mjs accepts `console:` and `autonomy:` blocks and rejects bad enums; existing config-validation unit tests green.
+- A workspace with no explicit value resolves autonomy.profile=balanced; ElMundi resolves high only when explicitly set.
+
+Key files: apps/backend/app/services/config_registry.py, packages/cli/lib/config/schema.mjs, apps/backend/app/api/v1/routes/config.py
+
+#### [M] Add per-workspace notification channel-routing config + global kill-switch
+*depends on:* Inventory and tag every engine emit-site (notification seam audit)
+
+Add the config surface notify()'s router reads, on the existing workspace.settings JSON column (tenancy.py Workspace.settings). Define a typed accessor `get_channel_routing(workspace) -> ChannelRouting` returning per-level channel lists with safe defaults INFO/ACTION/BLOCKER -> [inbox] (today's behavior: Inbox only, so the seam is a no-op until a workspace opts a level onto linear/email). Add a global kill-switch as a Settings field following the alias convention in core/config.py: `notification_channels_enabled: bool = Field(default=False, alias='SHIP_NOTIFY_CHANNELS')` — when False, notify() forces inbox-only regardless of per-ws config (instant global rollback). EmailChannel recipient lives at settings['notifications']['email_to'].
+
+FOUNDER DEFAULTS: ALL workspaces launch inbox-only (notification channels default OFF); Linear/email egress is OPT-IN per workspace. No workspace ships with external egress on by default. Email recipient = workspace.settings['notifications']['email_to']; fail-closed skip when absent (no guessing).
+
+Acceptance criteria:
+- get_channel_routing on empty settings returns inbox-only for all three levels.
+- SHIP_NOTIFY_CHANNELS unset/false makes the router return inbox-only even when a ws requests linear/email (test).
+- A ws settings requesting {INFO:[inbox], BLOCKER:[inbox,linear,email]} with the flag on yields exactly those lists.
+- Missing email_to yields a structured skip (not a guess); malformed settings fail closed to inbox-only with a logged warning, never raise. No DB migration (reuses settings JSON).
+
+Key files: apps/backend/app/services/notify_config.py, apps/backend/app/core/config.py, apps/backend/app/db/models/tenancy.py, apps/backend/tests/test_notify_config.py
+
+#### [L] Classify every console page + backend render route (pre-tag dashboard_priorities.py EXCLUDED)
+Produce the authoritative per-route ledger driving every console deletion. Walk apps/console/src/app (authed + public pages) and the console-serving backend routes, tagging each.
+
+DUPLICATE (delete — re-implements a Linear/GitHub view): analytics + analytics_dora.py + dashboard_live_system.py + dashboard.py render endpoints, audit render page (keep audit_log TABLE), deployments render page (NOT deploy.py engine), repos/[id] + repo_home.py, memory mirror, most of /r/[owner]/[repo].
+HEADLESS-CANDIDATE (keep behind the console flag — no headless equivalent yet): settings/config editor, process FSM editor, knowledge import wizard + knowledge_import_sources.py, telegram bind + telegram.py, api-keys, members + invites, onboarding/login/invite.
+RESIDUE: root dashboard->status, settings/danger, no-access, auth-error.
+EXCLUDED (do NOT classify for deletion): inbox page + inbox.py, agent_runs.py, runs.py public_router, all *_oauth.py/*_webhook.py/github_app.py, config.py.
+
+MUST-FIX — PRE-TAG dashboard_priorities.py EXCLUDED (control-plane-adjacent), NOT ambiguous/HEADLESS-CANDIDATE: its backing model WorkspaceProjectPriority is consumed by app/services/agent/project_state_sync.py (Backlog<->Todo projection), app/services/project_completion.py (sweep states), and app/services/agent/tools.py:2402 (Navigator picker/ordinal path). It MUST be retained.
+
+CRITICAL: grep each remaining candidate's callers across packages/cli + app/integrations/telegram + app/services BEFORE tagging; default ambiguous routes to HEADLESS-CANDIDATE. Check whether daily_scheduler reads analytics_dora.py/dashboard.py for its bundle summary (then HEADLESS-CANDIDATE).
+
+Acceptance criteria:
+- Every page.tsx and every router.include_router target carries exactly one tag.
+- Inbox store, agent_runs.py, runs.public_router, all oauth/webhook/github_app, config.py, AND dashboard_priorities.py tagged EXCLUDED with a reason.
+- Each DUPLICATE names the Linear/GitHub view it duplicates.
+- Ledger lists each route's frontend caller(s) so the deletion task can topo-sort.
+
+Key files: apps/console/src/app, apps/backend/app/api/v1/router.py, dashboard.py, dashboard_priorities.py, analytics_dora.py, repo_home.py
+
+#### [S] Add autonomy:{high|balanced|conservative} column to Workspace + migration 0086 (balanced backfill, pulled forward)
+MUST-FIX SEQUENCING: pulled FORWARD from Phase 5 to Phase 0 so the local executor gate (Phase 6) and the autonomy FSM gate (Phase 5) are not serialized behind the entire console teardown. This is a trivial S migration with no dependency on the console work.
+
+Per thesis 7, add the per-workspace autonomy profile. Add Workspace.autonomy (tenancy.py, alongside agent_provider at line 179 and max_concurrent_dispatches at line 185) as String(16) NOT NULL server_default 'balanced', with a CHECK constraint in ('high','balanced','conservative') in a NEW forward migration. HEAD is migration 0085 — this is 0086. This is the AGENT action-rights dial ONLY — it MUST NOT alter lease/cap/cascade/idempotency. Add resolve_autonomy_for_workspace(session, ws) -> Literal (extend agent_provider_resolver or a new module), default 'balanced'.
+
+FOUNDER DECISIONS (baked in): backfill ALL existing rows to 'balanced' (the beta target); default for new workspaces is 'balanced'; 'high' is OPT-IN everywhere — do NOT seed ElMundi to high in this migration; ElMundi (and any high workspace) is opted in explicitly later via config. The control plane is strictly off-limits to this dial: no cap/cascade/lease constant or table changes.
+
+Acceptance criteria:
+- Workspace.autonomy exists with CHECK in the three values + server_default 'balanced'.
+- Migration 0086 upgrades + downgrades cleanly; ALL existing rows backfill to 'balanced'.
+- Resolver returns the ws autonomy with 'balanced' as the safe default for legacy/unknown.
+- No change to any lock/cap/cascade constant or table; no row is seeded to 'high'.
+
+Key files: apps/backend/app/db/models/tenancy.py, apps/backend/migrations/versions/0086_workspace_autonomy.py, apps/backend/app/services/agent_provider_resolver.py
+
+### Phase 1 — Notification seam (reversible egress)
+
+#### [L] Define notify() interface + Inbox/Linear/email channel router
+*depends on:* Add per-workspace notification channel-routing config + global kill-switch, Inventory and tag every engine emit-site (notification seam audit)
+
+Create app/services/notify.py exposing `async def notify(session, *, workspace_id, ticket_ref, title, body, level, dedup_key=None, payload=None, repo_id=None) -> NotifyResult`. `level` in {INFO, ACTION, BLOCKER}. Resolve per-workspace ChannelRouting (from the config task), then fan out to channel adapters behind `class Channel(Protocol): async def emit(self, ctx) -> ChannelResult`. Ship THREE impls:
+1. InboxChannel — wraps the EXISTING intake._build_inbox_item (intake.py:303) so dedup/truncation/headline are identical to today (default for all levels). Map level->type (BLOCKER->'blocker', ACTION->'clarification', INFO->'improvement'); carry dedup_key into intake_handle.
+2. LinearCommentChannel — resolve tracker via the same resolve_for_workspace path action_executors.py uses, then gateway.comment(TicketRef, body=...) (tracker_adapter.py); structured skip (no-op) when ticket_ref is None.
+3. EmailChannel — recipient from settings['notifications']['email_to'] (fail-closed skip if absent, per founder decision), render via a new templates.render_notification_email, send via get_email_sender().send.
+
+All channels swallow transport errors into ChannelResult(ok=False, detail=...) — notify() NEVER raises into the engine control path. Returns aggregate per-channel results. Interface + impls only; no emit-site flipped here.
+
+Acceptance criteria:
+- notify(level=INFO, default routing) produces an InboxItem byte-identical (type/title/summary/headline/intake_handle/payload) to calling _build_inbox_item directly (parametrized test).
+- LinearCommentChannel posts via gateway.comment, ok=True; ticket_ref=None -> skip, posts nothing.
+- EmailChannel renders+sends through a RecordingEmailSender; absent email_to -> structured skip; a transport exception is caught -> ChannelResult(ok=False), no propagation.
+- A channel raising mid-fan-out does not stop the others; notify() never raises.
+
+Key files: apps/backend/app/services/notify.py, apps/backend/app/services/email/templates.py, apps/backend/tests/test_services_notify.py
+
+#### [M] Flip dispatcher + self-heal engine emit-sites onto notify()
+*depends on:* Define notify() interface + Inbox/Linear/email channel router
+
+Migrate the two lowest-risk pure-engine emit-sites, proving the seam end-to-end before the busier finish handler.
+1. dispatcher.py:741 `_file_no_target_repo_letter` — replace direct InboxItem( with notify(..., level=ACTION, dedup_key=f'no-target-repo:{ticket_ref}', payload=<existing>). InboxChannel must reproduce the 'skip if open item with same intake_handle exists' dedup so behavior is unchanged under inbox-only.
+2. runs.py:572 self_heal_failed — notify(..., level=BLOCKER, dedup based on existing source_table='self_heal_run'+source_id guard at runs.py:560-570). Keep the 'exists' dedup query in the caller OR move it into InboxChannel — pick one, be consistent. Support BOTH an intake_handle dedup_key AND a source_table/source_id dedup mode in InboxChannel.
+
+Launch egress stays inbox-only (default flag off), so both flips are observable no-ops until a workspace opts a level onto linear/email.
+
+Acceptance criteria:
+- Existing dispatcher + self-heal tests pass unchanged under inbox-only routing (same fields, same dedup, no dup row on re-tick).
+- With BLOCKER routing including linear+email, a self-heal failure additionally posts a Linear comment and sends one email.
+- No InboxItem( remains at dispatcher.py:741 or runs.py:572 (grep clean).
+
+Key files: apps/backend/app/services/dispatcher.py, apps/backend/app/api/v1/routes/runs.py, apps/backend/tests/test_services_dispatcher.py, apps/backend/tests/test_routes_runs.py
+
+#### [L] Flip agent_runs finish + pick-tick engine emit-sites onto notify()
+*depends on:* Flip dispatcher + self-heal engine emit-sites onto notify()
+
+Migrate the five engine-side InboxItem( sites in agent_runs.py (finish handler + pick-tick handler, both engine egress): :772 tracker_outage blocker (BLOCKER, dedup by existing same-window audit guard), :1689 orphan_skipped (INFO), :4023 code_review->auto_merge gate-fail (BLOCKER), :4433 needs_clarification mirror (ACTION — preserve the _try_ticket_snapshot enrichment via payload/body), :4523 blocked mirror (BLOCKER). DO NOT touch :2572 (POST manual inbox-create endpoint, bucket C).
+
+Keep the per-window audit-row dedup checks in the CALLER (e.g. tracker_outage short-circuits subsequent picks in the hour); route only the actual emit through notify(). Thread ticket_ref so LinearCommentChannel can target the clarification/blocked mirrors when a workspace opts in.
+
+COORDINATION NOTE: this file is also edited by the Phase-5 autonomy gate (finish_agent_run) and the Phase-2 StateProjector (transition_ticket :2421); hold the dedup-in-caller discipline and rebase deliberately.
+
+Acceptance criteria:
+- All five sites construct via notify(); :2572 untouched.
+- Existing finish-handler + pick-tick tests pass unchanged under inbox-only (same rows, same dedup).
+- needs_clarification carries the ticket snapshot in body/payload exactly as today.
+- With ACTION/BLOCKER routing including linear, clarification + blocked additionally post a Linear comment on the correct ticket.
+
+Key files: apps/backend/app/api/v1/routes/agent_runs.py, apps/backend/tests/test_v1_agent_runs.py
+
+#### [M] Flip sdlc_readiness + knowledge_synth service emit-sites onto notify()
+*depends on:* Define notify() interface + Inbox/Linear/email channel router
+
+Migrate the remaining engine-side service emit-sites: sdlc_readiness.py:354 (SDLC-setup improvement letter, INFO/ACTION) and knowledge_synth.py:384 + :550 (knowledge draft publish-vs-archive improvements, ACTION). These run under cron (cron_jobs._knowledge_synth_tick), clean headless-egress candidates. Thread the existing derive_headline output through notify()/InboxChannel. Keep type='improvement' for both knowledge drafts so the downstream action_executors/side_effects resolver still matches.
+
+Acceptance criteria:
+- Both services emit via notify(); no InboxItem( at the three sites (grep clean).
+- Existing sdlc_readiness + knowledge_synth tests pass under inbox-only with identical rows (including headline).
+- The side-effect resolver still finds the knowledge-draft rows (asserted).
+
+Key files: apps/backend/app/services/sdlc_readiness.py, apps/backend/app/services/knowledge_synth.py, apps/backend/tests/test_services_sdlc_readiness.py, apps/backend/tests/test_services_knowledge_synth.py
+
+#### [M] Wire notify() audit logging + sandbox email-transport check + rollback runbook
+*depends on:* Flip agent_runs finish + pick-tick engine emit-sites onto notify(), Flip sdlc_readiness + knowledge_synth service emit-sites onto notify()
+
+Make the seam observable, reversible, and proven against a real transport. (1) Record every notify() invocation + per-channel ChannelResult to the existing audit_log with action='notify.emit', target_kind='notification', so an operator sees which channels fired/failed. Make the audit write best-effort (catch+log) so a failed audit insert never rolls back the emit — consistent with the existing 'audit failure must not sink the response' pattern in agent_runs.py. (2) SHOULD-FIX: exercise a REAL (sandbox) email send end-to-end at least once — do NOT rely solely on RecordingEmailSender; the bootstrap-intelligence memory note ('harvest never runs in prod') is a reminder that an assumed-wired prod transport can silently fail-closed, so BLOCKER->email for an opted-in workspace must be proven against the actual get_email_sender().send path in a sandbox profile. (3) Document the rollback: SHIP_NOTIFY_CHANNELS=false forces inbox-only globally (instant kill, zero code), and per-workspace settings can dial a single level back to inbox-only. (4) Write the operator runbook under documentation/internal/operations/.
+
+Acceptance criteria:
+- Each notify() call writes one audit_log row capturing level, requested channels, per-channel ok/skip/fail.
+- A sandbox-profile test (or documented manual smoke) sends one real email through get_email_sender().send and asserts delivery, not just a recording.
+- SHIP_NOTIFY_CHANNELS=false demonstrably suppresses all linear+email emits in a test while inbox still works.
+- Runbook documents enable steps, the verification audit query, the sandbox email smoke, and both rollback levers.
+
+Key files: apps/backend/app/services/notify.py, documentation/internal/operations/notification-seam-runbook.md, apps/backend/tests/test_services_notify.py
+
+### Phase 2 — Control-plane guardrail + health residue
+
+#### [M] Audit + guard test: prove no control state is read from Linear labels/status
+Pin thesis-2's invariant. Inventory every place Ship READS Linear state for a control decision and classify legitimate (domain lifecycle) vs illegitimate (control masquerading as a label).
+
+Legitimate today: tracker_poller._poll_installation reads issue state + stage:* labels to emit a transition event — the STATUS field as sole transition trigger is settled-correct (tracker_fsm.py:277).
+Confirm the four control primitives are Postgres-only: AgentDispatchLock INSERT ON CONFLICT lease (agent_dispatch.py + dispatcher.acquire_lock dispatcher.py:235), two-level ticket:/project: lock (dispatcher.py:808/:1072), cascade budget via audit_log COUNT (_count_recent_dispatches, CASCADE_LIMIT=3 at dispatcher.py:148), per-ws cap via count_active_locks (dispatcher.py:466).
+Scrutinize freeze-overlay labels (OVERLAY_FREEZE_LABEL_PREFIXES) and stage:*/planning:anchor breadcrumbs — assert these gate PICKUP (domain), not LEASE/CAP (control).
+
+Land a guard test that greps the lock-primitive CALL SITES' arguments and fails if acquire_lock/count_active_locks/_count_recent_dispatches gain a Linear label/status input.
+
+Acceptance criteria:
+- Doc enumerates every Linear-read in the control path with file:line, labeled domain vs control.
+- Confirmed: lease, two-level lock, cascade budget, per-ws cap, idempotency all resolve solely against Postgres, zero Linear reads.
+- Guard test fails if a lock primitive gains a Linear input.
+- Each at-risk label classified pickup-gating (domain) or flagged as a violation.
+
+Key files: apps/backend/app/services/dispatcher.py, apps/backend/app/services/tracker_poller.py, apps/backend/app/db/models/agent_dispatch.py, apps/backend/tests/services/test_control_plane_invariant.py, documentation/internal/architecture/control-plane-vs-readmodel.md
+
+#### [M] Unify TRACKER_MAPPING_HINTS runtime consumer + the two hardcoded maps into one egress-only source of truth
+*depends on:* Audit + guard test: prove no control state is read from Linear labels/status
+
+MUST-FIX — CORRECTED PREMISE: TRACKER_MAPPING_HINTS (tracker_fsm.py:154) is NOT doc-only. It IS consulted at runtime at tracker_fsm.py:287 (`mapping = TRACKER_MAPPING_HINTS.get(normalised or '')`) inside the seed-render code path. Do NOT 'promote' it from doc-only; instead UNIFY the existing runtime consumer with the two hardcoded maps so there is one egress-only source of truth, not three.
+
+Make the table (or a typed sibling per tracker_kind) the single declarative WRITE map the projection layer uses to pick which native Linear/GitHub status to write for a given FSM state. Add a module docstring + assertion that it is consumed only on the egress (Ship->tracker) path and NEVER inverted to parse native status back into FSM state for a control decision. Reconcile the existing hardcoded mappings in linear tracker_adapter._fsm_to_linear_state (tracker_adapter.py:695) and project_state_sync._TRANSITION_PLAN against this table.
+
+Acceptance criteria:
+- The table is the single source consumed by the existing tracker_fsm.py:287 path AND the linear projection path.
+- tracker_adapter._fsm_to_linear_state and project_state_sync._TRANSITION_PLAN derive from the shared table.
+- Module docstring + test assert egress-only (no path inverts it to a lock/cap/cascade decision).
+- A per-state equivalence test confirms the unified table targets the same native states as before (guard against drift between display strings and live state IDs).
+
+Key files: apps/backend/app/services/tracker_fsm.py, apps/backend/app/integrations/linear/tracker_adapter.py, apps/backend/app/services/agent/project_state_sync.py, apps/backend/tests/services/test_tracker_fsm.py
+
+#### [L] Consolidate FSM->tracker status writes into one write-only StateProjector (flagged)
+*depends on:* Unify TRACKER_MAPPING_HINTS runtime consumer + the two hardcoded maps into one egress-only source of truth
+
+Today FSM state projects onto Linear from >=3 scattered sites: tracker_adapter.transition() (workflow-state move + stage: breadcrumb), project_state_sync.sync_project_tickets_for_state (Backlog<->Todo), and agent_runs.transition_ticket route (agent_runs.py:2421). Introduce a single StateProjector seam (app/services/state_projector.py) all FSM->tracker projections funnel through, parameterised by the shared table from the prior task.
+
+Constraint (thesis 2): ONE-DIRECTIONAL — writes the human read-model and returns success/failure, output NEVER consumed as control input; the stage:* breadcrumb stays the poller's pickup hint (domain), not a lease. Projection is best-effort + idempotent and decoupled from lock acquisition — a tracker 5xx must not release/acquire any Postgres lock. Strangler-fig behind SHIP_STATE_PROJECTOR_UNIFIED. Keep the human-only 'Done' authorization gate at the route layer, NOT in the projector.
+
+COORDINATION NOTE: agent_runs.py:2421 is also touched by the Phase-1 emit-flips and the Phase-5 autonomy gate; sequence/rebase deliberately.
+
+Acceptance criteria:
+- All FSM->tracker status/label writes route through StateProjector when the flag is on; flag-off path byte-identical to today.
+- Test asserts StateProjector never calls acquire_lock/release_lock/count_active_locks and its return is not consumed by a control decision.
+- Simulated tracker 5xx returns an errored report and provably does not mutate agent_dispatch_locks.
+- Re-projecting an already-projected state is idempotent (no dup labels, no churn).
+
+Key files: apps/backend/app/services/state_projector.py, apps/backend/app/integrations/linear/tracker_adapter.py, apps/backend/app/services/agent/project_state_sync.py, apps/backend/app/api/v1/routes/agent_runs.py, apps/backend/app/core/config.py, apps/backend/tests/services/test_state_projector.py
+
+#### [M] Add control-plane health/stall residue surface (is-alive / where-stuck)
+*depends on:* Audit + guard test: prove no control state is read from Linear labels/status
+
+Phase 2 of the rearchitecture deleted both self-heal crons + the scan_eligible_tickets backstop + runner-fail detectors. Net: the only health surface is /v1/health (DB ping only) — a stalled FSM goes silent. Per thesis 2 this is the ONE piece of state with no external home, so it lives in Ship. Build a READ-ONLY surface deriving stall/liveness purely from existing Postgres control state (no new authoritative store):
+(a) leases past expires_at but not swept (agent_dispatch_locks -> sweeper not running);
+(b) tickets with a project:/ticket: lock held > N minutes with no recent audit_log dispatch row (stuck-in-flight);
+(c) last successful dispatch timestamp per workspace (audit_log action='agent_run.dispatch');
+(d) reprovision drift count.
+Expose GET /v1/workspaces/{ws}/engine-health returning StalledTicket[] + EngineLiveness. Read-only; computes on request; never dispatches or mutates locks. Thresholds config-driven, start conservative (avoid re-creating the deleted cron's false positives).
+
+Acceptance criteria:
+- Endpoint returns liveness (last-dispatch ts, expired-but-unswept lock count) + stuck tickets with lock-key, age, stall reason.
+- All values from agent_dispatch_locks + audit_log only; endpoint mutates zero rows (asserted).
+- A ticket holding a project: lock > threshold with no audit dispatch in window is reported with reason 'lock_held_no_progress'.
+- Read-only and authorised per-workspace like other /v1/workspaces routes.
+
+Key files: apps/backend/app/api/v1/routes/engine_health.py, apps/backend/app/services/engine_health.py, apps/backend/app/api/v1/schemas.py, apps/backend/tests/api/test_engine_health.py
+
+#### [M] Stall-notification: emit engine-stalled signal through the notify() seam
+*depends on:* Add control-plane health/stall residue surface (is-alive / where-stuck), Wire notify() audit logging + sandbox email-transport check + rollback runbook
+
+Close the silent-failure gap: when engine_health detects a stalled ticket or dead engine (no dispatch > threshold, or sweeper not running), emit a structured failure SIGNAL through the Phase-1 notify() seam (level=BLOCKER) — do NOT build a new transport. The engine_health task defines the stall payload (workspace, ticket_ref, lock_key, age, reason); notify() handles channels. Drive from a lightweight scheduled check (reuse daily_scheduler / cron surface, NOT a resurrected self-heal cron that mutates state) that calls engine_health and forwards anything stuck past threshold, behind SHIP_STALL_NOTIFY (default off).
+
+Idempotency: never re-notify the same (ticket_ref, reason) within a cooldown window — dedupe via audit_log action='engine.stall_notified' (cascade-count pattern). The notification is context-only: MUST NOT move ticket status or touch a lock.
+
+Acceptance criteria:
+- The scheduled check forwards stuck tickets from engine_health to notify() behind SHIP_STALL_NOTIFY.
+- Re-running does not re-notify the same (ticket_ref, reason) inside the cooldown (deduped via audit_log); scheduler interval >= cooldown.
+- The notifier provably never calls transition/acquire_lock/release_lock (test).
+- Payload schema matches the notify() interface so it swaps cleanly.
+
+Key files: apps/backend/app/services/engine_health.py, apps/backend/app/services/stall_notifier.py, apps/backend/app/services/daily_scheduler.py, apps/backend/app/core/config.py, apps/backend/tests/services/test_stall_notifier.py
+
+### Phase 3 — Scheduled ticket-creating routines (trigger c)
+
+#### [S] Add open-ticket idempotency guard for scheduled-routine ticket creation
+The 'don't dup an open one' requirement. Before creating a routine ticket, check whether a ticket for the same (workspace, routine_kind, period) already exists and skip if so. Implement via the audit_log-as-ledger pattern the codebase already uses for cascade depth: write a `scheduled_routine.ticket_created` audit row carrying {routine_kind, period_key, ticket_ref} on creation, and gate creation on a COUNT of that action for the current period_key being zero. This avoids a tracker round-trip per tick and survives leader failover (audit_log is durable). period_key derived from cadence (UTC date for daily, ISO week for weekly).
+
+Acceptance criteria:
+- Two ticks within the same period_key create at most one ticket (second logs a skip).
+- The guard reads from audit_log (durable), holds across replica/leader failover.
+- A new period creates a fresh ticket — covered by a unit test against a mocked audit_log.
+- period_key granularity asserted to match the registered cron_expr cadence.
+
+Key files: apps/backend/app/services/scheduled_routines.py, apps/backend/tests/services/test_scheduled_routines.py
+
+#### [M] Add ticket-creating scheduled-routine mechanism (cron -> Linear ticket in FSM stage)
+*depends on:* Add open-ticket idempotency guard for scheduled-routine ticket creation
+
+Net-new (c) flavor. Today daily_scheduler.py only fires WORKSPACE-SCOPE bundles (maybe_dispatch_workspace_bundle, no ticket). Add a second shape that CREATES a Linear ticket in a target FSM stage so the already-shipped ticket->tracker_poller->dispatcher->run.mjs path executes it. Build services/scheduled_routines.py with a registry of specs {kind, cron_expr, target_fsm_stage, title_template, body_template, dedup_key}. Each tick: for every workspace with a ready Linear install (reuse the NativeIntegrationInstallation query from daily_scheduler, provider=='linear', status=='ready'), call the tracker create_ticket adapter (same path _tool_ticket_create uses) to open one ticket in target_fsm_stage. Wire ticks via register_cron + cron_with_lock with NEW CronLockId entries.
+
+GROUNDING NOTE: CronLockId max in use is now 1024 (DEPLOYMENTS_RECONCILE) — reserve fresh ids from 1025+ (do NOT reuse any retired number). register via a register_all delegated like daily_scheduler.register_all.
+
+FOUNDER DEFAULT: egress-off / disabled workspaces are skipped fail-closed.
+
+Acceptance criteria:
+- A new CronLockId reserved per routine kind (from 1025+, no number reuse).
+- On tick, exactly one Linear ticket created per eligible workspace in the configured target_fsm_stage (gated by the idempotency guard).
+- The ticket is picked up by the existing tracker_poller->dispatcher path with no new dispatch code.
+- Per-workspace failures isolated (one bad install does not abort the tick), matching daily_scheduler's try/except-per-install.
+
+Key files: apps/backend/app/services/scheduled_routines.py, apps/backend/app/services/cron.py, apps/backend/app/services/cron_jobs.py, apps/backend/app/services/daily_scheduler.py
+
+#### [S] Document scheduled-routine title/body templates in agent_roles
+*depends on:* Add ticket-creating scheduled-routine mechanism (cron -> Linear ticket in FSM stage)
+
+The new ticket-creating routines are the INVERSE of workspace-scope bundles: the cron creates a ticket and the NORMAL SDLC stage agents (intake/BA/dev) process it — so they need no new bundle role. What is net-new is the title/body TEMPLATE the cron writes so the downstream stage agent gets a well-shaped, self-contained brief. Add templates as data in scheduled_routines.py and a short doc block (or a thin agent_roles/*.md if a routine wants a custom downstream prompt) per routine kind (daily/retro/techdebt), its target stage, and body template. Mirror the 'use Ship's API, never reach into Linear via MCP' guardrail from daily-digest.md.
+
+Acceptance criteria:
+- Each routine kind has a title_template + body_template rendering a self-contained brief (no reliance on the cron run's transient context).
+- Templates do not instruct the downstream agent to bypass the FSM (no direct merge / no skipping stages).
+- A routine declaring a custom role resolves via the existing GET /agent-roles/{slug}/resolve path with no new resolution code.
+
+Key files: apps/backend/app/services/scheduled_routines.py, apps/backend/app/resources/agent_roles/scheduled-routine-techdebt.md
+
+### Phase 4 — Console strangler / teardown
+
+#### [M] Add SHIP_CONSOLE_MODE per-workspace flag gating the authed shell (Inbox reachable in every mode)
+*depends on:* Add console.surface + autonomy config scopes to config_registry, Classify every console page + backend render route (pre-tag dashboard_priorities.py EXCLUDED)
+
+Console-wide kill switch so the whole authed surface can go dark per-workspace without deleting code yet (strangler step 0, fully reversible). Today (authed)/layout.tsx only checks isApiConfigured() + session. Add a `console_mode` resolution (env default SHIP_CONSOLE_MODE=full|residual|off plus a per-workspace override from the console.surface config scope) consumed in the authed layout and app-shell.tsx NAV array. In `residual`: render only Dashboard(status) + Settings + Inbox, 302 every other authed path to a residual status page. Flag lives in config-as-code, not a Linear label.
+
+MUST-FIX (don't orphan operator approvals): the Inbox approval surface (actor-sensitive approvals live in the Inbox UI, thesis 4) MUST stay reachable in EVERY mode. In `off` mode, do NOT 302 the whole authed tree blindly — keep the Inbox route (and its approval items) reachable, OR explicitly document that 'off' is ElMundi-only (high autonomy, no operator approvals expected) and assert no workspace with pending approval items can be set to 'off'. Default to keeping Inbox reachable.
+
+Acceptance criteria:
+- SHIP_CONSOLE_MODE=off serves the residual health page for non-Inbox authed routes but the Inbox approval surface remains reachable and functional, 200 on status, no crashes.
+- SHIP_CONSOLE_MODE=full preserves today's behavior byte-for-byte (snapshot/e2e nav test green).
+- Per-workspace override beats the env default, read via console.surface scope.
+- A test asserts a pending operator approval is reachable under residual AND off modes.
+
+Key files: apps/console/src/app/(authed)/layout.tsx, apps/console/src/components/app-shell.tsx, apps/console/src/lib/api/client.ts
+
+#### [M] Migrate settings/general + workspace + agent settings to config-as-code keys
+*depends on:* Add console.surface + autonomy config scopes to config_registry
+
+Route every truly-declarative mutable knob through the config scope PUT instead of bespoke BFF endpoints. agent default/provider -> keep on agent.provider scope; registries/catalog -> catalog.sources scope; add the autonomy.profile + console.surface controls to the Config tab UI driven off the auto-rendered scope form (config.py GET returns JSONSchema so the renderer needs no per-key code). Retire apps/console/src/app/api/settings/{default-agent,config}/route.ts in favor of /api/proxy/v1/.../config. The Config tab becomes the single settings surface; general/workspaces collapse to read-only identity + the scope form.
+
+SCOPE LIMIT: agent_roles, members/invites, repo_secrets, telegram bind are NOT pure config (GitHub installs/secrets/OAuth side effects) — they stay as dedicated routes. This task touches only declarative knobs.
+
+Acceptance criteria:
+- Every settings write previously hitting /api/settings/* now goes through GET/PUT /v1/workspaces/{ws}/config/{scope}.
+- The Config tab auto-renders autonomy.profile + console.surface + agent.provider + catalog.sources from JSONSchema with no per-scope FE code.
+- Deleted /api/settings/* BFF routes have no remaining importers (grep clean).
+- Settings e2e (save agent provider, save autonomy) green.
+
+Key files: apps/console/src/app/(authed)/settings/_shell/settings-shell.tsx, apps/console/src/app/api/settings/default-agent/route.ts, apps/console/src/app/api/settings/config/route.ts, apps/console/src/app/(authed)/settings/config/page.tsx
+
+#### [M] Delete DUPLICATE analytics + dashboard render pages and their BFF proxies
+*depends on:* Classify every console page + backend render route (pre-tag dashboard_priorities.py EXCLUDED), Add SHIP_CONSOLE_MODE per-workspace flag gating the authed shell (Inbox reachable in every mode)
+
+First leaf-level deletion wave, gated behind the console.surface flag. Remove apps/console/src/app/(authed)/analytics/page.tsx, the (authed)/audit render page (keep audit_log table + audit.py write/ingest), the (authed)/deployments render page (NOT deploy.py engine), and their apps/console/src/app/api/dashboard/* + api/* proxy routes — all tagged DUPLICATE in the ledger (Linear cycles/insights + GitHub Insights already render velocity/DORA). Delete pages first, then the BFF proxies they called, leaving backend render endpoints orphaned for the next wave. The e2e suite is the net for cross-page imports.
+
+Acceptance criteria:
+- Deleted pages 404 (or redirect via residual mode) and are removed from app-shell NAV.
+- No remaining import of the deleted BFF proxy modules in apps/console (grep clean).
+- Full build + typecheck + Playwright suite green.
+- audit_log table + audit.py ingest untouched; deploy.py (deployment ENGINE) untouched — only the deployments render PAGE removed.
+
+Key files: apps/console/src/app/(authed)/analytics/page.tsx, apps/console/src/app/(authed)/audit/page.tsx, apps/console/src/app/api/dashboard, apps/console/src/app/(authed)/deployments/page.tsx
+
+#### [M] Delete orphaned dashboard/analytics/repo_home backend render routes (retain dashboard_priorities.py)
+*depends on:* Delete DUPLICATE analytics + dashboard render pages and their BFF proxies
+
+Second wave: now the FE pages + BFF proxies are gone, remove the orphaned console-only render endpoints from apps/backend/app/api/v1/router.py and their modules — dashboard.py, dashboard_live_system.py, analytics_dora.py, repo_home.py — ONLY routes with zero non-console callers per the ledger. Re-run the caller grep across packages/cli, app/integrations/telegram, app/services FIRST; any endpoint a routine or the bot consumes downgrades to HEADLESS-CANDIDATE and is kept. Delete include_router lines + modules together so the route table shrinks atomically.
+
+MUST-FIX: dashboard_priorities.py is PRE-TAGGED EXCLUDED (control-plane-adjacent) — its WorkspaceProjectPriority model feeds project_state_sync, project_completion, and the Navigator picker (tools.py:2402). It MUST be retained; do NOT delete its module or routes in this wave.
+
+Acceptance criteria:
+- Removed modules have no importer in apps/backend, packages/cli, or app/integrations (grep clean).
+- dashboard_priorities.py retained and asserted still imported by project_state_sync/project_completion/tools.py.
+- router.py include_router lines for deleted modules removed; app boots + OpenAPI regenerates.
+- Backend test suite green; no route referenced by agent_runs.py/runs.py/webhooks removed.
+
+Key files: apps/backend/app/api/v1/router.py, apps/backend/app/api/v1/routes/dashboard.py, dashboard_live_system.py, analytics_dora.py, repo_home.py
+
+#### [M] Collapse root dashboard + repo pages to the residual status surface
+*depends on:* Delete orphaned dashboard/analytics/repo_home backend render routes (retain dashboard_priorities.py), Migrate settings/general + workspace + agent settings to config-as-code keys
+
+Define the irreducible RESIDUE: a single authed status page (replacing the rich page.tsx WorkspaceHome + /r/[owner]/[repo] repo dashboards) showing only (a) is-Ship-connected/healthy, (b) deep links to Linear project + GitHub repo (not mirrors), (c) the Inbox + Settings/Config (kept), (d) autonomy.profile + console.surface current values. This is the headless end-state of the frontend: a thin control-panel + deep-link launcher, all domain views living in Linear/GitHub. Keep login/onboarding/invite/no-access/auth-error as-is. Remove heavy data-fetching imports (getOpsDashboard, getPriorities, getLiveSystem) from page.tsx once their endpoints are gone.
+
+Acceptance criteria:
+- Root authed page renders status + deep links + Inbox/Settings links only, no mirrored ticket/PR/CI tables.
+- page.tsx no longer imports getOpsDashboard/getPriorities/getLiveSystem (those clients deletable).
+- Inbox, Settings/Config, login/onboarding/invite unchanged and green.
+- app-shell NAV reduced to the residual set in residual mode; deep links resolve the correct Linear project per workspace.
+
+Key files: apps/console/src/app/page.tsx, apps/console/src/components/workspace-home.tsx, apps/console/src/app/r/[owner]/[repo]/page.tsx, apps/console/src/components/app-shell.tsx
+
+#### [M] Strangler regression gate: headless egress + Inbox + CLI boundary survive teardown
+*depends on:* Delete orphaned dashboard/analytics/repo_home backend render routes (retain dashboard_priorities.py), Collapse root dashboard + repo pages to the residual status surface
+
+Final safety task: explicit e2e proving nothing in the EXCLUDED set regressed. Prove: (1) ticket->tracker_poller->dispatcher->run.mjs still completes (agent_runs.py + runs.py untouched); (2) GitHub install + Linear webhook ingress still land (github_app.py / linear_webhook.py / *_oauth.py untouched); (3) the Inbox store reads/writes (inbox.py + tables untouched) AND the Inbox approval surface is reachable under residual + off console modes; (4) config.py GET/PUT round-trips the new scopes; (5) the Telegram bot's Navigator /chat/stream proxy still works; (6) dashboard_priorities.py + its model retained.
+
+Acceptance criteria:
+- Dispatch e2e (ticket -> run -> PR) green post-teardown.
+- Install + webhook + OAuth callback e2e green.
+- Inbox CRUD e2e green; Inbox approval reachable in residual + off; no inbox table dropped in any migration from this phase.
+- config scope GET/PUT e2e green; Telegram /chat/stream proxy smoke green.
+- OpenAPI diff shows ONLY console-render routes removed, zero EXCLUDED routes removed (dashboard_priorities.py present).
+
+Key files: apps/backend/app/api/v1/routes/agent_runs.py, apps/backend/app/api/v1/routes/runs.py, apps/backend/app/api/v1/routes/inbox.py, apps/backend/app/api/v1/routes/github_app.py
+
+### Phase 5 — Superstructure: adapters, self-spawn, autonomy dial
+
+#### [M] Add 'ship' self-spawn provider adapter + wire into runAgent behind a flag
+Create packages/cli/lib/agents/ship.mjs mirroring codex.mjs's ~30-LOC shape (spawn a CLI in workdir, return {agentId, branchName, status, exitCode}). Instead of 'codex exec' it invokes shipctl run nested on the same checkout — dogfood/debug the spawn+control loop in isolation (thesis 6). It bottoms out spawning the workspace's real provider (claude/cursor/codex) — does NOT duplicate the coding agent. Same guard pattern as codex.mjs (validate branchName + prompt; require env shipctl run needs, e.g. SHIP_API_TOKEN). Keep onLog + stdio convention identical.
+
+Register runShipAgent in agents/index.mjs RUNTIMES (today cursor/codex/claude). Gate it: runAgent rejects provider==='ship' unless SHIP_ALLOW_SELF_SPAWN=true or opts.allowSelfSpawn, so a misconfigured ws can never silently fork-bomb. Add 'ship' to agent_provider_resolver AgentProviderKind + the allowed set, AND a NEW forward migration (next free after 0086, i.e. 0087) extending 0063's CHECK constraint ck_workspaces_agent_provider_enum from (cursor,codex,claude) to include 'ship' (do NOT edit 0063 — already applied; downgrade restores the 3-value set). Update the index.mjs + run.mjs docblocks.
+
+FOUNDER DEFAULT: the ship provider is internal/dogfood-gated and NOT selectable by default customer workspaces.
+
+Acceptance criteria:
+- ship.mjs exports runShipAgent({workdir,branchName,prompt,env,onLog}) with the exact return shape as codex.mjs; spawns shipctl run (verified by argv in a unit test); throws on missing branchName/prompt; <= ~40 LOC ex-docblock.
+- runAgent('ship', ...) throws unless SHIP_ALLOW_SELF_SPAWN/allowSelfSpawn set.
+- New migration 0087 replaces the CHECK to allow 'ship', downgrades cleanly to the 3-value set.
+- Existing cursor/codex/claude resolution unaffected (regression green).
+
+Key files: packages/cli/lib/agents/ship.mjs, packages/cli/lib/agents/index.mjs, apps/backend/app/services/agent_provider_resolver.py, apps/backend/migrations/versions/0087_workspace_agent_provider_ship.py, packages/cli/lib/commands/run.mjs
+
+#### [M] Force self-spawn recursion THROUGH cascade-depth + per-ws cap (recursion guard)
+*depends on:* Add 'ship' self-spawn provider adapter + wire into runAgent behind a flag
+
+Per thesis 6, recursion MUST pass through existing controls, not around them. maybe_dispatch (dispatcher.py) applies the cascade guard via _count_recent_dispatches against CASCADE_LIMIT=3 (dispatcher.py:148/:855) and the per-ws cap via active>cap (dispatcher.py:917). A nested shipctl run that triggers a dispatch must be counted the SAME as any other. Add an explicit trigger_kind 'self_spawn' that is NOT in the is_cascade carve-out (dispatcher.py:1072 — is_cascade bypasses the project lock; self-spawn must NOT get that bypass) and NOT in any cap exemption.
+
+FOUNDER DECISION: the control plane is strictly off-limits to the autonomy dial — self_spawn gets no cap/cascade exemption under ANY profile, even ElMundi/high.
+
+Acceptance criteria:
+- trigger_kind='self_spawn' increments the same _count_recent_dispatches counter and is refused with CASCADE_BLOCKED at recent>=CASCADE_LIMIT.
+- self_spawn dispatches count against the per-ws cap (active>cap -> CAP_EXCEEDED), no exemption.
+- self_spawn excluded from the is_cascade project-lock bypass at dispatcher.py:1072 (acquires/respects project: lock like a fresh entrant).
+- Test proves a 4-deep self-spawn loop terminates via CASCADE_BLOCKED, not infinitely; the same test passes regardless of autonomy profile.
+
+Key files: apps/backend/app/services/dispatcher.py, apps/backend/app/db/models/agent_dispatch.py, apps/backend/tests/test_services_dispatcher.py
+
+#### [M] Map autonomy profile to the code_review->auto_merge FSM gate (CI-green non-negotiable)
+*depends on:* Add autonomy:{high|balanced|conservative} column to Workspace + migration 0086 (balanced backfill, pulled forward)
+
+Per thesis 7 the dial lives partly at the FSM gate. The Phase-4 server gate _validate_code_review_to_auto_merge (agent_runs.py, commit 776def6a) requires >=1 APPROVED GitHub review AND all checks green before allowing code_review->auto_merge; on failure forces outcome=blocked. Make the APPROVAL requirement autonomy-sensitive while keeping CI-green NON-NEGOTIABLE at every level: conservative = require human APPROVED review + CI green (today); balanced = require CI green + reviewer-bundle verdict, allow agent self-approval at FSM level (no human click) + CI green; high = require CI green only (skip the human-approval check, trust the reviewer bundle + auto-merger gate). Read the ws autonomy (resolve_autonomy_for_workspace) in finish_agent_run before invoking the gate; record the active profile in the transition.validation_failed / advance audit payload.
+
+FOUNDER DECISION: CI-green stays non-negotiable in ALL profiles; the control plane is off-limits to the dial (this gate loosens approval action-rights only, never cap/cascade/lease). high is opt-in.
+
+Acceptance criteria:
+- conservative: code_review->auto_merge still blocked without an APPROVED review (unchanged from 776def6a).
+- high: allowed with CI green even without a human APPROVED review.
+- ALL profiles still block when any completed check_run is not in {success,skipped,neutral} — CI-green never loosens.
+- The audit payload records which autonomy profile evaluated the gate.
+
+Key files: apps/backend/app/api/v1/routes/agent_runs.py, apps/backend/tests/test_v1_agent_runs_finish.py
+
+#### [M] Inject autonomy profile into agent-role prompts + auto-merger via policy preamble (high requires knowledge)
+*depends on:* Add autonomy:{high|balanced|conservative} column to Workspace + migration 0086 (balanced backfill, pulled forward)
+
+Per thesis 7 the dial also lives at the agent-role-prompt + auto-merger layer; per thesis 5 ALL value enters through the prompt/context, never tool-native config. Render a per-profile autonomy preamble through the SAME centralised path as policies (policies.py render_policies_preamble — already byte-identical across Navigator chat and shipctl run). Action-rights blocks: high = skip optional approvals, broader edits, self-pick work, create tickets/decompose without confirm, self-merge-eligible; balanced = confirm destructive/structural ops; conservative = confirm before merge, narrow edits, no ticket creation without confirm. auto-merger.md STALL/BOUNCE/MERGE thresholds read the profile. Inject via the prompt assembly path, NOT cursor/.cursorrules/claude hooks/codex config.
+
+Coupling guard (LOAD-BEARING, founder decision 'high requires rich knowledge injection'): when autonomy='high', the renderer (or a startup/seed check) must verify the ws has a non-empty knowledge surface (>=1 enabled policy AND/OR populated .ship/knowledge / Lighthouse binding) and warn/downgrade-to-balanced-with-audit if absent — high autonomy only works WITH rich knowledge injection.
+
+Acceptance criteria:
+- The autonomy preamble renders through the same module as the policies preamble (chat + CI agents byte-identical text).
+- Each profile produces a distinct action-rights block (diffs visible in the rendered string).
+- auto-merger.md references the profile in its STALL/BOUNCE/MERGE protocol.
+- autonomy='high' on a no-knowledge ws emits an audited warning (or downgrades to balanced), never silently runs high-without-knowledge.
+- No agent-tool-native config files written/read for the dial.
+
+Key files: apps/backend/app/services/policies.py, apps/backend/app/services/agent/topic.py, apps/backend/app/resources/agent_roles/auto-merger.md, packages/cli/lib/commands/run.mjs
+
+#### [S] Document the adapter discipline contract (thesis 5) as enforced docs + lint
+*depends on:* Add 'ship' self-spawn provider adapter + wire into runAgent behind a flag
+
+Codify thesis 5 so future adapters (and ship.mjs) stay agent-agnostic: the ONLY coupling allowed is (a) the non-interactive invocation contract and (b) 'the agent commits to the branch Ship checked out'. All Ship value (agent-roles, policies, .ship/knowledge, Lighthouse, autonomy preamble) injects THROUGH the prompt/context. Add a CONTRACT docblock at the top of packages/cli/lib/agents/index.mjs and a short doc enumerating the rule + the rejected Variant A (tool-native config/hooks/rules) + the rejected inversion (Ship becoming an MCP tool the agents call). Add a CI grep/lint check that fails if any adapter writes/reads a tool-native config file (.cursorrules, per-tool CLAUDE.md, codex config, *.mcp.json) — scoped to file-write/read calls, NOT string literals, so it does not become noise.
+
+Acceptance criteria:
+- index.mjs docblock states the two-point coupling contract + the two rejected patterns.
+- A doc file captures the contract with per-tool rationale.
+- A CI check fails if any file under packages/cli/lib/agents/ writes/reads a tool-native config artifact.
+- All four adapters (cursor/codex/claude/ship) pass the check.
+
+Key files: packages/cli/lib/agents/index.mjs, documentation/internal/architecture/agent-adapter-contract.md, apps/backend/tests/test_agent_adapter_discipline.py
+
+### Phase 6 — Local synchronous executor (trigger a)
+
+#### [M] Render a ticket-less / finish-less prompt variant for the local executor
+run.mjs's renderExitProtocol (run.mjs:1686) hard-codes the sidecar-finish + PR-authoring contract. For trigger (a) there is no ticket, no finish, no PR — the agent edits the scratch tree and stops. Factor the prompt renderer so the local executor gets system body + role body + policies preamble + lifecycle-hooks WITHOUT the exit-protocol/sidecar/PR/{{ISSUE}} blocks. Extract renderPrompt (run.mjs:1580) + renderExitProtocol so a `local` mode opts out. Keep renderLifecycleHooks (knowledge fetch/feedback). Add an explicit 'this is a local scratch run; do not push, do not open a PR, do not call any finish endpoint; if this turns into a big feature, tell the operator to escalate' instruction (E20 pattern: suggest, never block).
+
+RISK: refactoring the shared renderPrompt risks regressing the load-bearing (b) path — guard with existing run.mjs prompt tests before/after.
+
+Acceptance criteria:
+- The local prompt contains NO sidecar/finish/PR instructions and NO {{ISSUE}} ticket block.
+- The local prompt still injects system base + role body + policies preamble (thesis 5).
+- renderPrompt remains backward-compatible for run.mjs's ticket path (existing tests pass).
+- The local prompt explicitly instructs not to push/PR/finish and to recommend escalation for big-feature work.
+
+Key files: packages/cli/lib/commands/run.mjs, packages/cli/lib/commands/local.mjs
+
+#### [M] Gate the local executor behind a flag (default-off everywhere) + extend the E20 intent classifier (ESCALATE verdict, suggestion-only)
+*depends on:* Add autonomy:{high|balanced|conservative} column to Workspace + migration 0086 (balanced backfill, pulled forward)
+
+(a) must be flag + classifier gated. Two gates: (1) a per-workspace feature flag (FOUNDER DECISION: default-OFF everywhere, including ElMundi — high autonomy does NOT auto-enable the local executor) allowing the local executor to run at all; (2) a classifier detecting when a local turn is actually a big async feature belonging in (b). Extend the E20 intent classifier (services/agent/drafting_intent.py — DraftingIntentService.classify, Verdict ENTER/EXIT/NEUTRAL at line 38) with a new ESCALATE verdict + regex fast-paths + LLM fallback for 'multi-file feature / needs a PR / needs review' signals, mirroring _ENTER_PATTERNS (drafting_intent.py:65).
+
+FOUNDER DECISION: the classifier stays a SUGGESTION engine — on a misclassified big-feature local turn it SUGGESTS escalation (E20 pattern), it NEVER hard-blocks.
+
+Acceptance criteria:
+- A per-workspace flag gates whether the local executor runs; default-OFF for ALL workspaces (including ElMundi), sourced from the autonomy/config surface.
+- drafting_intent.py gains an ESCALATE verdict with regex + LLM-fallback coverage, unit-tested for >=3 big-feature phrasings (EN + RU, matching the bilingual pattern set).
+- The classifier defaults to NEUTRAL/no-escalate on any failure path (safe-fallback contract preserved).
+- A clearly big-feature local request produces an escalate SUGGESTION, never a silent local run and never a hard block.
+
+Key files: apps/backend/app/services/agent/drafting_intent.py, packages/cli/lib/commands/local.mjs, apps/backend/app/core/config.py
+
+#### [L] Add a distinct local synchronous executor command (no lease, scratch checkout, stop before push)
+*depends on:* Render a ticket-less / finish-less prompt variant for the local executor, Gate the local executor behind a flag (default-off everywhere) + extend the E20 intent classifier (ESCALATE verdict, suggestion-only)
+
+Net-new (a). run.mjs is hard-gated on a ticket: getNextTask + exit EXIT_NO_TASK when none (run.mjs:285-302), takes a dispatch lease, and --commit-and-pr OWNS push + gh pr create + /agent-runs/finish. De-ticketing run.mjs would entangle the local path with all that control-plane logic. Instead add a SEPARATE command (proposed `shipctl local`, new file commands/local.mjs) that: (1) takes NO lease, never calls the dispatcher; (2) prepares a SCRATCH checkout/worktree off current head (reuse the spirit of prepareGitBranch but a throwaway worktree, not a deterministic ticket branch); (3) renders the trimmed prompt (prior task); (4) spawns via the existing runAgent(provider) adapter; (5) STREAMS output and STOPS — no push, no gh pr create, no POST /agent-runs/finish. Must NOT import the push/PR/finish helpers at all.
+
+Acceptance criteria:
+- The command NEVER calls /tracker/next, /agent-runs/finish, pushBranch, or openPullRequest — verified by grep over the new command and by a run leaving origin untouched.
+- It NEVER acquires a dispatch lease (no dispatcher call); a concurrent (b) dispatch for the same workspace is unaffected.
+- Work happens on a scratch checkout/worktree; the operator's working tree and any ticket branches are not mutated.
+- Agent stdout/stderr streams in real time; on completion prints the scratch diff and exits without mutating any tracker/PR/lock state.
+- Reuses runAgent(provider) — no new agent-spawn code.
+
+Key files: packages/cli/lib/commands/local.mjs, packages/cli/lib/commands/run.mjs, packages/cli/lib/agents/index.mjs
+
+#### [M] Wire a->b escalation via create_issue (NOT lease handoff) from the local executor
+*depends on:* Add a distinct local synchronous executor command (no lease, scratch checkout, stop before push), Gate the local executor behind a flag (default-off everywhere) + extend the E20 intent classifier (ESCALATE verdict, suggestion-only)
+
+Thesis 3: the a->b escalation seam is create_issue, NOT a lease handoff. When the local executor (or its classifier) decides a scratch session is really a big async feature, it escalates by CREATING A TICKET — which flows through the normal tracker_poller->dispatcher (b) path — never by handing its (nonexistent) lease to a dispatcher. The primitive exists: Navigator's _tool_ticket_create (tools.py:2141) calls the tracker create_ticket adapter. Add a path in the local executor that, on ESCALATE, calls the same server-side create-ticket surface (via the Ship API the CLI authenticates against with SHIP_API_TOKEN) to open a ticket capturing the scratch context (operator ask + pointer to / patch from the scratch diff), then prints the ticket ref. Scratch work is NOT auto-pushed; the new ticket's dispatched agent re-derives the change under the controlled (b) lease.
+
+FOUNDER DECISION: escalation is operator-confirmed (suggestion-driven), never auto-forced — even under high autonomy the local turn proceeds and escalation is offered, consistent with the E20 suggest-not-block pattern. Dedup against a just-created ticket for the same session.
+
+Acceptance criteria:
+- Escalation creates a tracker ticket through the existing create_ticket adapter path — no new dispatch/lease code on the local side.
+- The escalation NEVER acquires or transfers a dispatch lease (grep confirms no dispatcher/lease call in the local command).
+- The created ticket carries enough context (operator ask + scratch summary/diff reference) for the downstream (b) agent.
+- After escalation the command prints the new ticket ref and exits; the scratch tree is not pushed.
+
+Key files: packages/cli/lib/commands/local.mjs, apps/backend/app/services/agent/tools.py
+
+### Phase 7 — Chat-edge / inbound control (thesis 4)
+
+#### [M] Harden comment-author disambiguation: replace _AGENT_COMMENT_MARKER_RE regex with Linear author identity
+tracker_poller.py:157 _AGENT_COMMENT_MARKER_RE = re.compile(r'\[Ship\s+SDLC:role-[\w-]+\]') decides agent-vs-human by scanning the comment BODY for a marker string. This is fragile: a human who quotes/pastes the marker (e.g. replying inline to the agent's question) is misclassified as the agent, breaking _operator_answered_clarification (tracker_poller.py:160); and any drift in the marker format silently mis-detects. Linear already returns the structured author — list_comments (tracker_adapter.py) populates CommentRef.author from user{displayName,email}, and the poller's comments(first:20) GraphQL block (tracker_poller.py:102) can request user{email,isMe} / botActor similarly. Switch the primary signal to author identity: a comment is 'agent' iff authored by the workspace's service account (the PAT identity / Linear bot actor) — fall back to the marker regex ONLY as a secondary heuristic for legacy rows lacking author. Centralize in one helper consumed by both _operator_answered_clarification and the new comment-inbound path (next task) so there is a single source of truth for agent-vs-human.
+
+OPEN QUESTION (founder): the canonical Linear identity of 'the workspace agent' (PAT user vs OAuth app/bot actor) differs per how each workspace's integration is provisioned; resolve the right field (user.isMe vs botActor) before relying on it.
+
+Acceptance criteria:
+- A comment whose body contains the literal marker string but authored by a human is classified as HUMAN.
+- A comment authored by the workspace service account is classified as AGENT even if the marker text is absent/changed.
+- The poller GraphQL comment fetch (comments(first:20)) returns the author identity field used for the decision (no extra round-trip).
+- _operator_answered_clarification and the new comment-inbound path both call the single shared classifier; a unit test covers paste-the-marker-as-human and missing-marker-as-agent.
+- Legacy comments lacking author identity still classify via the marker regex fallback (no regression on historical clarification tickets).
+
+Key files: apps/backend/app/services/tracker_poller.py, apps/backend/app/integrations/linear/tracker_adapter.py
+
+#### [L] Surface fresh Linear operator comments into a Navigator round-trip (context-only, never a transition)
+*depends on:* Harden comment-author disambiguation: replace _AGENT_COMMENT_MARKER_RE regex with Linear author identity
+
+Today a human reply on a Linear ticket only matters in the narrow clarification path (tracker_poller.py:160 _operator_answered_clarification -> _clear_clarification_and_dispatch, which strips needs:clarification and re-fires the SAME fsm_stage). For all other tickets, an operator comment is invisible until an agent happens to pull it via the get_ticket_snapshot tool (tools.py:4908, include_comments). Add a poller path that detects a NEW non-agent comment on an active ticket (reuse the comments(first:20) block already fetched in _poll_installation, tracker_poller.py:97-122, and the newest-first author walk) and feeds it into the Navigator as conversational inbound — append it as a user-role turn on the ticket's Navigator thread (chat.py POST /chat/stream, classify_shift=False) so the agent can answer/incorporate it.
+
+CRITICAL INVARIANT (thesis 2): this MUST NOT call transition() or write a tracker.event.received that changes FSM stage — the STATUS field stays the only transition signal (tracker_fsm.py:277-281). Model it exactly on the clarification path's restraint: comment -> context/notification, not control. Gate behind a per-workspace flag (off by default, consistent with inbox-only launch egress) and dedupe on comment id (persist last-seen comment id alongside the existing poller cursor, _load_cursor/_save_cursor tracker_poller.py:398-462) so the same comment isn't re-injected each poll tick.
+
+Acceptance criteria:
+- A new non-agent comment on a flagged-on workspace's active ticket triggers exactly one Navigator turn on that ticket's thread; the comment body is passed as the user message with classify_shift=False.
+- No code path added here calls transition(), issueUpdate on state, or emits a stage-changing tracker event — verified by a test asserting the ticket's FSM stage/status is unchanged after comment ingestion.
+- Comment ingestion is idempotent: re-running poll_once with no new comment produces zero additional Navigator turns (last-seen comment id persisted and honored).
+- Behavior is OFF by default; enabling requires the per-workspace flag.
+- Agent comments (per the author-disambiguation task) are excluded so the agent never replies to itself.
+
+Key files: apps/backend/app/services/tracker_poller.py, apps/backend/app/integrations/linear/tracker_adapter.py, apps/backend/app/api/v1/routes/chat.py, apps/backend/app/services/agent/tools.py
+
+#### [M] Replace process-local _CHOICE_CACHE with a durable pending-action store
+bot.py:233-250 _CHOICE_CACHE is a module-level OrderedDict mapping (chat_id, message_id) -> option list, populated when an inline keyboard is attached (bot.py:523) and popped on click (bot.py:737). run_with_leader_lock (bot.py:880) re-elects a new leader on every crash/deploy/autoscale event, and the new process starts with an EMPTY cache — so every previously-attached keyboard is dead-on-click. Replace with a durable store.
+
+FOUNDER-LEANING (cheaper) option: reuse inbox_items (db/models/inbox.py:248) with a new type='chat_action' (extend the type set), storing the option list + chat_id + message_id + thread_id in payload (JSONB). NOTE the Console-pollution risk: inbox_items feed the Console Inbox via ix_inbox_workspace_status / ix_inbox_workspace_category_status and the status='new' default — a chat_action row would appear in operator inbox views unless explicitly filtered. Mitigate by setting category='dismiss_silently' AND adding a 'type != chat_action' filter to the Console list queries (api/v1/routes/inbox.py). Prefer payload JSONB to avoid schema churn; if a new column/index is needed it is a forward migration (next free after 0087). DECISION POINT for founder (see open questions): inbox_items reuse vs a dedicated telegram_pending_action table (cleaner isolation, one more table) — recommend the dedicated table if Console-filter airtightness is doubtful. Replace _cache_choice_options/_pop_choice_options with async DB read/write keyed on (workspace_id, chat_id, message_id).
+
+Acceptance criteria:
+- A keyboard attached before a simulated leader-failover (new bot process / cleared in-memory state) resolves correctly on click — the option list is read from the durable store, not memory.
+- chat_action rows do NOT appear in the default Console Inbox list views (query test asserting type='chat_action' excluded or category='dismiss_silently' filtered out of operator surfaces).
+- Single-use: once a choice is resolved (or buttons stripped), the durable row is marked consumed so a stale click can't re-fire (coordinates with the idempotency-key task).
+- Existing in-group choice round-trip (on_choice_click, bot.py:708) still echoes the chosen label and runs the next Navigator turn on the same thread.
+- If a new migration is added it is a forward revision (after 0087) and does not edit any applied migration in place.
+
+Key files: apps/backend/app/integrations/telegram/bot.py, apps/backend/app/db/models/inbox.py, apps/backend/app/api/v1/routes/inbox.py
+
+#### [M] Signed nonce + single-use idempotency key in Telegram callback_data, validated server-side
+*depends on:* Replace process-local _CHOICE_CACHE with a durable pending-action store
+
+callback_data is currently the unsigned, forgeable 'c|<idx>' (bot.py:300, parsed bot.py:729). Anyone who can craft a callback (or a stale/duplicated update) can replay an index against whatever option list now occupies that (chat_id, message_id) slot, and there is no idempotency guard beyond a best-effort edit_message_reply_markup(None) that races. Mirror the existing JWT signed-nonce pattern in integrations/telegram/bind_state.py (build_bind_nonce/verify_bind_nonce, HMAC via _secret(settings)=settings.jwt_secret, short TTL, replay-resistant) to sign callback_data: pack a signed token carrying {chat_id, message_id, option_idx, single-use nonce, exp}, staying under Telegram's 64-byte cap (use a compact token / store the heavy payload in the durable store from the previous task and put only an opaque short id+sig in callback_data). On click (on_choice_click) verify the signature + TTL, then atomically mark the nonce consumed in the durable pending-action store (single-use idempotency) BEFORE running the Navigator turn — a second click with the same nonce is rejected as already-consumed, eliminating the double-fire race the current markup-strip only partially covers.
+
+Acceptance criteria:
+- callback_data carries a server-verifiable signature; a tampered/forged callback_data fails verification and is rejected with a user-facing 'expired/invalid' answer, no Navigator turn run.
+- The same callback fired twice (double-click / Telegram re-delivery) runs the Navigator turn exactly once — the second is rejected as already-consumed via an atomic single-use mark in the durable store.
+- Expired tokens (past TTL) are rejected; TTL is configurable and defaults to a short window comparable to bind_state.
+- callback_data stays within Telegram's 64-byte limit (test asserts encoded length for a representative payload).
+- Signing secret is sourced the same way as bind_state._secret(settings) (settings.jwt_secret); no new secret-management surface introduced.
+
+Key files: apps/backend/app/integrations/telegram/bot.py, apps/backend/app/integrations/telegram/bind_state.py
+
+#### [M] Keep actor-sensitive approvals authoritative in Inbox/Console — Telegram button is a deep-link, not a commit point
+*depends on:* Signed nonce + single-use idempotency key in Telegram callback_data, validated server-side
+
+Thesis 4 + founder decision: the control plane never commits through chat. Today on_choice_click (bot.py:708) treats a button as a commit point — it directly posts the chosen value as the next Navigator turn. That is fine for LOW-STAKES idempotent pre-enumerated Navigator choices (mode-a, lock-free chat), but ANY actor-sensitive approval (e.g. an Inbox 'approval' item, inbox.py:266 type='approval', or anything that would loosen the control plane) must NOT be committable from a chat button. Add a classification at keyboard-build time (_build_choice_markup, bot.py:253): a directive flagged as approval/control-stakes renders a deep-LINK button (url= into Console/Inbox at the specific item) instead of a callback button, so the click navigates the operator to the authoritative actor-sensitive surface where the real approval (with the correct actor identity, not the shared group PAT) is recorded.
+
+Cross-check with the Phase-4 'don't orphan pending operator approvals' constraint: ensure the deep-link lands on the reachable Inbox approval surface (which Phase 4 keeps reachable in every console mode). Document in code the boundary: callback button = low-stakes Navigator choice; url button = control-plane/approval deep-link.
+
+Acceptance criteria:
+- A directive marked as an approval / control-stakes action renders as a Telegram URL button deep-linking to the corresponding Console/Inbox item, NOT a callback button — verified by a unit test on _build_choice_markup.
+- Clicking an approval deep-link never runs a Navigator turn nor records an approval from the shared group PAT identity; the approval is recorded only in Inbox/Console under the acting user's identity.
+- Low-stakes pre-enumerated Navigator choices continue to render as signed callback buttons and round-trip as before.
+- The deep-link target is a reachable Inbox approval surface (no orphaned pending approvals) even when the Console surface is otherwise reduced.
+
+Key files: apps/backend/app/integrations/telegram/bot.py, apps/backend/app/integrations/telegram/render.py, apps/backend/app/api/v1/routes/inbox.py
+
+### Phase 8 — Deterministic workflow primitive (thesis 8)
+
+#### [S] W8.7 — Migration: workflow_runs + workflow_step_runs tables (durable run/step state + idempotency keys)
+Net-new forward migration (HEAD chain is 0085->0086 autonomy->0087 ship-provider; this is the next free revision, e.g. 0088) creating two tables. workflow_runs: id, workspace_id, spec_name, spec_version, inputs (jsonb), trigger_kind (chat|gate|cron), status (queued|running|completed|blocked|failed), created_at, finished_at, audit linkage. workflow_step_runs: id, workflow_run_id (fk), step_id, attempt (int), kind, agent_provider, status, output (jsonb, validated against the step output_schema), lock_key (the workflow:<run>:<step> key tying it to agent_dispatch_locks), run_id (correlates to a CI coding-leaf agent run), created_at, finished_at, with a UNIQUE (workflow_run_id, step_id, attempt) constraint that is the durable idempotency key W8.2 relies on. Add the SQLAlchemy models under apps/backend/app/db/models/workflow.py. Do NOT edit any applied migration in place; this is a forward revision.
+
+Acceptance criteria:
+- alembic upgrade head applies cleanly off the prior revision and downgrade reverses it.
+- UNIQUE (workflow_run_id, step_id, attempt) exists and a duplicate insert raises IntegrityError (the idempotency guarantee for W8.2).
+- Models expose status enums and jsonb inputs/output columns; output is nullable until the step completes.
+- lock_key + run_id columns let a step row be correlated to an agent_dispatch_locks row and a downstream CI agent run.
+- No existing migration file is modified; revision chains forward off the current head.
+
+Key files: apps/backend/migrations/versions/0088_workflow_runs.py, apps/backend/app/db/models/workflow.py
+
+#### [M] W8.1 — Workflow spec format + loader (.ship/workflows/*.yaml) with parallel/pipeline/loop/barrier + structured-output schema
+Define the deterministic workflow definition language and a loader. Net-new: apps/backend/app/services/workflow/spec.py (Pydantic models) + packages/cli/lib/workflow/loadSpec.mjs (CLI-side parser). A workflow spec lives at .ship/workflows/<name>.yaml in the customer repo and declares: name, version, inputs (typed), and an ordered list of steps. Each step has a kind from {parallel, pipeline, loop, barrier, synthesize, judge, verify} and an agent block selecting a leaf executor: either coding (spawns a tool CLI via runAgent — T5) or reasoning (runs a Navigator-style turn via the in-process subagent loop — reuse _run_subagent_loop in services/agent/tools.py:5885, role-prompted). parallel fans out N child steps; barrier joins them; pipeline chains step outputs->inputs; loop repeats a step until an until predicate or max_iters; synthesize/judge/verify are reasoning steps with a fixed role prompt that consume prior step outputs and emit a structured-output object validated against an inline JSON Schema (output_schema).
+
+The spec is DECLARATIVE/bounded (a DAG with a fan-out cap) — no unbounded recursion or event subscription; it INVOKES and COMPLETES. Mirror the existing _SUBAGENT_MAX_TOOL_CALLS=25 / _SUBAGENT_MAX_SECONDS=300 budget convention from tools.py. The spec MUST carry a top-level max_fanout (default 4) and max_depth (default 2) that the loader rejects-on-exceed BEFORE any dispatch, so a malformed spec can't request a fork-bomb. Validate that every leaf agent.kind resolves to a known provider (claude/codex/cursor/ship) or the reasoning loop.
+
+Acceptance criteria:
+- A .ship/workflows/*.yaml with all 7 step kinds round-trips through the loader into typed objects; an unknown step kind or unknown agent provider raises a validation error naming the offending step.
+- Loader rejects a spec whose declared max_fanout > a hard ceiling (e.g. 8) or whose static step graph exceeds max_depth, BEFORE any execution, with a clear error.
+- synthesize/judge/verify steps require an output_schema and the loader rejects them if missing; the schema itself is valid JSON Schema.
+- Spec models reuse the budget-naming convention (per-step max_tool_calls / max_seconds) defaulting to 25/300.
+- Unit tests cover: valid full spec, each invalid case above, and a pipeline whose step output keys feed the next step's inputs.
+
+Key files: apps/backend/app/services/workflow/spec.py, packages/cli/lib/workflow/loadSpec.mjs, apps/backend/app/services/agent/tools.py
+
+#### [L] W8.2 — WorkflowDispatchGate: route EVERY workflow-spawned agent through the control plane
+*depends on:* W8.1 — Workflow spec format + loader (.ship/workflows/*.yaml) with parallel/pipeline/loop/barrier + structured-output schema, W8.7 — Migration: workflow_runs + workflow_step_runs tables (durable run/step state + idempotency keys)
+
+CRITICAL safety task. Net-new: apps/backend/app/services/workflow/gate.py — a thin wrapper every workflow leaf (coding OR reasoning) calls before it spawns. It MUST reuse the dispatcher primitives, not reimplement them: acquire a lock via dispatcher.acquire_lock (dispatcher.py:235) under a workflow-scoped key namespace workflow:<workflow_run_id>:<step_id> (so workflow locks are countable + sweepable like ticket:* and <bundle>:* keys), check the per-workspace cap via dispatcher.count_active_locks AFTER acquire then walk-back-on-exceed exactly like maybe_dispatch (dispatcher.py:909/:917), and enforce cascade depth via dispatcher._count_recent_dispatches against CASCADE_LIMIT=3 keyed on the workflow_run (a fan-out of K leaves counts as K dispatches in the cascade window). Reuse the T6 self-spawn recursion guard: a workflow leaf that is itself the ship provider (W8.6) increments cascade depth, and the in-process reasoning leaf reuses the _subagent_active flag (tools.py:5758) so a reasoning leaf cannot itself call run_workflow/run_subagent. Idempotency: the gate writes/reads a durable workflow_step_runs row keyed (workflow_run_id, step_id, attempt) so a retried tick does not double-spawn. On refusal the gate returns the same DispatchResult/_Reason vocabulary (CAP_EXCEEDED/CASCADE_BLOCKED/LOCK_HELD) and the runtime records a skipped/blocked step rather than crashing. Add a lock-key namespace doc-comment next to the existing ticket:/project:/<bundle>: namespaces in dispatcher.py.
+
+FOUNDER DECISION: control plane is strictly off-limits to the autonomy dial — gate.py contains NO profile branch; even a 'high' workspace hits the same cap/cascade.
+
+Acceptance criteria:
+- A workflow with max_fanout leaves acquires exactly that many workflow:* locks; a fan-out that would push count_active_locks past the per-ws cap walks back the over-cap acquire (lock released) and the step is marked cap_exceeded — verified against an actual agent_dispatch_locks row count.
+- A workflow that recursively spawns workflows is refused once cascade depth reaches CASCADE_LIMIT=3 (reuses _count_recent_dispatches over audit_log, not a new counter).
+- A reasoning leaf has run_subagent/run_workflow tools filtered out (_subagent_active honored); attempting to call them returns the existing 'subagent cannot spawn' error.
+- Re-invoking the gate for the same (workflow_run_id, step_id, attempt) is idempotent — no second dispatch / no second lock; a NEW attempt is required to re-run a failed step.
+- Every gate decision writes an AuditLog row (workflow.step_dispatched / workflow.step_blocked) carrying workflow_run_id, step_id, reason.
+- No autonomy-profile branch exists in gate.py (asserted by a test/grep).
+
+Key files: apps/backend/app/services/workflow/gate.py, apps/backend/app/services/dispatcher.py, apps/backend/app/services/workflow/runtime.py
+
+#### [L] W8.3 — Workflow runtime executor: schedule the DAG, drive leaves through the gate, collect structured outputs
+*depends on:* W8.2 — WorkflowDispatchGate: route EVERY workflow-spawned agent through the control plane
+
+Net-new: apps/backend/app/services/workflow/runtime.py — the engine that takes a loaded spec (W8.1) + a workflow_run row and executes it to completion. It topologically schedules steps; for parallel/barrier it awaits the fan-out set; for pipeline it threads outputs; for loop it iterates until the predicate or max_iters; for synthesize/judge/verify it invokes a reasoning leaf and validates the result against output_schema. CRITICAL: the runtime NEVER calls runAgent or _run_subagent_loop directly — it ONLY spawns through workflow/gate.py (W8.2), the single chokepoint. A coding leaf, once the gate grants a lease, fires workflow_dispatch on ship-agent-run.yml exactly as the dispatcher does (reuse dispatcher.dispatch_workflow / the WORKFLOW_FILE constant) so the spawned coding agent runs run.mjs->runAgent in CI and reports back via the existing agent-runs/finish webhook; the runtime correlates that finish back to the step via the workflow:* lock run_id. A reasoning leaf runs IN-PROCESS via _run_subagent_loop (reuse, role-prompted from the spec). The runtime persists per-step status/output to workflow_step_runs and the overall run to workflow_runs; it is bounded (returns when the DAG drains or a budget trips) — distinct from the FSM which never completes. Provide a single async entrypoint run_workflow(session, workspace_id, spec_name, inputs, trigger_kind) that the three triggers call.
+
+DESIGN (per open question, lean event-driven): drive coding-leaf completion off the existing finish webhook + a reconcile tick rather than holding an in-process await; keep all runtime state in workflow_step_runs (DB) for cross-replica correctness.
+
+Acceptance criteria:
+- run_workflow executes a 3-step pipeline (reasoning->coding->synthesize) end-to-end in a test, threading step outputs and validating the synthesize output against its schema.
+- A parallel+barrier workflow awaits all branches before the barrier; a branch failure is recorded without aborting siblings, and the barrier sees the partial set.
+- A loop step terminates at max_iters even if the until-predicate never goes true (no infinite loop).
+- grep/AST check confirms runtime.py contains NO direct call to runAgent, dispatch_workflow, or _run_subagent_loop except via gate.py (single chokepoint).
+- A coding leaf's downstream agent-runs/finish webhook releases the corresponding workflow:* lock (correlated by run_id), mirroring how ticket dispatch releases on finish.
+- workflow_runs + workflow_step_runs rows reflect terminal status (completed/blocked/failed) and the run object is returned to the caller (bounded completion).
+
+Key files: apps/backend/app/services/workflow/runtime.py, apps/backend/app/services/workflow/gate.py, apps/backend/app/services/dispatcher.py
+
+#### [S] W8.6 — `ship` self-spawn provider as a workflow coding-leaf executor, passing through cascade + cap
+*depends on:* W8.2 — WorkflowDispatchGate: route EVERY workflow-spawned agent through the control plane, Force self-spawn recursion THROUGH cascade-depth + per-ws cap (recursion guard)
+
+Reuse the Phase-5 ship self-spawn provider (packages/cli/lib/agents/ship.mjs, already registered in agents/index.mjs RUNTIMES + gated by SHIP_ALLOW_SELF_SPAWN) as a workflow coding-leaf executor (dogfood/debug). No duplicate adapter — this task WIRES the existing provider into the workflow path and proves the recursion guard at the workflow boundary. On the server side, the WorkflowDispatchGate (W8.2) MUST treat a ship-provider leaf as a recursion edge: it increments cascade depth in dispatcher._count_recent_dispatches accounting so a Ship-spawning-Ship-spawning-Ship chain is refused at CASCADE_LIMIT=3, and it counts against the per-ws cap. This is the one place workflow execution can become genuinely recursive, so it is the highest-leverage point for the recursion guard. No tool-native config/hooks injected — value flows only through the prompt (T5).
+
+FOUNDER DECISION: the ship provider stays internal/dogfood-gated (flag/allowlist), not selectable by default customer workspaces; the control plane is off-limits to the autonomy dial so this recursion edge is counted under EVERY profile.
+
+Acceptance criteria:
+- A workflow whose leaf provider is 'ship' resolves to the existing Phase-5 adapter via runAgent('ship', ...).
+- A workflow whose leaf provider is 'ship' has its spawn counted as a cascade edge — a 4th nested ship-leaf in the cascade window is refused with CASCADE_BLOCKED.
+- ship.mjs injects context only through the prompt/argv to shipctl run (no tool-native config/hooks/rules written) — re-verified at the workflow boundary.
+- The ship provider is gated to internal/dogfood and not selectable by default customer workspaces.
+- The 4-deep refusal test passes regardless of autonomy profile.
+
+Key files: apps/backend/app/services/workflow/gate.py, packages/cli/lib/agents/ship.mjs, packages/cli/lib/agents/index.mjs
+
+#### [M] W8.4 — Chat trigger (a): invoke a workflow from Navigator via a run_workflow tool, lock-free escalation
+*depends on:* W8.3 — Workflow runtime executor: schedule the DAG, drive leaves through the gate, collect structured outputs
+
+Wire trigger (a) — chat. Add a run_workflow Navigator tool in services/agent/tools.py alongside the existing run_subagent (tools.py:1790/5588). The Navigator chat loop itself stays LOCK-FREE (thesis 3a); the tool does NOT acquire dispatch locks in the chat process — instead it persists a workflow_runs row in state=queued and returns immediately, and the runtime (W8.3) is driven by the gated path (a reconcile tick or an in-process task that goes THROUGH gate.py). This preserves the a->b escalation rule: chat creates the work item, the control plane owns the spawn. The tool is admin-gated (reuse _require_workspace_role(ROLES_ADMIN) like _tool_decomposition_start, tools.py:5658), filtered out inside a subagent (recursion guard via _subagent_active), and takes (workflow_name, inputs). Add the tool spec + dispatch entry to the _TOOL_DISPATCH map and the tool-spec list. Surface the resulting workflow_run id back to the user.
+
+FOUNDER/OPEN: who may fire workflows from chat likely varies by autonomy profile (control plane stays fixed, but invocation rights vary) — default to admin-gated + internal-dogfood at launch.
+
+Acceptance criteria:
+- Navigator can call run_workflow(workflow_name, inputs); the chat process acquires NO agent_dispatch_lock (assert lock table unchanged at tool-return time) — escalation, not in-loop dispatch.
+- The tool is admin-gated and filtered out when _subagent_active is set.
+- Calling run_workflow with an unknown workflow_name returns a structured error listing available .ship/workflows specs.
+- The created workflow_run id is returned to the user and the eventual spawn goes through gate.py (verified: cap/cascade still apply to the chat-triggered run).
+- Tool spec is registered in the dispatch map and appears in the Navigator tool list.
+
+Key files: apps/backend/app/services/agent/tools.py, apps/backend/app/services/workflow/runtime.py
+
+#### [M] W8.5 — Ticket/gate (b) + cron (c) triggers: fire a workflow from an FSM gate and a nightly cron
+*depends on:* W8.3 — Workflow runtime executor: schedule the DAG, drive leaves through the gate, collect structured outputs
+
+Wire triggers (b) and (c). (b) Gate: allow an FSM transition or PR gate to invoke a workflow as a gate action — e.g. on code_review entry, fire the multi-axis-review workflow (W8.8). Add a hook in the tracker_fsm/dispatcher path that, for a configured stage, calls workflow runtime.run_workflow(trigger_kind='gate') THROUGH gate.py rather than (or in addition to) the normal single-routine dispatch. This must respect the same lock — it counts against the ws cap and cascade. (c) Cron: register a new nightly workflow cron in services/cron_jobs.py using the existing @cron_with_lock(lock=CronLockId.<NEW>)+register_cron pattern.
+
+GROUNDING NOTE: CronLockId max in use is now 1024 (DEPLOYMENTS_RECONCILE) — reserve the next free integer (1025+), e.g. WORKFLOW_NIGHTLY=1025; do NOT reuse any retired id. The cron iterates workspaces (reuse _all_workspace_ids in cron_jobs.py) and for each enabled workspace enqueues the nightly review+techdebt workflow via run_workflow(trigger_kind='cron'). Cron-triggered workflows obey a WORKSPACE_BUNDLE-style separate accounting so they don't starve SDLC ticket dispatch (a workflow:* prefix cap distinct from the SDLC cap, mirroring WORKSPACE_BUNDLE_CAP=1 in dispatcher.py:1314).
+
+FOUNDER DEFAULT: disabled / egress-off workspaces are skipped fail-closed.
+
+Acceptance criteria:
+- A configured FSM stage entry fires run_workflow(trigger_kind='gate') through gate.py; the workflow's spawns count against the workspace cap + cascade (verified).
+- A new CronLockId (1025+, not a retired id) and a @cron_with_lock cron registered via register_cron with a nightly cron_expr; the cron skips cleanly when another replica holds the lock (reuses single-leader election).
+- The nightly cron iterates workspaces via _all_workspace_ids and enqueues per enabled workspace; disabled/egress-off workspaces are skipped fail-closed.
+- Cron/gate-triggered workflow dispatches use a separate accounting prefix so they cannot exhaust the SDLC ticket cap (mirrors WORKSPACE_BUNDLE_CAP).
+- Shadow mode (tracker_poll_fire off) records 'would have run' workflow audit rows without spawning, mirroring maybe_dispatch shadow behavior.
+
+Key files: apps/backend/app/services/cron_jobs.py, apps/backend/app/services/cron.py, apps/backend/app/services/dispatcher.py, apps/backend/app/services/tracker_fsm.py
+
+#### [M] W8.8 — First dogfood workflows: multi-axis PR review+verify and nightly codebase audit, + /process boundary doc
+*depends on:* W8.5 — Ticket/gate (b) + cron (c) triggers: fire a workflow from an FSM gate and a nightly cron, W8.4 — Chat trigger (a): invoke a workflow from Navigator via a run_workflow tool, lock-free escalation
+
+Author the first two internal/dogfood workflow specs and prove the relationship-to-/process boundary. (1) .ship/workflows/pr-review.yaml — a parallel fan-out of N reasoning leaves each reviewing one axis (correctness / security / simplification / test-coverage), a barrier, then a synthesize step (structured output: list of findings with severity) and a verify step that re-checks the highest-severity finding against the diff. Fired from the code_review FSM gate (W8.5 trigger b). (2) .ship/workflows/codebase-audit.yaml — a pipeline: a coding leaf (ship or claude provider) enumerates hotspots -> parallel reasoning leaves audit each -> judge step ranks tech-debt items -> emits a structured report. Fired nightly via cron (W8.5 trigger c).
+
+CRITICAL boundary doc (thesis 8): add a README/section under .ship/workflows/ stating these are imperative bounded pipelines that COMPLEMENT, never duplicate, the /process editor (processes.py) — /process defines the reactive per-ticket SDLC state machine (ProcessNodeType states + schedule/event/manual triggers), the workflow primitive is a deterministic bounded fan-out you INVOKE for one job. Do NOT add workflow execution into processes.py and do NOT add state-machine semantics into the workflow runtime.
+
+Acceptance criteria:
+- pr-review.yaml loads via W8.1, runs via W8.3, and produces a schema-valid findings object from its synthesize step; the verify step consumes the top finding.
+- codebase-audit.yaml runs as a pipeline (coding->parallel reasoning->judge) and emits a ranked tech-debt report; the nightly cron (W8.5) enqueues it per workspace.
+- Both workflows' fan-outs are gated (cap/cascade) — a manually inflated max_fanout is rejected by the loader/gate, not at runtime.
+- README explicitly states workflow = imperative bounded pipeline vs /process = reactive SDLC state-machine, with the rule 'do not merge or duplicate'; processes.py is unmodified by this workstream (verified by diff).
+- End-to-end dogfood: triggering pr-review on a real Ship PR produces a synthesized multi-axis review without exceeding the workspace dispatch cap.
+
+Key files: .ship/workflows/pr-review.yaml, .ship/workflows/codebase-audit.yaml, .ship/workflows/README.md

--- a/documentation/internal/architecture/notification-seam-emit-sites.md
+++ b/documentation/internal/architecture/notification-seam-emit-sites.md
@@ -1,0 +1,71 @@
+# Notification-seam emit-site ledger (ELS-217)
+
+> Authoritative inventory of every place the engine "tells a human something" by
+> constructing an `InboxItem` directly, plus the existing engine Linear-comment
+> egress sites that serve as reference implementations for the future
+> `LinearCommentChannel`. This ledger drives the Phase-1 notification seam
+> (ELS-222..226): every **bucket-A** row gets flipped onto `notify()`; **bucket-B**
+> rows become the Inbox *channel implementation*; **bucket-C** rows are console
+> render-path side-effects that are out of scope for the seam.
+>
+> Verification: `rg -n 'InboxItem\(' apps/backend/app -t py | grep -v tests`
+> returns 15 hits — 14 construction sites below + the class definition at
+> `apps/backend/app/db/models/inbox.py:248`.
+>
+> FOUNDER DEFAULT: launch egress is **inbox-only everywhere**. The target
+> `notify()` level below documents intended routing, but actual channel routing
+> stays `[inbox]` for every level until a workspace opts in (see ELS-219).
+
+## Bucket A — engine headless egress (flip to `notify()` in Phase 1)
+
+| # | Site | Caller (path type) | Current channel | Level → notify() | Dedup key today | Justification |
+|---|------|--------------------|-----------------|------------------|------------------|---------------|
+| A1 | `services/dispatcher.py:741` — `_file_no_target_repo_letter` (def :712, invoked from `maybe_dispatch` :1129) | Engine dispatch path (tracker poller / webhook → `maybe_dispatch`) | InboxItem `clarification` / `decision_needed` | **ACTION** | `intake_handle='no-target-repo:<ticket>'` + open-status pre-check at site | Pure engine emission: dispatch routing failed, operator must bind a repo. No HTTP request in the loop. |
+| A2 | `api/v1/routes/agent_runs.py:772` — tracker-outage blocker | Pick-tick (`GET …/tracker/next` called by `shipctl run` on a CI runner) | InboxItem `blocker` | **BLOCKER** | Audit-row gate: `agent_run.tracker_next_failed` within `_TRACKER_FAILURE_DEDUP_WINDOW` (1 h) — the InboxItem rides the same window | Engine-critical: the tracker adapter is rejecting calls; agents are stalled. The CLI is the caller but the emission is engine state, not a console action. **Seam note (review risk #1): keep the audit-row dedup in the caller; route only the emit through `notify()`.** |
+| A3 | `api/v1/routes/agent_runs.py:1689` — orphan-tickets-skipped improvement | Pick-tick (same `tracker/next` path) | InboxItem `improvement` | **INFO** | None at site (audit rows per orphan exist, but the inbox row is re-emitted per pick that sees orphans) | Engine picker telemetry: tickets without a project were skipped. Candidate for a `notify()`-level dedup key (`orphans:<stage>`), to be added when flipped. |
+| A4 | `api/v1/routes/agent_runs.py:4023` — finished-but-no-tracker blocker | Finish handler (`POST …/agent-runs/finish` from `shipctl run`) | InboxItem `blocker` | **BLOCKER** | None (one per finish in this state) | Agent completed work but the workspace has no tracker binding — outcome would otherwise be silently lost. |
+| A5 | `api/v1/routes/agent_runs.py:4433` — needs_clarification mirror | Finish handler (same) | InboxItem `clarification` / `decision_needed` | **ACTION** | None (one per `needs_clarification` finish; the paired tracker label `needs_clarification` is the de-facto state) | The agent's question must reach the operator; today it is mirrored to Inbox alongside a Linear comment + signal label — already a two-channel emission, making it the clearest `notify()` candidate. |
+| A6 | `api/v1/routes/agent_runs.py:4523` — blocked mirror | Finish handler (same) | InboxItem `blocker` | **BLOCKER** | `intake_handle='blocked:<ticket>:<stage>'` set on the row (no pre-check at site) | Ticket frozen via Linear `blocked` label; operator must unblock. Pairs with the freeze-label egress. |
+| A7 | `api/v1/routes/runs.py:572` — `_emit_self_heal_blocker_inbox` (invoked :999) | Routine-run callback (`routine.run.callback`, trusted CI callback path) | InboxItem `blocker` | **BLOCKER** | `source_table='self_heal_run'` + `source_id=<run>` + open-status pre-check | Self-heal failed; engine cannot recover without a human. |
+| A8 | `services/sdlc_readiness.py:354` — `file_bootstrap_recommendation` (def :298) | Worker loop (`workers/main.py:78`) | InboxItem `improvement` | **INFO** | `intake_handle='bootstrap_readiness:<repo_id>'` + open-status pre-check | Background worker recommends SDLC setup; informational with an action CTA (`start-bootstrap` action_item). |
+| A9 | `services/knowledge_synth.py:384` — auto-routed draft review | Cron `knowledge_synth` (`cron_jobs.py:153`) | InboxItem `improvement` | **ACTION** | None (one per draft created; `source_table='bucket_articles'` + `source_id` identifies the draft) | Knowledge pipeline produced a draft that needs operator review (accept → publish, dismiss → archive). |
+| A10 | `services/knowledge_synth.py:550` — archive proposal | Cron `knowledge_synth` (same tick) | InboxItem `improvement` | **ACTION** | None (`source_table='bucket_articles'` + `source_id=<target article>`) | Knowledge pipeline proposes archiving a stale article; operator decision. |
+
+## Bucket B — shared plumbing (do **not** flip; becomes the Inbox channel impl)
+
+| # | Site | Caller | Why it stays |
+|---|------|--------|--------------|
+| B1 | `services/inbox/intake.py:303` — `_build_inbox_item` | Findings-intake service (generic constructor: type/category/priority/headline/auto-resolve policy) | This *is* the canonical InboxItem factory. The Phase-1 `InboxChannel` implementation of `notify()` should delegate here (or to a thin wrapper) so all rows keep identical shape. Flipping it onto itself would be circular. |
+| B2 | `services/agent/tools.py:2521` — Navigator `inbox_create` agent tool | Chat surface (Navigator tool call) | Agent-initiated letters are a *conversational* action, not engine egress — the Navigator decides to write to the operator. It can adopt `notify()` later as a consumer, but it is not part of the engine seam flip. |
+
+## Bucket C — console render path / out of scope (dies or stays with the console)
+
+| # | Site | Caller | Why out of scope |
+|---|------|--------|------------------|
+| C1 | `api/v1/routes/dashboard.py:481` — `_mirror_stuck_prs_to_inbox` (def :404) | Console dashboard GET render side-effect | Created only when someone loads the dashboard; a render-time mirror, not engine egress. Slated for the Phase-4 console strangler (dashboard render routes are DUPLICATE). If stuck-PR detection is worth keeping headless, it must be re-homed onto a cron + `notify()` — tracked under Phase-4 classification (ELS-220), not the seam. |
+| C2 | `api/v1/routes/agent_runs.py:2572` — manual `POST /inbox` create endpoint | Explicit API request (agent/manual letter creation) | A request-scoped CRUD endpoint: the caller already chose the Inbox as the destination. Not an engine decision point — nothing to route. |
+
+## Engine Linear-comment egress (reference impls for `LinearCommentChannel`)
+
+These already post Linear comments from the engine side and prove the
+`tracker_adapter.comment()` path works in production. The Phase-1
+`LinearCommentChannel` should follow their shape (resolve binding → `gateway.comment(ref, body=…)`).
+
+| Site | What it does |
+|------|--------------|
+| `services/inbox/action_executors.py:112` | Operator-cancel executor: transitions the ticket to `Canceled` and posts the operator's optional comment via `resolved.gateway.comment(...)`. |
+| `services/clarifications_sync.py:642` | Posts the clarification answer back to the source ticket via `binding.gateway.comment(ticket, body=comment_body)`. |
+| `api/v1/routes/agent_runs.py:4410` (context of A5) | Finish handler posts the agent's comment to the ticket before mirroring to Inbox — the same two-channel pattern `notify()` formalizes. |
+
+## Counts
+
+- Bucket A: **10** sites (the engine seam scope for ELS-223/224/225)
+- Bucket B: **2** sites (channel plumbing — preserved)
+- Bucket C: **2** sites (console-path — Phase 4 territory)
+- Total `InboxItem(` construction sites in app code: **14** ✓
+
+## Flip assignment (Phase 1)
+
+- ELS-223 (dispatcher + self-heal): A1, A7
+- ELS-224 (agent_runs finish + pick-tick): A2, A3, A4, A5, A6
+- ELS-225 (services): A8, A9, A10

--- a/documentation/internal/operations/notification-seam-runbook.md
+++ b/documentation/internal/operations/notification-seam-runbook.md
@@ -1,0 +1,94 @@
+# Notification-seam operator runbook (ELS-226)
+
+The notification seam (`app/services/notify.py`, Phase 1 of the
+headless pivot) routes every engine emission ("Ship tells a human
+something") to per-workspace channels: **Inbox** (always), **Linear
+comment**, **email**. Launch posture: **inbox-only everywhere** — the
+seam is a no-op until you opt a workspace in AND flip the global
+switch.
+
+## Enable (two keys, both required)
+
+1. **Global kill-switch** (env, backend deployment):
+
+   ```
+   SHIP_NOTIFY_CHANNELS=true
+   ```
+
+   While unset/false, `notify()` forces inbox-only for every workspace
+   regardless of their settings (the router never even consults them).
+
+2. **Per-workspace routing** (`workspaces.settings` JSON — via the
+   config surface or SQL):
+
+   ```json
+   {
+     "notifications": {
+       "email_to": "ops@example.com",
+       "channels": {
+         "info":    ["inbox"],
+         "action":  ["inbox", "linear"],
+         "blocker": ["inbox", "linear", "email"]
+       }
+     }
+   }
+   ```
+
+   Rules baked into the router (`notify_config.get_channel_routing`):
+   - `inbox` is ALWAYS prepended even if omitted — a typo can never
+     silently drop an engine emission.
+   - Unknown channel strings are skipped with a logged warning.
+   - Malformed shapes fail closed to inbox-only (warning, never raise).
+   - Missing `email_to` → the email channel does a structured skip
+     (`skipped_no_email_to`); it never guesses a recipient.
+
+## Verify
+
+Every `notify()` call writes one best-effort audit row:
+
+```sql
+SELECT created_at, target_id, payload
+FROM audit_log
+WHERE workspace_id = :ws AND action = 'notify.emit'
+ORDER BY created_at DESC LIMIT 20;
+```
+
+`payload.requested_channels` shows what the router resolved;
+`payload.results[]` carries per-channel `ok` / `skipped` / `detail`.
+A failing channel shows `ok=false` with the error in `detail` — the
+Inbox letter still lands (fan-out is isolated per channel).
+
+## Email transport smoke (do once before opting any workspace in)
+
+The recording-sender tests prove rendering, not transport. Prove the
+real path once per environment:
+
+```
+RUN_EMAIL_SMOKE=1 EMAIL_SMOKE_TO=you@example.com \
+  pytest apps/backend/tests/test_services_notify.py::test_real_email_transport_smoke
+```
+
+(Needs the environment's real email creds — e.g. `SENDGRID_API_KEY` —
+in the env; the test asserts `EmailDeliveryResult.sent`, then check
+the mailbox.) Reminder: per the bootstrap-intelligence postmortem, an
+assumed-wired transport can silently fail-closed in prod — do not skip
+this step.
+
+## Rollback (two levers, no deploys needed for #2)
+
+1. **Instant global**: set `SHIP_NOTIFY_CHANNELS=false` (or unset) and
+   restart the backend → every workspace is inbox-only again. Zero code,
+   zero data migration; Inbox behavior is unchanged because it never
+   left.
+2. **Per-workspace / per-level**: edit the workspace's
+   `settings.notifications.channels` — e.g. drop `"email"` from
+   `blocker` — takes effect on the next emission, no restart.
+
+## Invariants the seam must keep (do not "fix" these)
+
+- Comments/email are **egress only** — nothing reads them back as a
+  transition signal (`tracker_fsm.py:277`: STATUS is the only signal).
+- Site-level dedup (audit windows, intake handles) lives in the
+  CALLERS, not the seam.
+- `notify()` never raises into the engine path; a failed audit write
+  never rolls back the emit.

--- a/packages/cli/lib/agents/index.mjs
+++ b/packages/cli/lib/agents/index.mjs
@@ -1,11 +1,36 @@
 /**
  * Agent runtime dispatcher.
  *
- * The workspace binds to one of the three local CLIs via
- * ``Workspace.agent_provider`` (cursor / codex / claude); ``shipctl
- * run`` resolves that binding through ``GET /v1/workspaces/{ws}/agent-provider``
- * before invoking ``runAgent`` so the runner installs and executes
- * only the right CLI on each tick.
+ * ## ADAPTER CONTRACT (thesis 5 — enforced, see ELS-245)
+ *
+ * Ship is a SUPERSTRUCTURE over coding agents: it spawns, controls and
+ * injects context — it never re-implements the agent. Every adapter in
+ * this directory may couple to its tool through EXACTLY two points:
+ *
+ *   1. The tool's NON-INTERACTIVE invocation contract (binary + a few
+ *      headless flags; prompt in).
+ *   2. "The agent commits to the branch Ship checked out" (+ exit code
+ *      out).
+ *
+ * ALL Ship value — agent-roles, policies, .ship/knowledge, Lighthouse
+ * retrieval, the autonomy preamble — enters THROUGH the prompt/context.
+ * Two patterns are REJECTED by design and linted against
+ * (test_agent_adapter_discipline.py):
+ *
+ *   - Variant A: delivering value via tool-native config (.cursorrules,
+ *     per-tool CLAUDE.md, codex config, hooks) — N foreign roadmaps of
+ *     maintenance and nowhere to hold the control plane.
+ *   - Inversion: Ship becoming an MCP tool the agents call — flips the
+ *     control direction; Ship spawns the agent, never the reverse.
+ *
+ * ## Runtime binding
+ *
+ * The workspace binds to one local CLI via ``Workspace.agent_provider``
+ * (cursor / codex / claude, plus the dogfood-gated ``ship``
+ * self-spawn); ``shipctl run`` resolves that binding through
+ * ``GET /v1/workspaces/{ws}/agent-provider`` before invoking
+ * ``runAgent`` so the runner installs and executes only the right CLI
+ * on each tick.
  *
  * Each adapter expects the runner to have already checked out the
  * target branch in ``workdir`` and configured git committer identity.
@@ -19,12 +44,19 @@
 import { runClaudeAgent } from "./claude.mjs";
 import { runCodexAgent } from "./codex.mjs";
 import { runCursorAgent } from "./cursor.mjs";
+import { runShipAgent } from "./ship.mjs";
 
 
 const RUNTIMES = {
   cursor: runCursorAgent,
   codex: runCodexAgent,
   claude: runClaudeAgent,
+  // Thesis-6 self-spawn (ELS-241): nested ``shipctl run`` for
+  // dogfood/debug of the spawn+control loop. Hard-gated below —
+  // a misconfigured workspace can never silently fork-bomb; the
+  // server-side cascade/cap controls count self_spawn dispatches
+  // like any other (ELS-242).
+  ship: runShipAgent,
 };
 
 export const DEFAULT_PROVIDER = "cursor";
@@ -35,9 +67,22 @@ export const DEFAULT_PROVIDER = "cursor";
  *
  * @param {string} provider — one of ``RUNTIMES``' keys.
  * @param {object} opts — passed straight through to the runtime.
+ *   ``opts.allowSelfSpawn`` (or env ``SHIP_ALLOW_SELF_SPAWN=true``)
+ *   is required for ``provider==='ship'``.
  * @returns {Promise<{ agentId: string, branchName: string, status: string, exitCode: number }>}
  */
 export async function runAgent(provider, opts) {
+  if (provider === "ship") {
+    const allowed =
+      process.env.SHIP_ALLOW_SELF_SPAWN === "true" ||
+      Boolean(opts && opts.allowSelfSpawn);
+    if (!allowed) {
+      throw new Error(
+        "agent runtime 'ship' (self-spawn) is dogfood-gated: set " +
+          "SHIP_ALLOW_SELF_SPAWN=true (or pass allowSelfSpawn) to enable.",
+      );
+    }
+  }
   const fn = RUNTIMES[provider];
   if (!fn) {
     const known = Object.keys(RUNTIMES).join(", ") || "(none)";

--- a/packages/cli/lib/agents/ship.mjs
+++ b/packages/cli/lib/agents/ship.mjs
@@ -1,0 +1,68 @@
+/**
+ * Ship self-spawn adapter (thesis 6, ELS-241).
+ *
+ * Mirrors the Cursor / Claude / Codex shape: the runner has already
+ * prepared the branch in ``workdir``; this adapter just invokes a
+ * NESTED ``shipctl run`` there and returns once it terminates. The
+ * nested run picks its own task through the normal engine API and
+ * bottoms out spawning the workspace's real coding provider
+ * (claude / cursor / codex) — Ship never duplicates the coding agent
+ * (thesis 5: spawn + control + inject, never re-implement).
+ *
+ * Dogfood/debug only: the ``runAgent`` dispatcher refuses
+ * ``provider==='ship'`` unless ``SHIP_ALLOW_SELF_SPAWN=true`` (or the
+ * caller passes ``allowSelfSpawn``), and every dispatch the nested
+ * run triggers passes THROUGH the cascade-depth + per-workspace cap
+ * controls server-side (trigger_kind='self_spawn', ELS-242) — a
+ * runaway loop terminates via CASCADE_BLOCKED, not by luck.
+ *
+ * Auth: the nested run needs the same env ``shipctl run`` always
+ * needs (``SHIP_API_TOKEN`` et al.) — merged from the caller env.
+ * The ``prompt`` (contract uniformity with the other adapters) is
+ * exported as ``SHIP_SELF_SPAWN_BRIEF`` for the nested run's context.
+ */
+
+import { spawn } from "node:child_process";
+
+/**
+ * @param {object} opts
+ * @param {string} opts.workdir      repo checkout dir; defaults to process.cwd()
+ * @param {string} opts.branchName   branch the nested run works on (already checked out)
+ * @param {string} opts.prompt       brief for the nested run (exported via env)
+ * @param {Record<string,string>} [opts.env]  extra env vars merged onto process.env
+ * @param {(line: string) => void} [opts.onLog] streaming log hook
+ * @returns {Promise<{ agentId: string, branchName: string, status: string, exitCode: number }>}
+ */
+export async function runShipAgent({
+  workdir = process.cwd(),
+  branchName,
+  prompt,
+  env = {},
+  onLog = (l) => process.stderr.write(`[ship] ${l}\n`),
+} = {}) {
+  if (!branchName) throw new Error("runShipAgent: branchName required");
+  if (!prompt || typeof prompt !== "string") {
+    throw new Error("runShipAgent: prompt required");
+  }
+  if (!(process.env.SHIP_API_TOKEN || env.SHIP_API_TOKEN)) {
+    throw new Error("SHIP_API_TOKEN is not set");
+  }
+
+  const args = ["run"];
+
+  onLog(`launch shipctl run (nested) branch=${branchName} cwd=${workdir}`);
+  const child = spawn("shipctl", args, {
+    cwd: workdir,
+    env: { ...process.env, ...env, SHIP_SELF_SPAWN_BRIEF: prompt },
+    stdio: ["ignore", "inherit", "inherit"],
+  });
+
+  const exitCode = await new Promise((resolve, reject) => {
+    child.on("error", reject);
+    child.on("exit", (code) => resolve(code ?? 1));
+  });
+
+  const status = exitCode === 0 ? "FINISHED" : "ERRORED";
+  onLog(`shipctl terminal: status=${status} exit=${exitCode}`);
+  return { agentId: `ship-${branchName}`, branchName, status, exitCode };
+}

--- a/packages/cli/lib/config/schema.mjs
+++ b/packages/cli/lib/config/schema.mjs
@@ -121,6 +121,11 @@ export const PRESETS = Object.freeze([
 
 export const CHANNELS = Object.freeze(["stable", "edge"]);
 
+/* Headless-pivot config spine (ELS-218): mirrors the backend
+ * config_registry scopes `console.surface` / `autonomy.profile`. */
+export const CONSOLE_SURFACES = Object.freeze(["full", "residual", "off"]);
+export const AUTONOMY_PROFILES = Object.freeze(["high", "balanced", "conservative"]);
+
 export const KINDS = Object.freeze(["collection"]);
 
 export const AGENT_IDS = Object.freeze(Object.keys(KNOWN_AGENTS));
@@ -247,6 +252,8 @@ const KNOWN_TOP_LEVEL_V2 = new Set([
   "artifacts",
   "cache",
   "telemetry",
+  "console",
+  "autonomy",
 ]);
 
 /* Back-compat export — keep the old symbol alive so external importers
@@ -261,6 +268,8 @@ const KNOWN_ARTIFACTS = new Set(["pins", "auto_update"]);
 const KNOWN_CACHE = new Set(["vcs_tracked"]);
 const KNOWN_TELEMETRY = new Set(["share", "anonymous_id", "scope"]);
 const KNOWN_TELEMETRY_SCOPE = new Set(["artifact_usage", "improvement_drafts", "errors"]);
+const KNOWN_CONSOLE = new Set(["surface"]);
+const KNOWN_AUTONOMY = new Set(["profile"]);
 
 function isPlainObject(v) {
   return v !== null && typeof v === "object" && !Array.isArray(v);
@@ -1030,6 +1039,38 @@ export function validateConfig(obj) {
             }
           }
         }
+      }
+    }
+  }
+
+  /* console / autonomy — the headless-pivot config spine (ELS-218).
+   * Both blocks are optional; absent means full console + balanced
+   * autonomy. Mirrors the backend config_registry scopes
+   * `console.surface` and `autonomy.profile`. */
+  const consoleBlock = obj.console;
+  if (consoleBlock !== undefined) {
+    if (!isPlainObject(consoleBlock)) {
+      errors.push("console: must be an object");
+    } else {
+      pushUnknownKeyWarnings(consoleBlock, KNOWN_CONSOLE, "console", warnings);
+      if (consoleBlock.surface !== undefined && !CONSOLE_SURFACES.includes(consoleBlock.surface)) {
+        errors.push(
+          `console.surface: ${JSON.stringify(consoleBlock.surface)} is not valid. Expected one of: ${CONSOLE_SURFACES.join(", ")}`,
+        );
+      }
+    }
+  }
+
+  const autonomy = obj.autonomy;
+  if (autonomy !== undefined) {
+    if (!isPlainObject(autonomy)) {
+      errors.push("autonomy: must be an object");
+    } else {
+      pushUnknownKeyWarnings(autonomy, KNOWN_AUTONOMY, "autonomy", warnings);
+      if (autonomy.profile !== undefined && !AUTONOMY_PROFILES.includes(autonomy.profile)) {
+        errors.push(
+          `autonomy.profile: ${JSON.stringify(autonomy.profile)} is not valid. Expected one of: ${AUTONOMY_PROFILES.join(", ")}`,
+        );
       }
     }
   }

--- a/packages/cli/tests/agents-ship.test.mjs
+++ b/packages/cli/tests/agents-ship.test.mjs
@@ -1,0 +1,73 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { runAgent, SUPPORTED_PROVIDERS, DEFAULT_PROVIDER } from "../lib/agents/index.mjs";
+import { runShipAgent } from "../lib/agents/ship.mjs";
+
+/* Thesis-6 self-spawn adapter (ELS-241). */
+
+test("ship is wired but cursor stays the default", () => {
+  assert.ok(SUPPORTED_PROVIDERS.includes("ship"));
+  assert.equal(DEFAULT_PROVIDER, "cursor");
+  for (const p of ["cursor", "codex", "claude"]) {
+    assert.ok(SUPPORTED_PROVIDERS.includes(p));
+  }
+});
+
+test("runAgent('ship') is dogfood-gated", async () => {
+  delete process.env.SHIP_ALLOW_SELF_SPAWN;
+  await assert.rejects(
+    () => runAgent("ship", { branchName: "b", prompt: "p" }),
+    /dogfood-gated/,
+  );
+});
+
+test("runShipAgent validates inputs before spawning", async () => {
+  await assert.rejects(() => runShipAgent({ prompt: "p" }), /branchName required/);
+  await assert.rejects(
+    () => runShipAgent({ branchName: "b" }),
+    /prompt required/,
+  );
+  delete process.env.SHIP_API_TOKEN;
+  await assert.rejects(
+    () => runShipAgent({ branchName: "b", prompt: "p" }),
+    /SHIP_API_TOKEN/,
+  );
+});
+
+test("runShipAgent spawns `shipctl run` with the brief in env", async () => {
+  // Intercept spawn via a PATH shim: create a fake `shipctl` that
+  // records argv + env and exits 0.
+  const { mkdtempSync, writeFileSync, readFileSync, chmodSync } = await import("node:fs");
+  const { join } = await import("node:path");
+  const os = await import("node:os");
+  const dir = mkdtempSync(join(os.tmpdir(), "ship-spawn-"));
+  const record = join(dir, "record.json");
+  const shim = join(dir, "shipctl");
+  writeFileSync(
+    shim,
+    `#!/bin/sh\nprintf '{"argv":"%s","brief":"%s"}' "$*" "$SHIP_SELF_SPAWN_BRIEF" > ${record}\nexit 0\n`,
+  );
+  chmodSync(shim, 0o755);
+
+  const prevPath = process.env.PATH;
+  process.env.PATH = `${dir}:${prevPath}`;
+  process.env.SHIP_API_TOKEN = "tok";
+  try {
+    const res = await runShipAgent({
+      workdir: dir,
+      branchName: "cursor/ship-test-1",
+      prompt: "nested brief",
+      onLog: () => {},
+    });
+    assert.equal(res.status, "FINISHED");
+    assert.equal(res.exitCode, 0);
+    assert.equal(res.agentId, "ship-cursor/ship-test-1");
+    const rec = JSON.parse(readFileSync(record, "utf8"));
+    assert.equal(rec.argv, "run");
+    assert.equal(rec.brief, "nested brief");
+  } finally {
+    process.env.PATH = prevPath;
+    delete process.env.SHIP_API_TOKEN;
+  }
+});

--- a/packages/cli/tests/config.test.mjs
+++ b/packages/cli/tests/config.test.mjs
@@ -582,3 +582,46 @@ test("write/read preserves lane key order", () => {
   assert.ok(zBlock.indexOf("key:") < zBlock.indexOf("store:"));
   assert.ok(zBlock.indexOf("store:") < zBlock.indexOf("reset_on:"));
 });
+
+/* ---------------------------------------------------------------------------
+ * Headless-pivot config spine (ELS-218): console + autonomy blocks
+ * ------------------------------------------------------------------------- */
+
+test("validateConfig accepts console + autonomy blocks (v2)", () => {
+  const cfg = DEFAULT_CONFIG();
+  cfg.console = { surface: "residual" };
+  cfg.autonomy = { profile: "high" };
+  const res = validateConfig(cfg);
+  assert.equal(res.ok, true, JSON.stringify(res.errors || []));
+  // No unknown-key warnings for the two new top-level blocks.
+  const unknown = (res.warnings || []).filter((w) => w.includes("unknown key"));
+  assert.deepEqual(unknown, [], JSON.stringify(res.warnings));
+});
+
+test("validateConfig rejects out-of-enum console.surface", () => {
+  const cfg = DEFAULT_CONFIG();
+  cfg.console = { surface: "hidden" };
+  const res = validateConfig(cfg);
+  assert.equal(res.ok, false);
+  assert.ok(
+    res.errors.some((e) => e.startsWith("console.surface:")),
+    JSON.stringify(res.errors),
+  );
+});
+
+test("validateConfig rejects out-of-enum autonomy.profile", () => {
+  const cfg = DEFAULT_CONFIG();
+  cfg.autonomy = { profile: "yolo" };
+  const res = validateConfig(cfg);
+  assert.equal(res.ok, false);
+  assert.ok(
+    res.errors.some((e) => e.startsWith("autonomy.profile:")),
+    JSON.stringify(res.errors),
+  );
+});
+
+test("validateConfig: console/autonomy absent stays valid (defaults)", () => {
+  const cfg = DEFAULT_CONFIG();
+  const res = validateConfig(cfg);
+  assert.equal(res.ok, true, JSON.stringify(res.errors || []));
+});


### PR DESCRIPTION
## What

First 20 tickets of the Headless Pivot (project [headless-pivot-strangler-rework](https://linear.app/elship/project/headless-pivot-strangler-rework-91c1f6127bb3)). All new behavior is behind default-off flags — merging is behavior-neutral until a workspace opts in.

### Phases
- **P0 config spine**: emit-site ledger, `console.surface` + `autonomy.profile` config scopes (+ v2 .ship/config.yml validator), channel-routing + `SHIP_NOTIFY_CHANNELS` kill-switch, console-route classification ledger, migration 0086 (workspaces.autonomy, balanced backfill)
- **P1 notification seam**: `notify()` + Inbox/Linear/email channels; all 10 engine emit-sites flipped byte-identically; `notify.emit` audit; runbook
- **P2 control-plane guardrail**: AST guard on lock primitives (zero Linear reads in control plane), unified egress-only projection maps, StateProjector behind `SHIP_STATE_PROJECTOR_UNIFIED`, `GET /engine-health`, stall notifier behind `SHIP_STALL_NOTIFY`
- **P3 scheduled routines (trigger c)**: cron→Linear-ticket (daily/retro/techdebt), audit-ledger idempotency, per-workspace opt-in fail-closed, CronLockIds 1026-1028
- **P5 superstructure**: `ship` self-spawn adapter (dogfood-gated, migration 0087), recursion guard (self_spawn through cascade+cap), autonomy-sensitive code_review→auto_merge gate (CI-green non-negotiable), per-profile prompt preamble, adapter-discipline contract + lint

### Tests
Backend 1589 passed (8 pre-existing env failures identical to baseline), CLI 150/150, migrations 0086/0087 up/down/up verified. ~60 new tests.

### Flags (all default-off)
`SHIP_NOTIFY_CHANNELS`, `SHIP_STALL_NOTIFY`, `SHIP_STATE_PROJECTOR_UNIFIED`, `SHIP_ALLOW_SELF_SPAWN`