### PR TITLE
Ship MCP Edge — the engine as an MCP server (ELS-268..275)

### DIFF
--- a/apps/backend/app/api/v1/routes/mcp.py
+++ b/apps/backend/app/api/v1/routes/mcp.py
@@ -1,0 +1,582 @@
+"""Ship MCP Edge (thesis 9, ELS-268/269/272/273/274/275).
+
+The engine exposed as an MCP server: the operator attaches Ship to
+the agent they already live in (Claude Code / Desktop / anything
+speaking MCP) and that agent becomes the brain — Ship provides the
+domain tools and keeps the control plane. Generalizes thesis 4
+("chat = edge") to "any operator agent = edge"; the inversion trap
+stays closed because this authenticates the OPERATOR's personal PAT,
+never a spawned execution agent.
+
+Transport: minimal streamable-HTTP — a single ``POST /mcp`` JSON-RPC
+endpoint (stateless mode; the MCP spec allows servers that neither
+issue session ids nor open SSE streams, and Claude clients handle
+both). Hand-rolled on purpose: the protocol subset we need
+(initialize / tools/list / tools/call / ping) is ~100 lines, which is
+cheaper than carrying the SDK dependency in the prod image.
+
+ONE tool registry: tools are projected from ``ToolBox.specs()``
+through :data:`MCP_TOOL_ALLOWLIST` and dispatched into the existing
+handlers — never a second catalog (W8-style single-source rule). The
+adapter injects an optional ``workspace_id`` parameter into every
+projected tool (PATs can be members of several workspaces) and adds a
+handful of MCP-native tools (workspace listing/creation, sibling
+GitHub-install attach) that have no chat-tool equivalent.
+
+Stakes policy (ELS-273): enforced HERE, server-side — an external
+agent's prompt etiquette is advisory by definition. Approval-type
+inbox items demand a verbatim ``approval_echo`` (anti silent-auto-
+approve), and hard-destructive actions are not exposed at all: they
+remain web-only behind the Console's typed-slug confirmation.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import Any
+
+from fastapi import APIRouter, Depends, Request, Response
+from fastapi.responses import JSONResponse
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.app.api.v1.deps import AuthContext, get_current_auth
+from backend.app.core.config import Settings, get_settings
+from backend.app.db.models.inbox import InboxItem
+from backend.app.db.models.tenancy import Workspace, WorkspaceMember
+from backend.app.db.session import get_session
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["mcp"])
+
+PROTOCOL_VERSION = "2025-03-26"
+
+# ---------------------------------------------------------------------------
+# Policy (ELS-269 allowlist + ELS-273 stakes)
+# ---------------------------------------------------------------------------
+
+# ToolBox tools projected into MCP. Deliberately NOT everything:
+# - web_fetch is excluded — the operator's agent has its own web
+#   tools and proxying fetches through Ship is an SSRF surface with
+#   zero upside;
+# - recall / recall_context are excluded — Navigator-thread memory
+#   has no meaning for an external-agent session.
+MCP_TOOL_ALLOWLIST: frozenset[str] = frozenset(
+    {
+        "audit_search",
+        "config_help",
+        "config_put",
+        "dashboard_get",
+        "inbox_create",
+        "inbox_get",
+        "inbox_list",
+        "inbox_update",
+        "knowledge_bucket_get",
+        "knowledge_search",
+        "members_list",
+        "pr_get",
+        "pr_list",
+        "project_create",
+        "project_get",
+        "project_list",
+        "project_update",
+        "propose_mass_plan",
+        "repo_file_get",
+        "repo_symbols",
+        "repo_tree",
+        "run_subagent",
+        "run_workflow",
+        "runs_get",
+        "runs_list",
+        "ticket_create",
+        "ticket_get",
+        "ticket_list",
+        "ticket_update",
+    }
+)
+
+# Inbox item types whose ``dispose`` is an APPROVAL: committing one
+# from an external agent requires the verbatim echo contract below.
+APPROVAL_ITEM_TYPES: frozenset[str] = frozenset({"approval"})
+
+# Inbox items the MCP edge refuses to dispose at all (web-only,
+# Console typed-slug surface). Matched against ``payload.stakes``.
+WEB_ONLY_STAKES: frozenset[str] = frozenset({"destructive", "web_only"})
+
+
+SERVER_INSTRUCTIONS = """\
+You are connected to Ship — the delivery engine that plans, builds,
+reviews and ships software through the operator's tracker (Linear/…)
+and GitHub. You act under the OPERATOR'S personal access token: every
+mutation is attributed to them, so never fire a mutating tool the
+operator did not explicitly ask for in this conversation
+(verify-before-mutate). Suggest first; call after they confirm.
+
+Workspaces: every tool accepts an optional `workspace_id`. If the
+operator belongs to exactly one workspace it is inferred; otherwise
+call `list_workspaces` and ask which one they mean.
+
+Typical flows:
+- "create a feature / project" → `project_create` (brief as body),
+  then `run_subagent` with kind="decomposition" to have Ship's
+  planner break it into tickets.
+- "what's in flight" → `dashboard_get`, `ticket_list`, `runs_list`.
+- "do ticket X" → `ticket_update` with the target state — the status
+  field is the engine's only transition signal; the FSM takes over
+  from there.
+- "review this PR" → `run_workflow` with workflow_name="pr-review".
+- open questions / approvals → `inbox_list`, then `inbox_get` and
+  `inbox_update`. Disposing an APPROVAL item requires passing
+  `approval_echo` with the item's exact title — quote it to the
+  operator and get a yes before calling. Items Ship marks as
+  destructive cannot be approved here at all; send the operator the
+  `web_url` from the error instead.
+
+Hard rule: you cannot spawn or steer Ship's execution agents
+directly — you create work items and the control plane (leases,
+caps, cascade limits) runs them.
+"""
+
+
+# ---------------------------------------------------------------------------
+# Workspace resolution
+# ---------------------------------------------------------------------------
+
+
+async def _member_workspaces(
+    session: AsyncSession, user_id: uuid.UUID
+) -> list[Workspace]:
+    rows = (
+        await session.execute(
+            select(Workspace)
+            .join(WorkspaceMember, WorkspaceMember.workspace_id == Workspace.id)
+            .where(WorkspaceMember.user_id == user_id)
+            .order_by(Workspace.created_at.asc())
+        )
+    ).scalars().all()
+    return list(rows)
+
+
+class _McpToolError(Exception):
+    """Tool-level failure — surfaced as an MCP tool result with
+    ``isError: true`` (protocol errors use JSON-RPC error objects)."""
+
+
+async def _resolve_workspace_id(
+    session: AsyncSession, auth: AuthContext, arguments: dict[str, Any]
+) -> uuid.UUID:
+    raw = arguments.pop("workspace_id", None)
+    workspaces = await _member_workspaces(session, auth.user.id)
+    if raw:
+        try:
+            ws_id = uuid.UUID(str(raw))
+        except ValueError as exc:
+            raise _McpToolError(f"invalid workspace_id: {raw!r}") from exc
+        if ws_id not in {w.id for w in workspaces}:
+            raise _McpToolError(
+                "you are not a member of that workspace; call "
+                "list_workspaces for the available set"
+            )
+        return ws_id
+    if len(workspaces) == 1:
+        return workspaces[0].id
+    listing = ", ".join(f"{w.slug}={w.id}" for w in workspaces) or "(none)"
+    raise _McpToolError(
+        "workspace_id is required (the token belongs to several "
+        f"workspaces): {listing}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tool registry (single source: ToolBox.specs + a few natives)
+# ---------------------------------------------------------------------------
+
+_WORKSPACE_ID_PROP = {
+    "type": "string",
+    "description": (
+        "Workspace UUID. Optional when the operator belongs to "
+        "exactly one workspace."
+    ),
+}
+
+_NATIVE_TOOLS: list[dict[str, Any]] = [
+    {
+        "name": "list_workspaces",
+        "description": (
+            "List workspaces the operator's token can act in "
+            "(id, slug, name)."
+        ),
+        "inputSchema": {"type": "object", "properties": {}},
+    },
+    {
+        "name": "workspace_create",
+        "description": (
+            "Create a new Ship workspace owned by the operator. "
+            "Second-and-later workspaces in an org can attach the "
+            "existing GitHub App install headlessly via "
+            "github_sibling_installs + github_attach_install; the "
+            "first-ever workspace needs the one-time OAuth dance in "
+            "the browser (the result carries the wiring URL)."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string", "minLength": 1, "maxLength": 120},
+                "slug": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 64,
+                    "description": "URL-safe slug, unique within the org.",
+                },
+            },
+            "required": ["name", "slug"],
+        },
+    },
+    {
+        "name": "github_sibling_installs",
+        "description": (
+            "List GitHub App installations from sibling workspaces the "
+            "operator admins — candidates for headless attach to the "
+            "given workspace."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {"workspace_id": _WORKSPACE_ID_PROP},
+        },
+    },
+    {
+        "name": "github_attach_install",
+        "description": (
+            "Attach an existing GitHub App installation (from a sibling "
+            "workspace) to the given workspace — the headless half of "
+            "workspace wiring."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "workspace_id": _WORKSPACE_ID_PROP,
+                "installation_id": {
+                    "type": "integer",
+                    "description": "GitHub's numeric installation id.",
+                },
+            },
+            "required": ["installation_id"],
+        },
+    },
+]
+
+
+def _projected_tools(settings: Settings) -> list[dict[str, Any]]:
+    """ToolBox.specs() → MCP tool definitions (allowlist + injected
+    workspace_id). The ToolBox instance here is schema-only — no
+    session, never invoked."""
+    from backend.app.services.agent.tools import ToolBox
+
+    schema_box = ToolBox(
+        None,  # type: ignore[arg-type] — specs() never touches the session
+        settings=settings,
+        workspace_id=uuid.uuid4(),
+        user_id=None,
+    )
+    tools: list[dict[str, Any]] = []
+    for spec in schema_box.specs():
+        if spec.name not in MCP_TOOL_ALLOWLIST:
+            continue
+        params = dict(spec.parameters or {"type": "object", "properties": {}})
+        props = dict(params.get("properties") or {})
+        props["workspace_id"] = _WORKSPACE_ID_PROP
+        if spec.name == "inbox_update":
+            props["approval_echo"] = {
+                "type": "string",
+                "description": (
+                    "REQUIRED when disposing an approval-type item: the "
+                    "item's exact title, echoed verbatim. Quote it to "
+                    "the operator and get an explicit yes first."
+                ),
+            }
+        params["properties"] = props
+        tools.append(
+            {
+                "name": spec.name,
+                "description": spec.description,
+                "inputSchema": params,
+            }
+        )
+    tools.extend(_NATIVE_TOOLS)
+    return tools
+
+
+# ---------------------------------------------------------------------------
+# Stakes gate (ELS-273) — runs BEFORE dispatch
+# ---------------------------------------------------------------------------
+
+
+async def _stakes_gate(
+    session: AsyncSession,
+    settings: Settings,
+    workspace_id: uuid.UUID,
+    name: str,
+    arguments: dict[str, Any],
+) -> None:
+    if name != "inbox_update":
+        return
+    if arguments.get("action") != "dispose":
+        return
+    raw_id = arguments.get("item_id") or arguments.get("id")
+    if not raw_id:
+        return  # the handler will reject the malformed call itself
+    try:
+        item = await session.get(InboxItem, uuid.UUID(str(raw_id)))
+    except ValueError:
+        return
+    if item is None or item.workspace_id != workspace_id:
+        return
+    stakes = str((item.payload or {}).get("stakes") or "").lower()
+    if stakes in WEB_ONLY_STAKES:
+        web_url = (
+            f"{settings.console_url.rstrip('/')}/inbox"
+            f"?ws={workspace_id}&selected={item.id}"
+        )
+        raise _McpToolError(
+            "this item is marked destructive and cannot be approved "
+            f"over MCP — the operator must act in the Console: {web_url}"
+        )
+    if item.type in APPROVAL_ITEM_TYPES:
+        echo = str(arguments.pop("approval_echo", "") or "").strip()
+        if echo != (item.title or "").strip():
+            raise _McpToolError(
+                "approval items require approval_echo matching the "
+                f"item title verbatim. Title: {item.title!r}. Quote it "
+                "to the operator and retry only after an explicit yes."
+            )
+    arguments.pop("approval_echo", None)
+
+
+# ---------------------------------------------------------------------------
+# Native tool handlers
+# ---------------------------------------------------------------------------
+
+
+async def _call_native(
+    name: str,
+    arguments: dict[str, Any],
+    *,
+    session: AsyncSession,
+    auth: AuthContext,
+    settings: Settings,
+) -> str:
+    import json
+
+    if name == "list_workspaces":
+        rows = await _member_workspaces(session, auth.user.id)
+        return json.dumps(
+            [{"id": str(w.id), "slug": w.slug, "name": w.name} for w in rows]
+        )
+
+    if name == "workspace_create":
+        from backend.app.api.v1.routes.workspaces import create_workspace
+        from backend.app.api.v1.schemas import WorkspaceCreate
+
+        payload = WorkspaceCreate(
+            name=str(arguments.get("name") or "").strip(),
+            slug=str(arguments.get("slug") or "").strip(),
+        )
+        out = await create_workspace(payload, auth=auth, session=session)
+        wiring = (
+            f"{settings.console_url.rstrip('/')}/onboarding"
+            f"?step=github&ws={out.id}"
+        )
+        return json.dumps(
+            {
+                "id": str(out.id),
+                "slug": out.slug,
+                "name": out.name,
+                "next": (
+                    "attach GitHub via github_sibling_installs + "
+                    "github_attach_install (same org), or the one-time "
+                    f"browser wiring: {wiring}"
+                ),
+            }
+        )
+
+    if name == "github_sibling_installs":
+        from backend.app.api.v1.routes.github_app import (
+            _list_linkable_install_candidates,
+        )
+
+        ws_id = await _resolve_workspace_id(session, auth, arguments)
+        candidates = await _list_linkable_install_candidates(
+            session, workspace_id=ws_id, user_id=auth.user.id
+        )
+        return json.dumps(
+            [
+                {
+                    "installation_id": c.installation_id,
+                    "account_login": c.account_login,
+                    "from_workspace": c.source_workspace_slug,
+                }
+                for c in candidates
+            ]
+        )
+
+    if name == "github_attach_install":
+        from backend.app.api.v1.routes.github_app import (
+            _link_installation_from_sibling,
+        )
+
+        ws_id = await _resolve_workspace_id(session, auth, arguments)
+        installation_id = arguments.get("installation_id")
+        if not isinstance(installation_id, int):
+            raise _McpToolError("installation_id (integer) is required")
+        row = await _link_installation_from_sibling(
+            session,
+            workspace_id=ws_id,
+            user_id=auth.user.id,
+            installation_id=installation_id,
+        )
+        return json.dumps(
+            {
+                "attached": True,
+                "installation_id": row.installation_id,
+                "account_login": row.account_login,
+            }
+        )
+
+    raise _McpToolError(f"unknown tool: {name}")
+
+
+_NATIVE_NAMES = {t["name"] for t in _NATIVE_TOOLS}
+
+
+async def _call_tool(
+    name: str,
+    arguments: dict[str, Any],
+    *,
+    session: AsyncSession,
+    auth: AuthContext,
+    settings: Settings,
+) -> str:
+    if name in _NATIVE_NAMES:
+        return await _call_native(
+            name, arguments, session=session, auth=auth, settings=settings
+        )
+    if name not in MCP_TOOL_ALLOWLIST:
+        raise _McpToolError(f"unknown tool: {name}")
+
+    from backend.app.services.agent.tools import ToolBox
+
+    ws_id = await _resolve_workspace_id(session, auth, arguments)
+    await _stakes_gate(session, settings, ws_id, name, arguments)
+    toolbox = ToolBox(
+        session,
+        settings=settings,
+        workspace_id=ws_id,
+        user_id=auth.user.id,
+    )
+    return await toolbox.invoke(name, arguments)
+
+
+# ---------------------------------------------------------------------------
+# JSON-RPC endpoint (stateless streamable HTTP)
+# ---------------------------------------------------------------------------
+
+
+def _rpc_result(req_id: Any, result: dict[str, Any]) -> JSONResponse:
+    return JSONResponse({"jsonrpc": "2.0", "id": req_id, "result": result})
+
+
+def _rpc_error(req_id: Any, code: int, message: str) -> JSONResponse:
+    return JSONResponse(
+        {
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "error": {"code": code, "message": message},
+        }
+    )
+
+
+@router.post("/mcp")
+async def mcp_endpoint(
+    request: Request,
+    auth: AuthContext = Depends(get_current_auth),
+    session: AsyncSession = Depends(get_session),
+    settings: Settings = Depends(get_settings),
+) -> Response:
+    try:
+        body = await request.json()
+    except Exception:  # noqa: BLE001
+        return _rpc_error(None, -32700, "parse error")
+    if not isinstance(body, dict):
+        return _rpc_error(None, -32600, "batch requests are not supported")
+
+    method = body.get("method")
+    req_id = body.get("id")
+    params = body.get("params") or {}
+
+    # Notifications (no id) — acknowledge and move on.
+    if req_id is None:
+        return Response(status_code=202)
+
+    if method == "initialize":
+        client_version = str(params.get("protocolVersion") or PROTOCOL_VERSION)
+        return _rpc_result(
+            req_id,
+            {
+                "protocolVersion": client_version,
+                "capabilities": {"tools": {}},
+                "serverInfo": {"name": "ship", "version": "1.0.0"},
+                "instructions": SERVER_INSTRUCTIONS,
+            },
+        )
+
+    if method == "ping":
+        return _rpc_result(req_id, {})
+
+    if method == "tools/list":
+        return _rpc_result(req_id, {"tools": _projected_tools(settings)})
+
+    if method == "tools/call":
+        name = str(params.get("name") or "")
+        arguments = params.get("arguments")
+        arguments = dict(arguments) if isinstance(arguments, dict) else {}
+        try:
+            text = await _call_tool(
+                name, arguments, session=session, auth=auth, settings=settings
+            )
+            await session.commit()
+            return _rpc_result(
+                req_id,
+                {"content": [{"type": "text", "text": text}], "isError": False},
+            )
+        except _McpToolError as exc:
+            await session.rollback()
+            return _rpc_result(
+                req_id,
+                {
+                    "content": [{"type": "text", "text": str(exc)}],
+                    "isError": True,
+                },
+            )
+        except Exception as exc:  # noqa: BLE001 — tool failures are results, not 500s
+            await session.rollback()
+            logger.warning("mcp tool %s failed: %s", name, exc)
+            return _rpc_result(
+                req_id,
+                {
+                    "content": [
+                        {"type": "text", "text": f"tool failed: {exc}"}
+                    ],
+                    "isError": True,
+                },
+            )
+
+    return _rpc_error(req_id, -32601, f"method not found: {method}")
+
+
+@router.get("/mcp")
+async def mcp_get() -> Response:
+    # Stateless mode: no server-initiated SSE stream. 405 tells the
+    # client to keep using plain POST per the streamable HTTP spec.
+    return Response(status_code=405)

--- a/apps/backend/app/main.py
+++ b/apps/backend/app/main.py
@@ -259,6 +259,13 @@ async def _surface_uncaught_exceptions(request, exc):  # type: ignore[no-untyped
 
 app.include_router(v1_api_router)
 
+# Ship MCP Edge (thesis 9): the engine as an MCP server at /mcp —
+# bearer PAT auth, stateless streamable HTTP. Mounted at the app root
+# (not under /v1) so client configs read https://api.../mcp.
+from backend.app.api.v1.routes.mcp import router as mcp_router  # noqa: E402
+
+app.include_router(mcp_router)
+
 
 @app.get("/healthz", tags=["meta"], include_in_schema=False)
 async def healthz() -> dict[str, str]:

--- a/apps/backend/tests/test_mcp_edge.py
+++ b/apps/backend/tests/test_mcp_edge.py
@@ -1,0 +1,283 @@
+"""Ship MCP Edge (thesis 9) — protocol + policy tests.
+
+JSON-RPC over POST /mcp with bearer-PAT auth. Pins:
+
+- initialize returns instructions + tools capability;
+- tools/list = ToolBox allowlist projection (workspace_id injected,
+  web_fetch/recall excluded) + the native workspace/github tools;
+- tools/call dispatches into the existing handlers and commits;
+- auth is mandatory (401 without a PAT);
+- stakes gate: approval items demand a verbatim approval_echo,
+  destructive-marked items are web-only with a Console deep-link;
+- workspace_create works end-to-end over MCP.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+
+import pytest
+
+from backend.app.db.models.inbox import InboxItem
+from backend.app.api.v1.routes.mcp import MCP_TOOL_ALLOWLIST
+
+
+def _rpc(method: str, params: dict | None = None, req_id: int = 1) -> dict:
+    return {"jsonrpc": "2.0", "id": req_id, "method": method, "params": params or {}}
+
+
+async def _post(client, raw_pat: str, payload: dict):
+    return await client.post(
+        "/mcp",
+        headers={"Authorization": f"Bearer {raw_pat}"},
+        json=payload,
+    )
+
+
+@pytest.mark.asyncio
+async def test_mcp_requires_auth(v1_client) -> None:
+    res = await v1_client.post("/mcp", json=_rpc("initialize"))
+    assert res.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_initialize_carries_instructions(
+    db_session, v1_client, seed_workspace
+) -> None:
+    _, raw, _ = seed_workspace
+    res = await _post(v1_client, raw, _rpc("initialize", {"protocolVersion": "2025-03-26"}))
+    assert res.status_code == 200
+    result = res.json()["result"]
+    assert result["serverInfo"]["name"] == "ship"
+    assert "verify-before-mutate" in result["instructions"]
+    assert result["capabilities"]["tools"] == {}
+
+
+@pytest.mark.asyncio
+async def test_tools_list_projection_and_natives(
+    db_session, v1_client, seed_workspace
+) -> None:
+    _, raw, _ = seed_workspace
+    res = await _post(v1_client, raw, _rpc("tools/list"))
+    tools = {t["name"]: t for t in res.json()["result"]["tools"]}
+    # Allowlist projected, exclusions held.
+    assert MCP_TOOL_ALLOWLIST <= set(tools)
+    assert "web_fetch" not in tools
+    assert "recall" not in tools
+    # Natives present.
+    for native in (
+        "list_workspaces",
+        "workspace_create",
+        "github_sibling_installs",
+        "github_attach_install",
+    ):
+        assert native in tools
+    # workspace_id injected into projected tools.
+    assert "workspace_id" in tools["dashboard_get"]["inputSchema"]["properties"]
+    # approval_echo contract surfaced on inbox_update.
+    assert "approval_echo" in tools["inbox_update"]["inputSchema"]["properties"]
+
+
+@pytest.mark.asyncio
+async def test_tools_call_dispatches_toolbox(
+    db_session, v1_client, seed_workspace
+) -> None:
+    _, raw, workspace = seed_workspace
+    res = await _post(
+        v1_client,
+        raw,
+        _rpc("tools/call", {"name": "inbox_list", "arguments": {}}),
+    )
+    result = res.json()["result"]
+    assert result["isError"] is False
+    assert result["content"][0]["type"] == "text"
+
+
+@pytest.mark.asyncio
+async def test_unknown_method_is_rpc_error(
+    db_session, v1_client, seed_workspace
+) -> None:
+    _, raw, _ = seed_workspace
+    res = await _post(v1_client, raw, _rpc("resources/list"))
+    assert res.json()["error"]["code"] == -32601
+
+
+@pytest.mark.asyncio
+async def test_notification_acknowledged(
+    db_session, v1_client, seed_workspace
+) -> None:
+    _, raw, _ = seed_workspace
+    res = await _post(
+        v1_client,
+        raw,
+        {"jsonrpc": "2.0", "method": "notifications/initialized"},
+    )
+    assert res.status_code == 202
+
+
+@pytest.mark.asyncio
+async def test_approval_without_echo_refused(
+    db_session, v1_client, seed_workspace
+) -> None:
+    """Missing/wrong echo → refused with the title quoted back.
+
+    (The refusal path rolls the request back, which in this shared-
+    transaction test harness discards the seeds — so the happy path
+    lives in its own test below.)"""
+    _, raw, workspace = seed_workspace
+    item = InboxItem(
+        workspace_id=workspace.id,
+        type="approval",
+        status="new",
+        title="Approve deploy of api to prod",
+        summary="s",
+    )
+    db_session.add(item)
+    await db_session.flush()
+
+    res = await _post(
+        v1_client,
+        raw,
+        _rpc(
+            "tools/call",
+            {
+                "name": "inbox_update",
+                "arguments": {
+                    "item_id": str(item.id),
+                    "action": "dispose",
+                    "resolution": "approved",
+                },
+            },
+        ),
+    )
+    result = res.json()["result"]
+    assert result["isError"] is True
+    assert "Approve deploy of api to prod" in result["content"][0]["text"]
+
+
+@pytest.mark.asyncio
+async def test_approval_with_exact_echo_passes_gate(
+    db_session, v1_client, seed_workspace
+) -> None:
+    _, raw, workspace = seed_workspace
+    item = InboxItem(
+        workspace_id=workspace.id,
+        type="approval",
+        status="new",
+        title="Approve deploy of api to prod",
+        summary="s",
+    )
+    db_session.add(item)
+    await db_session.flush()
+
+    res = await _post(
+        v1_client,
+        raw,
+        _rpc(
+            "tools/call",
+            {
+                "name": "inbox_update",
+                "arguments": {
+                    "item_id": str(item.id),
+                    "action": "dispose",
+                    "resolution": "approved",
+                    "approval_echo": "Approve deploy of api to prod",
+                },
+            },
+        ),
+    )
+    result = res.json()["result"]
+    # The gate passed — whatever the handler said, it is NOT the echo
+    # refusal (which quotes the title).
+    if result["isError"]:
+        assert "approval_echo" not in result["content"][0]["text"]
+
+
+@pytest.mark.asyncio
+async def test_destructive_items_are_web_only(
+    db_session, v1_client, seed_workspace
+) -> None:
+    _, raw, workspace = seed_workspace
+    item = InboxItem(
+        workspace_id=workspace.id,
+        type="approval",
+        status="new",
+        title="Delete repository acme/legacy",
+        summary="s",
+        payload={"stakes": "destructive"},
+    )
+    db_session.add(item)
+    await db_session.flush()
+
+    res = await _post(
+        v1_client,
+        raw,
+        _rpc(
+            "tools/call",
+            {
+                "name": "inbox_update",
+                "arguments": {
+                    "item_id": str(item.id),
+                    "action": "dispose",
+                    "resolution": "approved",
+                    "approval_echo": "Delete repository acme/legacy",
+                },
+            },
+        ),
+    )
+    result = res.json()["result"]
+    assert result["isError"] is True
+    assert "/inbox?ws=" in result["content"][0]["text"]
+
+
+@pytest.mark.asyncio
+async def test_workspace_create_over_mcp(
+    db_session, v1_client, seed_workspace
+) -> None:
+    _, raw, _ = seed_workspace
+    slug = f"mcp-{uuid.uuid4().hex[:8]}"
+    res = await _post(
+        v1_client,
+        raw,
+        _rpc(
+            "tools/call",
+            {
+                "name": "workspace_create",
+                "arguments": {"name": "MCP made me", "slug": slug},
+            },
+        ),
+    )
+    result = res.json()["result"]
+    assert result["isError"] is False, result
+    body = json.loads(result["content"][0]["text"])
+    assert body["slug"] == slug
+    assert "onboarding" in body["next"]
+
+    # And the new workspace shows up in list_workspaces.
+    res2 = await _post(
+        v1_client, raw, _rpc("tools/call", {"name": "list_workspaces", "arguments": {}})
+    )
+    listing = json.loads(res2.json()["result"]["content"][0]["text"])
+    assert any(w["slug"] == slug for w in listing)
+
+
+@pytest.mark.asyncio
+async def test_foreign_workspace_refused(
+    db_session, v1_client, seed_workspace
+) -> None:
+    _, raw, _ = seed_workspace
+    res = await _post(
+        v1_client,
+        raw,
+        _rpc(
+            "tools/call",
+            {
+                "name": "dashboard_get",
+                "arguments": {"workspace_id": str(uuid.uuid4())},
+            },
+        ),
+    )
+    result = res.json()["result"]
+    assert result["isError"] is True
+    assert "not a member" in result["content"][0]["text"]


