### PR TITLE
fix(workflow): queued runs lost to the commit race + 5-min reconcile tick

### DIFF
--- a/apps/backend/app/services/cron_jobs.py
+++ b/apps/backend/app/services/cron_jobs.py
@@ -776,14 +776,28 @@ async def _inbox_stale_sweep_tick() -> None:
 )
 async def _agent_dispatch_lock_sweep_tick() -> None:
     """Periodic cleanup for expired TTL locks and dangling ``project:*`` locks.
-    See :mod:`dispatch_lock_sweep` for the algorithms + thresholds."""
+    See :mod:`dispatch_lock_sweep` for the algorithms + thresholds.
+
+    Also the workflow reconcile tick (W8.3): re-advances non-terminal
+    workflow runs — queued rows whose chat-side background task lost
+    the commit race or died with its replica (dogfood bug #1,
+    2026-06-12: a live pr-review sat in `queued` forever), and running
+    rows whose coding leaves completed via the finish webhook.
+    Idempotent by gate design, so the 5-min cadence is safe."""
     from backend.app.services.dispatch_lock_sweep import (
         sweep_dangling_project_locks_tick,
         sweep_expired_locks_tick,
     )
+    from backend.app.services.workflow.runtime import reconcile_stuck_runs
 
     await sweep_expired_locks_tick()
     await sweep_dangling_project_locks_tick()
+    try:
+        advanced = await reconcile_stuck_runs()
+        if advanced:
+            log.info("workflow reconcile: advanced %d stale run(s)", advanced)
+    except Exception:  # noqa: BLE001 — reconcile must not break the sweep
+        log.exception("workflow reconcile tick failed")
 
 
 @cron_with_lock(

--- a/apps/backend/app/services/workflow/runtime.py
+++ b/apps/backend/app/services/workflow/runtime.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 import logging
 import re
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from sqlalchemy import select
@@ -397,30 +397,81 @@ async def advance_run_by_id(
     """Background entrypoint for queued runs (chat trigger) and the
     reconcile tick: open a fresh session, load the run + its packaged
     spec, advance. Best-effort — failures land on the run row, never
-    on the caller."""
+    on the caller.
+
+    Visibility retry (dogfood bug #1, 2026-06-12): the chat tool
+    creates this task BEFORE its request transaction commits, so the
+    first read can race the commit and see no row. A fresh session
+    per attempt (a held session would pin the first snapshot) for up
+    to ~30s; if the row never appears the run was rolled back and
+    there is nothing to do — but we LOG it, silence was how the race
+    hid."""
+    import asyncio as _asyncio
+
     from backend.app.db.session import get_sessionmaker
     from backend.app.services.workflow.registry import resolve_spec
 
     sessionmaker = get_sessionmaker()
     try:
-        async with sessionmaker() as session:
-            run = await session.get(AgentWorkflowRun, run_id)
-            if run is None:
-                return
-            spec = resolve_spec(run.spec_name)
-            if spec is None:
-                run.status = "failed"
-                run.finished_at = datetime.now(timezone.utc)
+        run_exists = False
+        for attempt in range(10):
+            async with sessionmaker() as session:
+                run = await session.get(AgentWorkflowRun, run_id)
+                if run is None:
+                    await _asyncio.sleep(3)
+                    continue
+                run_exists = True
+                spec = resolve_spec(run.spec_name)
+                if spec is None:
+                    run.status = "failed"
+                    run.finished_at = datetime.now(timezone.utc)
+                    await session.commit()
+                    return
+                if run.status == "queued":
+                    run.status = "running"
+                await advance_workflow(
+                    session, run=run, spec=spec, actor_user_id=actor_user_id
+                )
                 await session.commit()
                 return
