### PR TITLE
Headless Pivot P8 — deterministic workflow primitive (ELS-255..262)

### DIFF
--- a/.ship/workflows/README.md
+++ b/.ship/workflows/README.md
@@ -1,0 +1,47 @@
+# Ship workflows — imperative bounded pipelines
+
+A workflow here is a **deterministic, bounded fan-out you INVOKE for
+one job** (thesis 8): it fans out N agents, joins, synthesizes, and
+**completes**. Specs are YAML (`<name>.yaml`), validated by
+`packages/cli/lib/workflow/loadSpec.mjs` (lint) and
+`apps/backend/app/services/workflow/spec.py` (authoritative, at
+dispatch time). Seven step kinds: `parallel`, `pipeline`, `loop`,
+`barrier`, `synthesize`, `judge`, `verify`.
+
+Every leaf spawn passes the **WorkflowDispatchGate**
+(`services/workflow/gate.py`): `workflow:<run>:<step>` lease, a
+`workflow:`-prefix cap separate from the SDLC ticket cap, cascade
+depth counted on recursion edges (`ship` self-spawn leaves / nested
+workflows), and a durable per-attempt idempotency row. `max_fanout`
+(hard ceiling 8) and `max_depth` are rejected at LOAD time — a
+malformed spec can't even ask for a fork-bomb. No autonomy profile
+loosens any of this.
+
+## The boundary with /process — do not merge or duplicate
+
+| | `/process` (processes.py) | workflows (this directory) |
+|---|---|---|
+| nature | **reactive state machine** | **imperative bounded pipeline** |
+| lifetime | per-ticket, continuous — waits for events, never "finishes" | one invocation — runs the DAG, returns a result |
+| triggers | schedule / event / manual stage transitions | chat (`run_workflow` tool), FSM gate, cron |
+| defines | which SDLC stages exist and how tickets move | how N agents fan out for ONE job |
+
+**Rule: do NOT add workflow execution into `processes.py`, and do NOT
+add state-machine semantics into the workflow runtime.** They
+complement each other: a /process stage (e.g. `code_review`) may FIRE
+a workflow as a gate action — that is the only sanctioned coupling.
+
+## Dogfood set
+
+- `pr-review.yaml` — 4 parallel review axes (correctness / security /
+  simplification / test-coverage) → barrier → synthesize (structured
+  findings with severity) → verify (adversarially re-check the top
+  finding). Fired from the `code_review` gate or chat.
+- `codebase-audit.yaml` — coding leaf enumerates hotspots → 3
+  parallel reasoning audits → judge ranks tech-debt items into a
+  structured report. Fired nightly via cron (per-workspace opt-in,
+  fail-closed).
+
+The server currently executes the **packaged** copies of these specs
+(`apps/backend/app/services/workflow/specs/`); the files here are the
+repo-side contract the CLI lints. Keep them in sync.

--- a/.ship/workflows/codebase-audit.yaml
+++ b/.ship/workflows/codebase-audit.yaml
@@ -1,0 +1,52 @@
+# Nightly codebase audit: enumerate hotspots → parallel audits →
+# judge ranks tech-debt items (W8.8, dogfood). Fired via cron
+# (trigger c).
+name: codebase-audit
+version: "1"
+inputs:
+  focus: string
+max_fanout: 3
+max_depth: 2
+steps:
+  - id: enumerate
+    kind: pipeline
+    agent: {kind: coding, provider: claude}
+    inputs:
+      routine_id: weekly-audit
+      focus: "{{ inputs.focus }}"
+  - id: audits
+    kind: parallel
+    needs: [enumerate]
+    steps:
+      - id: audit.complexity
+        kind: pipeline
+        agent: {kind: reasoning, role: tech-architect}
+        inputs: {hotspots: "{{ steps.enumerate.output }}", lens: complexity}
+      - id: audit.coupling
+        kind: pipeline
+        agent: {kind: reasoning, role: tech-architect}
+        inputs: {hotspots: "{{ steps.enumerate.output }}", lens: coupling}
+      - id: audit.test-gaps
+        kind: pipeline
+        agent: {kind: reasoning, role: qa-architect}
+        inputs: {hotspots: "{{ steps.enumerate.output }}", lens: test-gaps}
+  - id: rank
+    kind: judge
+    needs: [audits]
+    inputs:
+      complexity: "{{ steps.audit.complexity.output }}"
+      coupling: "{{ steps.audit.coupling.output }}"
+      test_gaps: "{{ steps.audit.test-gaps.output }}"
+    output_schema:
+      type: object
+      required: [items]
+      properties:
+        items:
+          type: array
+          items:
+            type: object
+            required: [rank, title]
+            properties:
+              rank: {type: integer}
+              title: {type: string}
+              effort: {type: string}

--- a/.ship/workflows/pr-review.yaml
+++ b/.ship/workflows/pr-review.yaml
@@ -1,0 +1,72 @@
+# Multi-axis PR review + adversarial verify (W8.8, dogfood).
+# Fired from the code_review FSM gate (trigger b) or from chat.
+name: pr-review
+version: "1"
+inputs:
+  pr_url: string
+max_fanout: 4
+max_depth: 2
+steps:
+  - id: fan
+    kind: parallel
+    steps:
+      - id: axis.correctness
+        kind: pipeline
+        agent: {kind: reasoning, role: reviewer}
+        inputs:
+          axis: correctness
+          pr_url: "{{ inputs.pr_url }}"
+      - id: axis.security
+        kind: pipeline
+        agent: {kind: reasoning, role: security-reviewer}
+        inputs:
+          axis: security
+          pr_url: "{{ inputs.pr_url }}"
+      - id: axis.simplification
+        kind: pipeline
+        agent: {kind: reasoning, role: reviewer}
+        inputs:
+          axis: simplification
+          pr_url: "{{ inputs.pr_url }}"
+      - id: axis.test-coverage
+        kind: pipeline
+        agent: {kind: reasoning, role: qa-architect}
+        inputs:
+          axis: test-coverage
+          pr_url: "{{ inputs.pr_url }}"
+  - id: join
+    kind: barrier
+    needs: [fan]
+  - id: synth
+    kind: synthesize
+    needs: [join]
+    inputs:
+      correctness: "{{ steps.axis.correctness.output }}"
+      security: "{{ steps.axis.security.output }}"
+      simplification: "{{ steps.axis.simplification.output }}"
+      test_coverage: "{{ steps.axis.test-coverage.output }}"
+    output_schema:
+      type: object
+      required: [findings]
+      properties:
+        findings:
+          type: array
+          items:
+            type: object
+            required: [severity, title]
+            properties:
+              severity: {type: string, enum: [low, medium, high]}
+              title: {type: string}
+              detail: {type: string}
+  - id: recheck
+    kind: verify
+    needs: [synth]
+    inputs:
+      top_finding: "{{ steps.synth.output.findings }}"
+      pr_url: "{{ inputs.pr_url }}"
+    output_schema:
+      type: object
+      required: [verdict]
+      properties:
+        verdict: {type: string, enum: [confirmed, refuted, uncertain]}
+        reason: {type: string}

--- a/apps/backend/app/api/v1/routes/agent_runs.py
+++ b/apps/backend/app/api/v1/routes/agent_runs.py
@@ -3987,6 +3987,42 @@ async def finish_agent_run(
             tracker_kind=(prev.payload or {}).get("tracker_kind"),
         )
 
+    # W8.3 (ELS-258): a finishing run may be a WORKFLOW coding leaf —
+    # correlate by run_id, persist the outcome on the step row and
+    # release its workflow:* lock (mirrors how ticket dispatch
+    # releases on finish). Ticket-less leaves stop here: they carry
+    # no FSM side-effects.
+    from backend.app.services.workflow.leaves import complete_coding_step
+
+    matched_workflow_step = await complete_coding_step(
+        session,
+        workspace_id=workspace_id,
+        run_id=payload.run_id,
+        success=payload.outcome in ("ready_next_step", "done"),
+        output={
+            "outcome": payload.outcome,
+            "comment": (payload.comment or "")[:2000],
+        },
+    )
+    if matched_workflow_step and not (payload.ticket_ref or "").strip():
+        session.add(
+            AuditLog(
+                workspace_id=workspace_id,
+                action="agent_run.finish",
+                target_kind="workflow_step",
+                target_id=payload.run_id,
+                payload={"outcome": payload.outcome, "workflow_leaf": True},
+            )
+        )
+        await session.flush()
+        return FinishOut(
+            ok=True,
+            outcome=payload.outcome,
+            run_id=payload.run_id,
+            actions=["workflow_step_completed"],
+            tracker_kind=None,
+        )
+
     # ELS-120 safety net — fire BEFORE tracker resolution so the gate
     # works on workspaces with no tracker bound too. A code-changing
     # finish without a PR URL means the agent bypassed the sidecar

