### PR TITLE
Headless Pivot P7 — chat-edge / inbound control (ELS-250..254)

### DIFF
--- a/apps/backend/app/db/models/telegram.py
+++ b/apps/backend/app/db/models/telegram.py
@@ -27,7 +27,7 @@ from sqlalchemy import (
     UniqueConstraint,
     text,
 )
-from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
 from backend.app.db.base import Base
@@ -117,5 +117,67 @@ class TelegramThreadMap(Base):
         UUID(as_uuid=True),
         ForeignKey("chat_threads.id", ondelete="CASCADE"),
         nullable=False,
+    )
+    created_at: Mapped[datetime] = _ts_created()
+
+
+class TelegramPendingAction(Base):
+    """Durable store for inline-keyboard option lists (ELS-252).
+
+    Replaces the process-local ``_CHOICE_CACHE``: leader failover /
+    deploy / autoscale used to wipe the cache and leave every
+    previously-attached keyboard dead-on-click. One row per attached
+    keyboard; the row id travels inside the signed ``callback_data``
+    (ELS-253) and the option list lives here, safely past Telegram's
+    64-byte callback cap.
+
+    Single-use: ``consumed_at`` is claimed atomically on the first
+    valid click (UPDATE … WHERE consumed_at IS NULL); a second click
+    with the same nonce loses the race and is answered as stale.
+
+    Deliberately NOT an ``inbox_items`` row — chat plumbing must never
+    leak into the operator's Console Inbox views (the founder-flagged
+    pollution risk in ELS-252).
+    """
+
+    __tablename__ = "telegram_pending_actions"
+    __table_args__ = (
+        UniqueConstraint("token_nonce", name="uq_telegram_pending_nonce"),
+        Index(
+            "ix_telegram_pending_chat_message",
+            "telegram_chat_id",
+            "bot_message_id",
+        ),
+        Index("ix_telegram_pending_workspace", "workspace_id"),
+    )
+
+    id: Mapped[uuid.UUID] = _pk()
+    workspace_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("workspaces.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    telegram_chat_id: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    bot_message_id: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    # Navigator thread the buttons belong to (resolved at click time
+    # from telegram_thread_map historically; cached here so the click
+    # handler has one read).
+    ship_thread_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("chat_threads.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    # [{"label": "...", "value": "..."}, ...] in button order.
+    options: Mapped[list] = mapped_column(
+        JSONB, nullable=False, server_default=text("'[]'::jsonb")
+    )
+    # Random server-side nonce mixed into the callback HMAC — a forged
+    # callback_data can't be signed without it + the JWT secret.
+    token_nonce: Mapped[str] = mapped_column(String(64), nullable=False)
+    expires_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+    consumed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
     )
     created_at: Mapped[datetime] = _ts_created()

--- a/apps/backend/app/integrations/telegram/bot.py
+++ b/apps/backend/app/integrations/telegram/bot.py
@@ -29,10 +29,11 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import secrets
 import time
 import uuid
-from collections import OrderedDict
 from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
 from typing import AsyncIterator
 
 import httpx
@@ -49,9 +50,19 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.app.core.config import Settings, get_settings
-from backend.app.db.models.telegram import TelegramChatLink, TelegramThreadMap
+from backend.app.db.models.telegram import (
+    TelegramChatLink,
+    TelegramPendingAction,
+    TelegramThreadMap,
+)
 from backend.app.db.session import get_sessionmaker
 from backend.app.integrations.telegram.bind_state import build_bind_nonce
+from backend.app.integrations.telegram.callback_token import (
+    CALLBACK_TTL_SECONDS,
+    build_callback_data,
+    parse_callback_data,
+    verify_callback,
+)
 from backend.app.integrations.telegram.render import (
     Directive,
     extract_directives,
@@ -225,85 +236,194 @@ async def _stream_navigator_turn(
 # ---------------------------------------------------------------------------
 
 
-# Bounded process-local cache: ``(chat_id, message_id) → option list``.
-# We can't pack the option value into ``callback_data`` (Telegram caps it
-# at 64 bytes) so the button payload is just the index and we resolve
-# the actual text here. LRU-evicted to bound memory; on miss the click
-# handler tells the user the choice expired and asks them to retype.
-_CHOICE_CACHE_LIMIT: int = 256
-_CHOICE_CACHE: "OrderedDict[tuple[int, int], list[dict]]" = OrderedDict()
+# Durable pending-action store (ELS-252) — replaces the process-local
+# ``_CHOICE_CACHE`` that died on every leader failover and left
+# previously-attached keyboards dead-on-click. The option list lives
+# in ``telegram_pending_actions``; ``callback_data`` carries only a
+# signed pointer (ELS-253).
 
 
-def _cache_choice_options(
-    *, chat_id: int, message_id: int, options: list[dict]
-) -> None:
-    key = (chat_id, message_id)
-    _CHOICE_CACHE[key] = options
-    _CHOICE_CACHE.move_to_end(key)
-    while len(_CHOICE_CACHE) > _CHOICE_CACHE_LIMIT:
-        _CHOICE_CACHE.popitem(last=False)
+async def _store_pending_action(
+    session: AsyncSession,
+    *,
+    workspace_id: uuid.UUID,
+    chat_id: int,
+    message_id: int,
+    thread_id: uuid.UUID | None,
+    options: list[dict],
+) -> tuple[uuid.UUID, str]:
+    """Persist the option list; returns ``(action_id, nonce)`` for the
+    callback signer."""
+    nonce = secrets.token_urlsafe(24)
+    row = TelegramPendingAction(
+        workspace_id=workspace_id,
+        telegram_chat_id=chat_id,
+        bot_message_id=message_id,
+        ship_thread_id=thread_id,
+        options=options,
+        token_nonce=nonce,
+        expires_at=datetime.now(timezone.utc)
+        + timedelta(seconds=CALLBACK_TTL_SECONDS),
+    )
+    session.add(row)
+    await session.flush()
+    return row.id, nonce
 
 
-def _pop_choice_options(
-    *, chat_id: int, message_id: int
-) -> list[dict] | None:
-    return _CHOICE_CACHE.pop((chat_id, message_id), None)
+async def _claim_pending_action(
+    session: AsyncSession, *, action_id: uuid.UUID
+) -> TelegramPendingAction | None:
+    """Atomically consume the action row (single-use, ELS-253).
 
-
-def _build_choice_markup(
-    directives: list[Directive],
-) -> tuple[InlineKeyboardMarkup, list[dict]] | None:
-    """Build a Telegram inline keyboard from ship-choice directives.
-
-    All ship-choice options across one assistant turn collapse into a
-    single keyboard so a multi-choice reply doesn't fragment across
-    several attached messages. Each option is one row (cleanest layout
-    for variable-length labels). Returns ``None`` if there are no
-    valid options to render.
+    ``UPDATE … WHERE consumed_at IS NULL RETURNING`` means a double
+    click / Telegram re-delivery loses the race deterministically —
+    the second caller gets ``None`` and answers "already used". The
+    TTL check rides the same statement so an expired row can never be
+    claimed.
     """
-    rows: list[list[InlineKeyboardButton]] = []
+    from sqlalchemy import update
+
+    now = datetime.now(timezone.utc)
+    row = (
+        await session.execute(
+            update(TelegramPendingAction)
+            .where(
+                TelegramPendingAction.id == action_id,
+                TelegramPendingAction.consumed_at.is_(None),
+                TelegramPendingAction.expires_at > now,
+            )
+            .values(consumed_at=now)
+            .returning(TelegramPendingAction)
+        )
+    ).scalar_one_or_none()
+    return row
+
+
+def _normalize_choice_option(raw_opt: object) -> dict | None:
+    if isinstance(raw_opt, str):
+        return {"label": raw_opt, "value": raw_opt}
+    if isinstance(raw_opt, dict):
+        label_raw = raw_opt.get("label")
+        value_raw = raw_opt.get("value")
+        label = str(label_raw).strip() if isinstance(label_raw, str) else ""
+        value = (
+            str(value_raw).strip() if isinstance(value_raw, str) else label
+        )
+        if not label:
+            return None
+        return {"label": label, "value": value or label}
+    return None
+
+
+def _is_approval_directive(directive: Directive) -> bool:
+    """Boundary classifier (ELS-254, thesis 4): callback button =
+    low-stakes Navigator choice; url button = control-plane/approval
+    deep-link. A directive is approval/control-stakes when its payload
+    says so — the Navigator marks Inbox-approval prompts with
+    ``approval: true`` (or ``stakes: approval|control``)."""
+    payload = directive.payload or {}
+    if payload.get("approval") is True:
+        return True
+    return str(payload.get("stakes") or "").lower() in ("approval", "control")
+
+
+def _approval_deep_link(
+    payload: dict, *, console_url: str, workspace_id: uuid.UUID
+) -> str:
+    """Deep-link into the authoritative Inbox approval surface.
+
+    The Inbox stays reachable in EVERY console mode (the Phase-4
+    ``console.surface`` gate pins it), so this link can never orphan
+    a pending approval. The real approval is recorded there under the
+    acting user's identity — never under the shared group PAT.
+    """
+    base = console_url.rstrip("/")
+    item_id = payload.get("inbox_item_id")
+    if item_id:
+        return f"{base}/inbox?ws={workspace_id}&selected={item_id}"
+    href = payload.get("href")
+    if isinstance(href, str) and href.startswith(base):
+        return href
+    return f"{base}/inbox?ws={workspace_id}"
+
+
+def _collect_directive_actions(
+    directives: list[Directive],
+    *,
+    console_url: str,
+    workspace_id: uuid.UUID,
+) -> tuple[list[dict], list[dict]]:
+    """Split one turn's directives into ``(options, links)``.
+
+    ``options`` are low-stakes pre-enumerated Navigator choices that
+    render as signed callback buttons; ``links`` are approval /
+    control-stakes actions that render as URL buttons deep-linking to
+    the Console Inbox (ELS-254 — chat never commits the control
+    plane).
+    """
     options: list[dict] = []
+    links: list[dict] = []
     for directive in directives:
         if directive.kind != "ship-choice" or not directive.payload:
             continue
-        raw_options = directive.payload.get("options") or []
-        for raw_opt in raw_options:
-            if isinstance(raw_opt, str):
-                normalized = {"label": raw_opt, "value": raw_opt}
-            elif isinstance(raw_opt, dict):
-                label_raw = raw_opt.get("label")
-                value_raw = raw_opt.get("value")
-                label = (
-                    str(label_raw).strip() if isinstance(label_raw, str) else ""
-                )
-                value = (
-                    str(value_raw).strip()
-                    if isinstance(value_raw, str)
-                    else label
-                )
-                if not label:
-                    continue
-                normalized = {"label": label, "value": value or label}
-            else:
-                continue
-            idx = len(options)
-            options.append(normalized)
-            # Telegram caps the button text at 64 chars; truncate
-            # politely with an ellipsis so the original label survives
-            # in the cache for the actual chat reply.
-            display = normalized["label"]
-            if len(display) > 64:
-                display = display[:63] + "…"
-            rows.append(
-                [
-                    InlineKeyboardButton(
-                        text=display, callback_data=f"c|{idx}"
-                    )
-                ]
+        if _is_approval_directive(directive):
+            url = _approval_deep_link(
+                directive.payload,
+                console_url=console_url,
+                workspace_id=workspace_id,
             )
+            label = str(
+                directive.payload.get("label")
+                or directive.payload.get("title")
+                or "Review in Inbox"
+            ).strip() or "Review in Inbox"
+            links.append({"label": label, "url": url})
+            continue
+        for raw_opt in directive.payload.get("options") or []:
+            normalized = _normalize_choice_option(raw_opt)
+            if normalized is not None:
+                options.append(normalized)
+    return options, links
+
+
+def _button_text(label: str) -> str:
+    # Telegram caps the button text at 64 chars; truncate politely
+    # with an ellipsis — the full label survives in the durable row
+    # for the actual chat echo.
+    return label if len(label) <= 64 else label[:63] + "…"
+
+
+def _build_choice_markup(
+    options: list[dict],
+    links: list[dict],
+    *,
+    sign,  # type: ignore[no-untyped-def] — (idx: int) -> callback_data str
+) -> InlineKeyboardMarkup | None:
+    """Assemble the keyboard: one row per option (signed callback
+    button) followed by one row per approval link (URL button).
+    Returns ``None`` when there is nothing to render."""
+    rows: list[list[InlineKeyboardButton]] = []
+    for idx, opt in enumerate(options):
+        rows.append(
+            [
+                InlineKeyboardButton(
+                    text=_button_text(opt["label"]),
+                    callback_data=sign(idx),
+                )
+            ]
+        )
+    for link in links:
+        rows.append(
+            [
+                InlineKeyboardButton(
+                    text=_button_text(link["label"]),
+                    url=link["url"],
+                )
+            ]
+        )
     if not rows:
         return None
-    return InlineKeyboardMarkup(inline_keyboard=rows), options
+    return InlineKeyboardMarkup(inline_keyboard=rows)
 
 
 # ---------------------------------------------------------------------------
@@ -505,24 +625,51 @@ async def _drive_turn(
 
         # End-of-turn: attach an InlineKeyboardMarkup to the last bot
         # message if Navigator emitted any ship-choice directives.
-        # Buttons render as a row per option below the assistant text;
-        # clicks round-trip through ``on_choice_click`` (registered in
-        # ``_build_dispatcher``) which posts the chosen value as the
-        # next user message in the same Navigator thread.
+        # Low-stakes options render as SIGNED callback buttons whose
+        # option list persists in telegram_pending_actions (survives
+        # leader failover, single-use); approval/control-stakes
+        # directives render as URL deep-links into the Console Inbox
+        # and never round-trip through the bot (ELS-252/253/254).
         _, final_directives = extract_directives(buf)
-        keyboard = _build_choice_markup(final_directives)
-        if keyboard is not None and messages:
-            markup, options = keyboard
+        settings = get_settings()
+        options, links = _collect_directive_actions(
+            final_directives,
+            console_url=settings.console_url,
+            workspace_id=workspace_id,
+        )
+        if (options or links) and messages:
             target_id = messages[-1]
             try:
-                await bot.edit_message_reply_markup(
-                    chat_id=chat_id,
-                    message_id=target_id,
-                    reply_markup=markup,
-                )
-                _cache_choice_options(
-                    chat_id=chat_id, message_id=target_id, options=options
-                )
+                if options:
+                    async with sessionmaker() as session, session.begin():
+                        action_id, nonce = await _store_pending_action(
+                            session,
+                            workspace_id=workspace_id,
+                            chat_id=chat_id,
+                            message_id=target_id,
+                            thread_id=thread_id,
+                            options=options,
+                        )
+
+                    def _sign(idx: int) -> str:
+                        return build_callback_data(
+                            settings,
+                            action_id=action_id,
+                            idx=idx,
+                            nonce=nonce,
+                        )
+
+                else:
+                    def _sign(idx: int) -> str:  # pragma: no cover — no options
+                        raise RuntimeError("no callback options to sign")
+
+                markup = _build_choice_markup(options, links, sign=_sign)
+                if markup is not None:
+                    await bot.edit_message_reply_markup(
+                        chat_id=chat_id,
+                        message_id=target_id,
+                        reply_markup=markup,
+                    )
             except Exception as exc:  # noqa: BLE001 — Telegram 400 on benign edits
                 logger.debug(
                     "telegram attach choice markup failed (chat=%s msg=%s): %s",
@@ -708,12 +855,15 @@ def _build_dispatcher(settings: Settings) -> Dispatcher:
     async def on_choice_click(query: CallbackQuery) -> None:
         """Translate a ship-choice button click into a Navigator turn.
 
-        The button's ``callback_data`` is ``c|<idx>`` where ``idx``
-        points at the option list cached when the buttons were
-        attached. We strip the buttons (so the user can't double-click
-        and stack two turns), echo the chosen label as a confirmation
-        message, and run the next turn against the same Navigator
-        thread the buttons came from.
+        ``callback_data`` is the signed pointer from ELS-253:
+        ``c|<action_id>|<idx>|<sig>``. The option list lives in the
+        durable ``telegram_pending_actions`` row (ELS-252), so clicks
+        survive leader failover. Verification order: parse → load row
+        → HMAC check against the row's nonce → ATOMIC single-use
+        consume (+TTL) — only then does a Navigator turn run, so a
+        double click / Telegram re-delivery fires exactly once.
+        Legacy ``c|<idx>`` payloads from pre-failover keyboards parse
+        as ``None`` and get the stale answer.
         """
         if (
             query.data is None
@@ -725,19 +875,10 @@ def _build_dispatcher(settings: Settings) -> Dispatcher:
             await query.answer("Invalid click", show_alert=False)
             return
 
-        try:
-            _, idx_str = query.data.split("|", 1)
-            idx = int(idx_str)
-        except (ValueError, IndexError):
-            await query.answer("Invalid click", show_alert=False)
-            return
-
         chat_id = query.message.chat.id
         button_message_id = query.message.message_id
-        options = _pop_choice_options(
-            chat_id=chat_id, message_id=button_message_id
-        )
-        if options is None or idx < 0 or idx >= len(options):
+
+        async def _reject_stale() -> None:
             await query.answer(
                 "Этот выбор уже не активен — напиши свой ответ текстом.",
                 show_alert=True,
@@ -751,9 +892,34 @@ def _build_dispatcher(settings: Settings) -> Dispatcher:
                 )
             except Exception:  # noqa: BLE001
                 pass
+
+        parsed = parse_callback_data(query.data)
+        if parsed is None:
+            await _reject_stale()
             return
 
-        chosen = options[idx]
+        async with sessionmaker() as session, session.begin():
+            action = await session.get(TelegramPendingAction, parsed.action_id)
+            if action is None or not verify_callback(
+                settings, parsed=parsed, nonce=action.token_nonce
+            ):
+                # Unknown row or bad signature — forged/tampered
+                # callback_data. No Navigator turn.
+                action = None
+            elif parsed.idx >= len(action.options or []):
+                action = None
+            else:
+                # Atomic single-use claim; expired or already-consumed
+                # rows come back None and the click is rejected.
+                action = await _claim_pending_action(
+                    session, action_id=parsed.action_id
+                )
+
+        if action is None:
+            await _reject_stale()
+            return
+
+        chosen = (action.options or [])[parsed.idx]
         label = chosen.get("label") or chosen.get("value") or ""
         value = chosen.get("value") or label
 
@@ -784,10 +950,11 @@ def _build_dispatcher(settings: Settings) -> Dispatcher:
             link = await _get_link(session, chat_id)
             if link is None:
                 return
-            # Resolve the Navigator thread from the button-bearing
-            # message — it's registered in telegram_thread_map as part
-            # of the prior turn's chunks.
-            seed_thread_id = await _resolve_thread_id(
+            # The durable row caches the Navigator thread the buttons
+            # came from; the telegram_thread_map lookup stays as the
+            # fallback for rows attached before the thread event
+            # arrived.
+            seed_thread_id = action.ship_thread_id or await _resolve_thread_id(
                 session,
                 chat_id=chat_id,
                 reply_to_message_id=button_message_id,

--- a/apps/backend/app/integrations/telegram/callback_token.py
+++ b/apps/backend/app/integrations/telegram/callback_token.py
@@ -1,0 +1,101 @@
+"""Signed single-use ``callback_data`` for Telegram inline buttons
+(ELS-253).
+
+Telegram caps ``callback_data`` at 64 bytes, so a JWT (the
+:mod:`bind_state` pattern) does not fit. Same security properties,
+compact encoding instead:
+
+- the HEAVY payload (option list, thread id) lives in the durable
+  :class:`TelegramPendingAction` row (ELS-252);
+- ``callback_data`` carries only ``c|<row_id_hex>|<idx>|<sig>`` where
+  ``sig`` is a truncated HMAC-SHA256 over ``row_id|idx|token_nonce``
+  keyed with ``settings.jwt_secret`` — the same secret source as
+  ``bind_state._secret``;
+- the per-row ``token_nonce`` is random and server-side only, so a
+  forged/tampered callback cannot be signed without both the nonce
+  and the secret;
+- TTL is enforced server-side via the row's ``expires_at`` (set from
+  ``CALLBACK_TTL_SECONDS``), and single-use via the atomic
+  ``consumed_at`` claim — both checked before any Navigator turn runs.
+
+Wire format budget: ``c|`` (2) + 32 hex + ``|`` + ≤2 digits + ``|`` +
+16 sig chars = 54 bytes worst case, comfortably under the 64-byte cap
+(pinned by a unit test).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import uuid
+from dataclasses import dataclass
+from typing import Final
+
+from backend.app.core.config import Settings
+
+# Mirrors bind_state's short-window philosophy. Choice keyboards are
+# conversational — ten minutes of validity matches the bind nonce and
+# keeps a forgotten keyboard from being a standing attack surface.
+CALLBACK_TTL_SECONDS: Final[int] = 10 * 60
+
+_SIG_CHARS: Final[int] = 16
+_PREFIX: Final[str] = "c"
+
+
+def _secret(settings: Settings) -> str:
+    return settings.jwt_secret
+
+
+def sign_callback(
+    settings: Settings, *, action_id: uuid.UUID, idx: int, nonce: str
+) -> str:
+    mac = hmac.new(
+        _secret(settings).encode("utf-8"),
+        f"{action_id.hex}|{idx}|{nonce}".encode("utf-8"),
+        hashlib.sha256,
+    )
+    return mac.hexdigest()[:_SIG_CHARS]
+
+
+def build_callback_data(
+    settings: Settings, *, action_id: uuid.UUID, idx: int, nonce: str
+) -> str:
+    sig = sign_callback(settings, action_id=action_id, idx=idx, nonce=nonce)
+    data = f"{_PREFIX}|{action_id.hex}|{idx}|{sig}"
+    # Telegram rejects >64-byte callback_data at send time with an
+    # opaque 400; fail loudly at build time instead.
+    if len(data.encode("utf-8")) > 64:
+        raise ValueError(f"callback_data exceeds 64 bytes: {data!r}")
+    return data
+
+
+@dataclass(frozen=True, slots=True)
+class ParsedCallback:
+    action_id: uuid.UUID
+    idx: int
+    sig: str
+
+
+def parse_callback_data(data: str) -> ParsedCallback | None:
+    """Parse ``c|<hex>|<idx>|<sig>``; ``None`` for malformed or
+    legacy (``c|<idx>``) payloads — callers treat both as stale."""
+    parts = (data or "").split("|")
+    if len(parts) != 4 or parts[0] != _PREFIX:
+        return None
+    try:
+        action_id = uuid.UUID(hex=parts[1])
+        idx = int(parts[2])
+    except (ValueError, TypeError):
+        return None
+    if idx < 0 or not parts[3]:
+        return None
+    return ParsedCallback(action_id=action_id, idx=idx, sig=parts[3])
+
+
+def verify_callback(
+    settings: Settings, *, parsed: ParsedCallback, nonce: str
+) -> bool:
+    expected = sign_callback(
+        settings, action_id=parsed.action_id, idx=parsed.idx, nonce=nonce
+    )
+    return hmac.compare_digest(expected, parsed.sig)

--- a/apps/backend/app/services/agent/comment_inbound.py
+++ b/apps/backend/app/services/agent/comment_inbound.py
@@ -1,0 +1,187 @@
+"""Linear-comment → Navigator inbound (thesis 4, ELS-251).
+
+The tracker poller hands fresh NON-AGENT comments on active tickets to
+this service, which appends them as a user-role turn on the ticket's
+Navigator thread and drives one agent turn so the reply lands in the
+same conversation the operator reads in the Console.
+
+CRITICAL INVARIANT (thesis 2): this module is context-only. It never
+calls ``transition()``, never writes a stage-changing tracker event —
+the tracker STATUS field stays the only FSM transition signal
+(``tracker_fsm`` enforces it; the test suite pins it here too).
+
+The turn loop is the same ``_run_agent_turn`` generator the
+``POST /chat/stream`` route drives — imported as a function, NOT
+self-called over HTTP (per the ELS-251 design note). The SSE frames
+it yields are drained and discarded; the durable outcome is the
+persisted assistant message on the thread.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.app.core.config import Settings
+from backend.app.db.models.agent_surface import ChatMessage, ChatThread
+from backend.app.db.models.tenancy import WorkspaceMember
+
+logger = logging.getLogger(__name__)
+
+
+async def _resolve_service_actor(
+    session: AsyncSession, workspace_id: uuid.UUID
+) -> uuid.UUID | None:
+    """Pick the user identity the ingested turn runs under.
+
+    The chat turn loop (TopicService / ToolBox) requires a real
+    member id for authz + audit. Prefer the workspace owner, then
+    any admin — the same set that could have typed the message into
+    the Console themselves.
+    """
+    for roles in (("owner",), ("admin",), ("member",)):
+        row = (
+            await session.execute(
+                select(WorkspaceMember.user_id)
+                .where(
+                    WorkspaceMember.workspace_id == workspace_id,
+                    WorkspaceMember.role.in_(roles),
+                )
+                .order_by(WorkspaceMember.created_at.asc())
+                .limit(1)
+            )
+        ).scalar_one_or_none()
+        if row:
+            return row
+    return None
+
+
+async def _find_or_create_ticket_thread(
+    session: AsyncSession,
+    *,
+    workspace_id: uuid.UUID,
+    ticket_ref: str,
+    ticket_title: str | None,
+    actor_user_id: uuid.UUID,
+) -> ChatThread:
+    """Return the ticket's active Navigator thread, creating one when
+    none exists. ``resolved_ticket_ref`` doubles as the ticket binding
+    key — threads that SPAWNED the ticket already carry it, and the
+    poller-created thread reuses the same column so the Console's
+    existing deep-links keep working."""
+    thread = (
+        await session.execute(
+            select(ChatThread)
+            .where(
+                ChatThread.workspace_id == workspace_id,
+                ChatThread.resolved_ticket_ref == ticket_ref,
+                ChatThread.status == "active",
+            )
+            .order_by(ChatThread.created_at.desc())
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+    if thread is not None:
+        return thread
+    thread = ChatThread(
+        workspace_id=workspace_id,
+        created_by_user_id=actor_user_id,
+        title=f"{ticket_ref} — {(ticket_title or 'tracker thread')[:480]}",
+        status="active",
+        resolved_ticket_ref=ticket_ref,
+    )
+    session.add(thread)
+    await session.flush()
+    return thread
+
+
+async def ingest_operator_comment(
+    session: AsyncSession,
+    *,
+    settings: Settings,
+    workspace_id: uuid.UUID,
+    ticket_ref: str,
+    ticket_title: str | None,
+    comment_id: str,
+    comment_body: str,
+    comment_author: str | None,
+) -> bool:
+    """Append one operator comment as a Navigator turn. Returns True
+    when a turn ran, False when ingestion was skipped (no actor, no
+    LLM, empty body). Best-effort by contract — the caller (poller)
+    wraps this in try/except so chat problems never break polling."""
+    body = (comment_body or "").strip()
+    if not body:
+        return False
+
+    actor_user_id = await _resolve_service_actor(session, workspace_id)
+    if actor_user_id is None:
+        logger.warning(
+            "comment_inbound: workspace %s has no members; skipping",
+            workspace_id,
+        )
+        return False
+
+    from backend.app.services.agent.client import pick_default_client
+
+    try:
+        agent = pick_default_client(settings)
+    except RuntimeError:
+        logger.warning(
+            "comment_inbound: no LLM configured; skipping ws=%s ref=%s",
+            workspace_id,
+            ticket_ref,
+        )
+        return False
+
+    thread = await _find_or_create_ticket_thread(
+        session,
+        workspace_id=workspace_id,
+        ticket_ref=ticket_ref,
+        ticket_title=ticket_title,
+        actor_user_id=actor_user_id,
+    )
+
+    prefix = (
+        f"[Linear comment on {ticket_ref}"
+        + (f" by {comment_author}" if comment_author else "")
+        + "]\n\n"
+    )
+    user_msg = ChatMessage(
+        thread_id=thread.id,
+        role="user",
+        author_user_id=actor_user_id,
+        body=prefix + body,
+        meta={
+            "source": "linear_comment",
+            "comment_id": comment_id,
+            "ticket_ref": ticket_ref,
+            "author": comment_author,
+        },
+    )
+    session.add(user_msg)
+    thread.last_user_activity_at = datetime.now(timezone.utc)
+    await session.flush()
+
+    # Local import — the turn generator lives next to the HTTP route
+    # but is a plain async generator; driving it here is the
+    # service-function extraction ELS-251 asked for (no HTTP hop).
+    from backend.app.api.v1.routes.chat import _run_agent_turn
+
+    async for _frame in _run_agent_turn(
+        session=session,
+        settings=settings,
+        agent=agent,
+        workspace_id=workspace_id,
+        user_id=actor_user_id,
+        thread=thread,
+        user_msg=user_msg,
+        user_attachments=[],
+        classify_shift=False,
+    ):
+        pass
+    return True

--- a/apps/backend/app/services/config_registry.py
+++ b/apps/backend/app/services/config_registry.py
@@ -156,6 +156,22 @@ async def _write_autonomy_profile(_s: AsyncSession, ws: Workspace, value: Any) -
     ws.autonomy = str(value)
 
 
+async def _read_comment_inbound(_s: AsyncSession, ws: Workspace) -> Any:
+    raw = (ws.settings or {}).get("chat") or {}
+    return bool(raw.get("comment_inbound", False))
+
+
+async def _write_comment_inbound(_s: AsyncSession, ws: Workspace, value: Any) -> None:
+    if not isinstance(value, bool):
+        raise ValueError("chat.comment_inbound must be a boolean")
+    settings = dict(ws.settings or {})
+    chat = dict(settings.get("chat") or {})
+    chat["comment_inbound"] = value
+    settings["chat"] = chat
+    # Reassign (not mutate) so SQLAlchemy's JSONB change detection fires.
+    ws.settings = settings
+
+
 async def _read_local_executor_enabled(_s: AsyncSession, ws: Workspace) -> Any:
     raw = (ws.settings or {}).get("local_executor") or {}
     return bool(raw.get("enabled", False))
@@ -322,6 +338,26 @@ _SCOPE_LIST: tuple[ConfigScope, ...] = (
         read=_read_local_executor_enabled,
         write=_write_local_executor_enabled,
         audit_event="workspace.local_executor_enabled.set",
+    ),
+    ConfigScope(
+        slug="chat.comment_inbound",
+        description=(
+            "Whether fresh operator comments on active tracker tickets "
+            "flow into the ticket's Navigator thread as conversational "
+            "context (thesis 4, ELS-251). Context only — comments NEVER "
+            "transition the FSM; the STATUS field stays the only "
+            "transition signal. Default-OFF, consistent with the "
+            "inbox-only launch egress."
+        ),
+        schema={
+            "type": "boolean",
+            "description": (
+                "Opt-in flag for Linear-comment → Navigator inbound."
+            ),
+        },
+        read=_read_comment_inbound,
+        write=_write_comment_inbound,
+        audit_event="workspace.chat_comment_inbound.set",
     ),
 )
 

--- a/apps/backend/app/services/tracker_poller.py
+++ b/apps/backend/app/services/tracker_poller.py
@@ -56,7 +56,7 @@ from backend.app.db.models.integrations import (
     NativeIntegrationInstallation,
     NativeIntegrationSyncState,
 )
-from backend.app.db.models.tenancy import AuditLog, Integration
+from backend.app.db.models.tenancy import AuditLog, Integration, Workspace
 from backend.app.db.session import get_sessionmaker
 from backend.app.integrations.linear.tracker_adapter import LinearTracker
 from backend.app.security.encryption import safe_decrypt
@@ -222,6 +222,81 @@ def _operator_answered_clarification(comments: list[dict]) -> bool:
         # Non-agent comment newer than the latest agent comment.
         return True
     return False
+
+
+async def _ingest_fresh_operator_comments(
+    session: AsyncSession,
+    *,
+    workspace_id: uuid.UUID,
+    ticket_ref: str,
+    ticket_title: str | None,
+    comments: list[dict],
+    comment_cursor: dict[str, str],
+) -> int:
+    """Feed NEW non-agent comments on ``ticket_ref`` into the
+    Navigator (ELS-251). Returns the number of turns run.
+
+    Dedup contract: ``comment_cursor[ticket_ref]`` holds the
+    ``createdAt`` of the newest comment already handled. First sight
+    of a ticket BASELINES to its newest existing comment without
+    ingesting — enabling the flag must not replay months of history.
+    The caller persists the mutated cursor alongside the poller's
+    state cursor, so re-running poll_once with no new comment is a
+    no-op.
+    """
+    rows = sorted(
+        (c for c in comments if isinstance(c, dict) and c.get("createdAt")),
+        key=lambda c: c["createdAt"],
+    )
+    if not rows:
+        return 0
+    newest = rows[-1]["createdAt"]
+    baseline = comment_cursor.get(ticket_ref)
+    if baseline is None:
+        comment_cursor[ticket_ref] = newest
+        return 0
+    fresh_human = [
+        c
+        for c in rows
+        if c["createdAt"] > baseline and not _is_agent_comment(c)
+    ]
+    # Advance the cursor past EVERYTHING seen this tick (agent
+    # comments included) so an agent reply doesn't get re-examined
+    # forever.
+    if newest > baseline:
+        comment_cursor[ticket_ref] = newest
+    if not fresh_human:
+        return 0
+
+    from backend.app.core.config import get_settings as _gs
+    from backend.app.services.agent.comment_inbound import (
+        ingest_operator_comment,
+    )
+
+    settings = _gs()
+    ingested = 0
+    for c in fresh_human:
+        author = None
+        user = c.get("user")
+        if isinstance(user, dict):
+            author = user.get("displayName") or user.get("email")
+        ran = await ingest_operator_comment(
+            session,
+            settings=settings,
+            workspace_id=workspace_id,
+            ticket_ref=ticket_ref,
+            ticket_title=ticket_title,
+            comment_id=str(c.get("id") or ""),
+            comment_body=c.get("body") or "",
+            comment_author=author,
+        )
+        if ran:
+            ingested += 1
+            log.info(
+                "tracker_poll: comment inbound ws=%s ref=%s comment=%s",
+                workspace_id, ticket_ref, c.get("id"),
+            )
+    return ingested
 
 
 async def _clear_clarification_and_dispatch(
@@ -434,8 +509,14 @@ async def _fetch_updated_issues(
 
 async def _load_cursor(
     session: AsyncSession, installation_id: uuid.UUID
-) -> tuple[str | None, dict[str, str]]:
-    """Return ``(updated_at_iso, last_seen_states)`` for this installation."""
+) -> tuple[str | None, dict[str, str], dict[str, str]]:
+    """Return ``(updated_at_iso, last_seen_states, comment_cursor)``.
+
+    ``comment_cursor`` maps ticket_ref → the ``createdAt`` of the
+    newest comment already ingested (or baselined) by the comment-
+    inbound path (ELS-251); it rides the same cursor JSONB so the
+    dedup guarantee survives restarts exactly like state dedup does.
+    """
     row = (
         await session.execute(
             select(NativeIntegrationSyncState).where(
@@ -446,8 +527,12 @@ async def _load_cursor(
         )
     ).scalar_one_or_none()
     if row is None or not row.cursor:
-        return None, {}
-    return row.cursor.get("updated_at"), dict(row.cursor.get("states") or {})
+        return None, {}, {}
+    return (
+        row.cursor.get("updated_at"),
+        dict(row.cursor.get("states") or {}),
+        dict(row.cursor.get("comments") or {}),
+    )
 
 
 async def _save_cursor(
@@ -456,6 +541,7 @@ async def _save_cursor(
     updated_at_iso: str | None,
     states: dict[str, str],
     *,
+    comments: dict[str, str] | None = None,
     status: str = "ready",
     last_error: str | None = None,
 ) -> None:
@@ -467,6 +553,8 @@ async def _save_cursor(
     do the upsert by hand inside one transaction.
     """
     payload: dict[str, Any] = {"states": states}
+    if comments:
+        payload["comments"] = comments
     if updated_at_iso:
         payload["updated_at"] = updated_at_iso
     existing = (
@@ -618,7 +706,17 @@ async def _poll_installation(
         )
         return 0, 0
 
-    cursor_iso, last_states = await _load_cursor(session, install.id)
+    cursor_iso, last_states, comment_cursor = await _load_cursor(
+        session, install.id
+    )
+
+    # Comment-inbound flag (ELS-251): one settings read per
+    # installation tick. Default OFF — the whole block below is inert
+    # until the workspace opts in via ``chat.comment_inbound``.
+    ws_row = await session.get(Workspace, install.workspace_id)
+    comment_inbound_enabled = bool(
+        ((ws_row.settings or {}).get("chat") or {}).get("comment_inbound", False)
+    ) if ws_row else False
 
     issues = await _fetch_updated_issues(
         token=token, team_id=team_id, since_iso=cursor_iso, client=client
@@ -695,6 +793,38 @@ async def _poll_installation(
                         "ws=%s ref=%s err=%s",
                         install.workspace_id, ref, exc,
                     )
+        # Comment-inbound (ELS-251): surface fresh NON-AGENT comments
+        # on active tickets into the ticket's Navigator thread.
+        # Context only — nothing in this block (or in the service it
+        # calls) touches transition()/state; the STATUS field stays
+        # the only FSM signal. Skips:
+        #   - terminal tickets (no conversation to continue),
+        #   - needs:clarification tickets (the clarification flow
+        #     above owns that round-trip),
+        #   - everything, when the per-workspace flag is off.
+        elif (
+            comment_inbound_enabled
+            and new_state not in ("Done", "Canceled", "Duplicate")
+        ):
+            comment_nodes = (
+                (issue.get("comments") or {}).get("nodes") or []
+            )
+            try:
+                ingested = await _ingest_fresh_operator_comments(
+                    session,
+                    workspace_id=install.workspace_id,
+                    ticket_ref=ref,
+                    ticket_title=issue.get("title"),
+                    comments=comment_nodes,
+                    comment_cursor=comment_cursor,
+                )
+                events += ingested
+            except Exception as exc:  # noqa: BLE001 — best-effort
+                log.warning(
+                    "tracker_poll: comment inbound failed ws=%s ref=%s "
+                    "err=%s",
+                    install.workspace_id, ref, exc,
+                )
         if updated_at and (
             max_updated_at is None or updated_at > max_updated_at
         ):
@@ -713,8 +843,19 @@ async def _poll_installation(
         except Exception:  # noqa: BLE001 — best-effort, keep raw
             pass
 
+    # Prune comment-cursor entries for terminal tickets so the JSONB
+    # doesn't grow unbounded across a team's history.
+    for ref_key, state_val in last_states.items():
+        if state_val in ("Done", "Canceled", "Duplicate"):
+            comment_cursor.pop(ref_key, None)
+
     await _save_cursor(
-        session, install.id, next_cursor, last_states, status="ready"
+        session,
+        install.id,
+        next_cursor,
+        last_states,
+        comments=comment_cursor,
+        status="ready",
     )
     return events, len(issues)
 
@@ -796,14 +937,15 @@ async def poll_once() -> dict[str, int]:
                         # Record the failure in sync_state so operators
                         # can see "this tenant is stuck" in the dashboard.
                         try:
-                            cursor_iso, last_states = await _load_cursor(
-                                session, install.id
+                            cursor_iso, last_states, comment_cursor = (
+                                await _load_cursor(session, install.id)
                             )
                             await _save_cursor(
                                 session,
                                 install.id,
                                 cursor_iso,
                                 last_states,
+                                comments=comment_cursor,
                                 status="error",
                                 last_error=str(exc)[:1000],
                             )

--- a/apps/backend/app/services/tracker_poller.py
+++ b/apps/backend/app/services/tracker_poller.py
@@ -99,12 +99,18 @@ query ShipTrackerPoll($filter: IssueFilter, $after: String) {
       # (createdAt DESC by default on the connection). 20 is enough
       # to cover the most-recent agent question + the answer; older
       # threads don't affect the trigger decision.
+      # ``isMe`` + ``botActor`` carry the author identity the
+      # agent-vs-human classifier keys on (ELS-250) — Ship writes
+      # through the same OAuth identity this poller reads with, so
+      # ``isMe: true`` means "our own comment"; app-actor
+      # provisioned installs surface as ``botActor`` instead.
       comments(first: 20) {
         nodes {
           id
           body
           createdAt
-          user { displayName email }
+          user { displayName email isMe }
+          botActor { id }
         }
       }
     }
@@ -152,21 +158,53 @@ def _extract_fsm_stage(labels: list[str], state: str | None = None) -> str | Non
 
 
 # Agent comments end with ``[Ship SDLC:role-<name>]`` per system.md
-# `outcome` rules. A comment that doesn't carry this marker is from
-# a human and counts as a "real answer" for clarification flow.
+# `outcome` rules. Since ELS-250 the marker is only the LEGACY
+# fallback — the primary agent-vs-human signal is the structured
+# Linear author identity (see :func:`_is_agent_comment`).
 _AGENT_COMMENT_MARKER_RE = re.compile(r"\[Ship\s+SDLC:role-[\w-]+\]")
+
+
+def _is_agent_comment(comment: dict) -> bool:
+    """Single source of truth for agent-vs-human on a Linear comment
+    (ELS-250). Consumed by the clarification trigger and the
+    comment-inbound path so the two can never disagree.
+
+    Identity first, marker second:
+
+    - ``user.isMe`` true → AGENT. Ship writes tracker comments
+      through the same OAuth identity the poller reads with, so
+      "authored by me" means "authored by the workspace agent".
+    - ``botActor`` present → AGENT (app-actor provisioned installs
+      surface the OAuth application as the author instead of a user).
+    - any OTHER known author → HUMAN, even when the body quotes the
+      ``[Ship SDLC:role-…]`` marker (operators paste it when replying
+      inline to the agent's question).
+    - no author identity at all (legacy rows / older snapshots) →
+      fall back to the marker regex.
+    """
+    if not isinstance(comment, dict):
+        return False
+    user = comment.get("user")
+    if isinstance(user, dict) and user.get("isMe") is True:
+        return True
+    if comment.get("botActor"):
+        return True
+    if isinstance(user, dict) and user:
+        return False
+    body = comment.get("body") or ""
+    return bool(_AGENT_COMMENT_MARKER_RE.search(body))
 
 
 def _operator_answered_clarification(comments: list[dict]) -> bool:
     """Decide whether the operator has replied to the last agent
     clarification question.
 
-    Walks comments newest-first. The first marker-bearing comment
-    we hit is the agent's question (the one that asked). If we see
-    a non-marker comment BEFORE the agent comment in time
-    (i.e. AFTER it in the newest-first walk's prefix), the operator
-    has answered. Returns ``True`` if a fresh operator comment
-    exists since the last agent question.
+    Walks comments newest-first. The first AGENT comment we hit is
+    the agent's question (the one that asked). If we see a human
+    comment BEFORE the agent comment in time (i.e. AFTER it in the
+    newest-first walk's prefix), the operator has answered. Returns
+    ``True`` if a fresh operator comment exists since the last agent
+    question.
     """
     # Sort newest-first defensively (Linear returns newest-first
     # by default on this connection, but the contract isn't
@@ -177,8 +215,7 @@ def _operator_answered_clarification(comments: list[dict]) -> bool:
         reverse=True,
     )
     for c in rows:
-        body = c.get("body") or ""
-        if _AGENT_COMMENT_MARKER_RE.search(body):
+        if _is_agent_comment(c):
             # Hit the latest agent comment without finding an
             # operator one above it → operator hasn't replied.
             return False

--- a/apps/backend/migrations/versions/0088_telegram_pending_actions.py
+++ b/apps/backend/migrations/versions/0088_telegram_pending_actions.py
@@ -1,0 +1,88 @@
+"""telegram_pending_actions — durable inline-keyboard store (ELS-252)
+
+Replaces the bot's process-local ``_CHOICE_CACHE``: option lists now
+survive leader failover, and the row id + server-side nonce back the
+signed single-use ``callback_data`` (ELS-253). Forward revision after
+0087 (applied in prod; never edited in place).
+
+Revision ID: 0088_telegram_pending_actions
+Revises: 0087_agent_provider_ship
+Create Date: 2026-06-12
+"""
+
+from __future__ import annotations
+
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+
+
+revision: str = "0088_telegram_pending_actions"
+down_revision: Union[str, None] = "0087_agent_provider_ship"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "telegram_pending_actions",
+        sa.Column(
+            "id",
+            UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "workspace_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("workspaces.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("telegram_chat_id", sa.BigInteger(), nullable=False),
+        sa.Column("bot_message_id", sa.BigInteger(), nullable=False),
+        sa.Column(
+            "ship_thread_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("chat_threads.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column(
+            "options",
+            JSONB(),
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        sa.Column("token_nonce", sa.String(64), nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("consumed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.UniqueConstraint("token_nonce", name="uq_telegram_pending_nonce"),
+    )
+    op.create_index(
+        "ix_telegram_pending_chat_message",
+        "telegram_pending_actions",
+        ["telegram_chat_id", "bot_message_id"],
+    )
+    op.create_index(
+        "ix_telegram_pending_workspace",
+        "telegram_pending_actions",
+        ["workspace_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_telegram_pending_workspace", table_name="telegram_pending_actions"
+    )
+    op.drop_index(
+        "ix_telegram_pending_chat_message",
+        table_name="telegram_pending_actions",
+    )
+    op.drop_table("telegram_pending_actions")

--- a/apps/backend/tests/test_comment_inbound.py
+++ b/apps/backend/tests/test_comment_inbound.py
@@ -1,0 +1,304 @@
+"""ELS-251 — Linear operator comments → Navigator turn (context-only).
+
+Pins the four contract points:
+
+- OFF by default: the poller never calls the ingest service unless the
+  workspace opted into ``chat.comment_inbound``.
+- Baseline-then-ingest: first sight of a ticket baselines its newest
+  comment without ingesting (no history replay); a comment newer than
+  the baseline triggers exactly one Navigator turn.
+- Idempotency: re-polling with no new comment runs zero turns (the
+  comment cursor rides the poller cursor JSONB).
+- Context-only: ingestion writes NO ``tracker.event.received`` rows —
+  the FSM sees nothing.
+
+The ingest service itself is unit-tested with the turn generator
+stubbed: user message persisted on the ticket thread with
+source-metadata, turn driven with classify_shift=False semantics
+(the service hard-codes it).
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlalchemy import select
+
+from backend.app.db.models.agent_surface import ChatMessage, ChatThread
+from backend.app.db.models.tenancy import AuditLog
+from backend.app.services import tracker_poller
+from backend.app.services.agent import comment_inbound
+
+from backend.tests.test_tracker_poller import (  # noqa: F401 — reuse harness
+    _patch_sessionmaker,
+    _seed_linear_install,
+)
+
+
+def _issue_with_comments(
+    identifier: str,
+    state: str,
+    updated_at: str,
+    comments: list[dict[str, Any]],
+) -> dict[str, Any]:
+    return {
+        "id": str(uuid.uuid4()),
+        "identifier": identifier,
+        "title": f"Ticket {identifier}",
+        "state": {"name": state},
+        "updatedAt": updated_at,
+        "comments": {"nodes": comments},
+    }
+
+
+def _human(body: str, created_at: str) -> dict[str, Any]:
+    return {
+        "id": str(uuid.uuid4()),
+        "body": body,
+        "createdAt": created_at,
+        "user": {"displayName": "Denys", "email": "d@x", "isMe": False},
+    }
+
+
+def _agent(body: str, created_at: str) -> dict[str, Any]:
+    return {
+        "id": str(uuid.uuid4()),
+        "body": body,
+        "createdAt": created_at,
+        "user": {"displayName": "Ship", "email": "a@x", "isMe": True},
+    }
+
+
+async def _enable_flag(db_session, workspace) -> None:
+    workspace.settings = {
+        **(workspace.settings or {}),
+        "chat": {"comment_inbound": True},
+    }
+    await db_session.flush()
+
+
+@pytest.fixture
+def ingest_spy(monkeypatch):
+    spy = AsyncMock(return_value=True)
+    monkeypatch.setattr(comment_inbound, "ingest_operator_comment", spy)
+    return spy
+
+
+@pytest.mark.asyncio
+async def test_flag_off_by_default_never_ingests(
+    db_session, seed_workspace, monkeypatch, _patch_sessionmaker, ingest_spy
+) -> None:
+    _, _, workspace = seed_workspace
+    await _seed_linear_install(db_session, workspace.id)
+    await db_session.commit()
+
+    issues = [
+        _issue_with_comments(
+            "TST-1", "In Progress", "2026-06-12T10:00:00.000Z",
+            [_human("ship it", "2026-06-12T09:00:00.000Z")],
+        )
+    ]
+
+    async def _fake_fetch(**_kw):
+        return issues
+
+    monkeypatch.setattr(tracker_poller, "_fetch_updated_issues", _fake_fetch)
+
+    await tracker_poller.poll_once()
+    await tracker_poller.poll_once()
+    ingest_spy.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_baseline_then_single_turn_then_idempotent(
+    db_session, seed_workspace, monkeypatch, _patch_sessionmaker, ingest_spy
+) -> None:
+    _, _, workspace = seed_workspace
+    await _seed_linear_install(db_session, workspace.id)
+    await _enable_flag(db_session, workspace)
+    await db_session.commit()
+
+    old_comment = _agent("Asked something. [Ship SDLC:role-ba]", "2026-06-12T08:00:00.000Z")
+    tick: dict[str, Any] = {
+        "issues": [
+            _issue_with_comments(
+                "TST-1", "In Progress", "2026-06-12T08:30:00.000Z", [old_comment]
+            )
+        ]
+    }
+
+    async def _fake_fetch(**_kw):
+        return tick["issues"]
+
+    monkeypatch.setattr(tracker_poller, "_fetch_updated_issues", _fake_fetch)
+
+    # Tick 1 — first sight baselines, no ingestion (no history replay).
+    await tracker_poller.poll_once()
+    ingest_spy.assert_not_awaited()
+
+    # Tick 2 — fresh human comment newer than the baseline → exactly
+    # one turn, carrying the comment body.
+    fresh = _human("please use eu-central", "2026-06-12T09:00:00.000Z")
+    tick["issues"] = [
+        _issue_with_comments(
+            "TST-1", "In Progress", "2026-06-12T09:00:01.000Z",
+            [old_comment, fresh],
+        )
+    ]
+    audit_before = (
+        await db_session.execute(
+            select(AuditLog).where(
+                AuditLog.workspace_id == workspace.id,
+                AuditLog.action == "tracker.event.received",
+            )
+        )
+    ).scalars().all()
+
+    await tracker_poller.poll_once()
+    assert ingest_spy.await_count == 1
+    kwargs = ingest_spy.await_args.kwargs
+    assert kwargs["ticket_ref"] == "TST-1"
+    assert kwargs["comment_body"] == "please use eu-central"
+    assert kwargs["comment_author"] == "Denys"
+
+    # Context-only: comment ingestion produced NO tracker events —
+    # the FSM never hears about comments.
+    audit_after = (
+        await db_session.execute(
+            select(AuditLog).where(
+                AuditLog.workspace_id == workspace.id,
+                AuditLog.action == "tracker.event.received",
+            )
+        )
+    ).scalars().all()
+    assert len(audit_after) == len(audit_before)
+
+    # Tick 3 — same payload again → zero additional turns.
+    await tracker_poller.poll_once()
+    assert ingest_spy.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_agent_comments_never_ingested(
+    db_session, seed_workspace, monkeypatch, _patch_sessionmaker, ingest_spy
+) -> None:
+    """The agent must never reply to itself: a fresh comment authored
+    by the workspace identity is cursor-advanced but not ingested."""
+    _, _, workspace = seed_workspace
+    await _seed_linear_install(db_session, workspace.id)
+    await _enable_flag(db_session, workspace)
+    await db_session.commit()
+
+    seed_comment = _human("kickoff note", "2026-06-12T08:00:00.000Z")
+    tick: dict[str, Any] = {
+        "issues": [
+            _issue_with_comments(
+                "TST-2", "In Progress", "2026-06-12T08:30:00.000Z", [seed_comment]
+            )
+        ]
+    }
+
+    async def _fake_fetch(**_kw):
+        return tick["issues"]
+
+    monkeypatch.setattr(tracker_poller, "_fetch_updated_issues", _fake_fetch)
+    await tracker_poller.poll_once()  # baseline
+
+    tick["issues"] = [
+        _issue_with_comments(
+            "TST-2", "In Progress", "2026-06-12T09:00:01.000Z",
+            [seed_comment, _agent("On it. [Ship SDLC:role-developer]", "2026-06-12T09:00:00.000Z")],
+        )
+    ]
+    await tracker_poller.poll_once()
+    ingest_spy.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Service-level: thread + message persistence with the turn stubbed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ingest_persists_user_message_and_runs_turn(
+    db_session, seed_workspace, monkeypatch
+) -> None:
+    user, _, workspace = seed_workspace
+
+    async def _fake_turn(**kwargs):
+        # The service must hard-code classify_shift=False (context
+        # inbound is never a topic/drafting trigger).
+        assert kwargs["classify_shift"] is False
+        yield b"data: {}\n\n"
+
+    monkeypatch.setattr(
+        "backend.app.api.v1.routes.chat._run_agent_turn", _fake_turn
+    )
+    monkeypatch.setattr(
+        "backend.app.services.agent.client.pick_default_client",
+        lambda _s: object(),
+    )
+
+    from backend.app.core.config import Settings
+
+    ran = await comment_inbound.ingest_operator_comment(
+        db_session,
+        settings=Settings(OPENAI_API_KEY="test"),  # type: ignore[call-arg]
+        workspace_id=workspace.id,
+        ticket_ref="TST-9",
+        ticket_title="Demo ticket",
+        comment_id="c-1",
+        comment_body="use the staging bucket",
+        comment_author="Denys",
+    )
+    assert ran is True
+
+    thread = (
+        await db_session.execute(
+            select(ChatThread).where(
+                ChatThread.workspace_id == workspace.id,
+                ChatThread.resolved_ticket_ref == "TST-9",
+            )
+        )
+    ).scalar_one()
+    assert thread.status == "active"
+    assert thread.created_by_user_id == user.id
+
+    msg = (
+        await db_session.execute(
+            select(ChatMessage).where(ChatMessage.thread_id == thread.id)
+        )
+    ).scalar_one()
+    assert msg.role == "user"
+    assert "use the staging bucket" in msg.body
+    assert msg.meta["source"] == "linear_comment"
+    assert msg.meta["comment_id"] == "c-1"
+
+
+@pytest.mark.asyncio
+async def test_ingest_skips_cleanly_without_llm(
+    db_session, seed_workspace, monkeypatch
+) -> None:
+    def _raise(_s):
+        raise RuntimeError("no key")
+
+    monkeypatch.setattr(
+        "backend.app.services.agent.client.pick_default_client", _raise
+    )
+
+    from backend.app.core.config import Settings
+
+    ran = await comment_inbound.ingest_operator_comment(
+        db_session,
+        settings=Settings(OPENAI_API_KEY="test"),  # type: ignore[call-arg]
+        workspace_id=seed_workspace[2].id,
+        ticket_ref="TST-9",
+        ticket_title=None,
+        comment_id="c-2",
+        comment_body="hello",
+        comment_author=None,
+    )
+    assert ran is False

--- a/apps/backend/tests/test_config_registry.py
+++ b/apps/backend/tests/test_config_registry.py
@@ -41,6 +41,7 @@ def test_list_scopes_returns_every_registered_slug() -> None:
         "console.surface",
         "autonomy.profile",
         "local_executor.enabled",
+        "chat.comment_inbound",
     }
     # Every row carries a non-empty description (consumed by the
     # help-without-scope path).

--- a/apps/backend/tests/test_telegram_pending_actions.py
+++ b/apps/backend/tests/test_telegram_pending_actions.py
@@ -1,0 +1,255 @@
+"""P7 chat-edge hardening (ELS-252/253/254).
+
+- Durable pending-action store: option lists survive "leader
+  failover" (no process memory involved at all — write and claim are
+  pure DB), single-use claim is atomic, expired rows can't be
+  claimed.
+- Signed callback_data: build/parse/verify round-trip, tamper
+  rejection, legacy ``c|<idx>`` payloads parse as None (stale), and
+  the wire format stays under Telegram's 64-byte cap.
+- Approval boundary: approval/control-stakes directives render URL
+  deep-links into the Console Inbox; low-stakes options render signed
+  callback buttons. Chat never commits the control plane.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from backend.app.core.config import Settings
+from backend.app.db.models.telegram import TelegramPendingAction
+from backend.app.integrations.telegram.bot import (
+    _build_choice_markup,
+    _claim_pending_action,
+    _collect_directive_actions,
+    _store_pending_action,
+)
+from backend.app.integrations.telegram.callback_token import (
+    build_callback_data,
+    parse_callback_data,
+    sign_callback,
+    verify_callback,
+)
+from backend.app.integrations.telegram.render import Directive
+
+
+def _settings() -> Settings:
+    return Settings(OPENAI_API_KEY="test", JWT_SECRET="unit-secret")  # type: ignore[call-arg]
+
+
+# ---------------------------------------------------------------------------
+# callback_token (ELS-253)
+# ---------------------------------------------------------------------------
+
+
+def test_callback_round_trip_and_length() -> None:
+    settings = _settings()
+    action_id = uuid.uuid4()
+    nonce = "n" * 32
+    data = build_callback_data(settings, action_id=action_id, idx=7, nonce=nonce)
+    assert len(data.encode("utf-8")) <= 64
+    parsed = parse_callback_data(data)
+    assert parsed is not None
+    assert parsed.action_id == action_id
+    assert parsed.idx == 7
+    assert verify_callback(settings, parsed=parsed, nonce=nonce) is True
+
+
+def test_tampered_callback_fails_verification() -> None:
+    settings = _settings()
+    action_id = uuid.uuid4()
+    nonce = "abc"
+    data = build_callback_data(settings, action_id=action_id, idx=0, nonce=nonce)
+    # Flip the option index — the signature no longer matches.
+    forged = data.rsplit("|", 2)
+    forged = f"{forged[0]}|1|{forged[2]}"
+    parsed = parse_callback_data(forged)
+    assert parsed is not None
+    assert verify_callback(settings, parsed=parsed, nonce=nonce) is False
+    # Wrong nonce (e.g. replay against a different row) also fails.
+    parsed_ok = parse_callback_data(data)
+    assert verify_callback(settings, parsed=parsed_ok, nonce="other") is False
+
+
+def test_legacy_unsigned_payload_parses_as_none() -> None:
+    assert parse_callback_data("c|0") is None
+    assert parse_callback_data("c|not-a-uuid|0|sig") is None
+    assert parse_callback_data("") is None
+
+
+def test_signature_is_deterministic_per_inputs() -> None:
+    settings = _settings()
+    action_id = uuid.uuid4()
+    assert sign_callback(
+        settings, action_id=action_id, idx=1, nonce="x"
+    ) == sign_callback(settings, action_id=action_id, idx=1, nonce="x")
+    assert sign_callback(
+        settings, action_id=action_id, idx=1, nonce="x"
+    ) != sign_callback(settings, action_id=action_id, idx=2, nonce="x")
+
+
+# ---------------------------------------------------------------------------
+# Durable store (ELS-252)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_options_survive_failover_and_claim_once(
+    db_session, seed_workspace
+) -> None:
+    """Store → claim reads from the DB (no process memory), and the
+    second claim — a double click or Telegram re-delivery — loses."""
+    _, _, workspace = seed_workspace
+    options = [{"label": "Deploy", "value": "deploy"}]
+    action_id, nonce = await _store_pending_action(
+        db_session,
+        workspace_id=workspace.id,
+        chat_id=-100123,
+        message_id=42,
+        thread_id=None,
+        options=options,
+    )
+    assert nonce
+
+    # "New leader process": nothing held in memory — the claim is a
+    # pure DB read+update on the id from callback_data.
+    row = await _claim_pending_action(db_session, action_id=action_id)
+    assert row is not None
+    assert row.options == options
+    assert row.consumed_at is not None
+
+    again = await _claim_pending_action(db_session, action_id=action_id)
+    assert again is None
+
+
+@pytest.mark.asyncio
+async def test_expired_action_cannot_be_claimed(
+    db_session, seed_workspace
+) -> None:
+    _, _, workspace = seed_workspace
+    row = TelegramPendingAction(
+        workspace_id=workspace.id,
+        telegram_chat_id=-100123,
+        bot_message_id=43,
+        options=[{"label": "x", "value": "x"}],
+        token_nonce=f"nonce-{uuid.uuid4().hex}",
+        expires_at=datetime.now(timezone.utc) - timedelta(minutes=1),
+    )
+    db_session.add(row)
+    await db_session.flush()
+
+    assert await _claim_pending_action(db_session, action_id=row.id) is None
+
+
+# ---------------------------------------------------------------------------
+# Approval boundary (ELS-254)
+# ---------------------------------------------------------------------------
+
+
+_WS = uuid.UUID("00000000-0000-0000-0000-00000000abcd")
+
+
+def test_approval_directive_renders_url_button() -> None:
+    """AC: approval/control-stakes → URL deep-link into the Inbox
+    item, NOT a callback button."""
+    directives = [
+        Directive(
+            kind="ship-choice",
+            payload={
+                "approval": True,
+                "label": "Approve deploy",
+                "inbox_item_id": "11111111-2222-3333-4444-555555555555",
+            },
+            raw="",
+        )
+    ]
+    options, links = _collect_directive_actions(
+        directives, console_url="https://app.ship.test", workspace_id=_WS
+    )
+    assert options == []
+    assert len(links) == 1
+    assert links[0]["label"] == "Approve deploy"
+    assert links[0]["url"] == (
+        f"https://app.ship.test/inbox?ws={_WS}"
+        "&selected=11111111-2222-3333-4444-555555555555"
+    )
+
+    markup = _build_choice_markup(options, links, sign=lambda i: "c|x")
+    assert markup is not None
+    button = markup.inline_keyboard[0][0]
+    assert button.url == links[0]["url"]
+    assert button.callback_data is None
+
+
+def test_stakes_control_also_routes_to_url() -> None:
+    directives = [
+        Directive(
+            kind="ship-choice",
+            payload={"stakes": "control", "title": "Unblock merge"},
+            raw="",
+        )
+    ]
+    options, links = _collect_directive_actions(
+        directives, console_url="https://app.ship.test", workspace_id=_WS
+    )
+    assert options == []
+    assert links[0]["url"].startswith(f"https://app.ship.test/inbox?ws={_WS}")
+
+
+def test_low_stakes_options_render_signed_callbacks() -> None:
+    """AC: pre-enumerated Navigator choices keep round-tripping as
+    callback buttons, signed via the provided signer."""
+    directives = [
+        Directive(
+            kind="ship-choice",
+            payload={"options": ["Option A", {"label": "Option B", "value": "b"}]},
+            raw="",
+        )
+    ]
+    options, links = _collect_directive_actions(
+        directives, console_url="https://app.ship.test", workspace_id=_WS
+    )
+    assert links == []
+    assert [o["value"] for o in options] == ["Option A", "b"]
+
+    signed: list[int] = []
+
+    def _sign(idx: int) -> str:
+        signed.append(idx)
+        return f"c|deadbeefdeadbeefdeadbeefdeadbeef|{idx}|sig"
+
+    markup = _build_choice_markup(options, links, sign=_sign)
+    assert markup is not None
+    assert signed == [0, 1]
+    for row in markup.inline_keyboard:
+        assert row[0].callback_data is not None
+        assert row[0].url is None
+
+
+def test_mixed_turn_renders_both_kinds() -> None:
+    directives = [
+        Directive(
+            kind="ship-choice",
+            payload={"options": ["Continue locally"]},
+            raw="",
+        ),
+        Directive(
+            kind="ship-choice",
+            payload={"approval": True, "label": "Approve in Inbox"},
+            raw="",
+        ),
+    ]
+    options, links = _collect_directive_actions(
+        directives, console_url="https://app.ship.test", workspace_id=_WS
+    )
+    markup = _build_choice_markup(options, links, sign=lambda i: f"c|a|{i}|s")
+    assert markup is not None
+    kinds = [
+        "url" if b.url else "callback"
+        for row in markup.inline_keyboard
+        for b in row
+    ]
+    assert kinds == ["callback", "url"]

--- a/apps/backend/tests/test_tracker_poller.py
+++ b/apps/backend/tests/test_tracker_poller.py
@@ -295,3 +295,72 @@ async def test_install_without_team_id_is_skipped(
     # and reports 0 errors. The installation IS counted in ``installs``.
     assert summary["errors"] == 0
     assert summary["events"] == 0
+
+
+# ---------------------------------------------------------------------------
+# ELS-250 — agent-vs-human via author identity (marker = legacy fallback)
+# ---------------------------------------------------------------------------
+
+
+def test_human_pasting_marker_is_human() -> None:
+    """AC: a comment whose body QUOTES the marker but authored by a
+    human classifies as HUMAN."""
+    from backend.app.services.tracker_poller import _is_agent_comment
+
+    comment = {
+        "body": "Replying inline:\n> blah [Ship SDLC:role-developer]\nyes, ship it",
+        "user": {"displayName": "Denys", "email": "denys@bodyman.io", "isMe": False},
+    }
+    assert _is_agent_comment(comment) is False
+
+
+def test_service_account_comment_is_agent_without_marker() -> None:
+    """AC: authored by the workspace identity → AGENT even when the
+    marker text is absent."""
+    from backend.app.services.tracker_poller import _is_agent_comment
+
+    comment = {
+        "body": "Working on it.",
+        "user": {"displayName": "Ship Agent", "email": "agent@ship", "isMe": True},
+    }
+    assert _is_agent_comment(comment) is True
+
+
+def test_bot_actor_comment_is_agent() -> None:
+    from backend.app.services.tracker_poller import _is_agent_comment
+
+    comment = {"body": "Done.", "user": None, "botActor": {"id": "app-1"}}
+    assert _is_agent_comment(comment) is True
+
+
+def test_legacy_comment_without_author_falls_back_to_marker() -> None:
+    """AC: no author identity → marker regex keeps classifying
+    historical rows."""
+    from backend.app.services.tracker_poller import _is_agent_comment
+
+    agent_legacy = {"body": "Asked a question. [Ship SDLC:role-ba]"}
+    human_legacy = {"body": "here's the answer"}
+    assert _is_agent_comment(agent_legacy) is True
+    assert _is_agent_comment(human_legacy) is False
+
+
+def test_clarification_walk_uses_identity() -> None:
+    """Newest-first walk: human answer above the agent question →
+    answered; agent question on top → not answered. Identity decides
+    even when the human quotes the marker."""
+    from backend.app.services.tracker_poller import (
+        _operator_answered_clarification,
+    )
+
+    agent_q = {
+        "body": "Which region? [Ship SDLC:role-ba]",
+        "createdAt": "2026-06-12T10:00:00Z",
+        "user": {"displayName": "Ship", "isMe": True},
+    }
+    human_quoting = {
+        "body": "> [Ship SDLC:role-ba] Which region?\neu-central please",
+        "createdAt": "2026-06-12T11:00:00Z",
+        "user": {"displayName": "Denys", "isMe": False},
+    }
+    assert _operator_answered_clarification([agent_q, human_quoting]) is True
+    assert _operator_answered_clarification([agent_q]) is False


### PR DESCRIPTION
## Summary

Phase 7 of the headless-pivot strangler rework — thesis 4 (chat = edge, never control plane). Five tickets:

- **ELS-250** — agent-vs-human on Linear comments keys on **author identity** (`user.isMe` / `botActor` requested in the same poller GraphQL block), marker regex demoted to legacy fallback. One shared classifier (`_is_agent_comment`) feeds both the clarification trigger and the new comment-inbound path. A human pasting the `[Ship SDLC:role-…]` marker now classifies as HUMAN.
- **ELS-251** — fresh non-agent comments on active tickets flow into the ticket's Navigator thread as a user-role turn via a **service function** (`comment_inbound.ingest_operator_comment` drives `_run_agent_turn(classify_shift=False)` directly — no HTTP self-call). Context only: a test pins that ingestion writes zero `tracker.event.received` rows; STATUS stays the only FSM signal. Gated by `chat.comment_inbound` config scope (default-OFF); per-ticket comment cursor rides the poller cursor JSONB — first sight baselines (no history replay), re-polls idempotent, terminal tickets pruned, `needs:clarification` tickets excluded (their flow owns the round-trip).
- **ELS-252** — `telegram_pending_actions` (migration **0088**) replaces the process-local `_CHOICE_CACHE`: inline-keyboard option lists survive leader failover. Dedicated table (no `inbox_items` reuse → zero Console-pollution risk).
- **ELS-253** — `callback_data` = signed pointer `c|<row>|<idx>|<sig>` (truncated HMAC-SHA256 keyed with `settings.jwt_secret`, per-row server-side nonce, ≤64 bytes pinned by test). Server-side TTL + **atomic single-use consume before the Navigator turn** — double-click/re-delivery fires exactly once; forged/tampered/legacy payloads are rejected with the stale answer.
- **ELS-254** — boundary enforced at keyboard build: low-stakes pre-enumerated choices → signed callback buttons; approval/control-stakes directives → **URL deep-link into the Console Inbox item** (reachable in every `console.surface` mode), so the real approval is recorded under the acting user's identity, never the shared group PAT.

## Test plan
- [x] ELS-250: paste-the-marker-as-human, service-account-without-marker, botActor, legacy fallback, identity-driven clarification walk
- [x] ELS-251: flag-off default, baseline→single-turn→idempotent, agent-comment exclusion, zero tracker events, service persistence + no-LLM degrade
- [x] ELS-252/253: failover claim-once, expiry, token round-trip/tamper/legacy/length
- [x] ELS-254: approval→URL, stakes:control→URL, low-stakes→signed callbacks, mixed turn ordering
- [x] Targeted backend suites: 117 passed locally (incl. poller, telegram, config-registry, strangler gate)
- [ ] CI green

Closes ELS-250, ELS-251, ELS-252, ELS-253, ELS-254