### PR TITLE
fix(mcp): stakes gate keyed on wrong arg name — approval echo + destructive web-only were bypassed for real MCP calls

### DIFF
--- a/apps/backend/app/api/v1/routes/mcp.py
+++ b/apps/backend/app/api/v1/routes/mcp.py
@@ -324,7 +324,14 @@ async def _stakes_gate(
         return
     if arguments.get("action") != "dispose":
         return
-    raw_id = arguments.get("item_id") or arguments.get("id")
+    # ``inbox_item_id`` is the ToolSpec contract (what real MCP clients
+    # send — see _tool_inbox_dispose); the aliases are paranoia so a
+    # creative client can't sidestep the gate by renaming the key.
+    raw_id = (
+        arguments.get("inbox_item_id")
+        or arguments.get("item_id")
+        or arguments.get("id")
+    )
     if not raw_id:
         return  # the handler will reject the malformed call itself
     try:

--- a/apps/backend/tests/test_mcp_edge.py
+++ b/apps/backend/tests/test_mcp_edge.py
@@ -117,6 +117,23 @@ async def test_notification_acknowledged(
 
 
 @pytest.mark.asyncio
+async def test_inbox_update_spec_param_matches_gate_contract(
+    db_session, v1_client, seed_workspace
+) -> None:
+    """The stakes gate keys on ``inbox_item_id`` — pin that the
+    published inputSchema requires exactly that name, so the spec and
+    the gate can't drift apart silently again (the original gate read
+    ``item_id`` and no-opped on every real call)."""
+    _, raw, _ = seed_workspace
+    res = await _post(v1_client, raw, _rpc("tools/list"))
+    tools = {t["name"]: t for t in res.json()["result"]["tools"]}
+    schema = tools["inbox_update"]["inputSchema"]
+    assert "inbox_item_id" in schema["properties"]
+    assert "inbox_item_id" in schema.get("required", [])
+    assert "item_id" not in schema["properties"]
+
+
+@pytest.mark.asyncio
 async def test_approval_without_echo_refused(
     db_session, v1_client, seed_workspace
 ) -> None:
@@ -143,10 +160,15 @@ async def test_approval_without_echo_refused(
             "tools/call",
             {
                 "name": "inbox_update",
+                # The REAL ToolSpec contract: ``inbox_item_id`` +
+                # ``disposition``. The gate originally keyed on
+                # ``item_id`` and silently no-opped for genuine MCP
+                # calls (caught live 2026-06-13) — these tests must
+                # speak the same dialect as real clients.
                 "arguments": {
-                    "item_id": str(item.id),
+                    "inbox_item_id": str(item.id),
                     "action": "dispose",
-                    "resolution": "approved",
+                    "disposition": "approve",
                 },
             },
         ),
@@ -179,9 +201,9 @@ async def test_approval_with_exact_echo_passes_gate(
             {
                 "name": "inbox_update",
                 "arguments": {
-                    "item_id": str(item.id),
+                    "inbox_item_id": str(item.id),
                     "action": "dispose",
-                    "resolution": "approved",
+                    "disposition": "approve",
                     "approval_echo": "Approve deploy of api to prod",
                 },
             },
@@ -218,9 +240,9 @@ async def test_destructive_items_are_web_only(
             {
                 "name": "inbox_update",
                 "arguments": {
-                    "item_id": str(item.id),
+                    "inbox_item_id": str(item.id),
                     "action": "dispose",
-                    "resolution": "approved",
+                    "disposition": "approve",
                     "approval_echo": "Delete repository acme/legacy",
                 },
             },


### PR DESCRIPTION
The gate read arguments['item_id'] while the inbox_update ToolSpec
contract (and the underlying _tool_inbox_dispose handler) use
'inbox_item_id' — so for every genuine MCP client call the gate
silently no-opped: approvals disposed without the verbatim echo and
destructive-marked items were approvable over MCP. Caught live during
the post-#382 smoke pass.

- _stakes_gate now resolves inbox_item_id first (item_id/id kept as
  paranoia aliases).
- Gate tests rewritten to speak the real tool dialect
  (inbox_item_id + disposition) — they previously passed precisely
  because they used the same wrong key as the gate.
- New pin: the published inputSchema must require inbox_item_id, so
  spec and gate can't drift apart unnoticed.
