### PR TITLE
Headless Pivot P6 — local synchronous executor: shipctl local (ELS-246..249)

### DIFF
--- a/apps/backend/app/api/v1/routes/agent_runs.py
+++ b/apps/backend/app/api/v1/routes/agent_runs.py
@@ -3239,7 +3239,10 @@ class CreateTicketIn(BaseModel):
     in the wrong inbox.
     """
 
-    project_id: str = Field(min_length=1, max_length=128)
+    # Optional since ELS-249: the local-executor a→b escalation files
+    # tickets without a project anchor — the tracker adapter lands
+    # them in the team's default backlog and task_intake routes them.
+    project_id: str | None = Field(default=None, max_length=128)
     title: str = Field(min_length=1, max_length=300)
     body: str = Field(min_length=1, max_length=32 * 1024)
     labels: list[str] = Field(default_factory=list, max_length=20)
@@ -3350,6 +3353,62 @@ async def post_create_ticket(
     await session.flush()
     return CreateTicketOut(
         ok=True, ticket_ref=created.display_id, url=created.url or None
+    )
+
+
+class LocalEscalationIn(BaseModel):
+    """Ask text a ``shipctl local`` session submits for escalation
+    classification (ELS-247/249)."""
+
+    ask: str = Field(min_length=1, max_length=16 * 1024)
+    scratch_summary: str | None = Field(default=None, max_length=8 * 1024)
+
+
+class LocalEscalationOut(BaseModel):
+    verdict: Literal["ESCALATE", "NEUTRAL"]
+    reason: str = ""
+    suggested_title: str | None = None
+
+
+@router.post("/local-executor/classify", response_model=LocalEscalationOut)
+async def post_local_executor_classify(
+    workspace_id: uuid.UUID,
+    payload: LocalEscalationIn,
+    auth: AuthContext = Depends(get_current_auth),
+    session: AsyncSession = Depends(get_session),
+    settings: Settings = Depends(get_settings),
+) -> LocalEscalationOut:
+    """Classify a local-executor ask as ESCALATE (big async feature
+    that belongs in a tracked ticket) or NEUTRAL.
+
+    Suggestion-only contract (E20): the CLI renders the verdict as an
+    offer; the local run proceeds either way. Degrades to the regex
+    fast-path when no LLM key is configured — never 412s, because a
+    missing suggestion must not break ``shipctl local``.
+    """
+    from backend.app.services.agent.client import pick_default_client
+    from backend.app.services.agent.drafting_intent import DraftingIntentService
+
+    await _require_membership(session, workspace_id, auth.user.id, ROLES_ADMIN)
+
+    try:
+        client = pick_default_client(settings)
+    except RuntimeError:
+        # No LLM configured: the service's regex fast-path still runs;
+        # the LLM fallback raises inside classify_local_escalation's
+        # try block and degrades to NEUTRAL by contract.
+        client = None
+
+    service = DraftingIntentService(settings=settings, client=client)
+    decision = await service.classify_local_escalation(
+        operator_ask=payload.ask,
+        scratch_summary=payload.scratch_summary,
+    )
+    verdict = "ESCALATE" if decision.verdict == "ESCALATE" else "NEUTRAL"
+    return LocalEscalationOut(
+        verdict=verdict,
+        reason=decision.reason,
+        suggested_title=decision.suggested_title,
     )
 
 

--- a/apps/backend/app/services/agent/drafting_intent.py
+++ b/apps/backend/app/services/agent/drafting_intent.py
@@ -35,7 +35,7 @@ from backend.app.services.agent.topic import _last_turns_text
 logger = logging.getLogger(__name__)
 
 
-Verdict = Literal["ENTER", "EXIT", "NEUTRAL"]
+Verdict = Literal["ENTER", "EXIT", "NEUTRAL", "ESCALATE"]
 
 
 @dataclass(slots=True)
@@ -95,6 +95,30 @@ _EXIT_PATTERNS: tuple[re.Pattern[str], ...] = tuple(
 )
 
 
+# Canonical "this local turn is really a big async feature" cues
+# (ELS-247, trigger-(a) → (b) escalation). Mirrors _ENTER_PATTERNS'
+# bilingual structure. Fired by ``classify_local_escalation`` only —
+# the chat ENTER/EXIT path never sees these.
+_ESCALATE_PATTERNS: tuple[re.Pattern[str], ...] = tuple(
+    re.compile(p, re.IGNORECASE)
+    for p in (
+        # English — needs a PR / review / a tracked ticket
+        r"\b(?:open|raise|create|needs?|want)\s+(?:a\s+)?(?:pull request|pr)\b",
+        r"\bneeds?\s+(?:a\s+)?(?:code\s+)?review\b",
+        r"\b(?:create|file|open)\s+(?:a\s+)?ticket\b",
+        r"\b(?:big|large|major)\s+(?:feature|refactor|change|rework)\b",
+        r"\b(?:multi[- ]file|across\s+(?:the\s+)?(?:codebase|repo|many files))\b",
+        r"\bend[- ]to[- ]end\s+feature\b",
+        # Russian — нужен ПР / ревью / тикет / большая фича
+        r"\b(?:нужен|нужно|надо|сдела(?:й|ть))\s+(?:пулл?[- ]?реквест|пр|pr)\b",
+        r"\bнужно?\s+ревью\b",
+        r"\b(?:заведи|создай|оформи)\s+тикет\b",
+        r"\b(?:больш(?:ая|ой|ую)|крупн(?:ая|ый|ую))\s+(?:фич[ауи]|задач[ауи]|рефакторинг)\b",
+        r"\bпо\s+всему\s+(?:коду|репо|репозиторию)\b",
+    )
+)
+
+
 def _matches_any(message: str, patterns: tuple[re.Pattern[str], ...]) -> bool:
     if not message:
         return False
@@ -109,6 +133,11 @@ def explicit_enter(message: str) -> bool:
 def explicit_exit(message: str) -> bool:
     """Cheap "stop drafting" detector."""
     return _matches_any(message, _EXIT_PATTERNS)
+
+
+def explicit_escalate(message: str) -> bool:
+    """Cheap "this belongs in a tracked ticket / PR" detector."""
+    return _matches_any(message, _ESCALATE_PATTERNS)
 
 
 # ---------------------------------------------------------------------------
@@ -248,10 +277,101 @@ class DraftingIntentService:
         )
 
 
+    async def classify_local_escalation(
+        self,
+        *,
+        operator_ask: str,
+        scratch_summary: str | None = None,
+    ) -> DraftingIntentDecision:
+        """Decide whether a trigger-(a) local scratch ask is really a
+        big async feature that belongs in a tracked (b) ticket
+        (ELS-247).
+
+        Separate entry point from :meth:`classify` on purpose: the
+        chat ENTER/EXIT path and the local-executor ESCALATE path
+        share the cost model (regex fast-path → small JSON LLM) but
+        never each other's verdicts.
+
+        Returns ``ESCALATE`` or ``NEUTRAL``; ``NEUTRAL`` on every
+        failure path. FOUNDER DECISION: this is a *suggestion* engine
+        — the local run proceeds either way; the caller renders an
+        offer, never a block.
+        """
+        ask = (operator_ask or "").strip()
+        if not ask:
+            return DraftingIntentDecision(verdict="NEUTRAL")
+
+        if explicit_escalate(ask):
+            return DraftingIntentDecision(
+                verdict="ESCALATE",
+                reason=(
+                    "This sounds like a tracked feature (PR/review/"
+                    "multi-file scope) — consider escalating to a "
+                    "ticket so it runs the full pipeline."
+                ),
+            )
+
+        # LLM fallback only when the ask is meaty enough to carry
+        # signal; one-liners ("fix typo on the landing") stay local
+        # without spending tokens.
+        context = f"{ask}\n{scratch_summary or ''}"
+        if len(context.strip()) < _LLM_MIN_CONTEXT_CHARS:
+            return DraftingIntentDecision(verdict="NEUTRAL")
+
+        prompt = (
+            "You are an escalation classifier for a local scratch "
+            "coding session (no ticket, no PR, throwaway checkout). "
+            "Decide whether the operator's ask is really a BIG async "
+            "feature that deserves a tracked ticket with review and a "
+            "pull request — verdict ESCALATE — or a small local tweak "
+            "— verdict NEUTRAL. Signals for ESCALATE: multi-file "
+            "feature work, schema/API changes, anything the operator "
+            "says needs review or a PR.\n\n"
+            f"Operator ask:\n{ask}\n\n"
+            f"Scratch context (may be empty): {scratch_summary or '—'}\n\n"
+            "Respond with a single JSON object: "
+            '{"verdict": "ESCALATE"|"NEUTRAL", '
+            '"reason": "short explanation", '
+            '"suggested_title": "one-line ticket title or null"}. '
+            "No prose outside the JSON."
+        )
+
+        try:
+            raw = await self._client.acomplete(
+                [ChatMessage(role="user", content=prompt)],
+                model=self._settings.agent_model_fast,
+                max_tokens=160,
+                temperature=0.0,
+                response_format={"type": "json_object"},
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("local-escalation classifier failed: %s", exc)
+            return DraftingIntentDecision(verdict="NEUTRAL")
+
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError:
+            return DraftingIntentDecision(verdict="NEUTRAL")
+
+        verdict_raw = str(payload.get("verdict") or "").upper().strip()
+        if verdict_raw not in {"ESCALATE", "NEUTRAL"}:
+            return DraftingIntentDecision(verdict="NEUTRAL")
+
+        title = payload.get("suggested_title")
+        if not isinstance(title, str) or not title.strip():
+            title = None
+        return DraftingIntentDecision(
+            verdict=verdict_raw,  # type: ignore[arg-type]
+            reason=str(payload.get("reason") or "")[:512],
+            suggested_title=title,
+        )
+
+
 __all__ = [
     "DraftingIntentDecision",
     "DraftingIntentService",
     "Verdict",
     "explicit_enter",
+    "explicit_escalate",
     "explicit_exit",
 ]

--- a/apps/backend/app/services/config_registry.py
+++ b/apps/backend/app/services/config_registry.py
@@ -156,6 +156,24 @@ async def _write_autonomy_profile(_s: AsyncSession, ws: Workspace, value: Any) -
     ws.autonomy = str(value)
 
 
+async def _read_local_executor_enabled(_s: AsyncSession, ws: Workspace) -> Any:
+    raw = (ws.settings or {}).get("local_executor") or {}
+    return bool(raw.get("enabled", False))
+
+
+async def _write_local_executor_enabled(
+    _s: AsyncSession, ws: Workspace, value: Any
+) -> None:
+    if not isinstance(value, bool):
+        raise ValueError("local_executor.enabled must be a boolean")
+    settings = dict(ws.settings or {})
+    local_executor = dict(settings.get("local_executor") or {})
+    local_executor["enabled"] = value
+    settings["local_executor"] = local_executor
+    # Reassign (not mutate) so SQLAlchemy's JSONB change detection fires.
+    ws.settings = settings
+
+
 _CATALOG_KEYS = ("global", "workspace", "project")
 
 
@@ -285,6 +303,25 @@ _SCOPE_LIST: tuple[ConfigScope, ...] = (
         read=_read_autonomy_profile,
         write=_write_autonomy_profile,
         audit_event="workspace.autonomy.set",
+    ),
+    ConfigScope(
+        slug="local_executor.enabled",
+        description=(
+            "Whether ``shipctl local`` (trigger-(a) scratch sessions: "
+            "no ticket, no lease, stop-before-push) may run for this "
+            "workspace. FOUNDER DECISION: default-OFF everywhere — "
+            "``autonomy.profile: high`` does NOT auto-enable it."
+        ),
+        schema={
+            "type": "boolean",
+            "description": (
+                "Opt-in flag for the local synchronous executor. "
+                "Independent of the autonomy dial by design."
+            ),
+        },
+        read=_read_local_executor_enabled,
+        write=_write_local_executor_enabled,
+        audit_event="workspace.local_executor_enabled.set",
     ),
 )
 

--- a/apps/backend/tests/test_config_registry.py
+++ b/apps/backend/tests/test_config_registry.py
@@ -40,6 +40,7 @@ def test_list_scopes_returns_every_registered_slug() -> None:
         "catalog.sources",
         "console.surface",
         "autonomy.profile",
+        "local_executor.enabled",
     }
     # Every row carries a non-empty description (consumed by the
     # help-without-scope path).
@@ -141,3 +142,33 @@ async def test_autonomy_profile_read_falls_back_on_garbage_column() -> None:
     ws = _FakeWorkspace()
     ws.autonomy = "wat"
     assert await scope.read(None, ws) == "balanced"
+
+
+@pytest.mark.asyncio
+async def test_local_executor_enabled_defaults_off() -> None:
+    """ELS-247 FOUNDER DECISION: default-OFF for every workspace."""
+    scope = SCOPES["local_executor.enabled"]
+    ws = _FakeWorkspace()
+    assert await scope.read(None, ws) is False
+
+
+@pytest.mark.asyncio
+async def test_local_executor_enabled_round_trips_and_merges() -> None:
+    scope = SCOPES["local_executor.enabled"]
+    ws = _FakeWorkspace()
+    ws.settings = {"console": {"surface": "residual"}}
+    await scope.write(None, ws, True)
+    assert ws.settings["console"] == {"surface": "residual"}
+    assert ws.settings["local_executor"] == {"enabled": True}
+    assert await scope.read(None, ws) is True
+    await scope.write(None, ws, False)
+    assert await scope.read(None, ws) is False
+
+
+@pytest.mark.asyncio
+async def test_local_executor_enabled_rejects_non_bool() -> None:
+    scope = SCOPES["local_executor.enabled"]
+    ws = _FakeWorkspace()
+    with pytest.raises(ValueError):
+        await scope.write(None, ws, "yes")
+    assert "local_executor" not in ws.settings

--- a/apps/backend/tests/test_drafting_intent.py
+++ b/apps/backend/tests/test_drafting_intent.py
@@ -288,3 +288,98 @@ async def test_empty_message_returns_neutral() -> None:
         ],
     )
     assert decision.verdict == "NEUTRAL"
+
+
+# ---------------------------------------------------------------------------
+# ESCALATE — local-executor escalation classifier (ELS-247)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "phrase",
+    [
+        "build the export flow end to end, then open a PR for review",
+        "this is a big feature touching auth, billing and the console",
+        "needs a code review once done — multi-file change",
+        "сделай пулл-реквест с этой фичей",
+        "это большая фича, заведи тикет",
+        "нужно ревью — меняем схему по всему репозиторию",
+    ],
+)
+def test_explicit_escalate_canonical_phrases(phrase: str) -> None:
+    from backend.app.services.agent.drafting_intent import explicit_escalate
+
+    assert explicit_escalate(phrase) is True
+
+
+@pytest.mark.parametrize(
+    "phrase",
+    [
+        "fix the typo on the landing hero",
+        "make the subtitle shorter",
+        "поправь отступ в хедере",
+        "rename this variable to snake_case",
+    ],
+)
+def test_explicit_escalate_negative_cases(phrase: str) -> None:
+    from backend.app.services.agent.drafting_intent import explicit_escalate
+
+    assert explicit_escalate(phrase) is False
+
+
+@pytest.mark.asyncio
+async def test_escalate_fast_path_skips_llm() -> None:
+    svc = _service()  # acomplete would assert if called
+    decision = await svc.classify_local_escalation(
+        operator_ask="this is a big feature, needs a PR",
+    )
+    assert decision.verdict == "ESCALATE"
+    assert decision.reason
+
+
+@pytest.mark.asyncio
+async def test_escalate_short_ask_neutral_without_llm() -> None:
+    svc = _service()  # acomplete would assert if called
+    decision = await svc.classify_local_escalation(
+        operator_ask="tweak the hero copy",
+    )
+    assert decision.verdict == "NEUTRAL"
+
+
+@pytest.mark.asyncio
+async def test_escalate_llm_verdict_propagates() -> None:
+    svc = _service(
+        llm_response='{"verdict": "ESCALATE", "reason": "schema change", "suggested_title": "Rework billing exports"}'
+    )
+    decision = await svc.classify_local_escalation(
+        operator_ask=(
+            "rework how exports are produced so the billing data lands in "
+            "the warehouse with the new partitioning scheme and backfill"
+        ),
+    )
+    assert decision.verdict == "ESCALATE"
+    assert decision.suggested_title == "Rework billing exports"
+
+
+@pytest.mark.asyncio
+async def test_escalate_llm_failure_degrades_neutral() -> None:
+    svc = _service(llm_raises=RuntimeError("llm down"))
+    decision = await svc.classify_local_escalation(
+        operator_ask=(
+            "rework how exports are produced so the billing data lands in "
+            "the warehouse with the new partitioning scheme and backfill"
+        ),
+    )
+    assert decision.verdict == "NEUTRAL"
+
+
+@pytest.mark.asyncio
+async def test_escalate_llm_bogus_verdict_neutral() -> None:
+    svc = _service(llm_response='{"verdict": "ENTER", "reason": "nope"}')
+    decision = await svc.classify_local_escalation(
+        operator_ask=(
+            "rework how exports are produced so the billing data lands in "
+            "the warehouse with the new partitioning scheme and backfill"
+        ),
+    )
+    assert decision.verdict == "NEUTRAL"

--- a/apps/backend/tests/test_local_executor.py
+++ b/apps/backend/tests/test_local_executor.py
@@ -1,0 +1,112 @@
+"""P6 local executor server surface (ELS-247/248/249).
+
+Pins the two endpoints ``shipctl local`` talks to:
+
+- ``POST /local-executor/classify`` — escalation suggestion. Regex
+  fast-path must work with NO LLM configured (the endpoint builds the
+  service with ``client=None`` and the service degrades to NEUTRAL on
+  the fallback path) — a missing suggestion must never break the
+  local run.
+- ``POST /tracker/tickets`` with ``project_id`` omitted — the a→b
+  escalation files project-less tickets into the team's default
+  backlog (ELS-249 relaxed the previously-required field).
+"""
+
+from __future__ import annotations
+
+import types
+import uuid
+from unittest.mock import AsyncMock
+
+import pytest
+
+from backend.app.api.v1.routes import agent_runs as agent_runs_routes
+from backend.app.services.tracker_resolver import ResolvedTracker
+
+
+class _FakeCreateGateway:
+    def __init__(self) -> None:
+        created = types.SimpleNamespace(
+            display_id="ELS-999",
+            url="https://linear.app/elship/issue/ELS-999",
+            ref=types.SimpleNamespace(id=uuid.uuid4()),
+        )
+        self.create_ticket = AsyncMock(return_value=created)
+
+    async def comment(self, _ref, *, body: str) -> None:
+        return None
+
+
+@pytest.fixture
+def fake_create_tracker(monkeypatch):
+    gateway = _FakeCreateGateway()
+    resolved = ResolvedTracker(
+        kind="memory",
+        gateway=gateway,
+        scope_hint=None,
+        source="legacy",
+    )
+
+    async def _resolve(*_a, **_k):
+        return resolved
+
+    monkeypatch.setattr(agent_runs_routes, "resolve_for_workspace", _resolve)
+    return gateway
+
+
+@pytest.mark.asyncio
+async def test_classify_escalate_fast_path_no_llm(
+    db_session, v1_client, seed_workspace
+) -> None:
+    """Bilingual regex cues fire without any LLM key configured."""
+    _, raw, ws = seed_workspace
+    res = await v1_client.post(
+        f"/v1/workspaces/{ws.id}/local-executor/classify",
+        headers={"Authorization": f"Bearer {raw}"},
+        json={"ask": "это большая фича, заведи тикет и сделай PR"},
+    )
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["verdict"] == "ESCALATE"
+    assert body["reason"]
+
+
+@pytest.mark.asyncio
+async def test_classify_small_ask_neutral(
+    db_session, v1_client, seed_workspace
+) -> None:
+    """Short non-matching asks stay NEUTRAL without an LLM call —
+    and with no LLM configured the fallback path still degrades to
+    NEUTRAL instead of erroring."""
+    _, raw, ws = seed_workspace
+    res = await v1_client.post(
+        f"/v1/workspaces/{ws.id}/local-executor/classify",
+        headers={"Authorization": f"Bearer {raw}"},
+        json={"ask": "tweak the hero copy"},
+    )
+    assert res.status_code == 200, res.text
+    assert res.json()["verdict"] == "NEUTRAL"
+
+
+@pytest.mark.asyncio
+async def test_create_ticket_without_project_id(
+    db_session, v1_client, seed_workspace, fake_create_tracker
+) -> None:
+    """ELS-249: escalation tickets carry no project anchor — the
+    adapter lands them in the team's default backlog."""
+    _, raw, ws = seed_workspace
+    res = await v1_client.post(
+        f"/v1/workspaces/{ws.id}/tracker/tickets",
+        headers={"Authorization": f"Bearer {raw}"},
+        json={
+            "title": "Escalated: rework billing exports",
+            "body": "## Escalated from a local scratch session\n\nask…",
+        },
+    )
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["ok"] is True
+    assert body["ticket_ref"] == "ELS-999"
+    kwargs = fake_create_tracker.create_ticket.await_args.kwargs
+    assert kwargs["project_id"] is None
+    assert kwargs["title"].startswith("Escalated:")

