### PR TITLE
feat(workflow): fetch-diff leaf — pr-review reviews the actual change

### DIFF
--- a/.ship/workflows/pr-review.yaml
+++ b/.ship/workflows/pr-review.yaml
@@ -1,45 +1,75 @@
 # Multi-axis PR review + adversarial verify (W8.8, dogfood).
 # Fired from the code_review FSM gate (trigger b) or from chat.
+#
+# v2 (fetch-diff): step 'diff' deterministically pulls the PR diff
+# server-side (GitHub API + installation token) so every axis reviews
+# the ACTUAL change — the v1 tool-less leaves emitted boilerplate and
+# the verify step rightly returned 'uncertain — no evidence'.
 name: pr-review
-version: "1"
+version: "2"
 inputs:
   pr_url: string
 max_fanout: 4
 max_depth: 2
 steps:
+  - id: diff
+    kind: pipeline
+    agent: {kind: fetch}
+    inputs:
+      url: "{{ inputs.pr_url }}"
   - id: fan
     kind: parallel
+    needs: [diff]
     steps:
       - id: axis.correctness
         kind: pipeline
-        agent: {kind: reasoning, role: reviewer}
+        agent:
+          kind: reasoning
+          role: reviewer
+          prompt: "Review ONLY the correctness axis of this PR diff: logic errors, broken contracts, races, edge cases. Cite file+hunk for every finding. If the diff is clean on this axis, say so explicitly."
         inputs:
           axis: correctness
           pr_url: "{{ inputs.pr_url }}"
+          diff: "{{ steps.diff.output.content }}"
       - id: axis.security
         kind: pipeline
-        agent: {kind: reasoning, role: security-reviewer}
+        agent:
+          kind: reasoning
+          role: security-reviewer
+          prompt: "Review ONLY the security axis of this PR diff: injection, authz/authn gaps, secret handling, unsafe deserialization, SSRF. Cite file+hunk for every finding. If the diff is clean on this axis, say so explicitly."
         inputs:
           axis: security
           pr_url: "{{ inputs.pr_url }}"
+          diff: "{{ steps.diff.output.content }}"
       - id: axis.simplification
         kind: pipeline
-        agent: {kind: reasoning, role: reviewer}
+        agent:
+          kind: reasoning
+          role: reviewer
+          prompt: "Review ONLY the simplification axis of this PR diff: duplication, dead code, needless complexity, missed reuse of existing helpers. Cite file+hunk for every finding. If the diff is clean on this axis, say so explicitly."
         inputs:
           axis: simplification
           pr_url: "{{ inputs.pr_url }}"
+          diff: "{{ steps.diff.output.content }}"
       - id: axis.test-coverage
         kind: pipeline
-        agent: {kind: reasoning, role: qa-architect}
+        agent:
+          kind: reasoning
+          role: qa-architect
+          prompt: "Review ONLY the test-coverage axis of this PR diff: changed behavior without tests, asserts that can't fail, missing negative cases. Cite file+hunk for every finding. If the diff is clean on this axis, say so explicitly."
         inputs:
           axis: test-coverage
           pr_url: "{{ inputs.pr_url }}"
+          diff: "{{ steps.diff.output.content }}"
   - id: join
     kind: barrier
     needs: [fan]
   - id: synth
     kind: synthesize
     needs: [join]
+    agent:
+      kind: reasoning
+      prompt: "Merge the four axis reviews into one deduplicated findings list. Keep ONLY findings grounded in a cited file+hunk; drop generic advice. Severity reflects blast radius."
     inputs:
       correctness: "{{ steps.axis.correctness.output }}"
       security: "{{ steps.axis.security.output }}"
@@ -58,12 +88,16 @@ steps:
               severity: {type: string, enum: [low, medium, high]}
               title: {type: string}
               detail: {type: string}
+              location: {type: string}
   - id: recheck
     kind: verify
     needs: [synth]
+    agent:
+      kind: reasoning
+      prompt: "Adversarially re-check the HIGHEST-severity finding against the diff below. Confirm only if the cited hunk actually shows the problem; refute if it does not."
     inputs:
       top_finding: "{{ steps.synth.output.findings }}"
-      pr_url: "{{ inputs.pr_url }}"
+      diff: "{{ steps.diff.output.content }}"
     output_schema:
       type: object
       required: [verdict]