--- a/apps/backend/app/db/models/__init__.py
+++ b/apps/backend/app/db/models/__init__.py
@@ -65,7 +65,12 @@ from backend.app.db.models.repo_intel import RepoIntel, RepoIntelTriggeredBy
 from backend.app.db.models.repo_secrets import RepoSecret
 from backend.app.db.models.telegram import (
     TelegramChatLink,
+    TelegramPendingAction,
     TelegramThreadMap,
+)
+from backend.app.db.models.workflow import (
+    AgentWorkflowRun,
+    AgentWorkflowStepRun,
 )
 from backend.app.db.models.tenancy import (
     ApiToken,
@@ -84,6 +89,9 @@ from backend.app.db.models.tenancy import (
 
 __all__ = [
     "AgentDispatchLock",
+    "AgentWorkflowRun",
+    "AgentWorkflowStepRun",
+    "TelegramPendingAction",
     "AgentRequest",
     "AgentRole",
     "ApiToken",

--- a/apps/backend/app/db/models/workflow.py
+++ b/apps/backend/app/db/models/workflow.py
@@ -1,0 +1,144 @@
+"""Deterministic workflow primitive — durable run/step state (W8.7).
+
+Thesis 8: the workflow engine is a BOUNDED, imperative fan-out you
+INVOKE for one job — distinct from the FSM (reactive, per-ticket,
+never completes) and from /process (the state-machine *definition*
+editor). These two tables are the engine's only state:
+
+- :class:`AgentWorkflowRun` — one invocation of a named spec, fired by one
+  of the three triggers (chat / gate / cron). Bounded: it reaches a
+  terminal status when the DAG drains or a budget trips.
+- :class:`AgentWorkflowStepRun` — one attempt of one step. The UNIQUE
+  ``(workflow_run_id, step_id, attempt)`` constraint is the durable
+  idempotency key the dispatch gate (W8.2) relies on: a retried
+  reconcile tick upserts into the same attempt row instead of
+  double-spawning; re-running a failed step REQUIRES a new attempt.
+
+``lock_key`` ties a step to its ``workflow:<run>:<step>`` row in
+``agent_dispatch_locks`` (countable + sweepable like ``ticket:*``);
+``run_id`` correlates a coding leaf to the CI agent run that reports
+back via ``/agent-runs/finish``.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import (
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    UniqueConstraint,
+    text,
+)
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from backend.app.db.base import Base
+from backend.app.db.models.tenancy import (
+    _pk,  # noqa: PLC2701 — shared column helper, intra-package.
+    _ts_created,  # noqa: PLC2701
+)
+
+
+# Closed status sets — kept as plain tuples (not DB enums) so adding a
+# member is a code change, not a migration.
+WORKFLOW_RUN_STATUSES = ("queued", "running", "completed", "blocked", "failed")
+WORKFLOW_STEP_STATUSES = (
+    "pending",
+    "dispatched",
+    "running",
+    "completed",
+    "blocked",
+    "failed",
+    "skipped",
+)
+
+
+class AgentWorkflowRun(Base):
+    __tablename__ = "agent_workflow_runs"
+    __table_args__ = (
+        Index("ix_agent_workflow_runs_ws_status", "workspace_id", "status"),
+    )
+
+    id: Mapped[uuid.UUID] = _pk()
+    workspace_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("workspaces.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    spec_name: Mapped[str] = mapped_column(String(120), nullable=False)
+    spec_version: Mapped[str] = mapped_column(
+        String(32), nullable=False, server_default=text("'1'")
+    )
+    inputs: Mapped[dict] = mapped_column(
+        JSONB, nullable=False, server_default=text("'{}'::jsonb")
+    )
+    # chat | gate | cron — the three triggers (thesis 3).
+    trigger_kind: Mapped[str] = mapped_column(String(16), nullable=False)
+    status: Mapped[str] = mapped_column(
+        String(16), nullable=False, server_default=text("'queued'")
+    )
+    # Final synthesized output (when the spec's last step emits one).
+    output: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    # Audit linkage: who/what fired it (user id for chat, ticket ref
+    # for gate, cron lock id for cron) — free-form, for the audit
+    # trail, never control flow.
+    triggered_by: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    created_at: Mapped[datetime] = _ts_created()
+    finished_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
+
+class AgentWorkflowStepRun(Base):
+    __tablename__ = "agent_workflow_step_runs"
+    __table_args__ = (
+        UniqueConstraint(
+            "workflow_run_id",
+            "step_id",
+            "attempt",
+            name="uq_agent_workflow_step_attempt",
+        ),
+        Index("ix_agent_workflow_step_runs_run", "workflow_run_id"),
+        Index("ix_agent_workflow_step_runs_ci_run", "run_id"),
+    )
+
+    id: Mapped[uuid.UUID] = _pk()
+    workflow_run_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("agent_workflow_runs.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    step_id: Mapped[str] = mapped_column(String(120), nullable=False)
+    attempt: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default=text("1")
+    )
+    # Step kind from the spec (parallel/pipeline/loop/barrier/
+    # synthesize/judge/verify) — denormalized for dashboards.
+    kind: Mapped[str] = mapped_column(String(32), nullable=False)
+    # Leaf executor (claude/codex/cursor/ship for coding leaves,
+    # 'reasoning' for the in-process subagent loop).
+    agent_provider: Mapped[str | None] = mapped_column(String(32), nullable=True)
+    status: Mapped[str] = mapped_column(
+        String(16), nullable=False, server_default=text("'pending'")
+    )
+    # Validated against the step's output_schema before persisting;
+    # nullable until the step completes.
+    output: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    # ``workflow:<run>:<step>`` — the agent_dispatch_locks key the
+    # gate acquired for this attempt.
+    lock_key: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    # Correlates a coding leaf to its CI agent run (the run_id the
+    # /agent-runs/finish webhook reports with).
+    run_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    # Why the gate refused (cap_exceeded/cascade_blocked/lock_held)
+    # when status='blocked'/'skipped'.
+    reason: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    created_at: Mapped[datetime] = _ts_created()
+    finished_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )

--- a/apps/backend/app/services/agent/tools.py
+++ b/apps/backend/app/services/agent/tools.py
@@ -1545,6 +1545,42 @@ class ToolBox:
                 },
             ),
             ToolSpec(
+                name="run_workflow",
+                description=(
+                    "Fire a deterministic bounded workflow (thesis 8): "
+                    "a named multi-agent pipeline from the workspace's "
+                    "workflow registry (e.g. ``pr-review``, "
+                    "``codebase-audit``). The chat stays LOCK-FREE — "
+                    "this tool only QUEUES the run and returns its id; "
+                    "the control plane (cap / cascade / leases) governs "
+                    "every spawn afterwards. Admin-only, "
+                    "internal/dogfood at launch."
+                ),
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "workflow_name": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 120,
+                            "description": (
+                                "Registered workflow spec name. Unknown "
+                                "names return the available list."
+                            ),
+                        },
+                        "inputs": {
+                            "type": "object",
+                            "description": (
+                                "Input values declared by the spec "
+                                "(e.g. {\"pr_url\": …})."
+                            ),
+                        },
+                    },
+                    "required": ["workflow_name"],
+                    "additionalProperties": False,
+                },
+            ),
+            ToolSpec(
                 name="web_fetch",
                 description=(
                     "Fetch one URL via Firecrawl and return its "
@@ -1788,6 +1824,7 @@ class ToolBox:
             "ticket_update": self._tool_ticket_update,
             "project_priority_set": self._tool_project_priority_set,
             "run_subagent": self._tool_run_subagent,
+            "run_workflow": self._tool_run_workflow,
             "config_help": self._tool_config_help,
             "config_put": self._tool_config_put,
             "web_fetch": self._tool_web_fetch,
@@ -5585,6 +5622,93 @@ class ToolBox:
             )
         return _json_result(result)
 
+    async def _tool_run_workflow(self, args: dict[str, Any]) -> str:
+        """W8.4 (ELS-260) — chat trigger for the workflow primitive.
+
+        The chat loop stays LOCK-FREE (thesis 3a): this handler only
+        persists a ``queued`` run row and schedules a background task
+        that drives the runtime THROUGH the dispatch gate — no
+        ``agent_dispatch_locks`` row is taken in the chat process.
+        Escalation, not in-loop dispatch (the a→b rule).
+        """
+        if self._subagent_active:
+            raise ToolInvocationError(
+                "nested run_workflow is not allowed (already running "
+                "inside a subagent)"
+            )
+        from backend.app.api.v1.routes.workspaces import ROLES_ADMIN
+
+        await self._require_workspace_role(ROLES_ADMIN)
+
+        from backend.app.db.models.workflow import AgentWorkflowRun
+        from backend.app.services.workflow.registry import (
+            list_available_specs,
+            resolve_spec,
+        )
+
+        workflow_name = _require_str(args, "workflow_name").strip()
+        inputs_raw = args.get("inputs")
+        inputs = inputs_raw if isinstance(inputs_raw, dict) else {}
+
+        spec = resolve_spec(workflow_name)
+        if spec is None:
+            return _json_result(
+                {
+                    "error": "unknown_workflow",
+                    "message": f"no workflow named '{workflow_name}'",
+                    "available": list_available_specs(),
+                }
+            )
+
+        run = AgentWorkflowRun(
+            workspace_id=self._workspace_id,
+            spec_name=spec.name,
+            spec_version=spec.version,
+            inputs=inputs,
+            trigger_kind="chat",
+            triggered_by=f"user:{self._user_id}" if self._user_id else "chat",
+            status="queued",
+        )
+        self._session.add(run)
+        await self._session.flush()
+
+        self._session.add(
+            AuditLog(
+                workspace_id=self._workspace_id,
+                actor_user_id=self._user_id,
+                action="workflow.run_queued",
+                target_kind="workflow_run",
+                target_id=str(run.id),
+                payload={
+                    "spec_name": spec.name,
+                    "trigger_kind": "chat",
+                    "inputs": {k: str(v)[:200] for k, v in inputs.items()},
+                },
+            )
+        )
+        await self._session.flush()
+
+        import asyncio as _asyncio
+
+        from backend.app.services.workflow.runtime import advance_run_by_id
+
+        _asyncio.create_task(
+            advance_run_by_id(run.id, actor_user_id=self._user_id),
+            name=f"ship.workflow.{run.id}",
+        )
+        return _json_result(
+            {
+                "workflow_run_id": str(run.id),
+                "spec_name": spec.name,
+                "status": "queued",
+                "note": (
+                    "queued; spawns go through the dispatch gate "
+                    "(cap/cascade apply). Check status via the audit "
+                    "log (workflow.step_*) or the run row."
+                ),
+            }
+        )
+
     async def _tool_run_subagent(self, args: dict[str, Any]) -> str:
         """Polymorphic subagent spawner. Branches on ``kind`` to
         decomposition (project-anchor chain) or specialist consult
@@ -5832,7 +5956,13 @@ class ToolBox:
         # it doesn't know about); the ``_subagent_active`` flag is
         # guard #2.
         all_specs = self.specs()
-        sub_specs = [s for s in all_specs if s.name != "consult_specialist"]
+        # run_workflow joins the recursion-guard exclusion set (W8.4):
+        # a subagent must never fan out further agents.
+        sub_specs = [
+            s
+            for s in all_specs
+            if s.name not in ("consult_specialist", "run_workflow")
+        ]
 
         self._subagent_active = True
         try:

--- a/apps/backend/app/services/cron.py
+++ b/apps/backend/app/services/cron.py
@@ -171,6 +171,9 @@ class CronLockId(IntEnum):
     SCHEDULED_ROUTINE_DAILY = 1026
     SCHEDULED_ROUTINE_RETRO = 1027
     SCHEDULED_ROUTINE_TECHDEBT = 1028
+    # W8.5 (ELS-261) — nightly workflow trigger (c). Next free
+    # integer; never reuse a retired id.
+    WORKFLOW_NIGHTLY = 1029
 
 
 # ---------------------------------------------------------------------------

--- a/apps/backend/app/services/cron_jobs.py
+++ b/apps/backend/app/services/cron_jobs.py
@@ -608,6 +608,13 @@ def register_all() -> None:
         cron_expr=_ROUTINE_SPECS["techdebt"].cron_expr,
         job_id="scheduled_routine_techdebt",
     )
+    # W8.5 (ELS-261) — nightly codebase-audit workflow, 03:30 UTC
+    # weekdays (off the routine crons' slots; per-workspace opt-in).
+    register_cron(
+        fn=_workflow_nightly_tick,
+        cron_expr="30 3 * * 1-5",
+        job_id="workflow_nightly",
+    )
     # E16/ELS-124 retired the Ship-side trigger-workflow scheduler.
     # The tracker poller + dispatcher (``apps/backend/app/services/
     # tracker_poller.py`` + ``dispatcher.py``) now drive every agent
@@ -813,6 +820,74 @@ async def _scheduled_routine_techdebt_tick() -> None:
     )
 
     await run_routine_for_all_workspaces("techdebt")
+
+
+@cron_with_lock(lock=CronLockId.WORKFLOW_NIGHTLY, name="workflow_nightly")
+async def _workflow_nightly_tick() -> None:
+    """Trigger-(c) for the thesis-8 workflow primitive (ELS-261).
+
+    Enqueues the nightly ``codebase-audit`` workflow per OPT-IN
+    workspace (``settings.workflows.nightly`` — fail-closed: missing/
+    false/disabled means skip). Every spawn the runtime makes goes
+    through the WorkflowDispatchGate on the ``workflow:`` prefix —
+    its own accounting pool, so a fleet of nightly audits can never
+    starve SDLC ticket dispatch (mirrors WORKSPACE_BUNDLE_CAP's
+    separation).
+
+    Shadow mode mirrors ``maybe_dispatch``: with
+    ``SHIP_TRACKER_POLL_FIRE=false`` we record a
+    ``workflow.would_have_run`` audit row and spawn nothing.
+    """
+    from backend.app.core.config import get_settings as _gs
+    from backend.app.db.models.tenancy import AuditLog as _AuditLog
+    from backend.app.db.models.tenancy import Workspace as _Workspace
+    from backend.app.services.workflow.registry import resolve_spec
+    from backend.app.services.workflow.runtime import run_workflow
+
+    settings = _gs()
+    spec = resolve_spec("codebase-audit")
+    if spec is None:
+        log.warning("workflow_nightly: codebase-audit spec missing; skip")
+        return
+
+    sm = get_sessionmaker()
+    workspace_ids = await _all_workspace_ids()
+    for ws_id in workspace_ids:
+        try:
+            async with sm() as session:
+                ws = await session.get(_Workspace, ws_id)
+                if ws is None:
+                    continue
+                enabled = bool(
+                    ((ws.settings or {}).get("workflows") or {}).get(
+                        "nightly", False
+                    )
+                )
+                if not enabled:
+                    continue  # fail-closed: opt-in only
+                if not settings.tracker_poll_fire:
+                    session.add(
+                        _AuditLog(
+                            workspace_id=ws_id,
+                            action="workflow.would_have_run",
+                            target_kind="workflow_run",
+                            target_id="codebase-audit",
+                            payload={"trigger_kind": "cron", "shadow": True},
+                        )
+                    )
+                    await session.commit()
+                    continue
+                await run_workflow(
+                    session,
+                    workspace_id=ws_id,
+                    spec=spec,
+                    inputs={"focus": "nightly"},
+                    trigger_kind="cron",
+                    triggered_by=f"cron:{int(CronLockId.WORKFLOW_NIGHTLY)}",
+                )
+                await session.commit()
+        except Exception:  # noqa: BLE001 — one workspace never blocks the tick
+            log.exception("workflow_nightly: workspace %s failed", ws_id)
 
 
 @cron_with_lock(lock=CronLockId.STALL_NOTIFY, name="stall_notify")

--- a/apps/backend/app/services/dispatcher.py
+++ b/apps/backend/app/services/dispatcher.py
@@ -778,6 +778,81 @@ async def _file_no_target_repo_letter(
 # ---------------------------------------------------------------------------
 
 
+async def _maybe_fire_stage_workflow(
+    session: AsyncSession,
+    *,
+    workspace_id: uuid.UUID,
+    fsm_stage: str,
+    ticket_ref: str,
+    settings: Settings,
+) -> None:
+    """W8.5 trigger (b) — fire a workflow configured for this FSM
+    stage (``workspace.settings.workflows.stage_triggers``, e.g.
+    ``{"code_review": "pr-review"}``). Fail-closed: no config, no
+    fire. Dedup: skip when a run for the same (spec, ticket) is
+    already queued/running. Shadow mode records
+    ``workflow.would_have_run`` without spawning, mirroring the
+    dispatch shadow path."""
+    ws = await session.get(Workspace, workspace_id)
+    if ws is None:
+        return
+    triggers = ((ws.settings or {}).get("workflows") or {}).get(
+        "stage_triggers"
+    ) or {}
+    spec_name = triggers.get(fsm_stage)
+    if not spec_name:
+        return
+
+    from backend.app.db.models.workflow import AgentWorkflowRun
+    from backend.app.services.workflow.registry import resolve_spec
+    from backend.app.services.workflow.runtime import run_workflow
+
+    spec = resolve_spec(str(spec_name))
+    if spec is None:
+        log.warning(
+            "stage workflow trigger: unknown spec '%s' ws=%s stage=%s",
+            spec_name, workspace_id, fsm_stage,
+        )
+        return
+    triggered_by = f"ticket:{ticket_ref}"
+    existing = (
+        await session.execute(
+            select(AgentWorkflowRun.id).where(
+                AgentWorkflowRun.workspace_id == workspace_id,
+                AgentWorkflowRun.spec_name == spec.name,
+                AgentWorkflowRun.triggered_by == triggered_by,
+                AgentWorkflowRun.status.in_(("queued", "running")),
+            ).limit(1)
+        )
+    ).scalar_one_or_none()
+    if existing is not None:
+        return
+    if not settings.tracker_poll_fire:
+        session.add(
+            AuditLog(
+                workspace_id=workspace_id,
+                action="workflow.would_have_run",
+                target_kind="workflow_run",
+                target_id=spec.name,
+                payload={
+                    "trigger_kind": "gate",
+                    "fsm_stage": fsm_stage,
+                    "ticket_ref": ticket_ref,
+                    "shadow": True,
+                },
+            )
+        )
+        return
+    await run_workflow(
+        session,
+        workspace_id=workspace_id,
+        spec=spec,
+        inputs={"ticket_ref": ticket_ref, "pr_url": ""},
+        trigger_kind="gate",
+        triggered_by=triggered_by,
+    )
+
+
 async def maybe_dispatch(
     session: AsyncSession,
     *,
@@ -820,6 +895,27 @@ async def maybe_dispatch(
     # stage label we'd rather refuse fast than hold a lock for a
     # ticket nobody can work on.
     routine_id = _STAGE_TO_ROUTINE.get(fsm_stage or "") if fsm_stage else None
+
+    # W8.5 (ELS-261) trigger (b): a stage entry may ALSO fire a
+    # configured workflow (e.g. code_review → pr-review) — in
+    # addition to, never instead of, the normal single-routine
+    # dispatch. Best-effort: workflow problems never block ticket
+    # dispatch. The workflow's own spawns ride the gate (workflow:
+    # prefix cap + cascade), and shadow mode is honored inside.
+    if fsm_stage:
+        try:
+            await _maybe_fire_stage_workflow(
+                session,
+                workspace_id=workspace_id,
+                fsm_stage=fsm_stage,
+                ticket_ref=ticket_ref,
+                settings=settings,
+            )
+        except Exception:  # noqa: BLE001
+            log.exception(
+                "stage workflow trigger failed ws=%s stage=%s",
+                workspace_id, fsm_stage,
+            )
 
     # 1. Shadow mode — recorded, never fires. Includes the resolved
     # routine so shadow audit rows let us validate the routing logic

--- a/apps/backend/app/services/dispatcher.py
+++ b/apps/backend/app/services/dispatcher.py
@@ -16,10 +16,16 @@ Public surface (everything else is private to this module):
   (tests, manual reconciliation jobs). Most callers should use
   ``maybe_dispatch``.
 
-Lock key namespace is opaque to the schema. Today the only key shape
-is ``ticket:<ref>`` (per-ticket serialisation); future namespaces
-(``daily:<routine>``, ``project:<anchor>``) drop in without a
-migration.
+Lock key namespace is opaque to the schema. Key shapes in use:
+
+- ``ticket:<ref>``        — per-ticket SDLC serialisation (this module);
+- ``project:<anchor>``    — per-project WIP lock (this module);
+- ``<bundle>:scheduled``  — workspace bundles (daily-digest /
+  weekly-audit / self-heal, ``maybe_dispatch_workspace_bundle``);
+- ``workflow:<run>:<step>`` — thesis-8 workflow leaves
+  (:mod:`backend.app.services.workflow.gate`) — counted on the
+  ``workflow:`` prefix (separate cap pool from ``ticket:``), swept by
+  the same TTL sweeper as everything else.
 """
 
 from __future__ import annotations

--- a/apps/backend/app/services/workflow/__init__.py
+++ b/apps/backend/app/services/workflow/__init__.py
@@ -1,0 +1,11 @@
+"""Deterministic workflow primitive (thesis 8, Phase 8).
+
+Bounded imperative fan-outs invoked for ONE job — complementary to
+the FSM (reactive per-ticket lifecycle) and to /process (state-machine
+definitions). Modules:
+
+- :mod:`spec` — the ``.ship/workflows/*.yaml`` definition language.
+- :mod:`gate` — the single control-plane chokepoint every leaf spawn
+  passes through (lease / cap / cascade / idempotency).
+- :mod:`runtime` — the DAG executor.
+"""

--- a/apps/backend/app/services/workflow/gate.py
+++ b/apps/backend/app/services/workflow/gate.py
@@ -1,0 +1,273 @@
+"""WorkflowDispatchGate — the single control-plane chokepoint (W8.2).
+
+EVERY workflow leaf (coding OR reasoning) passes through
+:func:`gate_step_dispatch` before it spawns. The gate REUSES the
+dispatcher primitives — it never reimplements them:
+
+- lease: :func:`dispatcher.acquire_lock` under the
+  ``workflow:<run_id>:<step_id>`` key namespace, so workflow locks
+  are countable + sweepable exactly like ``ticket:*`` and bundle
+  keys (the ELS-264 TTL sweeper covers them for free);
+- cap: :func:`dispatcher.count_active_locks` with the ``workflow:``
+  prefix — a SEPARATE accounting pool from the SDLC ``ticket:`` cap
+  (mirrors WORKSPACE_BUNDLE_CAP's separation) — checked AFTER acquire
+  with walk-back-on-exceed, byte-for-byte the ``maybe_dispatch``
+  pattern;
+- cascade: :func:`dispatcher._count_recent_dispatches` over audit_log
+  against ``CASCADE_LIMIT`` — counted on RECURSION EDGES (a ``ship``
+  self-spawn leaf or a nested workflow), keyed on the lineage root,
+  so Ship-spawning-Ship-spawning-Ship is refused at depth 3 while an
+  ordinary reasoning fan-out is not a recursion;
+- idempotency: the durable ``agent_workflow_step_runs`` row keyed
+  UNIQUE (workflow_run_id, step_id, attempt) — a retried reconcile
+  tick finds the row and does NOT double-spawn; re-running a failed
+  step requires a NEW attempt.
+
+FOUNDER DECISION: the control plane is strictly off-limits to the
+autonomy dial. This module contains NO profile branch — every
+workspace, including ``high``, hits the same cap and cascade. (A test
+greps this file to keep it that way.)
+"""
+
+from __future__ import annotations
+
+import secrets
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.app.core.config import Settings, get_settings
+from backend.app.db.models.tenancy import AuditLog, Workspace
+from backend.app.db.models.workflow import AgentWorkflowStepRun
+from backend.app.services.dispatcher import (
+    CASCADE_LIMIT,
+    _count_recent_dispatches,
+    acquire_lock,
+    count_active_locks,
+    release_lock,
+)
+
+
+class GateReason:
+    """Closed vocabulary — mirrors dispatcher._Reason so dashboards
+    can union the two."""
+
+    GRANTED = "granted"
+    DUPLICATE_ATTEMPT = "duplicate_attempt"
+    LOCK_HELD = "lock_held"
+    CAP_EXCEEDED = "cap_exceeded"
+    CASCADE_BLOCKED = "cascade_blocked"
+
+
+# Providers whose spawn is a RECURSION edge: the spawned process is
+# itself capable of firing more Ship work (T6 self-spawn). These — and
+# nested workflow invocations — are what the cascade guard counts.
+RECURSIVE_PROVIDERS = ("ship",)
+
+
+def workflow_lock_key(workflow_run_id: uuid.UUID, step_id: str) -> str:
+    return f"workflow:{workflow_run_id}:{step_id}"
+
+
+@dataclass(frozen=True, slots=True)
+class GateDecision:
+    granted: bool
+    reason: str
+    lock_key: str
+    step_row_id: uuid.UUID | None = None
+    # Correlation id for the spawned leaf (CI agent runs report back
+    # with it via /agent-runs/finish).
+    run_id: str | None = None
+
+
+async def gate_step_dispatch(
+    session: AsyncSession,
+    *,
+    workspace_id: uuid.UUID,
+    workflow_run_id: uuid.UUID,
+    step_id: str,
+    attempt: int,
+    kind: str,
+    agent_provider: str | None,
+    cascade_key: str | None = None,
+    is_nested_workflow: bool = False,
+    settings: Settings | None = None,
+) -> GateDecision:
+    """Decide whether one step attempt may spawn. Returns a granted
+    decision carrying the durable step row id + correlation run_id,
+    or a refusal in the dispatcher's reason vocabulary — the runtime
+    records a blocked/skipped step instead of crashing.
+    """
+    settings = settings or get_settings()
+    lock_key = workflow_lock_key(workflow_run_id, step_id)
+    cascade_key = cascade_key or f"workflow:{workflow_run_id}"
+
+    # 1. Idempotency — the durable step row is the source of truth.
+    existing = (
+        await session.execute(
+            select(AgentWorkflowStepRun).where(
+                AgentWorkflowStepRun.workflow_run_id == workflow_run_id,
+                AgentWorkflowStepRun.step_id == step_id,
+                AgentWorkflowStepRun.attempt == attempt,
+            )
+        )
+    ).scalar_one_or_none()
+    if existing is not None:
+        return GateDecision(
+            granted=False,
+            reason=GateReason.DUPLICATE_ATTEMPT,
+            lock_key=lock_key,
+            step_row_id=existing.id,
+            run_id=existing.run_id,
+        )
+
+    async def _blocked(reason: str) -> GateDecision:
+        row = AgentWorkflowStepRun(
+            workflow_run_id=workflow_run_id,
+            step_id=step_id,
+            attempt=attempt,
+            kind=kind,
+            agent_provider=agent_provider,
+            status="blocked",
+            reason=reason,
+            lock_key=lock_key,
+            finished_at=datetime.now(timezone.utc),
+        )
+        session.add(row)
+        session.add(
+            AuditLog(
+                workspace_id=workspace_id,
+                action="workflow.step_blocked",
+                target_kind="workflow_step",
+                target_id=f"{workflow_run_id}:{step_id}",
+                payload={
+                    "workflow_run_id": str(workflow_run_id),
+                    "step_id": step_id,
+                    "attempt": attempt,
+                    "reason": reason,
+                },
+            )
+        )
+        await session.flush()
+        return GateDecision(
+            granted=False,
+            reason=reason,
+            lock_key=lock_key,
+            step_row_id=row.id,
+        )
+
+    # 2. Cascade guard — recursion edges only (ship self-spawn leaves
+    # and nested workflow invocations). Counted over audit_log via the
+    # dispatcher's own counter, keyed on the lineage root, so the
+    # guard survives fast acquire/release cycles.
+    is_recursion_edge = (
+        (agent_provider in RECURSIVE_PROVIDERS) or is_nested_workflow
+    )
+    if is_recursion_edge:
+        recent = await _count_recent_dispatches(
+            session, workspace_id=workspace_id, ticket_ref=cascade_key
+        )
+        if recent >= CASCADE_LIMIT:
+            return await _blocked(GateReason.CASCADE_BLOCKED)
+
+    # 3. Lease — refuses fast when this exact step is already in
+    # flight (e.g. a parallel reconcile tick racing us).
+    got_lock = await acquire_lock(
+        session, workspace_id=workspace_id, key=lock_key
+    )
+    if not got_lock:
+        return await _blocked(GateReason.LOCK_HELD)
+
+    # 4. Per-workspace cap on the ``workflow:`` prefix — checked AFTER
+    # acquire so the count includes our own row; strictly-greater
+    # means "this acquire pushed us past the limit, walk it back"
+    # (the maybe_dispatch pattern, dispatcher.py step 4).
+    active = await count_active_locks(
+        session, workspace_id=workspace_id, key_prefix="workflow:"
+    )
+    ws_cap = (
+        await session.execute(
+            select(Workspace.max_concurrent_dispatches).where(
+                Workspace.id == workspace_id
+            )
+        )
+    ).scalar_one_or_none()
+    cap = ws_cap if ws_cap is not None else settings.default_workspace_dispatch_cap
+    if active > cap:
+        await release_lock(session, workspace_id=workspace_id, key=lock_key)
+        return await _blocked(GateReason.CAP_EXCEEDED)
+
+    # 5. Granted — persist the durable step row + audit, mint the
+    # correlation run_id the leaf reports back with.
+    run_id = f"run_{secrets.token_hex(8)}"
+    row = AgentWorkflowStepRun(
+        workflow_run_id=workflow_run_id,
+        step_id=step_id,
+        attempt=attempt,
+        kind=kind,
+        agent_provider=agent_provider,
+        status="dispatched",
+        lock_key=lock_key,
+        run_id=run_id,
+    )
+    session.add(row)
+    session.add(
+        AuditLog(
+            workspace_id=workspace_id,
+            action="workflow.step_dispatched",
+            target_kind="workflow_step",
+            target_id=f"{workflow_run_id}:{step_id}",
+            payload={
+                "workflow_run_id": str(workflow_run_id),
+                "step_id": step_id,
+                "attempt": attempt,
+                "agent_provider": agent_provider,
+                "lock_key": lock_key,
+                "run_id": run_id,
+            },
+        )
+    )
+    if is_recursion_edge:
+        # The cascade counter reads agent_run.dispatch rows — write
+        # one per recursion edge so a Ship-spawning-Ship chain is
+        # counted by the SAME counter ticket dispatch uses.
+        session.add(
+            AuditLog(
+                workspace_id=workspace_id,
+                action="agent_run.dispatch",
+                target_kind="workflow",
+                target_id=cascade_key,
+                payload={
+                    "workflow_run_id": str(workflow_run_id),
+                    "step_id": step_id,
+                    "recursion_edge": True,
+                },
+            )
+        )
+    await session.flush()
+    return GateDecision(
+        granted=True,
+        reason=GateReason.GRANTED,
+        lock_key=lock_key,
+        step_row_id=row.id,
+        run_id=run_id,
+    )
+
+
+async def release_step_lock(
+    session: AsyncSession,
+    *,
+    workspace_id: uuid.UUID,
+    workflow_run_id: uuid.UUID,
+    step_id: str,
+) -> bool:
+    """Release one step's workflow lock (leaf finished/failed) —
+    mirrors how ticket dispatch releases on /agent-runs/finish."""
+    return await release_lock(
+        session,
+        workspace_id=workspace_id,
+        key=workflow_lock_key(workflow_run_id, step_id),
+    )

--- a/apps/backend/app/services/workflow/leaves.py
+++ b/apps/backend/app/services/workflow/leaves.py
@@ -1,0 +1,230 @@
+"""Leaf executors for the workflow runtime (W8.3).
+
+The runtime never spawns anything itself — it calls the gate, then
+hands the granted step to one of these executors. Two leaf species:
+
+- **reasoning** — an in-process Navigator subagent turn
+  (:meth:`ToolBox._run_subagent_loop`, role-prompted from the spec).
+  Completes synchronously; its structured text is parsed into the
+  step output.
+- **coding** — a CI agent run: fire ``workflow_dispatch`` on
+  ``ship-agent-run.yml`` exactly as the dispatcher does (reuse
+  ``dispatch_workflow`` + ``WORKFLOW_FILE``), carrying the gate's
+  correlation ``run_id``. Completion arrives later via the
+  ``/agent-runs/finish`` webhook → :func:`complete_coding_step`
+  (lean event-driven design: no in-process await; all state in
+  ``agent_workflow_step_runs``).
+
+Tests inject fake executors; production wiring uses these defaults.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Awaitable, Callable
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.app.core.config import Settings
+from backend.app.db.models.workflow import AgentWorkflowStepRun
+from backend.app.services.workflow.spec import StepSpec
+
+logger = logging.getLogger(__name__)
+
+
+# Executor signatures: (session, settings, workspace_id, step, inputs,
+# run_id) → output dict for synchronous completion, or None when the
+# leaf completes asynchronously (CI webhook path).
+LeafExecutor = Callable[..., Awaitable[dict[str, Any] | None]]
+
+
+@dataclass(frozen=True, slots=True)
+class LeafExecutors:
+    run_reasoning: LeafExecutor
+    run_coding: LeafExecutor
+
+
+_ROLE_FLAVOR = {
+    "synthesize": (
+        "You are a synthesizer. Merge the prior step outputs into one "
+        "coherent result."
+    ),
+    "judge": (
+        "You are a judge. Rank/score the prior step outputs and pick "
+        "winners with reasons."
+    ),
+    "verify": (
+        "You are a verifier. Adversarially re-check the claim(s) in "
+        "your inputs; do not take them at face value."
+    ),
+}
+
+
+async def run_reasoning_leaf(
+    session: AsyncSession,
+    settings: Settings,
+    workspace_id: uuid.UUID,
+    step: StepSpec,
+    inputs: dict[str, Any],
+    run_id: str,
+    *,
+    user_id: uuid.UUID | None = None,
+) -> dict[str, Any] | None:
+    """In-process reasoning turn. The subagent loop sets
+    ``_subagent_active`` for its tool calls, so a reasoning leaf can
+    never call run_subagent/run_workflow (the W8.2 recursion guard)."""
+    from backend.app.services.agent.tools import ToolBox
+
+    toolbox = ToolBox(
+        session,
+        settings=settings,
+        workspace_id=workspace_id,
+        user_id=user_id,
+    )
+    flavor = _ROLE_FLAVOR.get(step.kind, "You are a focused specialist.")
+    role = (step.agent.role if step.agent else None) or step.kind
+    schema_clause = ""
+    if step.output_schema:
+        schema_clause = (
+            "\n\nRespond with a single JSON object matching this JSON "
+            f"Schema (no prose outside the JSON):\n"
+            f"{json.dumps(step.output_schema, ensure_ascii=False)}"
+        )
+    system_prompt = (
+        f"{flavor}\nRole: {role}. You are one bounded step "
+        f"('{step.id}') of a deterministic Ship workflow — produce "
+        "your result and stop; you cannot and must not spawn further "
+        "agents." + schema_clause
+    )
+    prompt = step.agent.prompt if step.agent and step.agent.prompt else ""
+    user_message = (
+        (prompt + "\n\n" if prompt else "")
+        + "Inputs:\n"
+        + json.dumps(inputs, ensure_ascii=False, default=str)[:16000]
+    )
+    # Reasoning leaves run tool-less by default: their value is
+    # synthesis over the inputs already collected by prior steps.
+    result = await toolbox._run_subagent_loop(  # noqa: SLF001 — deliberate reuse (W8.1)
+        system_prompt=system_prompt,
+        user_message=user_message,
+        tool_specs=[],
+    )
+    if result.get("error"):
+        raise RuntimeError(
+            f"reasoning leaf '{step.id}' failed: {result['error']}"
+        )
+    text = (result.get("text") or "").strip()
+    if step.output_schema:
+        try:
+            # Tolerate fenced JSON.
+            cleaned = text
+            if cleaned.startswith("```"):
+                cleaned = cleaned.strip("`")
+                cleaned = cleaned.split("\n", 1)[1] if "\n" in cleaned else cleaned
+            return json.loads(cleaned)
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(
+                f"reasoning leaf '{step.id}' did not return valid JSON: {exc}"
+            ) from exc
+    return {"text": text, "run_id": run_id}
+
+
+async def run_coding_leaf(
+    session: AsyncSession,
+    settings: Settings,
+    workspace_id: uuid.UUID,
+    step: StepSpec,
+    inputs: dict[str, Any],
+    run_id: str,
+    *,
+    user_id: uuid.UUID | None = None,
+) -> dict[str, Any] | None:
+    """Fire the CI coding run, exactly as ticket dispatch does.
+
+    Returns ``None`` — completion is asynchronous: the spawned agent
+    reports via ``/agent-runs/finish`` with our ``run_id`` and
+    :func:`complete_coding_step` closes the loop (releases the
+    ``workflow:*`` lock, persists the output).
+    """
+    import httpx
+
+    from backend.app.services.dispatcher import (
+        WORKFLOW_FILE,
+        _pick_dispatch_repo,
+        dispatch_workflow,
+    )
+
+    target = await _pick_dispatch_repo(session, workspace_id=workspace_id)
+    if target is None:
+        raise RuntimeError(
+            "no dispatch repo bound for this workspace — bind one in "
+            "Settings → Repos before running coding leaves"
+        )
+    repo, install, _route = target
+    routine_id = str(
+        inputs.get("routine_id")
+        or (step.agent.role if step.agent else None)
+        or "workflow-leaf"
+    )
+    dispatch_inputs: dict[str, str] = {
+        "routine_id": routine_id,
+        "ticket_ref": str(inputs.get("ticket_ref") or ""),
+        "ship_run_id": run_id,
+    }
+    async with httpx.AsyncClient(timeout=httpx.Timeout(15.0)) as client:
+        await dispatch_workflow(
+            repo,
+            install,
+            WORKFLOW_FILE,
+            inputs=dispatch_inputs,
+            settings=settings,
+            client=client,
+        )
+    return None
+
+
+DEFAULT_EXECUTORS = LeafExecutors(
+    run_reasoning=run_reasoning_leaf,
+    run_coding=run_coding_leaf,
+)
+
+
+async def complete_coding_step(
+    session: AsyncSession,
+    *,
+    workspace_id: uuid.UUID,
+    run_id: str,
+    success: bool,
+    output: dict[str, Any] | None = None,
+) -> bool:
+    """Webhook-side completion: correlate a finished CI agent run back
+    to its workflow step by ``run_id``, persist the outcome, release
+    the ``workflow:*`` lock. Returns True when a step matched."""
+    from backend.app.services.workflow.gate import release_step_lock
+
+    row = (
+        await session.execute(
+            select(AgentWorkflowStepRun).where(
+                AgentWorkflowStepRun.run_id == run_id,
+                AgentWorkflowStepRun.status.in_(("dispatched", "running")),
+            )
+        )
+    ).scalar_one_or_none()
+    if row is None:
+        return False
+    row.status = "completed" if success else "failed"
+    row.output = output
+    row.finished_at = datetime.now(timezone.utc)
+    await release_step_lock(
+        session,
+        workspace_id=workspace_id,
+        workflow_run_id=row.workflow_run_id,
+        step_id=row.step_id,
+    )
+    await session.flush()
+    return True

--- a/apps/backend/app/services/workflow/registry.py
+++ b/apps/backend/app/services/workflow/registry.py
@@ -1,0 +1,37 @@
+"""Workflow spec registry (W8.4/W8.5 support).
+
+Resolution order for a named workflow:
+
+1. **Packaged dogfood specs** — YAML files shipped inside the backend
+   under ``workflow/specs/`` (pr-review, codebase-audit). These are
+   the internal/dogfood launch set (thesis 8 scope decision).
+2. (future) **Repo specs** — ``.ship/workflows/<name>.yaml`` in the
+   customer repo, fetched via the code-host adapter; the in-repo
+   copies under ``.ship/workflows/`` document the contract today and
+   the CLI lints them via ``loadSpec.mjs``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from backend.app.services.workflow.spec import WorkflowSpec, load_spec
+
+_SPECS_DIR = Path(__file__).parent / "specs"
+
+
+def list_available_specs() -> list[str]:
+    if not _SPECS_DIR.is_dir():
+        return []
+    return sorted(p.stem for p in _SPECS_DIR.glob("*.yaml"))
+
+
+def resolve_spec(name: str) -> WorkflowSpec | None:
+    """Load a packaged spec by name; ``None`` when unknown."""
+    safe = name.strip()
+    if not safe or "/" in safe or "\\" in safe or ".." in safe:
+        return None
+    path = _SPECS_DIR / f"{safe}.yaml"
+    if not path.is_file():
+        return None
+    return load_spec(path.read_text())

--- a/apps/backend/app/services/workflow/runtime.py
+++ b/apps/backend/app/services/workflow/runtime.py
@@ -391,6 +391,38 @@ async def advance_workflow(
     return run
 
 
+async def advance_run_by_id(
+    run_id: uuid.UUID, *, actor_user_id: uuid.UUID | None = None
+) -> None:
+    """Background entrypoint for queued runs (chat trigger) and the
+    reconcile tick: open a fresh session, load the run + its packaged
+    spec, advance. Best-effort — failures land on the run row, never
+    on the caller."""
+    from backend.app.db.session import get_sessionmaker
+    from backend.app.services.workflow.registry import resolve_spec
+
+    sessionmaker = get_sessionmaker()
+    try:
+        async with sessionmaker() as session:
+            run = await session.get(AgentWorkflowRun, run_id)
+            if run is None:
+                return
+            spec = resolve_spec(run.spec_name)
+            if spec is None:
+                run.status = "failed"
+                run.finished_at = datetime.now(timezone.utc)
+                await session.commit()
+                return
+            if run.status == "queued":
+                run.status = "running"
+            await advance_workflow(
+                session, run=run, spec=spec, actor_user_id=actor_user_id
+            )
+            await session.commit()
+    except Exception:  # noqa: BLE001 — background task must not crash the loop
+        logger.exception("workflow %s background advance failed", run_id)
+
+
 async def _run_leaf(
     session: AsyncSession,
     *,

--- a/apps/backend/app/services/workflow/runtime.py
+++ b/apps/backend/app/services/workflow/runtime.py
@@ -1,0 +1,496 @@
+"""Workflow runtime executor (W8.3, ELS-258).
+
+Takes a loaded :class:`WorkflowSpec` + a workspace and drives the DAG
+to completion: topological scheduling, parallel fan-out + barrier
+joins, pipeline output threading, bounded loops, schema-validated
+synthesize/judge/verify outputs. BOUNDED by construction — it returns
+when the DAG drains or a budget trips, which is exactly what makes it
+NOT the FSM (reactive, never completes) and NOT /process (a state-
+machine definition).
+
+CRITICAL: this module never spawns anything directly — none of the
+spawn primitives (the CLI runtime adapter, the GH workflow-dispatch
+helper, the in-process subagent loop) are referenced here. Every leaf
+goes through :func:`workflow.gate.gate_step_dispatch` first and is
+then executed by the injected :class:`LeafExecutors` (defaults in
+:mod:`workflow.leaves`). A grep test pins the chokepoint.
+
+Lean event-driven coding leaves: the executor fires CI dispatch and
+returns ``None``; the step stays ``dispatched`` and the run stays
+``running`` until the ``/agent-runs/finish`` webhook correlates back
+via ``run_id`` (``leaves.complete_coding_step``) and a reconcile tick
+calls :func:`advance_workflow` again. All scheduling state lives in
+``agent_workflow_step_runs`` — cross-replica correct.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.app.core.config import Settings, get_settings
+from backend.app.db.models.workflow import AgentWorkflowRun, AgentWorkflowStepRun
+from backend.app.services.workflow.gate import (
+    GateReason,
+    gate_step_dispatch,
+    release_step_lock,
+)
+from backend.app.services.workflow.spec import (
+    StepSpec,
+    WorkflowSpec,
+    WorkflowSpecError,
+    validate_output,
+)
+
+logger = logging.getLogger(__name__)
+
+# Safety net on scheduling passes per advance call — the DAG is
+# statically bounded, so this should never bind; it exists so a
+# scheduling bug degrades into "run blocked" instead of a busy loop.
+_MAX_PASSES = 50
+
+_TEMPLATE_RE = re.compile(r"\{\{\s*([a-zA-Z0-9_.\-]+)\s*\}\}")
+
+
+def _flatten(spec: WorkflowSpec) -> dict[str, StepSpec]:
+    """Index every step (parallel children included) by id. Children
+    inherit the parallel container's ``needs`` implicitly."""
+    flat: dict[str, StepSpec] = {}
+
+    def walk(steps: list[StepSpec]) -> None:
+        for s in steps:
+            flat[s.id] = s
+            walk(s.steps)
+
+    walk(spec.steps)
+    return flat
+
+
+def _effective_needs(
+    spec: WorkflowSpec,
+) -> dict[str, list[str]]:
+    """Resolve each step's effective dependency list.
+
+    - explicit ``needs`` win;
+    - parallel children inherit the container's needs;
+    - a parallel CONTAINER completes when all its children do (the
+      container itself never executes);
+    - top-level steps without ``needs`` depend on nothing (the spec
+      author sequences explicitly via needs / barriers).
+    """
+    needs: dict[str, list[str]] = {}
+    children: dict[str, list[str]] = {}
+
+    def walk(steps: list[StepSpec], inherited: list[str]) -> None:
+        for s in steps:
+            own = list(s.needs) if s.needs else list(inherited)
+            needs[s.id] = own
+            if s.kind == "parallel":
+                children[s.id] = [c.id for c in s.steps]
+                walk(s.steps, own)
+
+    walk(spec.steps, [])
+    # Anything that needs a parallel container actually needs all of
+    # its children.
+    for sid, dep_list in needs.items():
+        expanded: list[str] = []
+        for dep in dep_list:
+            expanded.extend(children.get(dep, [dep]))
+        needs[sid] = expanded
+    return needs
+
+
+def _resolve_templates(value: Any, context: dict[str, Any]) -> Any:
+    """Substitute ``{{ inputs.x }}`` / ``{{ steps.<id>.output.<key> }}``
+    templates. A template that IS the whole string resolves to the
+    raw value (object passing); embedded templates stringify."""
+    if isinstance(value, dict):
+        return {k: _resolve_templates(v, context) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_resolve_templates(v, context) for v in value]
+    if not isinstance(value, str):
+        return value
+
+    def lookup(path: str) -> Any:
+        node: Any = context
+        for part in path.split("."):
+            if isinstance(node, dict) and part in node:
+                node = node[part]
+            else:
+                # steps.axis.correctness.output.findings — step ids may
+                # contain dots, so retry greedily against steps.*.
+                return _lookup_step_path(path, context)
+        return node
+
+    full = _TEMPLATE_RE.fullmatch(value.strip())
+    if full:
+        return lookup(full.group(1))
+    return _TEMPLATE_RE.sub(lambda m: str(lookup(m.group(1))), value)
+
+
+def _lookup_step_path(path: str, context: dict[str, Any]) -> Any:
+    """Handle dotted step ids: ``steps.<id-with-dots>.output.<key>``."""
+    if not path.startswith("steps."):
+        return None
+    rest = path[len("steps."):]
+    steps: dict[str, Any] = context.get("steps") or {}
+    # Longest matching step id wins.
+    for sid in sorted(steps, key=len, reverse=True):
+        prefix = f"{sid}."
+        if rest.startswith(prefix):
+            node: Any = steps[sid]
+            for part in rest[len(prefix):].split("."):
+                if isinstance(node, dict) and part in node:
+                    node = node[part]
+                else:
+                    return None
+            return node
+    return None
+
+
+def _until_satisfied(until: str | None, output: Any) -> bool:
+    """Evaluate the loop predicate: ``output.<key> == <literal>``."""
+    if not until:
+        return False
+    m = re.fullmatch(
+        r"\s*output\.([a-zA-Z0-9_]+)\s*==\s*(.+?)\s*", until
+    )
+    if not m or not isinstance(output, dict):
+        return False
+    key, literal = m.group(1), m.group(2).strip()
+    actual = output.get(key)
+    expected: Any = literal.strip("'\"")
+    if literal in ("true", "True"):
+        expected = True
+    elif literal in ("false", "False"):
+        expected = False
+    elif literal.isdigit():
+        expected = int(literal)
+    return actual == expected
+
+
+async def run_workflow(
+    session: AsyncSession,
+    *,
+    workspace_id: uuid.UUID,
+    spec: WorkflowSpec,
+    inputs: dict[str, Any],
+    trigger_kind: str,
+    triggered_by: str | None = None,
+    executors: Any = None,
+    settings: Settings | None = None,
+    actor_user_id: uuid.UUID | None = None,
+) -> AgentWorkflowRun:
+    """Single entrypoint the three triggers (chat/gate/cron) call.
+
+    Creates the durable run row and advances the DAG as far as it can
+    go synchronously. Reasoning leaves complete in-process; coding
+    leaves leave the run ``running`` until the finish webhook +
+    reconcile tick complete them.
+    """
+    run = AgentWorkflowRun(
+        workspace_id=workspace_id,
+        spec_name=spec.name,
+        spec_version=spec.version,
+        inputs=inputs,
+        trigger_kind=trigger_kind,
+        triggered_by=triggered_by,
+        status="running",
+    )
+    session.add(run)
+    await session.flush()
+    await advance_workflow(
+        session,
+        run=run,
+        spec=spec,
+        executors=executors,
+        settings=settings,
+        actor_user_id=actor_user_id,
+    )
+    return run
+
+
+async def advance_workflow(
+    session: AsyncSession,
+    *,
+    run: AgentWorkflowRun,
+    spec: WorkflowSpec,
+    executors: Any = None,
+    settings: Settings | None = None,
+    actor_user_id: uuid.UUID | None = None,
+) -> AgentWorkflowRun:
+    """Advance the DAG: dispatch every READY step, thread outputs,
+    finalize when all steps are terminal. Idempotent and resumable —
+    the reconcile tick calls this after coding leaves finish."""
+    if executors is None:
+        from backend.app.services.workflow.leaves import DEFAULT_EXECUTORS
+
+        executors = DEFAULT_EXECUTORS
+    settings = settings or get_settings()
+
+    flat = _flatten(spec)
+    needs = _effective_needs(spec)
+    cascade_key = f"workflow:{run.id}"
+
+    for _pass in range(_MAX_PASSES):
+        rows = (
+            await session.execute(
+                select(AgentWorkflowStepRun).where(
+                    AgentWorkflowStepRun.workflow_run_id == run.id
+                )
+            )
+        ).scalars().all()
+        # Latest attempt per step decides its state.
+        latest: dict[str, AgentWorkflowStepRun] = {}
+        for r in sorted(rows, key=lambda r: r.attempt):
+            latest[r.step_id] = r
+
+        context: dict[str, Any] = {
+            "inputs": dict(run.inputs or {}),
+            "steps": {
+                sid: {"output": r.output}
+                for sid, r in latest.items()
+                if r.status == "completed"
+            },
+        }
+
+        def is_done(sid: str) -> bool:
+            r = latest.get(sid)
+            return r is not None and r.status == "completed"
+
+        def is_terminal(sid: str) -> bool:
+            r = latest.get(sid)
+            return r is not None and r.status in (
+                "completed", "failed", "blocked", "skipped",
+            )
+
+        progressed = False
+        pending_async = False
+
+        for sid, step in flat.items():
+            if step.kind == "parallel":
+                continue  # containers never execute
+            row = latest.get(sid)
+            if row is not None and row.status in ("dispatched", "running"):
+                pending_async = True
+                continue
+            if row is not None:
+                continue  # terminal — done/failed/blocked
+            dep_states = [
+                (dep, is_done(dep), is_terminal(dep)) for dep in needs[sid]
+            ]
+            if any(not term for _, _, term in dep_states):
+                continue  # a dependency is still in flight
+            # All deps terminal. A barrier tolerates partial failure
+            # (sees the partial set); other steps require all deps
+            # completed — otherwise they are skipped.
+            if step.kind != "barrier" and any(
+                not done for _, done, _ in dep_states
+            ):
+                session.add(
+                    AgentWorkflowStepRun(
+                        workflow_run_id=run.id,
+                        step_id=sid,
+                        attempt=1,
+                        kind=step.kind,
+                        status="skipped",
+                        reason="dependency_failed",
+                        finished_at=datetime.now(timezone.utc),
+                    )
+                )
+                await session.flush()
+                progressed = True
+                continue
+
+            if step.kind == "barrier":
+                session.add(
+                    AgentWorkflowStepRun(
+                        workflow_run_id=run.id,
+                        step_id=sid,
+                        attempt=1,
+                        kind="barrier",
+                        status="completed",
+                        output={
+                            "joined": [
+                                dep for dep, done, _ in dep_states if done
+                            ],
+                            "failed": [
+                                dep for dep, done, _ in dep_states if not done
+                            ],
+                        },
+                        finished_at=datetime.now(timezone.utc),
+                    )
+                )
+                await session.flush()
+                progressed = True
+                continue
+
+            # Executable leaf (pipeline / loop / synthesize / judge /
+            # verify / parallel child).
+            resolved_inputs = _resolve_templates(dict(step.inputs), context)
+            ran = await _run_leaf(
+                session,
+                run=run,
+                step=step,
+                inputs=resolved_inputs,
+                cascade_key=cascade_key,
+                executors=executors,
+                settings=settings,
+                actor_user_id=actor_user_id,
+            )
+            progressed = progressed or ran is not None
+            if ran == "async":
+                pending_async = True
+
+        if not progressed:
+            break
+
+    # Finalize when nothing is left in flight.
+    rows = (
+        await session.execute(
+            select(AgentWorkflowStepRun).where(
+                AgentWorkflowStepRun.workflow_run_id == run.id
+            )
+        )
+    ).scalars().all()
+    latest = {}
+    for r in sorted(rows, key=lambda r: r.attempt):
+        latest[r.step_id] = r
+    executable_ids = [
+        sid for sid, s in flat.items() if s.kind != "parallel"
+    ]
+    in_flight = any(
+        latest.get(sid) is None
+        or latest[sid].status in ("dispatched", "running", "pending")
+        for sid in executable_ids
+    )
+    if not in_flight:
+        statuses = {latest[sid].status for sid in executable_ids}
+        if statuses <= {"completed"}:
+            run.status = "completed"
+        elif "completed" in statuses:
+            run.status = "completed"  # partial failure recorded per-step
+        elif "blocked" in statuses:
+            run.status = "blocked"
+        else:
+            run.status = "failed"
+        run.finished_at = datetime.now(timezone.utc)
+        # Final output = the last top-level step's output when it is
+        # an object.
+        last_id = spec.steps[-1].id
+        last_row = latest.get(last_id)
+        if last_row is not None and isinstance(last_row.output, dict):
+            run.output = last_row.output
+    await session.flush()
+    return run
+
+
+async def _run_leaf(
+    session: AsyncSession,
+    *,
+    run: AgentWorkflowRun,
+    step: StepSpec,
+    inputs: dict[str, Any],
+    cascade_key: str,
+    executors: Any,
+    settings: Settings,
+    actor_user_id: uuid.UUID | None,
+) -> str | None:
+    """Gate + execute one leaf. Returns 'sync' / 'async' / 'blocked',
+    or None when nothing happened."""
+    is_coding = step.agent is not None and step.agent.kind == "coding"
+    provider = (
+        step.agent.provider if step.agent else "reasoning"
+    )
+    max_iters = step.max_iters if step.kind == "loop" else 1
+
+    last_output: Any = None
+    for iteration in range(1, max_iters + 1):
+        decision = await gate_step_dispatch(
+            session,
+            workspace_id=run.workspace_id,
+            workflow_run_id=run.id,
+            step_id=step.id,
+            attempt=iteration,
+            kind=step.kind,
+            agent_provider=provider,
+            cascade_key=cascade_key,
+            settings=settings,
+        )
+        if not decision.granted:
+            if decision.reason == GateReason.DUPLICATE_ATTEMPT:
+                # Reconcile tick re-walking an already-handled step.
+                return None
+            return "blocked"
+
+        row = await session.get(AgentWorkflowStepRun, decision.step_row_id)
+        runner = executors.run_coding if is_coding else executors.run_reasoning
+        try:
+            output = await runner(
+                session,
+                settings,
+                run.workspace_id,
+                step,
+                inputs,
+                decision.run_id,
+                user_id=actor_user_id,
+            )
+        except Exception as exc:  # noqa: BLE001 — a leaf failure never aborts siblings
+            logger.warning(
+                "workflow %s step %s failed: %s", run.id, step.id, exc
+            )
+            row.status = "failed"
+            row.reason = str(exc)[:64]
+            row.finished_at = datetime.now(timezone.utc)
+            await release_step_lock(
+                session,
+                workspace_id=run.workspace_id,
+                workflow_run_id=run.id,
+                step_id=step.id,
+            )
+            await session.flush()
+            return "sync"
+
+        if output is None:
+            # Asynchronous coding leaf — finish webhook completes it.
+            return "async"
+
+        if step.output_schema:
+            try:
+                validate_output(output, step.output_schema, step_id=step.id)
+            except WorkflowSpecError as exc:
+                row.status = "failed"
+                row.reason = "schema_invalid"
+                row.output = output if isinstance(output, dict) else None
+                row.finished_at = datetime.now(timezone.utc)
+                await release_step_lock(
+                    session,
+                    workspace_id=run.workspace_id,
+                    workflow_run_id=run.id,
+                    step_id=step.id,
+                )
+                await session.flush()
+                logger.warning("workflow %s step %s: %s", run.id, step.id, exc)
+                return "sync"
+
+        row.status = "completed"
+        row.output = output if isinstance(output, dict) else {"value": output}
+        row.finished_at = datetime.now(timezone.utc)
+        await release_step_lock(
+            session,
+            workspace_id=run.workspace_id,
+            workflow_run_id=run.id,
+            step_id=step.id,
+        )
+        await session.flush()
+        last_output = output
+
+        if step.kind != "loop" or _until_satisfied(step.until, last_output):
+            return "sync"
+    return "sync"

--- a/apps/backend/app/services/workflow/spec.py
+++ b/apps/backend/app/services/workflow/spec.py
@@ -1,0 +1,282 @@
+"""Workflow definition language + loader (W8.1, ELS-256).
+
+A workflow spec lives at ``.ship/workflows/<name>.yaml`` in the
+customer repo and is DECLARATIVE and BOUNDED: a DAG with a fan-out
+cap, no unbounded recursion, no event subscription — it is INVOKED
+and COMPLETES. Seven step kinds:
+
+- ``parallel``  — fan out the nested ``steps`` concurrently;
+- ``barrier``   — join point: waits for everything in ``needs``;
+- ``pipeline``  — leaf chained behind ``needs``, prior outputs
+  available to its inputs via ``{{ steps.<id>.output.<key> }}``;
+- ``loop``      — repeat a leaf until ``until`` or ``max_iters``;
+- ``synthesize`` / ``judge`` / ``verify`` — reasoning steps with a
+  fixed role flavor that consume prior outputs and MUST emit a
+  structured object validated against their inline ``output_schema``.
+
+Budgets mirror the subagent convention (``_SUBAGENT_MAX_TOOL_CALLS=25``
+/ ``_SUBAGENT_MAX_SECONDS=300`` in :mod:`services.agent.tools`).
+``max_fanout`` (default 4, hard ceiling 8) and ``max_depth`` (default
+2) are enforced AT LOAD TIME, before any dispatch, so a malformed
+spec can't even request a fork-bomb.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+import yaml
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+# Hard ceilings — the loader refuses anything above these regardless
+# of what the spec declares. Control plane values, not preferences:
+# no autonomy profile loosens them.
+HARD_FANOUT_CEILING = 8
+DEFAULT_MAX_FANOUT = 4
+DEFAULT_MAX_DEPTH = 2
+
+STEP_KINDS = (
+    "parallel",
+    "pipeline",
+    "loop",
+    "barrier",
+    "synthesize",
+    "judge",
+    "verify",
+)
+# Step kinds whose leaf is a fixed-role reasoning turn and whose
+# output MUST validate against an inline JSON Schema.
+STRUCTURED_KINDS = ("synthesize", "judge", "verify")
+
+CODING_PROVIDERS = ("claude", "codex", "cursor", "ship")
+REASONING_PROVIDER = "reasoning"
+
+
+class WorkflowSpecError(ValueError):
+    """Raised by the loader for any invalid spec — always names the
+    offending step when one exists."""
+
+
+class AgentLeaf(BaseModel):
+    """Leaf executor selection (T5: spawn, never re-implement).
+
+    ``kind=coding`` spawns a tool CLI via ``runAgent`` (claude / codex
+    / cursor / ship); ``kind=reasoning`` runs an in-process Navigator
+    subagent turn, role-prompted.
+    """
+
+    kind: Literal["coding", "reasoning"]
+    provider: str = REASONING_PROVIDER
+    role: str | None = None
+    prompt: str | None = None
+
+    @model_validator(mode="after")
+    def _provider_matches_kind(self) -> "AgentLeaf":
+        if self.kind == "coding":
+            if self.provider not in CODING_PROVIDERS:
+                raise ValueError(
+                    f"unknown coding provider '{self.provider}' "
+                    f"(known: {', '.join(CODING_PROVIDERS)})"
+                )
+        else:
+            if self.provider not in (REASONING_PROVIDER,):
+                raise ValueError(
+                    "reasoning leaves use provider 'reasoning' "
+                    f"(got '{self.provider}')"
+                )
+        return self
+
+
+class StepSpec(BaseModel):
+    id: str = Field(min_length=1, max_length=120)
+    kind: str
+    agent: AgentLeaf | None = None
+    # Children — parallel only.
+    steps: list["StepSpec"] = Field(default_factory=list)
+    # DAG edges: ids of steps that must complete first. A barrier
+    # joins exclusively via needs.
+    needs: list[str] = Field(default_factory=list)
+    # Static inputs + ``{{ steps.<id>.output.<key> }}`` templates.
+    inputs: dict[str, Any] = Field(default_factory=dict)
+    output_schema: dict[str, Any] | None = None
+    # loop only.
+    until: str | None = None
+    max_iters: int = Field(default=3, ge=1, le=10)
+    # Budget convention from services/agent/tools.py.
+    max_tool_calls: int = Field(default=25, ge=1, le=100)
+    max_seconds: int = Field(default=300, ge=10, le=1800)
+
+    @field_validator("kind")
+    @classmethod
+    def _known_kind(cls, v: str) -> str:
+        if v not in STEP_KINDS:
+            raise ValueError(
+                f"unknown step kind '{v}' (known: {', '.join(STEP_KINDS)})"
+            )
+        return v
+
+    @model_validator(mode="after")
+    def _shape_for_kind(self) -> "StepSpec":
+        if self.kind in STRUCTURED_KINDS:
+            if not self.output_schema:
+                raise ValueError(
+                    f"step '{self.id}': {self.kind} requires output_schema"
+                )
+            if (
+                not isinstance(self.output_schema, dict)
+                or "type" not in self.output_schema
+            ):
+                raise ValueError(
+                    f"step '{self.id}': output_schema must be a JSON Schema "
+                    "object carrying 'type'"
+                )
+            if self.agent is not None and self.agent.kind != "reasoning":
+                raise ValueError(
+                    f"step '{self.id}': {self.kind} is a reasoning step"
+                )
+        if self.kind == "parallel":
+            if not self.steps:
+                raise ValueError(
+                    f"step '{self.id}': parallel requires nested steps"
+                )
+        elif self.steps:
+            raise ValueError(
+                f"step '{self.id}': only parallel steps nest children"
+            )
+        if self.kind == "barrier":
+            if not self.needs:
+                raise ValueError(
+                    f"step '{self.id}': barrier requires needs[]"
+                )
+            if self.agent is not None:
+                raise ValueError(
+                    f"step '{self.id}': barrier is a join point, no agent"
+                )
+        if self.kind in ("pipeline", "loop") and self.agent is None:
+            raise ValueError(f"step '{self.id}': {self.kind} requires agent")
+        return self
+
+
+class WorkflowSpec(BaseModel):
+    name: str = Field(min_length=1, max_length=120)
+    version: str = "1"
+    # Declared input names → type labels (string/int/bool/object) —
+    # documentation-grade typing, checked loosely at invocation.
+    inputs: dict[str, str] = Field(default_factory=dict)
+    max_fanout: int = Field(default=DEFAULT_MAX_FANOUT, ge=1)
+    max_depth: int = Field(default=DEFAULT_MAX_DEPTH, ge=1)
+    steps: list[StepSpec] = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def _bounded(self) -> "WorkflowSpec":
+        if self.max_fanout > HARD_FANOUT_CEILING:
+            raise ValueError(
+                f"max_fanout={self.max_fanout} exceeds the hard ceiling "
+                f"{HARD_FANOUT_CEILING}"
+            )
+        # Static depth: nesting levels of parallel children.
+        def depth(steps: list[StepSpec], level: int) -> int:
+            deepest = level
+            for s in steps:
+                if s.steps:
+                    deepest = max(deepest, depth(s.steps, level + 1))
+            return deepest
+
+        actual_depth = depth(self.steps, 1)
+        if actual_depth > self.max_depth:
+            raise ValueError(
+                f"static step graph depth {actual_depth} exceeds "
+                f"max_depth={self.max_depth}"
+            )
+        # Fan-out: no parallel step may declare more children than
+        # max_fanout.
+        def check_fanout(steps: list[StepSpec]) -> None:
+            for s in steps:
+                if s.kind == "parallel" and len(s.steps) > self.max_fanout:
+                    raise ValueError(
+                        f"step '{s.id}': fan-out {len(s.steps)} exceeds "
+                        f"max_fanout={self.max_fanout}"
+                    )
+                check_fanout(s.steps)
+
+        check_fanout(self.steps)
+        # Unique ids + resolvable needs edges.
+        ids: set[str] = set()
+
+        def collect(steps: list[StepSpec]) -> None:
+            for s in steps:
+                if s.id in ids:
+                    raise ValueError(f"duplicate step id '{s.id}'")
+                ids.add(s.id)
+                collect(s.steps)
+
+        collect(self.steps)
+
+        def check_needs(steps: list[StepSpec]) -> None:
+            for s in steps:
+                for need in s.needs:
+                    if need not in ids:
+                        raise ValueError(
+                            f"step '{s.id}': needs unknown step '{need}'"
+                        )
+                check_needs(s.steps)
+
+        check_needs(self.steps)
+        return self
+
+
+def load_spec(text: str) -> WorkflowSpec:
+    """Parse + validate one ``.ship/workflows/*.yaml`` document.
+
+    Raises :class:`WorkflowSpecError` with the offending step named
+    for every rejection — the loader runs BEFORE any dispatch, so a
+    malformed spec can never reach the gate."""
+    try:
+        raw = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        raise WorkflowSpecError(f"invalid YAML: {exc}") from exc
+    if not isinstance(raw, dict):
+        raise WorkflowSpecError("workflow spec must be a YAML mapping")
+    try:
+        return WorkflowSpec.model_validate(raw)
+    except Exception as exc:  # pydantic ValidationError → stable error type
+        raise WorkflowSpecError(str(exc)) from exc
+
+
+def validate_output(value: Any, schema: dict[str, Any], *, step_id: str) -> None:
+    """Minimal structural JSON-Schema check (no external dependency).
+
+    Supports the subset our structured steps use: ``type``,
+    ``properties`` + ``required`` for objects, ``items`` for arrays,
+    ``enum``. Raises :class:`WorkflowSpecError` naming the step."""
+    def fail(msg: str) -> None:
+        raise WorkflowSpecError(f"step '{step_id}': output invalid — {msg}")
+
+    def check(v: Any, s: dict[str, Any], path: str) -> None:
+        expected = s.get("type")
+        type_map = {
+            "object": dict,
+            "array": list,
+            "string": str,
+            "integer": int,
+            "number": (int, float),
+            "boolean": bool,
+        }
+        if expected in type_map and not isinstance(v, type_map[expected]):
+            fail(f"{path or '$'} expected {expected}, got {type(v).__name__}")
+        if expected == "boolean" and isinstance(v, bool) is False:
+            fail(f"{path or '$'} expected boolean")
+        if "enum" in s and v not in s["enum"]:
+            fail(f"{path or '$'} not in enum {s['enum']}")
+        if expected == "object":
+            for key in s.get("required", []):
+                if key not in v:
+                    fail(f"{path or '$'} missing required key '{key}'")
+            for key, sub in (s.get("properties") or {}).items():
+                if key in v and isinstance(sub, dict):
+                    check(v[key], sub, f"{path}.{key}")
+        if expected == "array" and isinstance(s.get("items"), dict):
+            for i, item in enumerate(v):
+                check(item, s["items"], f"{path}[{i}]")
+
+    check(value, schema, "")

--- a/apps/backend/app/services/workflow/specs/codebase-audit.yaml
+++ b/apps/backend/app/services/workflow/specs/codebase-audit.yaml
@@ -1,0 +1,52 @@
+# Nightly codebase audit: enumerate hotspots → parallel audits →
+# judge ranks tech-debt items (W8.8, dogfood). Fired via cron
+# (trigger c).
+name: codebase-audit
+version: "1"
+inputs:
+  focus: string
+max_fanout: 3
+max_depth: 2
+steps:
+  - id: enumerate
+    kind: pipeline
+    agent: {kind: coding, provider: claude}
+    inputs:
+      routine_id: weekly-audit
+      focus: "{{ inputs.focus }}"
+  - id: audits
+    kind: parallel
+    needs: [enumerate]
+    steps:
+      - id: audit.complexity
+        kind: pipeline
+        agent: {kind: reasoning, role: tech-architect}
+        inputs: {hotspots: "{{ steps.enumerate.output }}", lens: complexity}
+      - id: audit.coupling
+        kind: pipeline
+        agent: {kind: reasoning, role: tech-architect}
+        inputs: {hotspots: "{{ steps.enumerate.output }}", lens: coupling}
+      - id: audit.test-gaps
+        kind: pipeline
+        agent: {kind: reasoning, role: qa-architect}
+        inputs: {hotspots: "{{ steps.enumerate.output }}", lens: test-gaps}
+  - id: rank
+    kind: judge
+    needs: [audits]
+    inputs:
+      complexity: "{{ steps.audit.complexity.output }}"
+      coupling: "{{ steps.audit.coupling.output }}"
+      test_gaps: "{{ steps.audit.test-gaps.output }}"
+    output_schema:
+      type: object
+      required: [items]
+      properties:
+        items:
+          type: array
+          items:
+            type: object
+            required: [rank, title]
+            properties:
+              rank: {type: integer}
+              title: {type: string}
+              effort: {type: string}

--- a/apps/backend/app/services/workflow/specs/pr-review.yaml
+++ b/apps/backend/app/services/workflow/specs/pr-review.yaml
@@ -1,0 +1,72 @@
+# Multi-axis PR review + adversarial verify (W8.8, dogfood).
+# Fired from the code_review FSM gate (trigger b) or from chat.
+name: pr-review
+version: "1"
+inputs:
+  pr_url: string
+max_fanout: 4
+max_depth: 2
+steps:
+  - id: fan
+    kind: parallel
+    steps:
+      - id: axis.correctness
+        kind: pipeline
+        agent: {kind: reasoning, role: reviewer}
+        inputs:
+          axis: correctness
+          pr_url: "{{ inputs.pr_url }}"
+      - id: axis.security
+        kind: pipeline
+        agent: {kind: reasoning, role: security-reviewer}
+        inputs:
+          axis: security
+          pr_url: "{{ inputs.pr_url }}"
+      - id: axis.simplification
+        kind: pipeline
+        agent: {kind: reasoning, role: reviewer}
+        inputs:
+          axis: simplification
+          pr_url: "{{ inputs.pr_url }}"
+      - id: axis.test-coverage
+        kind: pipeline
+        agent: {kind: reasoning, role: qa-architect}
+        inputs:
+          axis: test-coverage
+          pr_url: "{{ inputs.pr_url }}"
+  - id: join
+    kind: barrier
+    needs: [fan]
+  - id: synth
+    kind: synthesize
+    needs: [join]
+    inputs:
+      correctness: "{{ steps.axis.correctness.output }}"
+      security: "{{ steps.axis.security.output }}"
+      simplification: "{{ steps.axis.simplification.output }}"
+      test_coverage: "{{ steps.axis.test-coverage.output }}"
+    output_schema:
+      type: object
+      required: [findings]
+      properties:
+        findings:
+          type: array
+          items:
+            type: object
+            required: [severity, title]
+            properties:
+              severity: {type: string, enum: [low, medium, high]}
+              title: {type: string}
+              detail: {type: string}
+  - id: recheck
+    kind: verify
+    needs: [synth]
+    inputs:
+      top_finding: "{{ steps.synth.output.findings }}"
+      pr_url: "{{ inputs.pr_url }}"
+    output_schema:
+      type: object
+      required: [verdict]
+      properties:
+        verdict: {type: string, enum: [confirmed, refuted, uncertain]}
+        reason: {type: string}

--- a/apps/backend/migrations/versions/0089_workflow_runs.py
+++ b/apps/backend/migrations/versions/0089_workflow_runs.py
@@ -1,0 +1,139 @@
+"""workflow_runs + workflow_step_runs — durable workflow state (W8.7)
+
+Thesis 8: bounded deterministic fan-outs. ``workflow_step_runs``
+carries the UNIQUE (workflow_run_id, step_id, attempt) idempotency
+key the dispatch gate (W8.2) relies on. Forward revision off 0088
+(chained off `alembic heads` at implement time per the ticket note —
+the pre-assigned 0088 collided with telegram_pending_actions).
+
+Revision ID: 0089_workflow_runs
+Revises: 0088_telegram_pending_actions
+Create Date: 2026-06-12
+"""
+
+from __future__ import annotations
+
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+
+
+revision: str = "0089_workflow_runs"
+down_revision: Union[str, None] = "0088_telegram_pending_actions"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "agent_workflow_runs",
+        sa.Column(
+            "id",
+            UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "workspace_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("workspaces.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("spec_name", sa.String(120), nullable=False),
+        sa.Column(
+            "spec_version",
+            sa.String(32),
+            nullable=False,
+            server_default=sa.text("'1'"),
+        ),
+        sa.Column(
+            "inputs",
+            JSONB(),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+        sa.Column("trigger_kind", sa.String(16), nullable=False),
+        sa.Column(
+            "status",
+            sa.String(16),
+            nullable=False,
+            server_default=sa.text("'queued'"),
+        ),
+        sa.Column("output", JSONB(), nullable=True),
+        sa.Column("triggered_by", sa.String(255), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column("finished_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index(
+        "ix_agent_workflow_runs_ws_status",
+        "agent_workflow_runs",
+        ["workspace_id", "status"],
+    )
+
+    op.create_table(
+        "agent_workflow_step_runs",
+        sa.Column(
+            "id",
+            UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "workflow_run_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("agent_workflow_runs.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("step_id", sa.String(120), nullable=False),
+        sa.Column(
+            "attempt", sa.Integer(), nullable=False, server_default=sa.text("1")
+        ),
+        sa.Column("kind", sa.String(32), nullable=False),
+        sa.Column("agent_provider", sa.String(32), nullable=True),
+        sa.Column(
+            "status",
+            sa.String(16),
+            nullable=False,
+            server_default=sa.text("'pending'"),
+        ),
+        sa.Column("output", JSONB(), nullable=True),
+        sa.Column("lock_key", sa.String(255), nullable=True),
+        sa.Column("run_id", sa.String(64), nullable=True),
+        sa.Column("reason", sa.String(64), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column("finished_at", sa.DateTime(timezone=True), nullable=True),
+        sa.UniqueConstraint(
+            "workflow_run_id",
+            "step_id",
+            "attempt",
+            name="uq_agent_workflow_step_attempt",
+        ),
+    )
+    op.create_index(
+        "ix_agent_workflow_step_runs_run", "agent_workflow_step_runs", ["workflow_run_id"]
+    )
+    op.create_index(
+        "ix_agent_workflow_step_runs_ci_run", "agent_workflow_step_runs", ["run_id"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_agent_workflow_step_runs_ci_run", table_name="agent_workflow_step_runs")
+    op.drop_index("ix_agent_workflow_step_runs_run", table_name="agent_workflow_step_runs")
+    op.drop_table("agent_workflow_step_runs")
+    op.drop_index(
+        "ix_agent_workflow_runs_ws_status", table_name="agent_workflow_runs"
+    )
+    op.drop_table("agent_workflow_runs")

--- a/apps/backend/tests/test_navigator_tool_inventory.py
+++ b/apps/backend/tests/test_navigator_tool_inventory.py
@@ -33,6 +33,7 @@ from backend.app.services.policies_seed import default_policies
 EXPECTED_TOOLS: frozenset[str] = frozenset(
     {
         "run_subagent",
+        "run_workflow",
         "config_help",
         "config_put",
         "web_fetch",

--- a/apps/backend/tests/test_workflow_gate.py
+++ b/apps/backend/tests/test_workflow_gate.py
@@ -1,0 +1,264 @@
+"""W8.2 (ELS-257) — WorkflowDispatchGate.
+
+The control-plane chokepoint: lease + cap (walk-back) + cascade
+(recursion edges) + durable idempotency, all reusing the dispatcher
+primitives. The last test pins the FOUNDER DECISION that no autonomy
+branch exists in gate.py.
+"""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+
+import pytest
+from sqlalchemy import select, text
+
+from backend.app.db.models.tenancy import AuditLog
+from backend.app.db.models.workflow import AgentWorkflowRun, AgentWorkflowStepRun
+from backend.app.services.workflow.gate import (
+    GateReason,
+    gate_step_dispatch,
+    release_step_lock,
+    workflow_lock_key,
+)
+
+
+async def _make_run(db_session, workspace_id) -> AgentWorkflowRun:
+    run = AgentWorkflowRun(
+        workspace_id=workspace_id,
+        spec_name="pr-review",
+        trigger_kind="chat",
+    )
+    db_session.add(run)
+    await db_session.flush()
+    return run
+
+
+async def _lock_count(db_session, workspace_id, prefix="workflow:") -> int:
+    return int(
+        (
+            await db_session.execute(
+                text(
+                    """
+                    SELECT COUNT(*)::int FROM agent_dispatch_locks
+                    WHERE workspace_id = :ws AND key LIKE :p
+                      AND expires_at > now()
+                    """
+                ),
+                {"ws": workspace_id, "p": f"{prefix}%"},
+            )
+        ).scalar_one()
+    )
+
+
+@pytest.mark.asyncio
+async def test_fanout_acquires_locks_and_cap_walks_back(
+    db_session, seed_workspace
+) -> None:
+    """AC: max_fanout leaves acquire exactly that many workflow:*
+    locks; the over-cap acquire is walked back (lock released, row
+    blocked) — verified against actual agent_dispatch_locks rows."""
+    _, _, workspace = seed_workspace
+    workspace.max_concurrent_dispatches = 3
+    await db_session.flush()
+    run = await _make_run(db_session, workspace.id)
+
+    decisions = []
+    for i in range(4):
+        decisions.append(
+            await gate_step_dispatch(
+                db_session,
+                workspace_id=workspace.id,
+                workflow_run_id=run.id,
+                step_id=f"axis.{i}",
+                attempt=1,
+                kind="parallel",
+                agent_provider="reasoning",
+            )
+        )
+    assert [d.granted for d in decisions] == [True, True, True, False]
+    assert decisions[3].reason == GateReason.CAP_EXCEEDED
+    # Exactly cap locks live — the 4th acquire was walked back.
+    assert await _lock_count(db_session, workspace.id) == 3
+    blocked = (
+        await db_session.execute(
+            select(AgentWorkflowStepRun).where(
+                AgentWorkflowStepRun.workflow_run_id == run.id,
+                AgentWorkflowStepRun.status == "blocked",
+            )
+        )
+    ).scalars().all()
+    assert len(blocked) == 1
+    assert blocked[0].reason == GateReason.CAP_EXCEEDED
+
+
+@pytest.mark.asyncio
+async def test_cascade_blocks_recursive_ship_leaves(
+    db_session, seed_workspace
+) -> None:
+    """AC: recursion edges (ship provider) are counted via
+    _count_recent_dispatches; the 4th in the window is refused —
+    regardless of autonomy profile (none is consulted)."""
+    _, _, workspace = seed_workspace
+    workspace.max_concurrent_dispatches = 10
+    workspace.autonomy = "high"  # the dial must not matter
+    await db_session.flush()
+    run = await _make_run(db_session, workspace.id)
+    cascade_key = f"workflow:{run.id}"
+
+    outcomes = []
+    for i in range(4):
+        d = await gate_step_dispatch(
+            db_session,
+            workspace_id=workspace.id,
+            workflow_run_id=run.id,
+            step_id=f"nest.{i}",
+            attempt=1,
+            kind="pipeline",
+            agent_provider="ship",
+            cascade_key=cascade_key,
+        )
+        outcomes.append(d)
+    assert [d.granted for d in outcomes] == [True, True, True, False]
+    assert outcomes[3].reason == GateReason.CASCADE_BLOCKED
+
+
+@pytest.mark.asyncio
+async def test_reasoning_fanout_is_not_a_recursion_edge(
+    db_session, seed_workspace
+) -> None:
+    """An ordinary 4-leaf reasoning fan-out must NOT trip the cascade
+    guard (it counts recursion edges only)."""
+    _, _, workspace = seed_workspace
+    workspace.max_concurrent_dispatches = 10
+    await db_session.flush()
+    run = await _make_run(db_session, workspace.id)
+    for i in range(4):
+        d = await gate_step_dispatch(
+            db_session,
+            workspace_id=workspace.id,
+            workflow_run_id=run.id,
+            step_id=f"axis.{i}",
+            attempt=1,
+            kind="parallel",
+            agent_provider="reasoning",
+        )
+        assert d.granted, d.reason
+
+
+@pytest.mark.asyncio
+async def test_same_attempt_is_idempotent(db_session, seed_workspace) -> None:
+    """AC: re-invoking the gate for the same (run, step, attempt) is
+    idempotent — no second dispatch, no second lock; a NEW attempt
+    re-runs."""
+    _, _, workspace = seed_workspace
+    run = await _make_run(db_session, workspace.id)
+
+    first = await gate_step_dispatch(
+        db_session,
+        workspace_id=workspace.id,
+        workflow_run_id=run.id,
+        step_id="synth",
+        attempt=1,
+        kind="synthesize",
+        agent_provider="reasoning",
+    )
+    assert first.granted
+    locks_after_first = await _lock_count(db_session, workspace.id)
+
+    retry = await gate_step_dispatch(
+        db_session,
+        workspace_id=workspace.id,
+        workflow_run_id=run.id,
+        step_id="synth",
+        attempt=1,
+        kind="synthesize",
+        agent_provider="reasoning",
+    )
+    assert retry.granted is False
+    assert retry.reason == GateReason.DUPLICATE_ATTEMPT
+    assert retry.run_id == first.run_id  # same durable row, no re-mint
+    assert await _lock_count(db_session, workspace.id) == locks_after_first
+
+    # New attempt after release → re-runs cleanly.
+    await release_step_lock(
+        db_session,
+        workspace_id=workspace.id,
+        workflow_run_id=run.id,
+        step_id="synth",
+    )
+    second = await gate_step_dispatch(
+        db_session,
+        workspace_id=workspace.id,
+        workflow_run_id=run.id,
+        step_id="synth",
+        attempt=2,
+        kind="synthesize",
+        agent_provider="reasoning",
+    )
+    assert second.granted
+
+
+@pytest.mark.asyncio
+async def test_every_decision_writes_audit(db_session, seed_workspace) -> None:
+    _, _, workspace = seed_workspace
+    workspace.max_concurrent_dispatches = 1
+    await db_session.flush()
+    run = await _make_run(db_session, workspace.id)
+
+    await gate_step_dispatch(
+        db_session,
+        workspace_id=workspace.id,
+        workflow_run_id=run.id,
+        step_id="a",
+        attempt=1,
+        kind="pipeline",
+        agent_provider="reasoning",
+    )
+    await gate_step_dispatch(
+        db_session,
+        workspace_id=workspace.id,
+        workflow_run_id=run.id,
+        step_id="b",
+        attempt=1,
+        kind="pipeline",
+        agent_provider="reasoning",
+    )
+    actions = [
+        r.action
+        for r in (
+            await db_session.execute(
+                select(AuditLog).where(
+                    AuditLog.workspace_id == workspace.id,
+                    AuditLog.action.like("workflow.step_%"),
+                )
+            )
+        ).scalars()
+    ]
+    assert "workflow.step_dispatched" in actions
+    assert "workflow.step_blocked" in actions
+
+
+def test_lock_key_namespace_shape() -> None:
+    rid = uuid.UUID(int=1)
+    assert workflow_lock_key(rid, "synth") == f"workflow:{rid}:synth"
+
+
+def test_gate_has_no_autonomy_branch() -> None:
+    """FOUNDER DECISION pinned: the control plane is off-limits to
+    the autonomy dial — gate.py must not consult it (the word may
+    only appear in comments explaining exactly this)."""
+    source = Path("apps/backend/app/services/workflow/gate.py").read_text()
+    in_doc = False
+    real_code = []
+    for line in source.splitlines():
+        stripped = line.strip()
+        if stripped.startswith('"""') or stripped.endswith('"""'):
+            in_doc = not in_doc if stripped.count('"""') == 1 else in_doc
+            continue
+        if in_doc or stripped.startswith("#"):
+            continue
+        real_code.append(line)
+    joined = "\n".join(real_code)
+    assert "autonomy" not in joined, "gate.py must not branch on autonomy"

--- a/apps/backend/tests/test_workflow_models.py
+++ b/apps/backend/tests/test_workflow_models.py
@@ -1,0 +1,89 @@
+"""W8.7 (ELS-255) — durable workflow state tables.
+
+The load-bearing assertion is the UNIQUE (workflow_run_id, step_id,
+attempt) constraint: it is the idempotency key the dispatch gate
+(W8.2) leans on, so a duplicate insert MUST raise instead of silently
+double-recording a spawn.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from backend.app.db.models.workflow import (
+    AgentWorkflowRun,
+    AgentWorkflowStepRun,
+    WORKFLOW_RUN_STATUSES,
+    WORKFLOW_STEP_STATUSES,
+)
+
+
+@pytest.mark.asyncio
+async def test_step_attempt_unique_is_idempotency_key(
+    db_session, seed_workspace
+) -> None:
+    _, _, workspace = seed_workspace
+    run = AgentWorkflowRun(
+        workspace_id=workspace.id,
+        spec_name="pr-review",
+        trigger_kind="chat",
+    )
+    db_session.add(run)
+    await db_session.flush()
+
+    db_session.add(
+        AgentWorkflowStepRun(
+            workflow_run_id=run.id,
+            step_id="review.correctness",
+            attempt=1,
+            kind="parallel",
+            agent_provider="reasoning",
+        )
+    )
+    await db_session.flush()
+
+    db_session.add(
+        AgentWorkflowStepRun(
+            workflow_run_id=run.id,
+            step_id="review.correctness",
+            attempt=1,
+            kind="parallel",
+        )
+    )
+    with pytest.raises(IntegrityError):
+        await db_session.flush()
+    await db_session.rollback()
+
+
+@pytest.mark.asyncio
+async def test_new_attempt_is_a_distinct_row(db_session, seed_workspace) -> None:
+    """Re-running a failed step requires a NEW attempt — same step_id,
+    attempt+1 inserts cleanly."""
+    _, _, workspace = seed_workspace
+    run = AgentWorkflowRun(
+        workspace_id=workspace.id,
+        spec_name="pr-review",
+        trigger_kind="gate",
+    )
+    db_session.add(run)
+    await db_session.flush()
+    for attempt in (1, 2):
+        db_session.add(
+            AgentWorkflowStepRun(
+                workflow_run_id=run.id,
+                step_id="synthesize",
+                attempt=attempt,
+                kind="synthesize",
+                lock_key=f"workflow:{run.id}:synthesize",
+                run_id=f"run_{attempt}",
+            )
+        )
+    await db_session.flush()
+
+
+def test_status_vocabularies_are_closed_sets() -> None:
+    assert "completed" in WORKFLOW_RUN_STATUSES
+    assert "blocked" in WORKFLOW_RUN_STATUSES
+    assert "skipped" in WORKFLOW_STEP_STATUSES
+    assert "dispatched" in WORKFLOW_STEP_STATUSES

--- a/apps/backend/tests/test_workflow_runtime.py
+++ b/apps/backend/tests/test_workflow_runtime.py
@@ -1,0 +1,339 @@
+"""W8.3 (ELS-258) — workflow runtime executor.
+
+Fake leaf executors complete synchronously so the DAG mechanics are
+testable without LLMs or CI: pipeline threading + schema validation,
+parallel/barrier with partial failure, loop bounded at max_iters, the
+single-chokepoint grep, and the finish-webhook lock release."""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+
+import pytest
+from sqlalchemy import select, text
+
+from backend.app.db.models.workflow import AgentWorkflowStepRun
+from backend.app.services.workflow.leaves import (
+    LeafExecutors,
+    complete_coding_step,
+)
+from backend.app.services.workflow.runtime import (
+    advance_workflow,
+    run_workflow,
+)
+from backend.app.services.workflow.spec import load_spec
+
+
+PIPELINE_SPEC = """
+name: three-step
+max_fanout: 4
+steps:
+  - id: enumerate
+    kind: pipeline
+    agent: {kind: reasoning}
+    inputs: {target: "{{ inputs.target }}"}
+  - id: implement
+    kind: pipeline
+    needs: [enumerate]
+    agent: {kind: coding, provider: claude}
+    inputs: {hotspots: "{{ steps.enumerate.output.hotspots }}"}
+  - id: synth
+    kind: synthesize
+    needs: [implement]
+    inputs: {result: "{{ steps.implement.output.result }}"}
+    output_schema:
+      type: object
+      required: [summary]
+      properties: {summary: {type: string}}
+"""
+
+
+def _executors(reasoning=None, coding=None) -> LeafExecutors:
+    async def default_reasoning(_s, _st, _ws, step, inputs, run_id, **_kw):
+        if step.kind == "synthesize":
+            return {"summary": f"synth over {inputs.get('result')}"}
+        return {"hotspots": ["a.py", "b.py"], "echo": inputs}
+
+    async def default_coding(_s, _st, _ws, step, inputs, run_id, **_kw):
+        return {"result": f"patched {len(inputs.get('hotspots') or [])} files"}
+
+    return LeafExecutors(
+        run_reasoning=reasoning or default_reasoning,
+        run_coding=coding or default_coding,
+    )
+
+
+async def _locks(db_session, ws_id) -> int:
+    return int(
+        (
+            await db_session.execute(
+                text(
+                    "SELECT COUNT(*)::int FROM agent_dispatch_locks "
+                    "WHERE workspace_id = :ws AND key LIKE 'workflow:%' "
+                    "AND expires_at > now()"
+                ),
+                {"ws": ws_id},
+            )
+        ).scalar_one()
+    )
+
+
+@pytest.mark.asyncio
+async def test_pipeline_threads_outputs_end_to_end(
+    db_session, seed_workspace
+) -> None:
+    """AC: reasoning→coding→synthesize, outputs threaded, synthesize
+    schema-validated, run completes bounded."""
+    _, _, workspace = seed_workspace
+    spec = load_spec(PIPELINE_SPEC)
+
+    seen_inputs: dict[str, dict] = {}
+
+    async def coding(_s, _st, _ws, step, inputs, run_id, **_kw):
+        seen_inputs["implement"] = inputs
+        return {"result": "patched"}
+
+    run = await run_workflow(
+        db_session,
+        workspace_id=workspace.id,
+        spec=spec,
+        inputs={"target": "billing"},
+        trigger_kind="chat",
+        executors=_executors(coding=coding),
+    )
+    assert run.status == "completed"
+    # Output threading: implement saw enumerate's hotspots.
+    assert seen_inputs["implement"]["hotspots"] == ["a.py", "b.py"]
+    # Final run output = last step (synthesize), schema-valid.
+    assert run.output == {"summary": "synth over patched"}
+    # All workflow locks released after completion.
+    assert await _locks(db_session, workspace.id) == 0
+
+
+@pytest.mark.asyncio
+async def test_parallel_barrier_tolerates_branch_failure(
+    db_session, seed_workspace
+) -> None:
+    """AC: a branch failure doesn't abort siblings; the barrier sees
+    the partial set."""
+    _, _, workspace = seed_workspace
+    spec = load_spec(
+        """
+name: fan
+max_fanout: 3
+steps:
+  - id: fan
+    kind: parallel
+    steps:
+      - {id: ok.a, kind: pipeline, agent: {kind: reasoning}}
+      - {id: boom, kind: pipeline, agent: {kind: reasoning}}
+      - {id: ok.b, kind: pipeline, agent: {kind: reasoning}}
+  - id: join
+    kind: barrier
+    needs: [fan]
+"""
+    )
+
+    async def reasoning(_s, _st, _ws, step, inputs, run_id, **_kw):
+        if step.id == "boom":
+            raise RuntimeError("branch exploded")
+        return {"ok": step.id}
+
+    run = await run_workflow(
+        db_session,
+        workspace_id=workspace.id,
+        spec=spec,
+        inputs={},
+        trigger_kind="chat",
+        executors=_executors(reasoning=reasoning),
+    )
+    rows = {
+        r.step_id: r
+        for r in (
+            await db_session.execute(
+                select(AgentWorkflowStepRun).where(
+                    AgentWorkflowStepRun.workflow_run_id == run.id
+                )
+            )
+        ).scalars()
+    }
+    assert rows["ok.a"].status == "completed"
+    assert rows["ok.b"].status == "completed"
+    assert rows["boom"].status == "failed"
+    assert rows["join"].status == "completed"
+    assert set(rows["join"].output["joined"]) == {"ok.a", "ok.b"}
+    assert rows["join"].output["failed"] == ["boom"]
+    assert run.status == "completed"  # partial failure recorded, bounded
+
+
+@pytest.mark.asyncio
+async def test_loop_terminates_at_max_iters(db_session, seed_workspace) -> None:
+    _, _, workspace = seed_workspace
+    spec = load_spec(
+        """
+name: looper
+steps:
+  - id: spin
+    kind: loop
+    agent: {kind: reasoning}
+    until: "output.done == true"
+    max_iters: 3
+"""
+    )
+    calls = {"n": 0}
+
+    async def reasoning(_s, _st, _ws, step, inputs, run_id, **_kw):
+        calls["n"] += 1
+        return {"done": False}  # never satisfies the predicate
+
+    run = await run_workflow(
+        db_session,
+        workspace_id=workspace.id,
+        spec=spec,
+        inputs={},
+        trigger_kind="cron",
+        executors=_executors(reasoning=reasoning),
+    )
+    assert calls["n"] == 3  # bounded — no infinite loop
+    assert run.status == "completed"
+
+
+@pytest.mark.asyncio
+async def test_loop_stops_when_until_satisfied(
+    db_session, seed_workspace
+) -> None:
+    _, _, workspace = seed_workspace
+    spec = load_spec(
+        """
+name: looper2
+steps:
+  - id: spin
+    kind: loop
+    agent: {kind: reasoning}
+    until: "output.done == true"
+    max_iters: 5
+"""
+    )
+    calls = {"n": 0}
+
+    async def reasoning(_s, _st, _ws, step, inputs, run_id, **_kw):
+        calls["n"] += 1
+        return {"done": calls["n"] >= 2}
+
+    await run_workflow(
+        db_session,
+        workspace_id=workspace.id,
+        spec=spec,
+        inputs={},
+        trigger_kind="cron",
+        executors=_executors(reasoning=reasoning),
+    )
+    assert calls["n"] == 2
+
+
+@pytest.mark.asyncio
+async def test_async_coding_leaf_finish_webhook_releases_lock(
+    db_session, seed_workspace
+) -> None:
+    """AC: a coding leaf left 'dispatched' is completed by the finish
+    correlation (run_id) which releases its workflow:* lock; the
+    reconcile advance then finishes the run."""
+    _, _, workspace = seed_workspace
+    spec = load_spec(
+        """
+name: ci-leaf
+steps:
+  - id: build
+    kind: pipeline
+    agent: {kind: coding, provider: claude}
+"""
+    )
+
+    async def coding(_s, _st, _ws, step, inputs, run_id, **_kw):
+        return None  # async: CI will report back
+
+    run = await run_workflow(
+        db_session,
+        workspace_id=workspace.id,
+        spec=spec,
+        inputs={},
+        trigger_kind="gate",
+        executors=_executors(coding=coding),
+    )
+    assert run.status == "running"
+    assert await _locks(db_session, workspace.id) == 1
+    row = (
+        await db_session.execute(
+            select(AgentWorkflowStepRun).where(
+                AgentWorkflowStepRun.workflow_run_id == run.id
+            )
+        )
+    ).scalar_one()
+    assert row.status == "dispatched"
+
+    matched = await complete_coding_step(
+        db_session,
+        workspace_id=workspace.id,
+        run_id=row.run_id,
+        success=True,
+        output={"outcome": "ready_next_step"},
+    )
+    assert matched is True
+    assert await _locks(db_session, workspace.id) == 0
+
+    await advance_workflow(
+        db_session, run=run, spec=spec, executors=_executors()
+    )
+    assert run.status == "completed"
+
+
+@pytest.mark.asyncio
+async def test_schema_invalid_output_fails_step(
+    db_session, seed_workspace
+) -> None:
+    _, _, workspace = seed_workspace
+    spec = load_spec(
+        """
+name: strict
+steps:
+  - id: synth
+    kind: synthesize
+    output_schema: {type: object, required: [summary], properties: {summary: {type: string}}}
+"""
+    )
+
+    async def reasoning(_s, _st, _ws, step, inputs, run_id, **_kw):
+        return {"wrong_key": 1}
+
+    run = await run_workflow(
+        db_session,
+        workspace_id=workspace.id,
+        spec=spec,
+        inputs={},
+        trigger_kind="chat",
+        executors=_executors(reasoning=reasoning),
+    )
+    row = (
+        await db_session.execute(
+            select(AgentWorkflowStepRun).where(
+                AgentWorkflowStepRun.workflow_run_id == run.id
+            )
+        )
+    ).scalar_one()
+    assert row.status == "failed"
+    assert row.reason == "schema_invalid"
+    assert run.status == "failed"
+
+
+def test_runtime_has_single_chokepoint() -> None:
+    """AC: runtime.py never calls runAgent / dispatch_workflow /
+    _run_subagent_loop — every spawn goes through gate.py + the
+    injected executors."""
+    source = Path(
+        "apps/backend/app/services/workflow/runtime.py"
+    ).read_text()
+    assert "runAgent" not in source
+    assert "dispatch_workflow" not in source
+    assert "_run_subagent_loop" not in source
+    assert "gate_step_dispatch" in source

--- a/apps/backend/tests/test_workflow_spec.py
+++ b/apps/backend/tests/test_workflow_spec.py
@@ -1,0 +1,197 @@
+"""W8.1 (ELS-256) — workflow spec loader.
+
+Covers the AC matrix: a valid full spec with all seven kinds
+round-trips; each invalid shape (unknown kind, unknown provider,
+missing output_schema, fan-out over ceiling, depth over max) rejects
+BEFORE anything runs, naming the offending step; a pipeline's output
+templates reference prior step ids.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from backend.app.services.workflow.spec import (
+    HARD_FANOUT_CEILING,
+    WorkflowSpecError,
+    load_spec,
+    validate_output,
+)
+
+
+FULL_SPEC = """
+name: pr-review
+version: "2"
+inputs:
+  pr_url: string
+max_fanout: 4
+max_depth: 2
+steps:
+  - id: fan
+    kind: parallel
+    steps:
+      - id: axis.correctness
+        kind: pipeline
+        agent: {kind: reasoning, role: reviewer}
+        inputs: {axis: correctness, pr_url: "{{ inputs.pr_url }}"}
+      - id: axis.security
+        kind: pipeline
+        agent: {kind: reasoning, role: reviewer}
+        inputs: {axis: security}
+  - id: join
+    kind: barrier
+    needs: [axis.correctness, axis.security]
+  - id: synth
+    kind: synthesize
+    needs: [join]
+    agent: {kind: reasoning, role: synthesizer}
+    inputs: {findings: "{{ steps.axis.correctness.output.findings }}"}
+    output_schema:
+      type: object
+      required: [findings]
+      properties:
+        findings:
+          type: array
+          items:
+            type: object
+            required: [severity, title]
+            properties:
+              severity: {type: string, enum: [low, medium, high]}
+              title: {type: string}
+  - id: recheck
+    kind: verify
+    needs: [synth]
+    output_schema: {type: object, required: [verdict], properties: {verdict: {type: string}}}
+  - id: deep-dive
+    kind: loop
+    needs: [synth]
+    agent: {kind: coding, provider: claude}
+    until: "output.done == true"
+    max_iters: 2
+  - id: judge-it
+    kind: judge
+    needs: [deep-dive]
+    output_schema: {type: object, required: [rank], properties: {rank: {type: integer}}}
+"""
+
+
+def test_full_spec_round_trips() -> None:
+    spec = load_spec(FULL_SPEC)
+    assert spec.name == "pr-review"
+    assert spec.version == "2"
+    kinds = {s.kind for s in spec.steps}
+    nested = {s.kind for s in spec.steps[0].steps}
+    assert kinds | nested == {
+        "parallel", "pipeline", "barrier", "synthesize", "verify", "loop", "judge",
+    }
+    # Budget defaults follow the subagent convention.
+    assert spec.steps[0].max_tool_calls == 25
+    assert spec.steps[0].max_seconds == 300
+    # Pipeline output template references a prior step.
+    assert "steps.axis.correctness.output" in str(
+        next(s for s in spec.steps if s.id == "synth").inputs["findings"]
+    )
+
+
+def test_unknown_step_kind_names_step() -> None:
+    bad = FULL_SPEC.replace("kind: barrier", "kind: teleport")
+    with pytest.raises(WorkflowSpecError, match="teleport"):
+        load_spec(bad)
+
+
+def test_unknown_provider_names_step() -> None:
+    bad = FULL_SPEC.replace("provider: claude", "provider: skynet")
+    with pytest.raises(WorkflowSpecError, match="skynet"):
+        load_spec(bad)
+
+
+def test_fanout_over_hard_ceiling_rejected() -> None:
+    bad = FULL_SPEC.replace(
+        "max_fanout: 4", f"max_fanout: {HARD_FANOUT_CEILING + 1}"
+    )
+    with pytest.raises(WorkflowSpecError, match="hard ceiling"):
+        load_spec(bad)
+
+
+def test_parallel_fanout_over_declared_cap_rejected() -> None:
+    spec = """
+name: wide
+max_fanout: 2
+steps:
+  - id: fan
+    kind: parallel
+    steps:
+      - {id: a, kind: pipeline, agent: {kind: reasoning}}
+      - {id: b, kind: pipeline, agent: {kind: reasoning}}
+      - {id: c, kind: pipeline, agent: {kind: reasoning}}
+"""
+    with pytest.raises(WorkflowSpecError, match="fan-out 3 exceeds"):
+        load_spec(spec)
+
+
+def test_depth_over_max_rejected() -> None:
+    spec = """
+name: deep
+max_depth: 1
+steps:
+  - id: fan
+    kind: parallel
+    steps:
+      - id: inner
+        kind: parallel
+        steps:
+          - {id: leaf, kind: pipeline, agent: {kind: reasoning}}
+"""
+    with pytest.raises(WorkflowSpecError, match="depth"):
+        load_spec(spec)
+
+
+def test_synthesize_without_schema_rejected() -> None:
+    spec = """
+name: x
+steps:
+  - id: s
+    kind: synthesize
+"""
+    with pytest.raises(WorkflowSpecError, match="output_schema"):
+        load_spec(spec)
+
+
+def test_unknown_needs_edge_rejected() -> None:
+    spec = """
+name: x
+steps:
+  - id: s
+    kind: barrier
+    needs: [ghost]
+"""
+    with pytest.raises(WorkflowSpecError, match="ghost"):
+        load_spec(spec)
+
+
+def test_validate_output_subset() -> None:
+    schema = {
+        "type": "object",
+        "required": ["findings"],
+        "properties": {
+            "findings": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "required": ["severity"],
+                    "properties": {
+                        "severity": {"type": "string", "enum": ["low", "high"]}
+                    },
+                },
+            }
+        },
+    }
+    validate_output(
+        {"findings": [{"severity": "high"}]}, schema, step_id="synth"
+    )
+    with pytest.raises(WorkflowSpecError, match="missing required key"):
+        validate_output({}, schema, step_id="synth")
+    with pytest.raises(WorkflowSpecError, match="enum"):
+        validate_output(
+            {"findings": [{"severity": "critical"}]}, schema, step_id="synth"
+        )

--- a/apps/backend/tests/test_workflow_triggers.py
+++ b/apps/backend/tests/test_workflow_triggers.py
@@ -1,0 +1,368 @@
+"""W8.4/W8.5/W8.6/W8.8 (ELS-259..262) — triggers + dogfood specs.
+
+- chat: run_workflow tool queues lock-free, admin-gated, lists
+  available specs on unknown names, excluded from subagent toolsets;
+- gate: a configured FSM stage fires the workflow (dedup +
+  fail-closed + shadow);
+- cron: nightly tick enqueues per opt-in workspace only;
+- ship leaf: spec accepts the provider, the config surface does NOT
+  offer it to customers (internal/dogfood);
+- dogfood: pr-review + codebase-audit load and run end-to-end with
+  fake executors; /process stays untouched by this workstream.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlalchemy import select, text
+
+from backend.app.core.config import Settings, get_settings
+from backend.app.db.models.workflow import AgentWorkflowRun
+from backend.app.services import dispatcher as dispatcher_mod
+from backend.app.services.workflow import runtime as runtime_mod
+from backend.app.services.workflow.leaves import LeafExecutors
+from backend.app.services.workflow.registry import (
+    list_available_specs,
+    resolve_spec,
+)
+from backend.app.services.workflow.runtime import run_workflow
+
+
+async def _workflow_locks(db_session, ws_id) -> int:
+    return int(
+        (
+            await db_session.execute(
+                text(
+                    "SELECT COUNT(*)::int FROM agent_dispatch_locks "
+                    "WHERE workspace_id = :ws AND key LIKE 'workflow:%' "
+                    "AND expires_at > now()"
+                ),
+                {"ws": ws_id},
+            )
+        ).scalar_one()
+    )
+
+
+# ---------------------------------------------------------------------------
+# Chat trigger (ELS-260)
+# ---------------------------------------------------------------------------
+
+
+def _toolbox(db_session, workspace, user):
+    from backend.app.services.agent.tools import ToolBox
+
+    return ToolBox(
+        db_session,
+        settings=Settings(OPENAI_API_KEY="test"),  # type: ignore[call-arg]
+        workspace_id=workspace.id,
+        user_id=user.id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_workflow_tool_queues_lock_free(
+    db_session, seed_workspace, monkeypatch
+) -> None:
+    user, _, workspace = seed_workspace
+    spy = AsyncMock()
+    monkeypatch.setattr(runtime_mod, "advance_run_by_id", spy)
+
+    toolbox = _toolbox(db_session, workspace, user)
+    result = await toolbox._tool_run_workflow(
+        {"workflow_name": "pr-review", "inputs": {"pr_url": "https://x/pr/1"}}
+    )
+    assert "workflow_run_id" in result
+
+    # AC: the chat process acquired NO dispatch lock at tool return.
+    assert await _workflow_locks(db_session, workspace.id) == 0
+    run = (
+        await db_session.execute(
+            select(AgentWorkflowRun).where(
+                AgentWorkflowRun.workspace_id == workspace.id
+            )
+        )
+    ).scalar_one()
+    assert run.status == "queued"
+    assert run.trigger_kind == "chat"
+    await asyncio.sleep(0)  # let the created task start
+    spy.assert_awaited()  # spawn deferred to the gated background path
+
+
+@pytest.mark.asyncio
+async def test_run_workflow_unknown_name_lists_available(
+    db_session, seed_workspace, monkeypatch
+) -> None:
+    user, _, workspace = seed_workspace
+    monkeypatch.setattr(runtime_mod, "advance_run_by_id", AsyncMock())
+    toolbox = _toolbox(db_session, workspace, user)
+    result = await toolbox._tool_run_workflow({"workflow_name": "nope"})
+    assert "unknown_workflow" in result
+    assert "pr-review" in result and "codebase-audit" in result
+
+
+@pytest.mark.asyncio
+async def test_run_workflow_filtered_inside_subagent(
+    db_session, seed_workspace
+) -> None:
+    from backend.app.services.agent.tools import ToolInvocationError
+
+    user, _, workspace = seed_workspace
+    toolbox = _toolbox(db_session, workspace, user)
+    toolbox._subagent_active = True
+    with pytest.raises(ToolInvocationError, match="nested run_workflow"):
+        await toolbox._tool_run_workflow({"workflow_name": "pr-review"})
+
+
+def test_run_workflow_registered_in_tool_specs() -> None:
+    source = Path("apps/backend/app/services/agent/tools.py").read_text()
+    assert '"run_workflow": self._tool_run_workflow' in source
+    assert '("consult_specialist", "run_workflow")' in source
+
+
+# ---------------------------------------------------------------------------
+# Gate trigger (ELS-261, b)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stage_trigger_fires_configured_workflow(
+    db_session, seed_workspace, monkeypatch
+) -> None:
+    _, _, workspace = seed_workspace
+    workspace.settings = {
+        **(workspace.settings or {}),
+        "workflows": {"stage_triggers": {"code_review": "pr-review"}},
+    }
+    await db_session.flush()
+
+    spy = AsyncMock()
+    monkeypatch.setattr(runtime_mod, "run_workflow", spy)
+
+    fire_settings = Settings(  # type: ignore[call-arg]
+        OPENAI_API_KEY="test", SHIP_TRACKER_POLL_FIRE=True
+    )
+    await dispatcher_mod._maybe_fire_stage_workflow(
+        db_session,
+        workspace_id=workspace.id,
+        fsm_stage="code_review",
+        ticket_ref="ELS-1",
+        settings=fire_settings,
+    )
+    spy.assert_awaited_once()
+    kwargs = spy.await_args.kwargs
+    assert kwargs["trigger_kind"] == "gate"
+    assert kwargs["triggered_by"] == "ticket:ELS-1"
+    assert kwargs["spec"].name == "pr-review"
+
+
+@pytest.mark.asyncio
+async def test_stage_trigger_fail_closed_without_config(
+    db_session, seed_workspace, monkeypatch
+) -> None:
+    _, _, workspace = seed_workspace
+    spy = AsyncMock()
+    monkeypatch.setattr(runtime_mod, "run_workflow", spy)
+    await dispatcher_mod._maybe_fire_stage_workflow(
+        db_session,
+        workspace_id=workspace.id,
+        fsm_stage="code_review",
+        ticket_ref="ELS-1",
+        settings=get_settings(),
+    )
+    spy.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_stage_trigger_dedups_running_run(
+    db_session, seed_workspace, monkeypatch
+) -> None:
+    _, _, workspace = seed_workspace
+    workspace.settings = {
+        "workflows": {"stage_triggers": {"code_review": "pr-review"}}
+    }
+    db_session.add(
+        AgentWorkflowRun(
+            workspace_id=workspace.id,
+            spec_name="pr-review",
+            trigger_kind="gate",
+            triggered_by="ticket:ELS-1",
+            status="running",
+        )
+    )
+    await db_session.flush()
+
+    spy = AsyncMock()
+    monkeypatch.setattr(runtime_mod, "run_workflow", spy)
+    await dispatcher_mod._maybe_fire_stage_workflow(
+        db_session,
+        workspace_id=workspace.id,
+        fsm_stage="code_review",
+        ticket_ref="ELS-1",
+        settings=get_settings(),
+    )
+    spy.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_stage_trigger_shadow_records_without_spawning(
+    db_session, seed_workspace, monkeypatch
+) -> None:
+    """AC: shadow mode (tracker_poll_fire off) records a
+    workflow.would_have_run audit row and spawns nothing."""
+    from backend.app.db.models.tenancy import AuditLog
+
+    _, _, workspace = seed_workspace
+    workspace.settings = {
+        "workflows": {"stage_triggers": {"code_review": "pr-review"}}
+    }
+    await db_session.flush()
+    spy = AsyncMock()
+    monkeypatch.setattr(runtime_mod, "run_workflow", spy)
+
+    shadow_settings = Settings(  # type: ignore[call-arg]
+        OPENAI_API_KEY="test", SHIP_TRACKER_POLL_FIRE=False
+    )
+    await dispatcher_mod._maybe_fire_stage_workflow(
+        db_session,
+        workspace_id=workspace.id,
+        fsm_stage="code_review",
+        ticket_ref="ELS-1",
+        settings=shadow_settings,
+    )
+    spy.assert_not_awaited()
+    row = (
+        await db_session.execute(
+            select(AuditLog).where(
+                AuditLog.workspace_id == workspace.id,
+                AuditLog.action == "workflow.would_have_run",
+            )
+        )
+    ).scalar_one()
+    assert row.payload["shadow"] is True
+    assert row.payload["fsm_stage"] == "code_review"
+
+
+# ---------------------------------------------------------------------------
+# Ship leaf (ELS-259)
+# ---------------------------------------------------------------------------
+
+
+def test_spec_accepts_ship_provider() -> None:
+    from backend.app.services.workflow.spec import load_spec
+
+    spec = load_spec(
+        """
+name: dogfood
+steps:
+  - id: nest
+    kind: pipeline
+    agent: {kind: coding, provider: ship}
+"""
+    )
+    assert spec.steps[0].agent.provider == "ship"
+
+
+def test_ship_provider_not_customer_selectable() -> None:
+    """AC: internal/dogfood only — the config surface offers cursor/
+    codex/claude, never ship."""
+    from backend.app.services.config_registry import SCOPES
+
+    enum = SCOPES["agent.provider"].schema["enum"]
+    assert "ship" not in enum
+
+
+# ---------------------------------------------------------------------------
+# Dogfood specs (ELS-262)
+# ---------------------------------------------------------------------------
+
+
+def test_registry_lists_dogfood_specs() -> None:
+    available = list_available_specs()
+    assert "pr-review" in available
+    assert "codebase-audit" in available
+    assert resolve_spec("../etc/passwd") is None
+
+
+@pytest.mark.asyncio
+async def test_pr_review_runs_end_to_end(db_session, seed_workspace) -> None:
+    """AC: pr-review loads via W8.1, runs via W8.3, synthesize emits a
+    schema-valid findings object, verify consumes the top finding."""
+    _, _, workspace = seed_workspace
+    workspace.max_concurrent_dispatches = 8
+    await db_session.flush()
+    spec = resolve_spec("pr-review")
+    assert spec is not None
+
+    verify_inputs: dict = {}
+
+    async def reasoning(_s, _st, _ws, step, inputs, run_id, **_kw):
+        if step.kind == "synthesize":
+            return {
+                "findings": [
+                    {"severity": "high", "title": "races on lock release"},
+                    {"severity": "low", "title": "naming nit"},
+                ]
+            }
+        if step.kind == "verify":
+            verify_inputs.update(inputs)
+            return {"verdict": "confirmed", "reason": "reproduced"}
+        return {"axis": inputs.get("axis"), "notes": ["n1"]}
+
+    async def coding(*_a, **_kw):  # pr-review has no coding leaves
+        raise AssertionError("pr-review must not spawn coding leaves")
+
+    run = await run_workflow(
+        db_session,
+        workspace_id=workspace.id,
+        spec=spec,
+        inputs={"pr_url": "https://github.com/x/y/pull/1"},
+        trigger_kind="gate",
+        executors=LeafExecutors(run_reasoning=reasoning, run_coding=coding),
+    )
+    assert run.status == "completed"
+    # verify consumed the synthesized findings.
+    assert verify_inputs["top_finding"][0]["severity"] == "high"
+    assert await _workflow_locks(db_session, workspace.id) == 0
+
+
+@pytest.mark.asyncio
+async def test_codebase_audit_runs_as_pipeline(
+    db_session, seed_workspace
+) -> None:
+    _, _, workspace = seed_workspace
+    workspace.max_concurrent_dispatches = 8
+    await db_session.flush()
+    spec = resolve_spec("codebase-audit")
+    assert spec is not None
+
+    async def reasoning(_s, _st, _ws, step, inputs, run_id, **_kw):
+        if step.kind == "judge":
+            return {"items": [{"rank": 1, "title": "split dispatcher.py"}]}
+        return {"lens": inputs.get("lens"), "items": ["x"]}
+
+    async def coding(_s, _st, _ws, step, inputs, run_id, **_kw):
+        return {"hotspots": ["dispatcher.py", "tools.py"]}
+
+    run = await run_workflow(
+        db_session,
+        workspace_id=workspace.id,
+        spec=spec,
+        inputs={"focus": "nightly"},
+        trigger_kind="cron",
+        executors=LeafExecutors(run_reasoning=reasoning, run_coding=coding),
+    )
+    assert run.status == "completed"
+    assert run.output == {"items": [{"rank": 1, "title": "split dispatcher.py"}]}
+
+
+def test_process_editor_untouched_by_workflows() -> None:
+    """Boundary doc AC: /process (reactive state machine) and the
+    workflow primitive (imperative bounded pipeline) never merge —
+    processes.py must not import the workflow runtime."""
+    source = Path("apps/backend/app/api/v1/routes/processes.py").read_text()
+    assert "services.workflow" not in source

--- a/packages/cli/lib/workflow/loadSpec.mjs
+++ b/packages/cli/lib/workflow/loadSpec.mjs
@@ -1,0 +1,154 @@
+/**
+ * CLI-side workflow spec parser (W8.1, ELS-256).
+ *
+ * Mirrors apps/backend/app/services/workflow/spec.py — same step
+ * kinds, same hard ceilings, same reject-before-anything-runs
+ * contract. The CLI uses this for `.ship/workflows/*.yaml` linting
+ * (init/doctor surface); the server-side loader stays the
+ * authoritative validator at dispatch time.
+ */
+
+import { parse as parseYaml } from "yaml";
+
+export const HARD_FANOUT_CEILING = 8;
+export const DEFAULT_MAX_FANOUT = 4;
+export const DEFAULT_MAX_DEPTH = 2;
+
+export const STEP_KINDS = [
+  "parallel",
+  "pipeline",
+  "loop",
+  "barrier",
+  "synthesize",
+  "judge",
+  "verify",
+];
+const STRUCTURED_KINDS = ["synthesize", "judge", "verify"];
+const CODING_PROVIDERS = ["claude", "codex", "cursor", "ship"];
+
+export class WorkflowSpecError extends Error {}
+
+function fail(msg) {
+  throw new WorkflowSpecError(msg);
+}
+
+function validateStep(step, path) {
+  if (!step || typeof step !== "object") fail(`${path}: step must be a mapping`);
+  const id = step.id;
+  if (!id || typeof id !== "string") fail(`${path}: step requires an id`);
+  if (!STEP_KINDS.includes(step.kind)) {
+    fail(`step '${id}': unknown step kind '${step.kind}' (known: ${STEP_KINDS.join(", ")})`);
+  }
+  if (step.agent) {
+    const { kind, provider = "reasoning" } = step.agent;
+    if (kind === "coding") {
+      if (!CODING_PROVIDERS.includes(provider)) {
+        fail(`step '${id}': unknown coding provider '${provider}'`);
+      }
+    } else if (kind === "reasoning") {
+      if (provider !== "reasoning") {
+        fail(`step '${id}': reasoning leaves use provider 'reasoning'`);
+      }
+    } else {
+      fail(`step '${id}': agent.kind must be coding|reasoning`);
+    }
+  }
+  if (STRUCTURED_KINDS.includes(step.kind)) {
+    if (!step.output_schema || typeof step.output_schema !== "object") {
+      fail(`step '${id}': ${step.kind} requires output_schema`);
+    }
+    if (!("type" in step.output_schema)) {
+      fail(`step '${id}': output_schema must carry 'type'`);
+    }
+  }
+  if (step.kind === "parallel") {
+    if (!Array.isArray(step.steps) || step.steps.length === 0) {
+      fail(`step '${id}': parallel requires nested steps`);
+    }
+  } else if (Array.isArray(step.steps) && step.steps.length > 0) {
+    fail(`step '${id}': only parallel steps nest children`);
+  }
+  if (step.kind === "barrier" && (!Array.isArray(step.needs) || !step.needs.length)) {
+    fail(`step '${id}': barrier requires needs[]`);
+  }
+  if ((step.kind === "pipeline" || step.kind === "loop") && !step.agent) {
+    fail(`step '${id}': ${step.kind} requires agent`);
+  }
+  (step.steps || []).forEach((s, i) => validateStep(s, `${path}.steps[${i}]`));
+}
+
+function staticDepth(steps, level) {
+  let deepest = level;
+  for (const s of steps) {
+    if (Array.isArray(s.steps) && s.steps.length) {
+      deepest = Math.max(deepest, staticDepth(s.steps, level + 1));
+    }
+  }
+  return deepest;
+}
+
+function collectIds(steps, ids) {
+  for (const s of steps) {
+    if (ids.has(s.id)) fail(`duplicate step id '${s.id}'`);
+    ids.add(s.id);
+    collectIds(s.steps || [], ids);
+  }
+}
+
+function checkNeeds(steps, ids) {
+  for (const s of steps) {
+    for (const need of s.needs || []) {
+      if (!ids.has(need)) fail(`step '${s.id}': needs unknown step '${need}'`);
+    }
+    checkNeeds(s.steps || [], ids);
+  }
+}
+
+function checkFanout(steps, maxFanout) {
+  for (const s of steps) {
+    if (s.kind === "parallel" && s.steps.length > maxFanout) {
+      fail(`step '${s.id}': fan-out ${s.steps.length} exceeds max_fanout=${maxFanout}`);
+    }
+    checkFanout(s.steps || [], maxFanout);
+  }
+}
+
+/**
+ * Parse + validate one workflow YAML document. Throws
+ * WorkflowSpecError naming the offending step on any rejection.
+ */
+export function loadSpec(text) {
+  let raw;
+  try {
+    raw = parseYaml(text);
+  } catch (err) {
+    fail(`invalid YAML: ${err.message}`);
+  }
+  if (!raw || typeof raw !== "object") fail("workflow spec must be a YAML mapping");
+  if (!raw.name || typeof raw.name !== "string") fail("workflow requires a name");
+  if (!Array.isArray(raw.steps) || raw.steps.length === 0) {
+    fail("workflow requires at least one step");
+  }
+  const maxFanout = raw.max_fanout ?? DEFAULT_MAX_FANOUT;
+  const maxDepth = raw.max_depth ?? DEFAULT_MAX_DEPTH;
+  if (maxFanout > HARD_FANOUT_CEILING) {
+    fail(`max_fanout=${maxFanout} exceeds the hard ceiling ${HARD_FANOUT_CEILING}`);
+  }
+  raw.steps.forEach((s, i) => validateStep(s, `steps[${i}]`));
+  const depth = staticDepth(raw.steps, 1);
+  if (depth > maxDepth) {
+    fail(`static step graph depth ${depth} exceeds max_depth=${maxDepth}`);
+  }
+  const ids = new Set();
+  collectIds(raw.steps, ids);
+  checkNeeds(raw.steps, ids);
+  checkFanout(raw.steps, maxFanout);
+  return {
+    name: raw.name,
+    version: String(raw.version ?? "1"),
+    inputs: raw.inputs ?? {},
+    max_fanout: maxFanout,
+    max_depth: maxDepth,
+    steps: raw.steps,
+  };
+}

--- a/packages/cli/tests/workflow-load-spec.test.mjs
+++ b/packages/cli/tests/workflow-load-spec.test.mjs
@@ -1,0 +1,66 @@
+/**
+ * W8.1 (ELS-256) — CLI-side workflow spec parser mirrors the
+ * server loader's reject-before-run contract.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { loadSpec, WorkflowSpecError, HARD_FANOUT_CEILING } from "../lib/workflow/loadSpec.mjs";
+
+const VALID = `
+name: pr-review
+steps:
+  - id: fan
+    kind: parallel
+    steps:
+      - {id: a, kind: pipeline, agent: {kind: reasoning}}
+      - {id: b, kind: pipeline, agent: {kind: coding, provider: claude}}
+  - id: join
+    kind: barrier
+    needs: [a, b]
+  - id: synth
+    kind: synthesize
+    needs: [join]
+    output_schema: {type: object}
+`;
+
+test("valid spec round-trips", () => {
+  const spec = loadSpec(VALID);
+  assert.equal(spec.name, "pr-review");
+  assert.equal(spec.max_fanout, 4);
+  assert.equal(spec.steps.length, 3);
+});
+
+test("unknown kind names the step", () => {
+  assert.throws(
+    () => loadSpec(VALID.replace("kind: barrier", "kind: warp")),
+    (e) => e instanceof WorkflowSpecError && /warp/.test(e.message),
+  );
+});
+
+test("unknown provider names the step", () => {
+  assert.throws(
+    () => loadSpec(VALID.replace("provider: claude", "provider: hal9000")),
+    /hal9000/,
+  );
+});
+
+test("fan-out ceiling enforced", () => {
+  assert.throws(
+    () => loadSpec(`name: x\nmax_fanout: ${HARD_FANOUT_CEILING + 1}\nsteps:\n  - {id: s, kind: pipeline, agent: {kind: reasoning}}`),
+    /hard ceiling/,
+  );
+});
+
+test("synthesize requires output_schema", () => {
+  assert.throws(
+    () => loadSpec("name: x\nsteps:\n  - {id: s, kind: synthesize}"),
+    /output_schema/,
+  );
+});
+
+test("unknown needs edge rejected", () => {
+  assert.throws(
+    () => loadSpec("name: x\nsteps:\n  - {id: s, kind: barrier, needs: [ghost]}"),
+    /ghost/,
+  );
+});


### PR DESCRIPTION
## Summary

Phase 8 — the LAST phase of the headless-pivot strangler rework (thesis 8): a deterministic, bounded multi-agent workflow primitive, distinct from the FSM (reactive, never completes) and from /process (state-machine definitions).

- **ELS-255 (W8.7)** — `agent_workflow_runs` + `agent_workflow_step_runs` (migration **0089**, chained off live heads; renamed from the ticket's `workflow_runs` which has been the GHA-runs mirror since 0005). UNIQUE `(run, step, attempt)` = the durable idempotency key.
- **ELS-256 (W8.1)** — `.ship/workflows/*.yaml` spec language: 7 step kinds, coding (claude/codex/cursor/ship) + reasoning leaves, `max_fanout` (hard ceiling 8) / `max_depth` rejected at LOAD time, `output_schema` required on synthesize/judge/verify, subagent budget convention (25/300). Server pydantic loader + mirrored CLI parser.
- **ELS-257 (W8.2)** — **WorkflowDispatchGate**: every leaf passes one chokepoint reusing dispatcher primitives — `workflow:<run>:<step>` lease (TTL-swept like everything else), `workflow:`-prefix cap pool (separate from SDLC `ticket:`) with acquire-then-walk-back, cascade via `_count_recent_dispatches` counted on RECURSION EDGES (ship leaves / nested workflows; 4-leaf reasoning fan-outs untouched), per-attempt idempotency, audit on every decision. **No autonomy branch — pinned by test.**
- **ELS-258 (W8.3)** — runtime executor: DAG scheduling (parallel children inherit container needs; barriers tolerate partial failure; pipelines thread `{{ steps.<id>.output.<key> }}`; loops bounded by attempts), schema-validated structured outputs, grep-pinned single chokepoint (no spawn primitive referenced). Lean event-driven coding leaves: CI dispatch + `/agent-runs/finish` correlation by `run_id` releases the lock; `advance_workflow` re-runs idempotently as the reconcile.
- **ELS-260 (W8.4)** — `run_workflow` Navigator tool: admin-gated, excluded from subagent toolsets, **lock-free at tool return** (queued row + background gated advance; pinned by test), unknown names list the registry.
- **ELS-261 (W8.5)** — gate trigger: `workflows.stage_triggers` (e.g. `code_review → pr-review`) hooked into `maybe_dispatch`, fail-closed, deduped, shadow-mode `would_have_run`. Cron trigger: `CronLockId.WORKFLOW_NIGHTLY=1029` (1025-1028 were taken since the ticket's grounding), weekday 03:30 UTC, per-workspace opt-in fail-closed.
- **ELS-259 (W8.6)** — `ship` self-spawn provider wired as a workflow coding leaf: cascade recursion edge under EVERY profile (4th nested refusal pinned), not customer-selectable (config enum unchanged).
- **ELS-262 (W8.8)** — dogfood specs `pr-review` (4 axes → barrier → synthesize findings → adversarial verify) + `codebase-audit` (enumerate → 3 lenses → judge), packaged server-side + repo copies, and the `.ship/workflows/README.md` boundary doc: workflow = imperative bounded pipeline vs /process = reactive SDLC state machine, do not merge (processes.py untouched — pinned by test).

## Test plan
- [x] 40 new backend tests across models/spec/gate/runtime/triggers (incl. cap walk-back against real lock rows, cascade refusal at depth 3 under autonomy=high, idempotent attempts, finish-webhook lock release, both dogfood specs end-to-end with fake executors)
- [x] 6 new CLI loadSpec tests; CLI suite 163/163
- [x] Migration 0089 upgrade/downgrade/upgrade round-trip
- [x] Targeted backend suites 77 passed
- [ ] CI green

Closes ELS-255, ELS-256, ELS-257, ELS-258, ELS-259, ELS-260, ELS-261, ELS-262