### PR TITLE
fix(workflow): leaf timeout — lost coding leaves can't hang a run forever

### DIFF
--- a/apps/backend/app/services/workflow/runtime.py
+++ b/apps/backend/app/services/workflow/runtime.py
@@ -444,25 +444,57 @@ async def advance_run_by_id(
         logger.exception("workflow %s background advance failed", run_id)
 
 
+# A coding leaf whose CI run dies — or whose /agent-runs/finish lands
+# with a run_id we can't correlate (dogfood finding #3, 2026-06-12:
+# the first nightly codebase-audit finished at 03:32 with a foreign
+# run_id and its enumerate step sat `dispatched` forever) — must not
+# hang the run. After this window the leaf's workflow lock has long
+# expired; declare the attempt failed and let the DAG finalize.
+LEAF_TIMEOUT = timedelta(hours=3)
+
+
 async def reconcile_stuck_runs(*, max_runs: int = 10) -> int:
     """Reconcile tick (W8.3): re-advance every non-terminal run that
     has sat untouched for a couple of minutes — queued rows whose
     background task lost the commit race or died with the replica,
     and running rows whose coding leaves finished via the webhook.
     ``advance_workflow`` is idempotent (duplicate attempts come back
-    DUPLICATE_ATTEMPT), so re-advancing is always safe. Returns the
+    DUPLICATE_ATTEMPT), so re-advancing is always safe. Also times out
+    ``dispatched`` steps older than :data:`LEAF_TIMEOUT` (lost CI run /
+    uncorrelated finish) so a run can't hang forever. Returns the
     number of runs advanced."""
     from backend.app.db.session import get_sessionmaker
 
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as session:
+        now = datetime.now(timezone.utc)
+        timed_out = (
+            await session.execute(
+                select(AgentWorkflowStepRun).where(
+                    AgentWorkflowStepRun.status.in_(("dispatched", "running")),
+                    AgentWorkflowStepRun.created_at < now - LEAF_TIMEOUT,
+                )
+            )
+        ).scalars().all()
+        for step in timed_out:
+            logger.warning(
+                "workflow reconcile: leaf timeout — run %s step %s "
+                "(dispatched %s, run_id %s)",
+                step.workflow_run_id, step.step_id,
+                step.created_at, step.run_id,
+            )
+            step.status = "failed"
+            step.reason = "leaf_timeout"
+            step.finished_at = now
+        if timed_out:
+            await session.commit()
+
         stale = (
             await session.execute(
                 select(AgentWorkflowRun.id)
                 .where(
                     AgentWorkflowRun.status.in_(("queued", "running")),
-                    AgentWorkflowRun.created_at
-                    < datetime.now(timezone.utc) - timedelta(minutes=2),
+                    AgentWorkflowRun.created_at < now - timedelta(minutes=2),
                 )
                 .order_by(AgentWorkflowRun.created_at.asc())
                 .limit(max_runs)

--- a/apps/backend/tests/test_workflow_runtime.py
+++ b/apps/backend/tests/test_workflow_runtime.py
@@ -467,3 +467,66 @@ def test_render_inputs_caps_huge_values() -> None:
     out = _render_inputs({"diff": "y" * (_PER_VALUE_CAP + 10_000)})
     assert "[truncated]" in out
     assert len(out) < _PER_VALUE_CAP + 1000
+
+
+@pytest.mark.asyncio
+async def test_reconcile_times_out_lost_coding_leaf(
+    db_session, seed_workspace, monkeypatch
+) -> None:
+    """Dogfood finding #3: a coding leaf whose CI run never correlates
+    back (foreign run_id / dead run) must not hang the workflow run
+    forever — the reconcile tick fails it after LEAF_TIMEOUT and the
+    next advance finalizes the run."""
+    from contextlib import asynccontextmanager
+    from datetime import datetime, timedelta, timezone
+    from unittest.mock import AsyncMock
+
+    from backend.app.db.models.workflow import (
+        AgentWorkflowRun,
+        AgentWorkflowStepRun,
+    )
+    from backend.app.services.workflow import runtime as runtime_mod
+
+    _, _, workspace = seed_workspace
+    run = AgentWorkflowRun(
+        workspace_id=workspace.id,
+        spec_name="codebase-audit",
+        trigger_kind="cron",
+        status="running",
+    )
+    db_session.add(run)
+    await db_session.flush()
+    step = AgentWorkflowStepRun(
+        workflow_run_id=run.id,
+        step_id="enumerate",
+        attempt=1,
+        kind="pipeline",
+        agent_provider="claude",
+        status="dispatched",
+        run_id="run_lost",
+    )
+    db_session.add(step)
+    await db_session.flush()
+    step.created_at = datetime.now(timezone.utc) - (
+        runtime_mod.LEAF_TIMEOUT + timedelta(minutes=5)
+    )
+    run.created_at = datetime.now(timezone.utc) - timedelta(hours=4)
+    await db_session.flush()
+
+    @asynccontextmanager
+    async def _bound():
+        yield db_session
+
+    class _SM:
+        def __call__(self):
+            return _bound()
+
+    monkeypatch.setattr(
+        "backend.app.db.session.get_sessionmaker", lambda: _SM()
+    )
+    monkeypatch.setattr(runtime_mod, "advance_run_by_id", AsyncMock())
+
+    await runtime_mod.reconcile_stuck_runs()
+    await db_session.refresh(step)
+    assert step.status == "failed"
+    assert step.reason == "leaf_timeout"


### PR DESCRIPTION
Dogfood finding #3: the first nightly codebase-audit's enumerate leaf
finished its CI run at 03:32 with a run_id we couldn't correlate
(foreign id from the routine-scheduler path, not our dispatch) and the
step sat 'dispatched' for 6+ hours with the run stuck 'running'. The
reconcile tick now fails dispatched/running steps older than
LEAF_TIMEOUT (3h — the workflow lock is long expired by then) with
reason='leaf_timeout' so the DAG finalizes instead of hanging. The
run_id correlation gap itself is filed for the engine to investigate
(trigger-scheduler vs workflow_dispatch SHIP_RUN_ID plumbing).