### PR DESCRIPTION
## Summary
Thesis 9 MVP: attach Ship to the agent you already live in — that agent becomes the brain, Ship stays the control plane.

- **POST /mcp** — hand-rolled streamable-HTTP JSON-RPC subset (initialize/tools-list/tools-call/ping, stateless), bearer **personal PAT** → standard AuthContext. Inversion trap stays closed: operator identity only.
- **One registry**: 28 ToolBox tools projected through an allowlist (web_fetch excluded — SSRF surface; recall/* excluded — Navigator-thread-only) + 4 natives: `list_workspaces`, `workspace_create` (returns the one-time browser wiring link), `github_sibling_installs`/`github_attach_install` (org's 2nd+ workspace wires fully headless). `workspace_id` injected into every tool, inferred for single-workspace tokens.
- **Stakes policy server-side at ingress** (ELS-273): approval-type inbox disposes demand `approval_echo` matching the item title verbatim (refusal quotes the title → the agent must surface it to the human); `payload.stakes=destructive` items are refused with a Console deep-link — typed-slug surfaces stay web-only.
- **In-protocol instructions** (ELS-275): verify-before-mutate etiquette, flows, the no-execution-agents hard rule.

## Test plan
- [x] 11 protocol/policy tests (auth 401, initialize+instructions, projection+exclusions+echo schema, dispatch, notifications 202, echo refusal/pass, destructive web-only deep-link, workspace_create e2e, foreign-workspace refusal)
- [x] Live local smoke: initialize, 33 tools, list_workspaces, scoped ticket_list
- [ ] CI green → prod attach: `claude mcp add ship https://api.ship.elmundi.com/mcp -t http -H "Authorization: Bearer <PAT>"`

Closes ELS-268, ELS-269, ELS-272, ELS-273, ELS-274, ELS-275