--- a/packages/cli/bin/shipctl.mjs
+++ b/packages/cli/bin/shipctl.mjs
@@ -129,6 +129,12 @@ try {
     process.exit(0);
   }
 
+  if (cmd === "local") {
+    const { localCommand } = await import("../lib/commands/local.mjs");
+    await localCommand(ctx, rest);
+    process.exit(0);
+  }
+
   if (cmd === "preflight") {
     const { preflightCommand } = await import("../lib/commands/preflight.mjs");
     await preflightCommand(ctx, rest);

--- a/packages/cli/lib/commands/help.mjs
+++ b/packages/cli/lib/commands/help.mjs
@@ -59,6 +59,12 @@ COMMANDS
                                          runtime, exit on terminal status.
                                          Spawned per routine by 'shipctl trigger'
                                          in the seed workflow.
+    shipctl local "<ask>" [--role <slug>] [--provider <name>] [--dry-run] [--escalate] [--json]
+                                       — local scratch session (trigger a):
+                                         throwaway worktree, no ticket, no
+                                         lease, stops before push; offers
+                                         a→b escalation via ticket create.
+                                         Gated by local_executor.enabled.
 
   Telemetry & feedback
     shipctl telemetry status|on|off|show-id|reset-id|flush|export|delete-my-data|buffer

--- a/packages/cli/lib/commands/local.mjs
+++ b/packages/cli/lib/commands/local.mjs
@@ -1,0 +1,433 @@
+/**
+ * `shipctl local` — trigger-(a) local synchronous executor (ELS-248).
+ *
+ * A scratch session: the operator types an ask, Ship spawns the
+ * workspace's agent runtime on a THROWAWAY git worktree, streams the
+ * session, prints the scratch diff and stops. By design this command
+ * lives entirely outside the (b) control plane:
+ *
+ *   - NO ticket   — the prompt renders in `mode: "local"` (ELS-246);
+ *   - NO lease    — the dispatcher is never called; a crashed local
+ *                   session costs nothing (the project_lock-leak
+ *                   postmortem class cannot happen here);
+ *   - NO push     — the scratch worktree never touches origin; the
+ *                   exit path prints the diff and a cleanup hint.
+ *
+ * Gates (ELS-247): the per-workspace `local_executor.enabled` config
+ * scope must be true (FOUNDER DECISION: default-OFF everywhere), and
+ * the server-side escalation classifier marks big-feature asks with
+ * an ESCALATE *suggestion* — never a block.
+ *
+ * a→b escalation (ELS-249): on operator confirmation (interactive
+ * yes or explicit `--escalate`), the command files a tracker ticket
+ * through `POST /v1/.../tracker/tickets` — the same create_ticket
+ * adapter surface the reviewer routines use. The new ticket flows
+ * through the normal tracker_poller → dispatcher path and leases
+ * fresh; the scratch tree itself is never pushed.
+ *
+ * Env contract (same trio as `shipctl run`):
+ *   - SHIP_API_BASE / SHIP_API_TOKEN / SHIP_WORKSPACE_ID
+ *   - provider key for the workspace's agent runtime
+ *     (CURSOR_API_KEY / ANTHROPIC_API_KEY / OPENAI_API_KEY)
+ */
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import readline from "node:readline";
+
+import { DEFAULT_PROVIDER, runAgent } from "../agents/index.mjs";
+import { fetchWithRetry } from "../retry.mjs";
+import {
+  fetchPoliciesPreamble,
+  fetchWorkspaceAgentProvider,
+  renderPrompt,
+  resolveAgentRole,
+} from "./run.mjs";
+
+const SYSTEM_ROLE_SLUG = "system";
+
+const EXIT_OK = 0;
+const EXIT_USAGE = 1;
+const EXIT_DISABLED = 3;
+const EXIT_AGENT_FAIL = 7;
+
+
+// ---------------------------------------------------------------------------
+// Args
+// ---------------------------------------------------------------------------
+
+
+function parseArgs(rest) {
+  const args = {
+    ask: "",
+    role: "developer",
+    provider: "",
+    dryRun: false,
+    escalate: false,
+    json: false,
+  };
+  const positional = [];
+  for (let i = 0; i < rest.length; i += 1) {
+    const a = rest[i];
+    if (a === "--role") args.role = rest[++i] || args.role;
+    else if (a === "--provider") args.provider = rest[++i] || "";
+    else if (a === "--dry-run") args.dryRun = true;
+    else if (a === "--escalate") args.escalate = true;
+    else if (a === "--json") args.json = true;
+    else if (a === "--help" || a === "-h") return { ...args, help: true };
+    else positional.push(a);
+  }
+  args.ask = positional.join(" ").trim();
+  return args;
+}
+
+
+function printUsage() {
+  console.log(`Usage: shipctl local "<ask>" [options]
+
+Run a local scratch agent session: throwaway worktree, no ticket,
+no lease, stop before push. Requires the workspace config scope
+local_executor.enabled=true (default OFF).
+
+Options:
+  --role <slug>      agent role to render (default: developer)
+  --provider <name>  override the workspace agent runtime
+  --dry-run          print the rendered prompt and exit
+  --escalate         file an escalation ticket without the interactive prompt
+  --json             machine-readable result line on stdout
+`);
+}
+
+
+// ---------------------------------------------------------------------------
+// Ship API helpers (read-only + create-ticket; nothing else)
+// ---------------------------------------------------------------------------
+
+
+async function fetchJson(url, { apiToken, method = "GET", body = null, description }) {
+  const res = await fetchWithRetry(
+    () =>
+      fetch(url, {
+        method,
+        headers: {
+          Accept: "application/json",
+          Authorization: `Bearer ${apiToken}`,
+          ...(body ? { "Content-Type": "application/json" } : {}),
+        },
+        ...(body ? { body: JSON.stringify(body) } : {}),
+      }),
+    { description },
+  );
+  return res;
+}
+
+
+async function fetchLocalExecutorEnabled({ apiBase, apiToken, workspaceId }) {
+  const url = `${apiBase}/v1/workspaces/${encodeURIComponent(workspaceId)}/config/local_executor.enabled`;
+  try {
+    const res = await fetchJson(url, { apiToken, description: "local_executor.enabled" });
+    if (!res.ok) return { enabled: false, reason: `config read ${res.status}` };
+    const detail = await res.json();
+    return { enabled: detail.current_value === true, reason: null };
+  } catch (err) {
+    return {
+      enabled: false,
+      reason: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+
+async function classifyEscalation({ apiBase, apiToken, workspaceId, ask }) {
+  // Best-effort: any failure means "no suggestion" (the classifier
+  // is a suggestion engine; its absence must not break the run).
+  const url = `${apiBase}/v1/workspaces/${encodeURIComponent(workspaceId)}/local-executor/classify`;
+  try {
+    const res = await fetchJson(url, {
+      apiToken,
+      method: "POST",
+      body: { ask },
+      description: "local-executor classify",
+    });
+    if (!res.ok) return null;
+    const verdict = await res.json();
+    return verdict?.verdict === "ESCALATE" ? verdict : null;
+  } catch {
+    return null;
+  }
+}
+
+
+async function createEscalationTicket({ apiBase, apiToken, workspaceId, title, body }) {
+  const url = `${apiBase}/v1/workspaces/${encodeURIComponent(workspaceId)}/tracker/tickets`;
+  const res = await fetchJson(url, {
+    apiToken,
+    method: "POST",
+    body: { title, body },
+    description: "escalation ticket create",
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`ticket create failed: ${res.status} ${text.slice(0, 300)}`);
+  }
+  return res.json();
+}
+
+
+// ---------------------------------------------------------------------------
+// Scratch worktree
+// ---------------------------------------------------------------------------
+
+
+function git(argv, opts = {}) {
+  const res = spawnSync("git", argv, {
+    encoding: "utf8",
+    ...(opts.cwd ? { cwd: opts.cwd } : {}),
+  });
+  if (res.status !== 0 && !opts.allowFail) {
+    throw new Error(
+      `git ${argv.join(" ")} failed: ${(res.stderr || res.stdout || "").trim()}`,
+    );
+  }
+  return (res.stdout || "").trim();
+}
+
+
+function createScratchWorktree() {
+  // The operator's checkout is sacred: we never mutate it. The agent
+  // gets a detached worktree at the current HEAD under the system
+  // temp dir; deleting it later is one `git worktree remove`.
+  const repoRoot = git(["rev-parse", "--show-toplevel"]);
+  const baseSha = git(["rev-parse", "HEAD"]);
+  const scratchDir = fs.mkdtempSync(path.join(os.tmpdir(), "ship-local-"));
+  git(["worktree", "add", "--detach", scratchDir, "HEAD"], { cwd: repoRoot });
+  return { repoRoot, scratchDir, baseSha };
+}
+
+
+function scratchDiffSummary(scratchDir, baseSha) {
+  // Diff against the worktree's creation point — covers both local
+  // commits the agent made (detached HEAD moved forward) and
+  // uncommitted edits. No upstream exists on a detached worktree.
+  const stat = git(["diff", baseSha, "--stat"], { cwd: scratchDir, allowFail: true });
+  const untracked = git(
+    ["ls-files", "--others", "--exclude-standard"],
+    { cwd: scratchDir, allowFail: true },
+  );
+  const commits = git(
+    ["log", "--oneline", `${baseSha}..HEAD`],
+    { cwd: scratchDir, allowFail: true },
+  );
+  return { stat, untracked, commits };
+}
+
+
+// ---------------------------------------------------------------------------
+// Interactive confirm (escalation is operator-confirmed, never forced)
+// ---------------------------------------------------------------------------
+
+
+async function confirmEscalation() {
+  if (!process.stdin.isTTY) return false;
+  const rl = readline.createInterface({ input: process.stdin, output: process.stderr });
+  const answer = await new Promise((resolve) => {
+    rl.question("File an escalation ticket for this ask? [y/N] ", resolve);
+  });
+  rl.close();
+  return /^y(es)?$/i.test((answer || "").trim());
+}
+
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+
+export async function localCommand(ctx, rest) {
+  const args = parseArgs(rest);
+  if (args.help) {
+    printUsage();
+    process.exit(EXIT_OK);
+  }
+  if (!args.ask) {
+    printUsage();
+    console.error("error: an ask is required, e.g. shipctl local \"tighten the hero copy\"");
+    process.exit(EXIT_USAGE);
+  }
+
+  const apiBase = (process.env.SHIP_API_BASE || "").replace(/\/+$/, "");
+  const apiToken = process.env.SHIP_API_TOKEN || "";
+  const workspaceId = process.env.SHIP_WORKSPACE_ID || "";
+  if (!apiBase || !apiToken || !workspaceId) {
+    console.error(
+      "shipctl local requires SHIP_API_BASE + SHIP_API_TOKEN + SHIP_WORKSPACE_ID",
+    );
+    process.exit(EXIT_USAGE);
+  }
+
+  // Gate 1 (ELS-247): per-workspace opt-in flag, default OFF.
+  const gate = await fetchLocalExecutorEnabled({ apiBase, apiToken, workspaceId });
+  if (!gate.enabled) {
+    console.error(
+      "local executor is disabled for this workspace" +
+        (gate.reason ? ` (${gate.reason})` : "") +
+        ".\nEnable it via Settings → Config → local_executor.enabled " +
+        "(or PUT /v1/workspaces/{ws}/config/local_executor.enabled).",
+    );
+    process.exit(EXIT_DISABLED);
+  }
+
+  // Role + system + policies — the same thesis-5 injection the (b)
+  // path gets; only the exit protocol differs (ELS-246).
+  const [roleResolved, systemResolved] = await Promise.all([
+    resolveAgentRole({ apiBase, apiToken, workspaceId, slug: args.role }),
+    resolveAgentRole({
+      apiBase,
+      apiToken,
+      workspaceId,
+      slug: SYSTEM_ROLE_SLUG,
+      optional: true,
+    }),
+  ]);
+  if (!roleResolved) {
+    console.error(`unknown agent role '${args.role}' for this workspace`);
+    process.exit(EXIT_USAGE);
+  }
+  const policiesPreamble = await fetchPoliciesPreamble({
+    apiBase,
+    apiToken,
+    workspaceId,
+    role: args.role,
+  });
+
+  const rendered = renderPrompt({
+    patternBody: roleResolved.prompt || "",
+    baseBody: systemResolved?.prompt || "",
+    role: args.role,
+    routineSpec: {},
+    task: null,
+    fsmStage: null,
+    finishCtx: null,
+    mode: "local",
+    localAsk: args.ask,
+  });
+  const prompt = policiesPreamble
+    ? `${policiesPreamble.trim()}\n\n---\n\n${rendered}`
+    : rendered;
+
+  if (args.dryRun || ctx.dryRun) {
+    console.log(prompt);
+    process.exit(EXIT_OK);
+  }
+
+  // Gate 2 (ELS-247): escalation classifier — a SUGGESTION, rendered
+  // before the run so the operator can bail early; the run proceeds
+  // regardless (suggest-not-block).
+  const suggestion = await classifyEscalation({ apiBase, apiToken, workspaceId, ask: args.ask });
+  if (suggestion) {
+    console.error(
+      `\n[ship] escalation suggestion: ${suggestion.reason || "this looks like tracked-feature work"}\n` +
+        "[ship] the local run proceeds; you can escalate to a ticket at the end.\n",
+    );
+  }
+
+  const { scratchDir, baseSha } = createScratchWorktree();
+  console.error(`[ship] scratch worktree: ${scratchDir}`);
+
+  const provider =
+    args.provider ||
+    (await fetchWorkspaceAgentProvider({ apiBase, apiToken, workspaceId })) ||
+    DEFAULT_PROVIDER;
+
+  let runtime;
+  try {
+    runtime = await runAgent(provider, {
+      workdir: scratchDir,
+      branchName: "local-scratch",
+      prompt,
+    });
+  } catch (err) {
+    console.error(
+      `[ship] agent launch failed: ${err instanceof Error ? err.message : err}`,
+    );
+    console.error(`[ship] scratch worktree kept at ${scratchDir}`);
+    process.exit(EXIT_AGENT_FAIL);
+  }
+
+  const diff = scratchDiffSummary(scratchDir, baseSha);
+  console.error("\n[ship] local scratch session finished.");
+  if (diff.commits) {
+    console.error(`\nScratch commits:\n${diff.commits}`);
+  }
+  if (diff.stat) {
+    console.error(`\nScratch diff (vs HEAD):\n${diff.stat}`);
+  }
+  if (diff.untracked) {
+    console.error(`\nNew files:\n${diff.untracked}`);
+  }
+  if (!diff.stat && !diff.untracked && !diff.commits) {
+    console.error("\nNo changes in the scratch tree.");
+  }
+  console.error(
+    `\nReview at: ${scratchDir}\nClean up:  git worktree remove --force ${scratchDir}`,
+  );
+
+  // a→b escalation (ELS-249): operator-confirmed, create_issue only.
+  let escalatedTicket = null;
+  if (suggestion && (args.escalate || (await confirmEscalation()))) {
+    const title =
+      suggestion.suggested_title ||
+      args.ask.split("\n", 1)[0].slice(0, 120);
+    const body = [
+      "## Escalated from a local scratch session",
+      "",
+      "**Operator ask:**",
+      "",
+      args.ask,
+      "",
+      "**Scratch outcome (not pushed — re-derive under the (b) lease):**",
+      "",
+      "```",
+      diff.stat || "(no diff)",
+      "```",
+      diff.untracked ? `New files:\n\`\`\`\n${diff.untracked}\n\`\`\`` : "",
+      "",
+      `_Filed by \`shipctl local\`; classifier: ${suggestion.reason || "escalation suggested"}_`,
+    ]
+      .filter((line) => line !== "")
+      .join("\n");
+    try {
+      escalatedTicket = await createEscalationTicket({
+        apiBase,
+        apiToken,
+        workspaceId,
+        title,
+        body,
+      });
+      console.error(
+        `\n[ship] escalation ticket created: ${escalatedTicket.ticket_ref}` +
+          (escalatedTicket.url ? ` (${escalatedTicket.url})` : ""),
+      );
+    } catch (err) {
+      console.error(
+        `[ship] escalation failed: ${err instanceof Error ? err.message : err}`,
+      );
+    }
+  }
+
+  if (args.json) {
+    console.log(
+      JSON.stringify({
+        status: runtime.status === "FINISHED" ? "ok" : "agent_error",
+        provider,
+        scratch_dir: scratchDir,
+        diff_stat: diff.stat || null,
+        escalation_suggested: Boolean(suggestion),
+        escalated_ticket: escalatedTicket?.ticket_ref || null,
+      }),
+    );
+  }
+  process.exit(runtime.status === "FINISHED" ? EXIT_OK : EXIT_AGENT_FAIL);
+}

--- a/packages/cli/lib/commands/run.mjs
+++ b/packages/cli/lib/commands/run.mjs
@@ -1577,10 +1577,19 @@ async function fetchWorkspaceAgentProvider({ apiBase, apiToken, workspaceId }) {
 }
 
 
-export function renderPrompt({ patternBody, baseBody, role, routineSpec, task, fsmStage, fileOverlapWarnings = "", finishCtx }) {
-  const issueRef = task?.ticket_ref ? task.ticket_ref : "(no ticket)";
-  const title = task?.title || "";
-  const description = task?.body || "";
+export function renderPrompt({ patternBody, baseBody, role, routineSpec, task, fsmStage, fileOverlapWarnings = "", finishCtx, mode = "ticket", localAsk = "" }) {
+  // ``mode: "local"`` (ELS-246) renders the trigger-(a) scratch-run
+  // variant: same system base + role body + lifecycle hooks, but NO
+  // ticket block and NO sidecar/finish/PR exit protocol — the local
+  // executor stops before any push. The ticket path is untouched.
+  const local = mode === "local";
+  const issueRef = local
+    ? "(local scratch session — no ticket)"
+    : task?.ticket_ref ? task.ticket_ref : "(no ticket)";
+  const title = local
+    ? (localAsk.trim().split("\n", 1)[0] || "Local scratch session")
+    : task?.title || "";
+  const description = local ? localAsk : task?.body || "";
 
   // Pattern-template substitution. Order matters: expand {{BASE}} first
   // so any further {{ROLE}} / {{SKILLS_CONTEXT}} placeholders inside
@@ -1615,8 +1624,14 @@ export function renderPrompt({ patternBody, baseBody, role, routineSpec, task, f
   }
   out.push(expanded.trim());
   out.push("");
-  out.push(renderLifecycleHooks());
-  if (task) {
+  out.push(renderLifecycleHooks({ local }));
+  if (local && localAsk.trim()) {
+    out.push("");
+    out.push("## Operator ask");
+    out.push("");
+    out.push(localAsk.trim());
+  }
+  if (task && !local) {
     // ELS-86: parent project context (Brief / WBS / Architecture /
     // Test architecture / Tasks). The server lifts and caps it; we
     // render it BEFORE the per-ticket block so the agent sees the
@@ -1651,12 +1666,12 @@ export function renderPrompt({ patternBody, baseBody, role, routineSpec, task, f
     }
   }
   out.push("");
-  out.push(renderExitProtocol(finishCtx));
+  out.push(local ? renderLocalScratchProtocol() : renderExitProtocol(finishCtx));
   return out.join("\n");
 }
 
 
-function renderLifecycleHooks() {
+function renderLifecycleHooks({ local = false } = {}) {
   // Phase 4: every run is bracketed by two auditable lifecycle hooks
   // — knowledge-fetch first, knowledge-feedback last. We render them
   // as explicit prompt instructions so they show up in the agent's
@@ -1673,13 +1688,41 @@ function renderLifecycleHooks() {
     "tool call wasn't a knowledge fetch; do not skip this to save",
     "tokens.",
     "",
-    "**Last call — knowledge feedback.** Before calling the finish",
-    "endpoint, leave one-line learnings via the Ship knowledge",
+    local
+      ? "**Last call — knowledge feedback.** Before your session ends,"
+      : "**Last call — knowledge feedback.** Before calling the finish\nendpoint,",
+    "leave one-line learnings via the Ship knowledge",
     "feedback channel (`shipctl feedback draft` → `feedback submit`)",
     "if you discovered something a future run on this codebase would",
     "want to know. Empty findings are a valid outcome — better no",
     "feedback than fabricated polish.",
   ].join("\n");
+}
+
+
+function renderLocalScratchProtocol() {
+  // Trigger-(a) contract (ELS-246): the scratch session edits the
+  // throwaway tree and stops. Escalation is a SUGGESTION to the
+  // operator (E20 pattern) — never a block, never an automatic
+  // ticket.
+  return `## Local scratch run — required behavior
+
+This is a **local scratch run**: a throwaway checkout, no ticket, no
+lease, no lifecycle state. When you are done editing, just stop.
+
+- Do **not** push any branch or commit to any remote.
+- Do **not** open a pull request.
+- Do **not** call any Ship finish endpoint or write any
+  \`.ship/agent-finish.json\` sidecar — there is no runner contract
+  here; the operator reviews the scratch diff directly.
+- Commit locally inside the scratch tree if it helps you organize the
+  work; the tree itself is disposable.
+
+If the ask turns out to be a **big feature** (multi-file change that
+deserves review, tests, and a PR), finish what is reasonable locally
+and tell the operator — in your final message — that this belongs in
+a tracked ticket and they should escalate (\`shipctl local\` offers
+escalation). Suggest; do not refuse the local work.`;
 }
 
 

--- a/packages/cli/lib/commands/run.mjs
+++ b/packages/cli/lib/commands/run.mjs
@@ -1417,7 +1417,7 @@ function stripSlash(s) {
  * unless ``optional`` is set (then 404 *and* errors return ``null``
  * with a one-line warning).
  */
-async function resolveAgentRole({
+export async function resolveAgentRole({
   apiBase,
   apiToken,
   workspaceId,
@@ -1475,7 +1475,7 @@ async function resolveAgentRole({
  * this flow because the CLI mints ``run_id`` locally; the
  * workspace-scoped variant takes membership instead.
  */
-async function fetchPoliciesPreamble({ apiBase, apiToken, workspaceId, role }) {
+export async function fetchPoliciesPreamble({ apiBase, apiToken, workspaceId, role }) {
   if (!apiBase || !apiToken || !workspaceId) return null;
   const qs = role ? `?role=${encodeURIComponent(role)}` : "";
   const url = `${apiBase}/v1/workspaces/${encodeURIComponent(workspaceId)}/policies/preamble${qs}`;
@@ -1549,7 +1549,7 @@ async function getNextTask({ apiBase, apiToken, workspaceId, state, ticketRef })
  * any failure so the caller can degrade to ``DEFAULT_PROVIDER``
  * rather than stranding the runner.
  */
-async function fetchWorkspaceAgentProvider({ apiBase, apiToken, workspaceId }) {
+export async function fetchWorkspaceAgentProvider({ apiBase, apiToken, workspaceId }) {
   if (!apiBase || !apiToken || !workspaceId) return null;
   const url = `${apiBase}/v1/workspaces/${encodeURIComponent(workspaceId)}/agent-provider`;
   let res;
@@ -1709,6 +1709,12 @@ function renderLocalScratchProtocol() {
 
 This is a **local scratch run**: a throwaway checkout, no ticket, no
 lease, no lifecycle state. When you are done editing, just stop.
+
+**This section supersedes the shared role template above.** Any
+earlier instructions about reading a Linear ticket, re-entrant
+pipeline reconciliation, branch naming, sidecars, or calling a
+finish endpoint come from the ticket-pipeline template and do NOT
+apply here — there is no ticket and no runner contract.
 
 - Do **not** push any branch or commit to any remote.
 - Do **not** open a pull request.

--- a/packages/cli/tests/local-command.test.mjs
+++ b/packages/cli/tests/local-command.test.mjs
@@ -1,0 +1,49 @@
+/**
+ * ELS-248 acceptance criteria as executable asserts.
+ *
+ * The local executor must live entirely outside the (b) control
+ * plane: no tracker/next picker, no dispatch lease, no push, no PR,
+ * no finish endpoint. We pin that with a source-level scan — the
+ * cheapest faithful encoding of the ticket's "verified by grep over
+ * the new command" criterion — plus arg-parsing sanity via the
+ * --help path.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(
+  path.join(here, "..", "lib", "commands", "local.mjs"),
+  "utf8",
+);
+
+test("local.mjs never references the ticket picker or finish endpoint", () => {
+  assert.ok(!source.includes("tracker/next"), "must not call /tracker/next");
+  assert.ok(!source.includes("agent-runs/finish"), "must not call /agent-runs/finish");
+  assert.ok(!source.includes("getNextTask"), "must not import the picker helper");
+});
+
+test("local.mjs never imports push/PR helpers", () => {
+  assert.ok(!source.includes("pushBranch"), "must not push");
+  assert.ok(!source.includes("openPullRequest"), "must not open PRs");
+  assert.ok(!source.includes("commitAndPr"), "no commit-and-pr mode");
+  assert.ok(!/git\(\["push/.test(source), "no raw git push either");
+});
+
+test("local.mjs never touches the dispatcher / lease surface", () => {
+  assert.ok(!/dispatch/i.test(source.replace(/\/\/[^\n]*|\/\*[\s\S]*?\*\//g, "").replace(/\*[^\n]*/g, "")), "no dispatcher calls outside comments");
+  assert.ok(!source.includes("/agent-dispatch"), "no lease endpoints");
+});
+
+test("local.mjs uses the shared runAgent adapter and the local prompt mode", () => {
+  assert.ok(source.includes("runAgent(provider"), "reuses runAgent");
+  assert.ok(source.includes('mode: "local"'), "renders the ELS-246 local prompt");
+  assert.ok(source.includes("worktree"), "scratch worktree based");
+});
+
+test("escalation goes through tracker/tickets create only", () => {
+  assert.ok(source.includes("/tracker/tickets"), "escalation = create_issue");
+});

--- a/packages/cli/tests/render-prompt.test.mjs
+++ b/packages/cli/tests/render-prompt.test.mjs
@@ -46,3 +46,51 @@ test("renderPrompt prefers FILE_OVERLAP_WARNINGS env over task field", () => {
   assert.ok(out.includes("0074"));
   assert.ok(!out.includes("stale task warning"));
 });
+
+test("renderPrompt mode=local strips ticket block + exit protocol (ELS-246)", () => {
+  const out = renderPrompt({
+    patternBody: "{{BASE}}\nDo work on {{ISSUE}}.\n{{DESCRIPTION}}",
+    baseBody: "System base for {{ROLE}}.",
+    role: "developer",
+    routineSpec: {},
+    task: null,
+    fsmStage: null,
+    finishCtx: null,
+    mode: "local",
+    localAsk: "Tweak the landing hero copy\n\nMake the subtitle shorter.",
+  });
+  // System base + role substitution still present (thesis 5).
+  assert.ok(out.includes("System base for developer."));
+  // No ticket block, no raw placeholder leakage.
+  assert.ok(!out.includes("## Task"));
+  assert.ok(!out.includes("{{ISSUE}}"));
+  assert.ok(out.includes("(local scratch session — no ticket)"));
+  // No sidecar/finish/PR protocol...
+  assert.ok(!out.includes("## Required exit protocol"));
+  assert.ok(!out.includes("agent-finish.json\\` in the repo workdir"));
+  assert.ok(!out.includes("/agent-runs/finish"));
+  // ...replaced by the local scratch contract.
+  assert.ok(out.includes("## Local scratch run — required behavior"));
+  assert.ok(out.includes("Do **not** open a pull request."));
+  assert.ok(out.includes("they should escalate"));
+  // Operator ask + lifecycle hooks survive.
+  assert.ok(out.includes("## Operator ask"));
+  assert.ok(out.includes("Make the subtitle shorter."));
+  assert.ok(out.includes("## Lifecycle hooks (Phase 4)"));
+  assert.ok(out.includes("Before your session ends,"));
+});
+
+test("renderPrompt default mode still renders the ticket exit protocol", () => {
+  const out = renderPrompt({
+    patternBody: "Do work on {{ISSUE}}.",
+    baseBody: "",
+    role: "developer",
+    routineSpec: { prompt: "Routine body here." },
+    task: { ticket_ref: "ELS-3", title: "Task", body: "Desc" },
+    fsmStage: "dev_implementation",
+    finishCtx: { process: "development", role: "developer", ticketRef: "ELS-3" },
+  });
+  assert.ok(out.includes("## Required exit protocol"));
+  assert.ok(out.includes("## Task"));
+  assert.ok(!out.includes("## Local scratch run"));
+});


### PR DESCRIPTION
## Summary

Phase 6 of the headless-pivot strangler rework — trigger (a), the local synchronous executor. Four tickets in dependency order:

- **ELS-246** — `renderPrompt(mode:'local')`: system base + role body + policies + lifecycle hooks WITHOUT the {{ISSUE}} ticket block or the sidecar/finish/PR exit protocol; replaced by a local-scratch contract that also explicitly supersedes ticket-pipeline language baked into shared role templates. Ticket path byte-identical.
- **ELS-247** — two gates: `local_executor.enabled` config scope (default-OFF everywhere — FOUNDER DECISION, autonomy:high does not auto-enable) + `classify_local_escalation` on the E20 intent classifier (new ESCALATE verdict, bilingual regex fast-paths → small JSON LLM fallback, NEUTRAL on every failure path).
- **ELS-248** — `shipctl local "<ask>"`: throwaway detached worktree at HEAD, streams `runAgent(provider)`, prints scratch diff, stops. Never calls /tracker/next, never leases, never pushes, never PRs, never finishes — pinned executably by `tests/local-command.test.mjs` grepping the command source.
- **ELS-249** — a→b escalation via create_issue: on ESCALATE suggestion + operator confirm (`--escalate` or interactive y/N, never auto-forced), files a ticket through `POST /tracker/tickets` (`project_id` now optional → default backlog + needs-intake routing); ticket carries the ask + scratch diffstat; scratch is never pushed; new ticket leases fresh under (b).

New endpoint: `POST /v1/workspaces/{ws}/local-executor/classify` — degrades to regex-only when no LLM key is configured.

## Test plan
- [x] CLI suite 157/157 (4 new render-prompt asserts + 5 source-scan ACs)
- [x] Backend: test_local_executor (classify ESCALATE/NEUTRAL via HTTP, project-less ticket create), drafting-intent ESCALATE suite (6 EN+RU phrasings + negatives + LLM propagate/degrade), config-registry scope round-trip — 72 passed
- [x] Live E2E on local stack: gate-off → exit 3; gate-on dry-run prompt; full run (provider=claude) created the file in the scratch tree, operator tree untouched, agent narrated the no-push contract; classify live returns ESCALATE (RU) / NEUTRAL
- [ ] CI green

Closes ELS-246, ELS-247, ELS-248, ELS-249