-            if run.status == "queued":
-                run.status = "running"
-            await advance_workflow(
-                session, run=run, spec=spec, actor_user_id=actor_user_id
+        if not run_exists:
+            logger.warning(
+                "workflow %s: run row never became visible — creating "
+                "transaction rolled back?",
+                run_id,
             )
-            await session.commit()
     except Exception:  # noqa: BLE001 — background task must not crash the loop
         logger.exception("workflow %s background advance failed", run_id)
+
+
+async def reconcile_stuck_runs(*, max_runs: int = 10) -> int:
+    """Reconcile tick (W8.3): re-advance every non-terminal run that
+    has sat untouched for a couple of minutes — queued rows whose
+    background task lost the commit race or died with the replica,
+    and running rows whose coding leaves finished via the webhook.
+    ``advance_workflow`` is idempotent (duplicate attempts come back
+    DUPLICATE_ATTEMPT), so re-advancing is always safe. Returns the
+    number of runs advanced."""
+    from backend.app.db.session import get_sessionmaker
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        stale = (
+            await session.execute(
+                select(AgentWorkflowRun.id)
+                .where(
+                    AgentWorkflowRun.status.in_(("queued", "running")),
+                    AgentWorkflowRun.created_at
+                    < datetime.now(timezone.utc) - timedelta(minutes=2),
+                )
+                .order_by(AgentWorkflowRun.created_at.asc())
+                .limit(max_runs)
+            )
+        ).scalars().all()
+    for run_id in stale:
+        logger.info("workflow reconcile: advancing stale run %s", run_id)
+        await advance_run_by_id(run_id)
+    return len(stale)
 
 
 async def _run_leaf(

--- a/apps/backend/tests/test_workflow_runtime.py
+++ b/apps/backend/tests/test_workflow_runtime.py
@@ -337,3 +337,57 @@ def test_runtime_has_single_chokepoint() -> None:
     assert "dispatch_workflow" not in source
     assert "_run_subagent_loop" not in source
     assert "gate_step_dispatch" in source
+
+
+@pytest.mark.asyncio
+async def test_reconcile_advances_stale_queued_run(
+    db_session, seed_workspace, monkeypatch
+) -> None:
+    """Dogfood bug #1 (2026-06-12): the chat tool's background task can
+    race the creating transaction's commit and exit silently, leaving
+    the run `queued` forever. The reconcile tick must pick such runs
+    up. We pin the selection logic (stale queued run found, fresh ones
+    left alone) with advance_run_by_id spied out."""
+    from contextlib import asynccontextmanager
+    from datetime import datetime, timedelta, timezone
+    from unittest.mock import AsyncMock
+
+    from backend.app.db.models.workflow import AgentWorkflowRun
+    from backend.app.services.workflow import runtime as runtime_mod
+
+    _, _, workspace = seed_workspace
+    stale = AgentWorkflowRun(
+        workspace_id=workspace.id,
+        spec_name="pr-review",
+        trigger_kind="chat",
+        status="queued",
+    )
+    fresh = AgentWorkflowRun(
+        workspace_id=workspace.id,
+        spec_name="pr-review",
+        trigger_kind="chat",
+        status="queued",
+    )
+    db_session.add_all([stale, fresh])
+    await db_session.flush()
+    # Backdate the stale run past the 2-minute threshold.
+    stale.created_at = datetime.now(timezone.utc) - timedelta(minutes=5)
+    await db_session.flush()
+
+    @asynccontextmanager
+    async def _bound():
+        yield db_session
+
+    class _SM:
+        def __call__(self):
+            return _bound()
+
+    monkeypatch.setattr(
+        "backend.app.db.session.get_sessionmaker", lambda: _SM()
+    )
+    spy = AsyncMock()
+    monkeypatch.setattr(runtime_mod, "advance_run_by_id", spy)
+
+    advanced = await runtime_mod.reconcile_stuck_runs()
+    assert advanced == 1
+    spy.assert_awaited_once_with(stale.id)


### PR DESCRIPTION
## Summary
Dogfood bug #1 from the first live `run_workflow('pr-review')` on prod (run `e6fc3ae7` sat in `queued` forever): the chat tool creates the background advance task **before** its request transaction commits → the task's first read races the commit, sees no run row, exits silently.

Fix in two layers:
- `advance_run_by_id`: visibility retry (~30s, fresh session per attempt so the snapshot isn't pinned) + a WARN when the row never appears — silence was how the race hid.
- `reconcile_stuck_runs` wired onto the existing 5-min `agent_dispatch_lock_sweep` cron: re-advances every non-terminal run older than 2 min (lost queued tasks, replica deaths, coding leaves completed via the finish webhook). Idempotent by gate design.

The stuck prod run will be picked up by the reconciler automatically after rollout.

## Test plan
- [x] test_reconcile_advances_stale_queued_run (stale found, fresh untouched)
- [x] workflow runtime/trigger/gate suites green locally
- [ ] CI green