--- a/apps/backend/app/services/workflow/leaves.py
+++ b/apps/backend/app/services/workflow/leaves.py
@@ -47,6 +47,40 @@ LeafExecutor = Callable[..., Awaitable[dict[str, Any] | None]]
 class LeafExecutors:
     run_reasoning: LeafExecutor
     run_coding: LeafExecutor
+    # Deterministic context leaf (no LLM). Optional so test fakes that
+    # predate the fetch kind keep constructing.
+    run_fetch: LeafExecutor | None = None
+
+
+# Long text inputs (a PR diff, a file body) render as their own
+# fenced sections instead of being JSON-escaped into one line — and
+# the old flat 16k cap silently destroyed exactly the context the
+# fetch leaf exists to provide. Per-value cap keeps one huge diff
+# from evicting the other inputs.
+_LONG_VALUE_CHARS = 1000
+_PER_VALUE_CAP = 60_000
+_TOTAL_INPUT_CAP = 100_000
+
+
+def _render_inputs(inputs: dict[str, Any]) -> str:
+    short: dict[str, Any] = {}
+    sections: list[str] = []
+    for key, value in inputs.items():
+        if isinstance(value, str) and len(value) > _LONG_VALUE_CHARS:
+            body = value[:_PER_VALUE_CAP]
+            suffix = (
+                "\n… [truncated]" if len(value) > _PER_VALUE_CAP else ""
+            )
+            sections.append(f"## {key}\n\n```\n{body}{suffix}\n```")
+        else:
+            short[key] = value
+    parts = []
+    if short:
+        parts.append(
+            "Inputs:\n" + json.dumps(short, ensure_ascii=False, default=str)
+        )
+    parts.extend(sections)
+    return "\n\n".join(parts)[:_TOTAL_INPUT_CAP]
 
 
 _ROLE_FLAVOR = {
@@ -103,9 +137,7 @@ async def run_reasoning_leaf(
     )
     prompt = step.agent.prompt if step.agent and step.agent.prompt else ""
     user_message = (
-        (prompt + "\n\n" if prompt else "")
-        + "Inputs:\n"
-        + json.dumps(inputs, ensure_ascii=False, default=str)[:16000]
+        (prompt + "\n\n" if prompt else "") + _render_inputs(inputs)
     )
     # Reasoning leaves run tool-less by default: their value is
     # synthesis over the inputs already collected by prior steps.
@@ -188,9 +220,106 @@ async def run_coding_leaf(
     return None
 
 
+_GH_PR_RE = None  # compiled lazily below
+
+_FETCH_MAX_BYTES = 400_000
+
+
+async def run_fetch_leaf(
+    session: AsyncSession,
+    settings: Settings,
+    workspace_id: uuid.UUID,
+    step: StepSpec,
+    inputs: dict[str, Any],
+    run_id: str,
+    *,
+    user_id: uuid.UUID | None = None,
+) -> dict[str, Any] | None:
+    """Deterministic context leaf: GET ``inputs.url``, return the body.
+
+    GitHub PR URLs (``github.com/<owner>/<repo>/pull/<n>``) are
+    resolved to the API endpoint with ``Accept: …diff`` and, when the
+    workspace has a GitHub App installation, authenticated with its
+    installation token — so private-repo diffs work and public ones
+    don't burn the anonymous rate limit. Output:
+    ``{content, url, status, truncated}``.
+    """
+    import re as _re
+
+    import httpx
+
+    global _GH_PR_RE
+    if _GH_PR_RE is None:
+        _GH_PR_RE = _re.compile(
+            r"https?://github\.com/([^/]+)/([^/]+)/pull/(\d+)"
+        )
+
+    url = str(inputs.get("url") or "").strip()
+    if not url.startswith(("http://", "https://")):
+        raise RuntimeError(f"fetch leaf '{step.id}': invalid url {url!r}")
+
+    headers: dict[str, str] = {"User-Agent": "ship-workflow-fetch"}
+    pr_match = _GH_PR_RE.match(url)
+    if pr_match:
+        owner, repo, number = pr_match.groups()
+        url = f"https://api.github.com/repos/{owner}/{repo}/pulls/{number}"
+        headers["Accept"] = "application/vnd.github.diff"
+        headers["X-GitHub-Api-Version"] = "2022-11-28"
+        token = await _workspace_github_token(session, workspace_id, settings)
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+
+    async with httpx.AsyncClient(
+        timeout=httpx.Timeout(30.0), follow_redirects=True
+    ) as client:
+        res = await client.get(url, headers=headers)
+    if res.status_code >= 400:
+        raise RuntimeError(
+            f"fetch leaf '{step.id}': GET {url} → {res.status_code}"
+        )
+    body = res.text or ""
+    truncated = len(body) > _FETCH_MAX_BYTES
+    return {
+        "content": body[:_FETCH_MAX_BYTES],
+        "url": url,
+        "status": res.status_code,
+        "truncated": truncated,
+    }
+
+
+async def _workspace_github_token(
+    session: AsyncSession, workspace_id: uuid.UUID, settings: Settings
+) -> str | None:
+    """Best-effort installation token for the workspace's GitHub App
+    install — ``None`` (anonymous fetch) on any miss."""
+    try:
+        from backend.app.db.models.integrations import GitHubInstallation
+        from backend.app.integrations.github.app_auth import (
+            fetch_installation_token,
+        )
+
+        install_id = (
+            await session.execute(
+                select(GitHubInstallation.installation_id)
+                .where(GitHubInstallation.workspace_id == workspace_id)
+                .order_by(GitHubInstallation.created_at.desc())
+                .limit(1)
+            )
+        ).scalar_one_or_none()
+        if install_id is None:
+            return None
+        return await fetch_installation_token(install_id, settings=settings)
+    except Exception:  # noqa: BLE001 — anonymous fetch is the fallback
+        logger.warning(
+            "fetch leaf: installation token unavailable ws=%s", workspace_id
+        )
+        return None
+
+
 DEFAULT_EXECUTORS = LeafExecutors(
     run_reasoning=run_reasoning_leaf,
     run_coding=run_coding_leaf,
+    run_fetch=run_fetch_leaf,
 )
 
 

--- a/apps/backend/app/services/workflow/runtime.py
+++ b/apps/backend/app/services/workflow/runtime.py
@@ -513,7 +513,16 @@ async def _run_leaf(
             return "blocked"
 
         row = await session.get(AgentWorkflowStepRun, decision.step_row_id)
-        runner = executors.run_coding if is_coding else executors.run_reasoning
+        if step.agent is not None and step.agent.kind == "fetch":
+            runner = executors.run_fetch
+            if runner is None:
+                raise RuntimeError(
+                    f"step '{step.id}': no fetch executor injected"
+                )
+        elif is_coding:
+            runner = executors.run_coding
+        else:
+            runner = executors.run_reasoning
         try:
             output = await runner(
                 session,

--- a/apps/backend/app/services/workflow/spec.py
+++ b/apps/backend/app/services/workflow/spec.py
@@ -57,15 +57,24 @@ class WorkflowSpecError(ValueError):
     offending step when one exists."""
 
 
+FETCH_PROVIDER = "fetch"
+
+
 class AgentLeaf(BaseModel):
     """Leaf executor selection (T5: spawn, never re-implement).
 
-    ``kind=coding`` spawns a tool CLI via ``runAgent`` (claude / codex
-    / cursor / ship); ``kind=reasoning`` runs an in-process Navigator
-    subagent turn, role-prompted.
+    - ``kind=coding`` spawns a tool CLI via ``runAgent`` (claude /
+      codex / cursor / ship);
+    - ``kind=reasoning`` runs an in-process Navigator subagent turn,
+      role-prompted;
+    - ``kind=fetch`` is DETERMINISTIC — no LLM at all: the server
+      HTTP-GETs ``inputs.url`` (GitHub PR URLs are auto-resolved to
+      the API diff endpoint with the workspace's installation token)
+      and returns ``{content, url, truncated}``. The context step the
+      pr-review dogfood was missing.
     """
 
-    kind: Literal["coding", "reasoning"]
+    kind: Literal["coding", "reasoning", "fetch"]
     provider: str = REASONING_PROVIDER
     role: str | None = None
     prompt: str | None = None
@@ -78,6 +87,12 @@ class AgentLeaf(BaseModel):
                     f"unknown coding provider '{self.provider}' "
                     f"(known: {', '.join(CODING_PROVIDERS)})"
                 )
+        elif self.kind == "fetch":
+            if self.provider not in (REASONING_PROVIDER, FETCH_PROVIDER):
+                raise ValueError(
+                    f"fetch leaves use provider 'fetch' (got '{self.provider}')"
+                )
+            self.provider = FETCH_PROVIDER
         else:
             if self.provider not in (REASONING_PROVIDER,):
                 raise ValueError(

--- a/apps/backend/app/services/workflow/specs/pr-review.yaml
+++ b/apps/backend/app/services/workflow/specs/pr-review.yaml
@@ -1,45 +1,75 @@
 # Multi-axis PR review + adversarial verify (W8.8, dogfood).
 # Fired from the code_review FSM gate (trigger b) or from chat.
+#
+# v2 (fetch-diff): step 'diff' deterministically pulls the PR diff
+# server-side (GitHub API + installation token) so every axis reviews
+# the ACTUAL change — the v1 tool-less leaves emitted boilerplate and
+# the verify step rightly returned 'uncertain — no evidence'.
 name: pr-review
-version: "1"
+version: "2"
 inputs:
   pr_url: string
 max_fanout: 4
 max_depth: 2
 steps:
+  - id: diff
+    kind: pipeline
+    agent: {kind: fetch}
+    inputs:
+      url: "{{ inputs.pr_url }}"
   - id: fan
     kind: parallel
+    needs: [diff]
     steps:
       - id: axis.correctness
         kind: pipeline
-        agent: {kind: reasoning, role: reviewer}
+        agent:
+          kind: reasoning
+          role: reviewer
+          prompt: "Review ONLY the correctness axis of this PR diff: logic errors, broken contracts, races, edge cases. Cite file+hunk for every finding. If the diff is clean on this axis, say so explicitly."
         inputs:
           axis: correctness
           pr_url: "{{ inputs.pr_url }}"
+          diff: "{{ steps.diff.output.content }}"
       - id: axis.security
         kind: pipeline
-        agent: {kind: reasoning, role: security-reviewer}
+        agent:
+          kind: reasoning
+          role: security-reviewer
+          prompt: "Review ONLY the security axis of this PR diff: injection, authz/authn gaps, secret handling, unsafe deserialization, SSRF. Cite file+hunk for every finding. If the diff is clean on this axis, say so explicitly."
         inputs:
           axis: security
           pr_url: "{{ inputs.pr_url }}"
+          diff: "{{ steps.diff.output.content }}"
       - id: axis.simplification
         kind: pipeline
-        agent: {kind: reasoning, role: reviewer}
+        agent:
+          kind: reasoning
+          role: reviewer
+          prompt: "Review ONLY the simplification axis of this PR diff: duplication, dead code, needless complexity, missed reuse of existing helpers. Cite file+hunk for every finding. If the diff is clean on this axis, say so explicitly."
         inputs:
           axis: simplification
           pr_url: "{{ inputs.pr_url }}"
+          diff: "{{ steps.diff.output.content }}"
       - id: axis.test-coverage
         kind: pipeline
-        agent: {kind: reasoning, role: qa-architect}
+        agent:
+          kind: reasoning
+          role: qa-architect
+          prompt: "Review ONLY the test-coverage axis of this PR diff: changed behavior without tests, asserts that can't fail, missing negative cases. Cite file+hunk for every finding. If the diff is clean on this axis, say so explicitly."
         inputs:
           axis: test-coverage
           pr_url: "{{ inputs.pr_url }}"
+          diff: "{{ steps.diff.output.content }}"
   - id: join
     kind: barrier
     needs: [fan]
   - id: synth
     kind: synthesize
     needs: [join]
+    agent:
+      kind: reasoning
+      prompt: "Merge the four axis reviews into one deduplicated findings list. Keep ONLY findings grounded in a cited file+hunk; drop generic advice. Severity reflects blast radius."
     inputs:
       correctness: "{{ steps.axis.correctness.output }}"
       security: "{{ steps.axis.security.output }}"
@@ -58,12 +88,16 @@ steps:
               severity: {type: string, enum: [low, medium, high]}
               title: {type: string}
               detail: {type: string}
+              location: {type: string}
   - id: recheck
     kind: verify
     needs: [synth]
+    agent:
+      kind: reasoning
+      prompt: "Adversarially re-check the HIGHEST-severity finding against the diff below. Confirm only if the cited hunk actually shows the problem; refute if it does not."
     inputs:
       top_finding: "{{ steps.synth.output.findings }}"
-      pr_url: "{{ inputs.pr_url }}"
+      diff: "{{ steps.diff.output.content }}"
     output_schema:
       type: object
       required: [verdict]

--- a/apps/backend/tests/test_workflow_runtime.py
+++ b/apps/backend/tests/test_workflow_runtime.py
@@ -391,3 +391,79 @@ async def test_reconcile_advances_stale_queued_run(
     advanced = await runtime_mod.reconcile_stuck_runs()
     assert advanced == 1
     spy.assert_awaited_once_with(stale.id)
+
+
+@pytest.mark.asyncio
+async def test_fetch_leaf_routes_to_fetch_executor(
+    db_session, seed_workspace
+) -> None:
+    """A kind=fetch leaf runs the deterministic fetch executor (no
+    LLM), and its output threads into downstream steps."""
+    from backend.app.services.workflow.spec import load_spec as _load
+
+    _, _, workspace = seed_workspace
+    spec = _load(
+        """
+name: ctx
+steps:
+  - id: diff
+    kind: pipeline
+    agent: {kind: fetch}
+    inputs: {url: "{{ inputs.pr_url }}"}
+  - id: review
+    kind: pipeline
+    needs: [diff]
+    agent: {kind: reasoning}
+    inputs: {diff: "{{ steps.diff.output.content }}"}
+"""
+    )
+    fetched: dict = {}
+    reviewed: dict = {}
+
+    async def fetch(_s, _st, _ws, step, inputs, run_id, **_kw):
+        fetched.update(inputs)
+        return {"content": "diff --git a/x b/x", "url": inputs["url"], "truncated": False}
+
+    async def reasoning(_s, _st, _ws, step, inputs, run_id, **_kw):
+        reviewed.update(inputs)
+        return {"ok": True}
+
+    async def coding(*_a, **_kw):
+        raise AssertionError("no coding leaves here")
+
+    run = await run_workflow(
+        db_session,
+        workspace_id=workspace.id,
+        spec=spec,
+        inputs={"pr_url": "https://github.com/o/r/pull/9"},
+        trigger_kind="chat",
+        executors=LeafExecutors(
+            run_reasoning=reasoning, run_coding=coding, run_fetch=fetch
+        ),
+    )
+    assert run.status == "completed"
+    assert fetched["url"] == "https://github.com/o/r/pull/9"
+    assert reviewed["diff"] == "diff --git a/x b/x"
+
+
+def test_render_inputs_sections_long_text() -> None:
+    from backend.app.services.workflow.leaves import _render_inputs
+
+    diff = "x" * 5000
+    out = _render_inputs({"axis": "security", "diff": diff})
+    assert '"axis": "security"' in out
+    assert "## diff" in out
+    assert "x" * 100 in out
+    # Long value is fenced, not JSON-escaped into the inputs line.
+    assert '"diff"' not in out
+
+
+def test_render_inputs_caps_huge_values() -> None:
+    from backend.app.services.workflow.leaves import (
+        _PER_VALUE_CAP,
+        _render_inputs,
+    )
+
+    out = _render_inputs({"diff": "y" * (_PER_VALUE_CAP + 10_000)})
+    assert "[truncated]" in out
+    assert len(out) < _PER_VALUE_CAP + 1000

--- a/apps/backend/tests/test_workflow_spec.py
+++ b/apps/backend/tests/test_workflow_spec.py
@@ -195,3 +195,31 @@ def test_validate_output_subset() -> None:
         validate_output(
             {"findings": [{"severity": "critical"}]}, schema, step_id="synth"
         )
+
+
+def test_fetch_leaf_accepted_and_normalized() -> None:
+    spec = load_spec(
+        """
+name: ctx
+steps:
+  - id: diff
+    kind: pipeline
+    agent: {kind: fetch}
+    inputs: {url: "{{ inputs.pr_url }}"}
+"""
+    )
+    assert spec.steps[0].agent.kind == "fetch"
+    assert spec.steps[0].agent.provider == "fetch"
+
+
+def test_fetch_leaf_rejects_foreign_provider() -> None:
+    with pytest.raises(WorkflowSpecError, match="fetch leaves"):
+        load_spec(
+            """
+name: ctx
+steps:
+  - id: diff
+    kind: pipeline
+    agent: {kind: fetch, provider: claude}
+"""
+        )

--- a/apps/backend/tests/test_workflow_triggers.py
+++ b/apps/backend/tests/test_workflow_triggers.py
@@ -299,6 +299,14 @@ async def test_pr_review_runs_end_to_end(db_session, seed_workspace) -> None:
     assert spec is not None
 
     verify_inputs: dict = {}
+    axis_inputs: list[dict] = []
+
+    async def fetch(_s, _st, _ws, step, inputs, run_id, **_kw):
+        return {
+            "content": "diff --git a/app.py b/app.py\n+raise",
+            "url": inputs["url"],
+            "truncated": False,
+        }
 
     async def reasoning(_s, _st, _ws, step, inputs, run_id, **_kw):
         if step.kind == "synthesize":
@@ -311,6 +319,7 @@ async def test_pr_review_runs_end_to_end(db_session, seed_workspace) -> None:
         if step.kind == "verify":
             verify_inputs.update(inputs)
             return {"verdict": "confirmed", "reason": "reproduced"}
+        axis_inputs.append(inputs)
         return {"axis": inputs.get("axis"), "notes": ["n1"]}
 
     async def coding(*_a, **_kw):  # pr-review has no coding leaves
@@ -322,11 +331,17 @@ async def test_pr_review_runs_end_to_end(db_session, seed_workspace) -> None:
         spec=spec,
         inputs={"pr_url": "https://github.com/x/y/pull/1"},
         trigger_kind="gate",
-        executors=LeafExecutors(run_reasoning=reasoning, run_coding=coding),
+        executors=LeafExecutors(
+            run_reasoning=reasoning, run_coding=coding, run_fetch=fetch
+        ),
     )
     assert run.status == "completed"
-    # verify consumed the synthesized findings.
+    # v2: every axis saw the ACTUAL diff content from the fetch step.
+    assert len(axis_inputs) == 4
+    assert all("+raise" in i["diff"] for i in axis_inputs)
+    # verify consumed the synthesized findings AND the diff.
     assert verify_inputs["top_finding"][0]["severity"] == "high"
+    assert "+raise" in verify_inputs["diff"]
     assert await _workflow_locks(db_session, workspace.id) == 0
 
 

--- a/packages/cli/lib/workflow/loadSpec.mjs
+++ b/packages/cli/lib/workflow/loadSpec.mjs
@@ -49,8 +49,12 @@ function validateStep(step, path) {
       if (provider !== "reasoning") {
         fail(`step '${id}': reasoning leaves use provider 'reasoning'`);
       }
+    } else if (kind === "fetch") {
+      if (provider !== "reasoning" && provider !== "fetch") {
+        fail(`step '${id}': fetch leaves use provider 'fetch'`);
+      }
     } else {
-      fail(`step '${id}': agent.kind must be coding|reasoning`);
+      fail(`step '${id}': agent.kind must be coding|reasoning|fetch`);
     }
   }
   if (STRUCTURED_KINDS.includes(step.kind)) {


### PR DESCRIPTION
## Summary
Dogfood finding #2 from the first live pr-review: tool-less reasoning leaves never saw the diff → generic findings, verify honestly said 'uncertain — no evidence'.

- New deterministic agent kind `fetch` (no LLM): server GETs `inputs.url`; GitHub PR URLs resolve to the API diff endpoint with the workspace installation token; 400KB cap + truncated flag; gated like every leaf.
- Reasoning-leaf inputs: long text renders as fenced sections (60k/value) instead of the flat 16k JSON dump that destroyed exactly this context.
- pr-review v2: `diff` step first → all 4 axes + adversarial recheck consume the real diff; prompts demand file+hunk citations.

## Test plan
- [x] fetch-leaf validation in both loaders; runtime routing + threading; input sectioning/truncation; pr-review v2 e2e (axes + recheck receive the diff) — 46 backend + 6 CLI green
- [ ] CI green
- [ ] Live re-run on PR #364 after rollout