### PR TITLE
feat(mcp): OAuth broker — attach the MCP edge with add → log in → grant (ELS-296)

### DIFF
--- a/apps/backend/app/api/v1/routes/mcp.py
+++ b/apps/backend/app/api/v1/routes/mcp.py
@@ -36,7 +36,7 @@ import logging
 import uuid
 from typing import Any
 
-from fastapi import APIRouter, Depends, Request, Response
+from fastapi import APIRouter, Depends, Header, HTTPException, Request, Response, status
 from fastapi.responses import JSONResponse
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -507,10 +507,37 @@ def _rpc_error(req_id: Any, code: int, message: str) -> JSONResponse:
     )
 
 
+async def get_mcp_auth(
+    authorization: str | None = Header(default=None, alias="Authorization"),
+    settings: Settings = Depends(get_settings),
+    session: AsyncSession = Depends(get_session),
+) -> AuthContext:
+    """Same bearer resolution as the rest of the API, but a 401 carries
+    the OAuth ``resource_metadata`` hint (RFC 9728 §5.1) so an MCP
+    client (Claude Code/Desktop) knows where to start the
+    add → log in → grant flow instead of demanding a pasted token."""
+    try:
+        return await get_current_auth(
+            authorization=authorization, settings=settings, session=session
+        )
+    except HTTPException as exc:
+        if exc.status_code == status.HTTP_401_UNAUTHORIZED:
+            meta = (
+                f"{settings.public_url.rstrip('/')}"
+                "/.well-known/oauth-protected-resource"
+            )
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail=exc.detail,
+                headers={"WWW-Authenticate": f'Bearer resource_metadata="{meta}"'},
+            ) from exc
+        raise
+
+
 @router.post("/mcp")
 async def mcp_endpoint(
     request: Request,
-    auth: AuthContext = Depends(get_current_auth),
+    auth: AuthContext = Depends(get_mcp_auth),
     session: AsyncSession = Depends(get_session),
     settings: Settings = Depends(get_settings),
 ) -> Response:

--- a/apps/backend/app/api/v1/routes/oauth.py
+++ b/apps/backend/app/api/v1/routes/oauth.py
@@ -1,0 +1,391 @@
+"""MCP OAuth broker — Ship as the OAuth 2.1 authorization server (ELS-296).
+
+Lets a business operator attach the MCP edge with *add → log in → grant
+→ done* instead of pasting a PAT. Ship is the authorization server; the
+human login + consent is delegated to the console (which already owns
+the Auth0 session + workspace context). The issued access token is a
+short-lived workspace-scoped ``ship_pat_`` — so the existing
+``_resolve_pat`` path validates it unchanged.
+
+Surface split:
+
+- **Machine-facing (here, app root):** discovery metadata, Dynamic
+  Client Registration (``POST /oauth/register``), the token endpoint
+  (``POST /oauth/token`` — public client + PKCE), and the
+  session-authed grant endpoint the console calls after consent.
+- **Human-facing (console):** ``GET /oauth/authorize`` renders the
+  consent screen; an unauthenticated operator hits the normal console
+  login first. On approve it POSTs to ``/oauth/authorize/grant`` with
+  the session token and 302s the browser back to the client's
+  ``redirect_uri`` with the code.
+
+Flow: client DCR → console consent (login if needed) → grant mints a
+single-use PKCE-bound code → ``/oauth/token`` exchanges code+verifier
+for the scoped PAT.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import secrets
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from urllib.parse import urlencode, urlsplit
+
+from fastapi import APIRouter, Depends, Form, HTTPException, Request, status
+from fastapi.responses import JSONResponse
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.app.api.v1.deps import AuthContext, get_current_auth
+from backend.app.core.config import Settings, get_settings
+from backend.app.db.models import McpOAuthClient, McpOAuthCode
+from backend.app.db.models.tenancy import ApiToken, AuditLog, WorkspaceMember
+from backend.app.db.session import get_session
+from backend.app.security.tokens import PAT_PREFIX, generate_pat, hash_pat
+
+router = APIRouter(tags=["mcp-oauth"])
+
+# The MCP resource the issued tokens are scoped to (the audience the
+# client requests). Kept as the canonical /mcp URL.
+MCP_SCOPE = "mcp"
+CODE_TTL = timedelta(minutes=10)
+# Access-token lifetime. MCP clients re-run the (one-click) consent when
+# this lapses; no refresh token in the MVP — a follow-up can add the
+# refresh grant if re-consent friction shows up.
+ACCESS_TOKEN_TTL_DAYS = 90
+
+
+def _base(settings: Settings) -> str:
+    return settings.public_url.rstrip("/")
+
+
+def _resource(settings: Settings) -> str:
+    return f"{_base(settings)}/mcp"
+
+
+def _b64url_sha256(value: str) -> str:
+    digest = hashlib.sha256(value.encode("ascii")).digest()
+    return base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+
+
+def _loopback(uri: str) -> bool:
+    host = (urlsplit(uri).hostname or "").lower()
+    return host in ("127.0.0.1", "localhost", "::1")
+
+
+def _redirect_uri_allowed(registered: list[str], requested: str) -> bool:
+    """Exact match, except loopback URIs match port-insensitively
+    (RFC 8252 §7.3 — native apps bind an ephemeral localhost port)."""
+    if requested in registered:
+        return True
+    if not _loopback(requested):
+        return False
+    req = urlsplit(requested)
+    for reg in registered:
+        if not _loopback(reg):
+            continue
+        r = urlsplit(reg)
+        if (r.scheme, r.hostname, r.path) == (req.scheme, req.hostname, req.path):
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Discovery (RFC 9728 + RFC 8414)
+# ---------------------------------------------------------------------------
+
+
+def _protected_resource_metadata(settings: Settings) -> dict[str, Any]:
+    return {
+        "resource": _resource(settings),
+        "authorization_servers": [_base(settings)],
+        "bearer_methods_supported": ["header"],
+        "scopes_supported": [MCP_SCOPE],
+        "resource_documentation": f"{_base(settings)}/mcp",
+    }
+
+
+@router.get("/.well-known/oauth-protected-resource")
+async def protected_resource_metadata(
+    settings: Settings = Depends(get_settings),
+) -> JSONResponse:
+    return JSONResponse(_protected_resource_metadata(settings))
+
+
+@router.get("/.well-known/oauth-protected-resource/mcp")
+async def protected_resource_metadata_mcp(
+    settings: Settings = Depends(get_settings),
+) -> JSONResponse:
+    # MCP clients may probe the path-suffixed variant per RFC 9728 §3.1.
+    return JSONResponse(_protected_resource_metadata(settings))
+
+
+@router.get("/.well-known/oauth-authorization-server")
+async def authorization_server_metadata(
+    settings: Settings = Depends(get_settings),
+) -> JSONResponse:
+    base = _base(settings)
+    console = settings.console_url.rstrip("/")
+    return JSONResponse(
+        {
+            "issuer": base,
+            # Human-facing consent lives in the console; token + DCR are
+            # machine-facing on the API.
+            "authorization_endpoint": f"{console}/oauth/authorize",
+            "token_endpoint": f"{base}/oauth/token",
+            "registration_endpoint": f"{base}/oauth/register",
+            "response_types_supported": ["code"],
+            "grant_types_supported": ["authorization_code"],
+            "code_challenge_methods_supported": ["S256"],
+            "token_endpoint_auth_methods_supported": ["none"],
+            "scopes_supported": [MCP_SCOPE],
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Dynamic Client Registration (RFC 7591)
+# ---------------------------------------------------------------------------
+
+
+@router.post("/oauth/register", status_code=status.HTTP_201_CREATED)
+async def register_client(
+    request: Request,
+    session: AsyncSession = Depends(get_session),
+) -> JSONResponse:
+    try:
+        body = await request.json()
+    except Exception:  # noqa: BLE001
+        raise HTTPException(status_code=400, detail="invalid_client_metadata")
+    if not isinstance(body, dict):
+        raise HTTPException(status_code=400, detail="invalid_client_metadata")
+
+    redirect_uris = body.get("redirect_uris")
+    if (
+        not isinstance(redirect_uris, list)
+        or not redirect_uris
+        or not all(isinstance(u, str) and u for u in redirect_uris)
+    ):
+        raise HTTPException(
+            status_code=400, detail="invalid_redirect_uri"
+        )
+
+    client_id = f"mcp_{secrets.token_urlsafe(18)}"
+    client = McpOAuthClient(
+        client_id=client_id,
+        client_name=str(body.get("client_name") or "")[:200] or None,
+        redirect_uris=redirect_uris,
+        grant_types=["authorization_code"],
+        token_endpoint_auth_method="none",
+    )
+    session.add(client)
+    await session.commit()
+
+    return JSONResponse(
+        status_code=status.HTTP_201_CREATED,
+        content={
+            "client_id": client_id,
+            "client_id_issued_at": int(datetime.now(timezone.utc).timestamp()),
+            "client_name": client.client_name,
+            "redirect_uris": redirect_uris,
+            "grant_types": ["authorization_code"],
+            "response_types": ["code"],
+            "token_endpoint_auth_method": "none",
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Console-facing helpers: describe a client + mint a code after consent
+# ---------------------------------------------------------------------------
+
+
+@router.get("/oauth/clients/{client_id}")
+async def describe_client(
+    client_id: str,
+    auth: AuthContext = Depends(get_current_auth),
+    session: AsyncSession = Depends(get_session),
+) -> JSONResponse:
+    """Public client metadata for the console consent screen. Session-
+    authed so anonymous callers can't enumerate the client table."""
+    client = await session.get(McpOAuthClient, client_id)
+    if client is None:
+        raise HTTPException(status_code=404, detail="unknown_client")
+    return JSONResponse(
+        {
+            "client_id": client.client_id,
+            "client_name": client.client_name,
+            "redirect_uris": client.redirect_uris,
+        }
+    )
+
+
+@router.post("/oauth/authorize/grant")
+async def authorize_grant(
+    request: Request,
+    auth: AuthContext = Depends(get_current_auth),
+    session: AsyncSession = Depends(get_session),
+) -> JSONResponse:
+    """Operator approved the consent screen (console, under their
+    session). Validate the request, mint a single-use PKCE-bound code,
+    and return the redirect URL the console should 302 the browser to.
+
+    Body: ``{client_id, redirect_uri, code_challenge,
+    code_challenge_method, state, scope, workspace_id}``.
+    """
+    try:
+        body = await request.json()
+    except Exception:  # noqa: BLE001
+        raise HTTPException(status_code=400, detail="invalid_request")
+
+    client_id = str(body.get("client_id") or "").strip()
+    redirect_uri = str(body.get("redirect_uri") or "").strip()
+    code_challenge = str(body.get("code_challenge") or "").strip()
+    method = str(body.get("code_challenge_method") or "S256").strip()
+    state = body.get("state")
+    workspace_raw = str(body.get("workspace_id") or "").strip()
+
+    client = await session.get(McpOAuthClient, client_id)
+    if client is None:
+        raise HTTPException(status_code=400, detail="unknown_client")
+    if not _redirect_uri_allowed(client.redirect_uris, redirect_uri):
+        raise HTTPException(status_code=400, detail="invalid_redirect_uri")
+    if method != "S256" or not code_challenge:
+        # PKCE S256 is mandatory — refuse plain/missing challenges.
+        raise HTTPException(status_code=400, detail="invalid_request")
+
+    # Resolve the workspace the token will be scoped to and assert
+    # membership. ``workspace_id`` is required — the token is always
+    # workspace-scoped so the operator's grant is explicit.
+    if not workspace_raw:
+        raise HTTPException(status_code=400, detail="workspace_required")
+    try:
+        workspace_id = uuid.UUID(workspace_raw)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="workspace_required")
+    member = (
+        await session.execute(
+            select(WorkspaceMember).where(
+                WorkspaceMember.workspace_id == workspace_id,
+                WorkspaceMember.user_id == auth.user.id,
+            )
+        )
+    ).scalar_one_or_none()
+    if member is None:
+        raise HTTPException(status_code=403, detail="not_a_member")
+
+    raw_code = secrets.token_urlsafe(32)
+    session.add(
+        McpOAuthCode(
+            code_hash=hash_pat(raw_code),
+            client_id=client_id,
+            redirect_uri=redirect_uri,
+            code_challenge=code_challenge,
+            code_challenge_method="S256",
+            user_id=auth.user.id,
+            workspace_id=workspace_id,
+            scopes=[MCP_SCOPE],
+            expires_at=datetime.now(timezone.utc) + CODE_TTL,
+        )
+    )
+    session.add(
+        AuditLog(
+            workspace_id=workspace_id,
+            actor_user_id=auth.user.id,
+            action="mcp_oauth.authorize.grant",
+            target_kind="mcp_oauth_client",
+            target_id=client_id,
+            payload={"redirect_uri": redirect_uri},
+        )
+    )
+    await session.commit()
+
+    params = {"code": raw_code}
+    if isinstance(state, str) and state:
+        params["state"] = state
+    sep = "&" if "?" in redirect_uri else "?"
+    return JSONResponse({"redirect_to": f"{redirect_uri}{sep}{urlencode(params)}"})
+
+
+# ---------------------------------------------------------------------------
+# Token endpoint (public client + PKCE; OAuth 2.1 code grant)
+# ---------------------------------------------------------------------------
+
+
+def _token_error(code: str, status_code: int = 400) -> JSONResponse:
+    return JSONResponse(status_code=status_code, content={"error": code})
+
+
+@router.post("/oauth/token")
+async def token(
+    grant_type: str = Form(...),
+    code: str | None = Form(default=None),
+    code_verifier: str | None = Form(default=None),
+    client_id: str | None = Form(default=None),
+    redirect_uri: str | None = Form(default=None),
+    session: AsyncSession = Depends(get_session),
+) -> JSONResponse:
+    if grant_type != "authorization_code":
+        return _token_error("unsupported_grant_type")
+    if not code or not code_verifier or not client_id or not redirect_uri:
+        return _token_error("invalid_request")
+
+    row = (
+        await session.execute(
+            select(McpOAuthCode).where(McpOAuthCode.code_hash == hash_pat(code))
+        )
+    ).scalar_one_or_none()
+    if row is None:
+        return _token_error("invalid_grant")
+    # Single-use + binding checks. A replayed or cross-client/redirect
+    # code is refused.
+    now = datetime.now(timezone.utc)
+    if (
+        row.consumed_at is not None
+        or row.expires_at <= now
+        or row.client_id != client_id
+        or row.redirect_uri != redirect_uri
+    ):
+        return _token_error("invalid_grant")
+    # PKCE: the verifier must hash to the stored challenge.
+    if _b64url_sha256(code_verifier) != row.code_challenge:
+        return _token_error("invalid_grant")
+
+    # Burn the code, mint the access token = a short-lived
+    # workspace-scoped PAT (validated by the existing _resolve_pat path).
+    row.consumed_at = now
+    raw_pat = generate_pat()
+    expires_at = now + timedelta(days=ACCESS_TOKEN_TTL_DAYS)
+    token_row = ApiToken(
+        user_id=row.user_id,
+        workspace_id=row.workspace_id,
+        name=f"mcp-oauth:{client_id[:24]}",
+        hashed_secret=hash_pat(raw_pat),
+        prefix=PAT_PREFIX,
+        scopes=list(row.scopes or []),
+        expires_at=expires_at,
+    )
+    session.add(token_row)
+    session.add(
+        AuditLog(
+            workspace_id=row.workspace_id,
+            actor_user_id=row.user_id,
+            action="mcp_oauth.token.issue",
+            target_kind="api_token",
+            target_id=str(token_row.id),
+            payload={"client_id": client_id},
+        )
+    )
+    await session.commit()
+
+    return JSONResponse(
+        {
+            "access_token": raw_pat,
+            "token_type": "Bearer",
+            "expires_in": ACCESS_TOKEN_TTL_DAYS * 24 * 3600,
+            "scope": " ".join(row.scopes or []),
+        }
+    )

--- a/apps/backend/app/api/v1/routes/oauth.py
+++ b/apps/backend/app/api/v1/routes/oauth.py
@@ -4,7 +4,9 @@ Lets a business operator attach the MCP edge with *add → log in → grant
 → done* instead of pasting a PAT. Ship is the authorization server; the
 human login + consent is delegated to the console (which already owns
 the Auth0 session + workspace context). The issued access token is a
-short-lived workspace-scoped ``ship_pat_`` — so the existing
+short-lived **user-scoped** ``ship_pat_`` (``workspace_id = NULL``) —
+the operator's agent sees every workspace they belong to and can create
+new ones, exactly like their manual PAT — so the existing
 ``_resolve_pat`` path validates it unchanged.
 
 Surface split:
@@ -29,7 +31,6 @@ from __future__ import annotations
 import base64
 import hashlib
 import secrets
-import uuid
 from datetime import datetime, timedelta, timezone
 from typing import Any
 from urllib.parse import urlencode, urlsplit
@@ -42,7 +43,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from backend.app.api.v1.deps import AuthContext, get_current_auth
 from backend.app.core.config import Settings, get_settings
 from backend.app.db.models import McpOAuthClient, McpOAuthCode
-from backend.app.db.models.tenancy import ApiToken, AuditLog, WorkspaceMember
+from backend.app.db.models.tenancy import ApiToken, AuditLog
 from backend.app.db.session import get_session
 from backend.app.security.tokens import PAT_PREFIX, generate_pat, hash_pat
 
@@ -233,8 +234,15 @@ async def authorize_grant(
     session). Validate the request, mint a single-use PKCE-bound code,
     and return the redirect URL the console should 302 the browser to.
 
+    The grant is **user-scoped, not workspace-scoped**: the operator's
+    own agent must see every workspace they belong to AND be able to
+    create new ones (``workspace_create`` is refused to workspace-pinned
+    tokens). So the issued access token mirrors the operator's manual
+    PAT — ``workspace_id = NULL`` — and the MCP edge infers / accepts a
+    per-tool ``workspace_id`` as it already does.
+
     Body: ``{client_id, redirect_uri, code_challenge,
-    code_challenge_method, state, scope, workspace_id}``.
+    code_challenge_method, state, scope}``.
     """
     try:
         body = await request.json()
@@ -246,7 +254,6 @@ async def authorize_grant(
     code_challenge = str(body.get("code_challenge") or "").strip()
     method = str(body.get("code_challenge_method") or "S256").strip()
     state = body.get("state")
-    workspace_raw = str(body.get("workspace_id") or "").strip()
 
     client = await session.get(McpOAuthClient, client_id)
     if client is None:
@@ -257,26 +264,6 @@ async def authorize_grant(
         # PKCE S256 is mandatory — refuse plain/missing challenges.
         raise HTTPException(status_code=400, detail="invalid_request")
 
-    # Resolve the workspace the token will be scoped to and assert
-    # membership. ``workspace_id`` is required — the token is always
-    # workspace-scoped so the operator's grant is explicit.
-    if not workspace_raw:
-        raise HTTPException(status_code=400, detail="workspace_required")
-    try:
-        workspace_id = uuid.UUID(workspace_raw)
-    except ValueError:
-        raise HTTPException(status_code=400, detail="workspace_required")
-    member = (
-        await session.execute(
-            select(WorkspaceMember).where(
-                WorkspaceMember.workspace_id == workspace_id,
-                WorkspaceMember.user_id == auth.user.id,
-            )
-        )
-    ).scalar_one_or_none()
-    if member is None:
-        raise HTTPException(status_code=403, detail="not_a_member")
-
     raw_code = secrets.token_urlsafe(32)
     session.add(
         McpOAuthCode(
@@ -286,19 +273,19 @@ async def authorize_grant(
             code_challenge=code_challenge,
             code_challenge_method="S256",
             user_id=auth.user.id,
-            workspace_id=workspace_id,
+            workspace_id=None,  # user-scoped: all workspaces + create
             scopes=[MCP_SCOPE],
             expires_at=datetime.now(timezone.utc) + CODE_TTL,
         )
     )
     session.add(
         AuditLog(
-            workspace_id=workspace_id,
+            workspace_id=None,
             actor_user_id=auth.user.id,
             action="mcp_oauth.authorize.grant",
             target_kind="mcp_oauth_client",
             target_id=client_id,
-            payload={"redirect_uri": redirect_uri},
+            payload={"redirect_uri": redirect_uri, "scope": "user_all_workspaces"},
         )
     )
     await session.commit()

--- a/apps/backend/app/db/models/__init__.py
+++ b/apps/backend/app/db/models/__init__.py
@@ -54,6 +54,7 @@ from backend.app.db.models.integrations import (
 )
 from backend.app.db.models.lanes import Routine, RoutineRun
 from backend.app.db.models.notifications import WorkspaceNotification
+from backend.app.db.models.oauth import McpOAuthClient, McpOAuthCode
 from backend.app.db.models.pipelines import (
     AgentRequest,
     FleetRequest,
@@ -106,6 +107,8 @@ __all__ = [
     "Clarification",
     "FleetRequest",
     "GitHubInstallation",
+    "McpOAuthClient",
+    "McpOAuthCode",
     "GroupAssignmentState",
     "Improvement",
     "InboxItem",

--- a/apps/backend/app/db/models/oauth.py
+++ b/apps/backend/app/db/models/oauth.py
@@ -1,0 +1,116 @@
+"""MCP OAuth broker tables (ELS-296).
+
+Ship acts as the OAuth 2.1 authorization server for the MCP edge,
+delegating the human login + consent to the console (which already
+owns the Auth0 session + workspace context). Two tables back the flow:
+
+- ``mcp_oauth_clients`` — Dynamic Client Registration (RFC 7591). MCP
+  clients (Claude Code / Desktop) self-register their loopback redirect
+  URIs and get a public ``client_id`` (no secret; PKCE is the proof).
+- ``mcp_oauth_codes`` — single-use authorization codes. Minted by the
+  console's consent grant (under the operator's session), bound to the
+  PKCE ``code_challenge`` + client + redirect_uri + user + workspace,
+  and exchanged once at ``/oauth/token`` for a short-lived
+  workspace-scoped Ship PAT (the access token).
+
+The issued access token is a normal ``ship_pat_`` row in
+``api_tokens`` — so the existing ``_resolve_pat`` path validates it and
+no second credential type is introduced.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import (
+    DateTime,
+    ForeignKey,
+    Index,
+    String,
+    text,
+)
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from backend.app.db.base import Base
+from backend.app.db.models.tenancy import (
+    _pk,  # noqa: PLC2701 — shared column helper, intra-package.
+    _ts_created,  # noqa: PLC2701
+)
+
+
+class McpOAuthClient(Base):
+    """A dynamically-registered MCP OAuth client (RFC 7591).
+
+    ``client_id`` is the opaque public identifier we hand back at
+    registration. Public clients only — ``token_endpoint_auth_method``
+    is always ``none`` and PKCE (S256) is mandatory, so there is no
+    client secret to store.
+    """
+
+    __tablename__ = "mcp_oauth_clients"
+
+    client_id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    client_name: Mapped[str | None] = mapped_column(String(200), nullable=True)
+    # Exact redirect URIs the client declared at registration. Loopback
+    # URIs (http://127.0.0.1 / http://localhost) match port-insensitively
+    # at /authorize time per RFC 8252 §7.3; everything else is exact.
+    redirect_uris: Mapped[list[str]] = mapped_column(
+        JSONB, nullable=False, server_default=text("'[]'::jsonb")
+    )
+    grant_types: Mapped[list[str]] = mapped_column(
+        JSONB, nullable=False, server_default=text("'[\"authorization_code\"]'::jsonb")
+    )
+    token_endpoint_auth_method: Mapped[str] = mapped_column(
+        String(40), nullable=False, server_default=text("'none'")
+    )
+    created_at: Mapped[datetime] = _ts_created()
+
+
+class McpOAuthCode(Base):
+    """A single-use authorization code (OAuth 2.1 code grant + PKCE).
+
+    Minted by the console consent grant under the operator's session,
+    redeemed once at ``/oauth/token``. ``consumed_at`` flips on first
+    redemption so a replayed code is refused.
+    """
+
+    __tablename__ = "mcp_oauth_codes"
+    __table_args__ = (
+        Index("ix_mcp_oauth_codes_client_id", "client_id"),
+        Index("ix_mcp_oauth_codes_expires_at", "expires_at"),
+    )
+
+    id: Mapped[uuid.UUID] = _pk()
+    # SHA-256 of the raw code; the plaintext only ever travels in the
+    # redirect back to the client and is never stored.
+    code_hash: Mapped[str] = mapped_column(String(128), nullable=False, unique=True)
+    client_id: Mapped[str] = mapped_column(
+        String(64),
+        ForeignKey("mcp_oauth_clients.client_id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    redirect_uri: Mapped[str] = mapped_column(String(2048), nullable=False)
+    code_challenge: Mapped[str] = mapped_column(String(128), nullable=False)
+    code_challenge_method: Mapped[str] = mapped_column(
+        String(10), nullable=False, server_default=text("'S256'")
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
+    workspace_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("workspaces.id", ondelete="CASCADE"),
+        nullable=True,
+    )
+    scopes: Mapped[list[str]] = mapped_column(
+        JSONB, nullable=False, server_default=text("'[]'::jsonb")
+    )
+    expires_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+    consumed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    created_at: Mapped[datetime] = _ts_created()

--- a/apps/backend/app/main.py
+++ b/apps/backend/app/main.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
 import asyncio
-import hashlib
 import json
 import logging
 import os
 import re
 import time
-import uuid
 from collections import defaultdict, deque
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
@@ -15,8 +13,7 @@ from pathlib import Path
 from typing import Any
 
 import httpx
-import yaml
-from fastapi import FastAPI, Header, HTTPException, Query, Response
+from fastapi import FastAPI, Header, HTTPException, Response
 from pydantic import BaseModel, ConfigDict, Field
 
 from backend.app.api.v1 import api_router as v1_api_router
@@ -265,6 +262,15 @@ app.include_router(v1_api_router)
 from backend.app.api.v1.routes.mcp import router as mcp_router  # noqa: E402
 
 app.include_router(mcp_router)
+
+# MCP OAuth broker (ELS-296): discovery metadata, Dynamic Client
+# Registration, and the token endpoint — Ship is the authorization
+# server for the MCP edge so business operators attach with
+# add → log in → grant instead of pasting a PAT. Mounted at the app
+# root so /.well-known/* discovery resolves on the API origin.
+from backend.app.api.v1.routes.oauth import router as oauth_router  # noqa: E402
+
+app.include_router(oauth_router)
 
 
 @app.get("/healthz", tags=["meta"], include_in_schema=False)

--- a/apps/backend/migrations/versions/0090_mcp_oauth.py
+++ b/apps/backend/migrations/versions/0090_mcp_oauth.py
@@ -1,0 +1,123 @@
+"""mcp_oauth_clients + mcp_oauth_codes — MCP OAuth broker (ELS-296)
+
+Ship becomes the OAuth 2.1 authorization server for the MCP edge:
+clients self-register (DCR), the console issues single-use PKCE-bound
+authorization codes under the operator's session, and /oauth/token
+exchanges a code for a short-lived workspace-scoped ``ship_pat_`` (an
+``api_tokens`` row — no new credential type). Forward revision after
+0089 (applied in prod; never edited in place).
+
+Revision ID: 0090_mcp_oauth
+Revises: 0089_workflow_runs
+Create Date: 2026-06-14
+"""
+
+from __future__ import annotations
+
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+
+
+revision: str = "0090_mcp_oauth"
+down_revision: Union[str, None] = "0089_workflow_runs"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "mcp_oauth_clients",
+        sa.Column("client_id", sa.String(64), primary_key=True),
+        sa.Column("client_name", sa.String(200), nullable=True),
+        sa.Column(
+            "redirect_uris",
+            JSONB(),
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        sa.Column(
+            "grant_types",
+            JSONB(),
+            nullable=False,
+            server_default=sa.text("'[\"authorization_code\"]'::jsonb"),
+        ),
+        sa.Column(
+            "token_endpoint_auth_method",
+            sa.String(40),
+            nullable=False,
+            server_default=sa.text("'none'"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+    )
+
+    op.create_table(
+        "mcp_oauth_codes",
+        sa.Column(
+            "id",
+            UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("code_hash", sa.String(128), nullable=False, unique=True),
+        sa.Column(
+            "client_id",
+            sa.String(64),
+            sa.ForeignKey("mcp_oauth_clients.client_id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("redirect_uri", sa.String(2048), nullable=False),
+        sa.Column("code_challenge", sa.String(128), nullable=False),
+        sa.Column(
+            "code_challenge_method",
+            sa.String(10),
+            nullable=False,
+            server_default=sa.text("'S256'"),
+        ),
+        sa.Column(
+            "user_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "workspace_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("workspaces.id", ondelete="CASCADE"),
+            nullable=True,
+        ),
+        sa.Column(
+            "scopes",
+            JSONB(),
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("consumed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+    )
+    op.create_index(
+        "ix_mcp_oauth_codes_client_id", "mcp_oauth_codes", ["client_id"]
+    )
+    op.create_index(
+        "ix_mcp_oauth_codes_expires_at", "mcp_oauth_codes", ["expires_at"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_mcp_oauth_codes_expires_at", table_name="mcp_oauth_codes")
+    op.drop_index("ix_mcp_oauth_codes_client_id", table_name="mcp_oauth_codes")
+    op.drop_table("mcp_oauth_codes")
+    op.drop_table("mcp_oauth_clients")

--- a/apps/backend/tests/test_mcp_oauth.py
+++ b/apps/backend/tests/test_mcp_oauth.py
@@ -6,9 +6,10 @@ Ship is the OAuth 2.1 authorization server for the MCP edge. Pins:
   /mcp 401 ``resource_metadata`` hint that bootstraps the client;
 - Dynamic Client Registration mints a public client;
 - the console grant endpoint (session-authed) issues a single-use
-  PKCE-bound code, asserting workspace membership;
-- /oauth/token exchanges code+verifier for a working ``ship_pat_``
-  access token, and refuses replay / wrong-verifier / wrong-redirect.
+  PKCE-bound code;
+- /oauth/token exchanges code+verifier for a working **user-scoped**
+  ``ship_pat_`` (all workspaces + workspace_create), and refuses
+  replay / wrong-verifier / wrong-redirect.
 """
 
 from __future__ import annotations
@@ -38,7 +39,7 @@ async def _register(client, redirect_uri="http://127.0.0.1:53682/callback") -> s
     return res.json()["client_id"]
 
 
-async def _grant(client, raw_pat, *, client_id, redirect_uri, challenge, workspace_id):
+async def _grant(client, raw_pat, *, client_id, redirect_uri, challenge):
     return await client.post(
         "/oauth/authorize/grant",
         headers={"Authorization": f"Bearer {raw_pat}"},
@@ -48,7 +49,6 @@ async def _grant(client, raw_pat, *, client_id, redirect_uri, challenge, workspa
             "code_challenge": challenge,
             "code_challenge_method": "S256",
             "state": "xyz",
-            "workspace_id": str(workspace_id),
         },
     )
 
@@ -112,10 +112,15 @@ async def test_dcr_register_and_validation(v1_client) -> None:
 
 
 @pytest.mark.asyncio
-async def test_full_code_flow_issues_working_token(
+async def test_full_code_flow_issues_user_scoped_token(
     db_session, v1_client, seed_workspace
 ) -> None:
-    _, raw, workspace = seed_workspace
+    """The grant is user-scoped (all workspaces + create), mirroring the
+    operator's manual PAT — NOT pinned to one workspace."""
+    from backend.app.db.models.tenancy import ApiToken
+    from sqlalchemy import select
+
+    _, raw, _ = seed_workspace
     verifier, challenge = _pkce()
     redirect_uri = "http://127.0.0.1:53682/callback"
     client_id = await _register(v1_client, redirect_uri)
@@ -126,7 +131,6 @@ async def test_full_code_flow_issues_working_token(
         client_id=client_id,
         redirect_uri=redirect_uri,
         challenge=challenge,
-        workspace_id=workspace.id,
     )
     assert granted.status_code == 200, granted.text
     code = _code_from_redirect(granted.json()["redirect_to"])
@@ -147,7 +151,17 @@ async def test_full_code_flow_issues_working_token(
     access = tok["access_token"]
     assert access.startswith("ship_pat_")
 
-    # The issued token works on the MCP edge.
+    # The minted token is user-scoped (workspace_id NULL) — the property
+    # that lets the operator's agent see every workspace and create new
+    # ones via workspace_create.
+    issued = (
+        await db_session.execute(
+            select(ApiToken).where(ApiToken.name == f"mcp-oauth:{client_id[:24]}")
+        )
+    ).scalar_one()
+    assert issued.workspace_id is None
+
+    # And it works on the MCP edge.
     mcp = await v1_client.post(
         "/mcp",
         headers={"Authorization": f"Bearer {access}"},
@@ -155,17 +169,35 @@ async def test_full_code_flow_issues_working_token(
             "jsonrpc": "2.0",
             "id": 1,
             "method": "tools/call",
-            "arguments": {},
             "params": {"name": "list_workspaces", "arguments": {}},
         },
     )
     assert mcp.status_code == 200
     assert mcp.json()["result"]["isError"] is False
 
+    # workspace_create is reachable (user-scoped tokens may create;
+    # workspace-pinned ones are refused) — proves the "create
+    # namespaces" grant.
+    created = await v1_client.post(
+        "/mcp",
+        headers={"Authorization": f"Bearer {access}"},
+        json={
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {
+                "name": "workspace_create",
+                "arguments": {"name": "OAuth made me", "slug": "oauth-made-me"},
+            },
+        },
+    )
+    assert created.status_code == 200
+    assert created.json()["result"]["isError"] is False
+
 
 @pytest.mark.asyncio
 async def test_pkce_mismatch_refused(db_session, v1_client, seed_workspace) -> None:
-    _, raw, workspace = seed_workspace
+    _, raw, _ = seed_workspace
     _, challenge = _pkce()
     redirect_uri = "http://127.0.0.1:53682/callback"
     client_id = await _register(v1_client, redirect_uri)
@@ -175,7 +207,6 @@ async def test_pkce_mismatch_refused(db_session, v1_client, seed_workspace) -> N
         client_id=client_id,
         redirect_uri=redirect_uri,
         challenge=challenge,
-        workspace_id=workspace.id,
     )
     code = _code_from_redirect(granted.json()["redirect_to"])
 
@@ -195,7 +226,7 @@ async def test_pkce_mismatch_refused(db_session, v1_client, seed_workspace) -> N
 
 @pytest.mark.asyncio
 async def test_code_is_single_use(db_session, v1_client, seed_workspace) -> None:
-    _, raw, workspace = seed_workspace
+    _, raw, _ = seed_workspace
     verifier, challenge = _pkce()
     redirect_uri = "http://127.0.0.1:53682/callback"
     client_id = await _register(v1_client, redirect_uri)
@@ -205,7 +236,6 @@ async def test_code_is_single_use(db_session, v1_client, seed_workspace) -> None
         client_id=client_id,
         redirect_uri=redirect_uri,
         challenge=challenge,
-        workspace_id=workspace.id,
     )
     code = _code_from_redirect(granted.json()["redirect_to"])
     payload = {
@@ -226,7 +256,7 @@ async def test_code_is_single_use(db_session, v1_client, seed_workspace) -> None
 async def test_token_refuses_redirect_uri_mismatch(
     db_session, v1_client, seed_workspace
 ) -> None:
-    _, raw, workspace = seed_workspace
+    _, raw, _ = seed_workspace
     verifier, challenge = _pkce()
     redirect_uri = "http://127.0.0.1:53682/callback"
     client_id = await _register(v1_client, redirect_uri)
@@ -236,7 +266,6 @@ async def test_token_refuses_redirect_uri_mismatch(
         client_id=client_id,
         redirect_uri=redirect_uri,
         challenge=challenge,
-        workspace_id=workspace.id,
     )
     code = _code_from_redirect(granted.json()["redirect_to"])
     res = await v1_client.post(
@@ -255,7 +284,7 @@ async def test_token_refuses_redirect_uri_mismatch(
 
 @pytest.mark.asyncio
 async def test_grant_refuses_plain_pkce(db_session, v1_client, seed_workspace) -> None:
-    _, raw, workspace = seed_workspace
+    _, raw, _ = seed_workspace
     redirect_uri = "http://127.0.0.1:53682/callback"
     client_id = await _register(v1_client, redirect_uri)
     res = await v1_client.post(
@@ -267,7 +296,6 @@ async def test_grant_refuses_plain_pkce(db_session, v1_client, seed_workspace) -
             "code_challenge": "",
             "code_challenge_method": "plain",
             "state": "xyz",
-            "workspace_id": str(workspace.id),
         },
     )
     assert res.status_code == 400
@@ -277,7 +305,7 @@ async def test_grant_refuses_plain_pkce(db_session, v1_client, seed_workspace) -
 async def test_grant_refuses_unregistered_redirect(
     db_session, v1_client, seed_workspace
 ) -> None:
-    _, raw, workspace = seed_workspace
+    _, raw, _ = seed_workspace
     _, challenge = _pkce()
     client_id = await _register(v1_client, "http://127.0.0.1:53682/callback")
     res = await _grant(
@@ -286,7 +314,6 @@ async def test_grant_refuses_unregistered_redirect(
         client_id=client_id,
         redirect_uri="https://evil.example.com/cb",
         challenge=challenge,
-        workspace_id=workspace.id,
     )
     assert res.status_code == 400
     assert res.json()["detail"] == "invalid_redirect_uri"

--- a/apps/backend/tests/test_mcp_oauth.py
+++ b/apps/backend/tests/test_mcp_oauth.py
@@ -1,0 +1,292 @@
+"""MCP OAuth broker (ELS-296) — discovery, DCR, PKCE code grant.
+
+Ship is the OAuth 2.1 authorization server for the MCP edge. Pins:
+
+- discovery metadata (protected-resource + authorization-server) and the
+  /mcp 401 ``resource_metadata`` hint that bootstraps the client;
+- Dynamic Client Registration mints a public client;
+- the console grant endpoint (session-authed) issues a single-use
+  PKCE-bound code, asserting workspace membership;
+- /oauth/token exchanges code+verifier for a working ``ship_pat_``
+  access token, and refuses replay / wrong-verifier / wrong-redirect.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+
+import pytest
+
+
+def _pkce() -> tuple[str, str]:
+    verifier = base64.urlsafe_b64encode(b"v" * 48).rstrip(b"=").decode()
+    challenge = (
+        base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest())
+        .rstrip(b"=")
+        .decode()
+    )
+    return verifier, challenge
+
+
+async def _register(client, redirect_uri="http://127.0.0.1:53682/callback") -> str:
+    res = await client.post(
+        "/oauth/register",
+        json={"client_name": "Claude Code (test)", "redirect_uris": [redirect_uri]},
+    )
+    assert res.status_code == 201, res.text
+    return res.json()["client_id"]
+
+
+async def _grant(client, raw_pat, *, client_id, redirect_uri, challenge, workspace_id):
+    return await client.post(
+        "/oauth/authorize/grant",
+        headers={"Authorization": f"Bearer {raw_pat}"},
+        json={
+            "client_id": client_id,
+            "redirect_uri": redirect_uri,
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+            "state": "xyz",
+            "workspace_id": str(workspace_id),
+        },
+    )
+
+
+def _code_from_redirect(redirect_to: str) -> str:
+    from urllib.parse import parse_qs, urlsplit
+
+    q = parse_qs(urlsplit(redirect_to).query)
+    assert q.get("state") == ["xyz"]
+    return q["code"][0]
+
+
+@pytest.mark.asyncio
+async def test_protected_resource_metadata(v1_client) -> None:
+    res = await v1_client.get("/.well-known/oauth-protected-resource")
+    assert res.status_code == 200
+    body = res.json()
+    assert body["resource"].endswith("/mcp")
+    assert len(body["authorization_servers"]) == 1
+    assert "mcp" in body["scopes_supported"]
+
+
+@pytest.mark.asyncio
+async def test_authorization_server_metadata(v1_client) -> None:
+    res = await v1_client.get("/.well-known/oauth-authorization-server")
+    assert res.status_code == 200
+    body = res.json()
+    assert body["token_endpoint"].endswith("/oauth/token")
+    assert body["registration_endpoint"].endswith("/oauth/register")
+    assert body["authorization_endpoint"].endswith("/oauth/authorize")
+    assert body["code_challenge_methods_supported"] == ["S256"]
+    assert body["token_endpoint_auth_methods_supported"] == ["none"]
+
+
+@pytest.mark.asyncio
+async def test_mcp_401_carries_resource_metadata(v1_client) -> None:
+    res = await v1_client.post(
+        "/mcp", json={"jsonrpc": "2.0", "id": 1, "method": "initialize"}
+    )
+    assert res.status_code == 401
+    www = res.headers.get("www-authenticate", "")
+    assert "resource_metadata=" in www
+    assert "/.well-known/oauth-protected-resource" in www
+
+
+@pytest.mark.asyncio
+async def test_dcr_register_and_validation(v1_client) -> None:
+    res = await v1_client.post(
+        "/oauth/register",
+        json={"client_name": "x", "redirect_uris": ["http://127.0.0.1:9/cb"]},
+    )
+    assert res.status_code == 201
+    body = res.json()
+    assert body["client_id"].startswith("mcp_")
+    assert body["token_endpoint_auth_method"] == "none"
+    assert body["redirect_uris"] == ["http://127.0.0.1:9/cb"]
+
+    # Missing redirect_uris → rejected.
+    bad = await v1_client.post("/oauth/register", json={"client_name": "x"})
+    assert bad.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_full_code_flow_issues_working_token(
+    db_session, v1_client, seed_workspace
+) -> None:
+    _, raw, workspace = seed_workspace
+    verifier, challenge = _pkce()
+    redirect_uri = "http://127.0.0.1:53682/callback"
+    client_id = await _register(v1_client, redirect_uri)
+
+    granted = await _grant(
+        v1_client,
+        raw,
+        client_id=client_id,
+        redirect_uri=redirect_uri,
+        challenge=challenge,
+        workspace_id=workspace.id,
+    )
+    assert granted.status_code == 200, granted.text
+    code = _code_from_redirect(granted.json()["redirect_to"])
+
+    res = await v1_client.post(
+        "/oauth/token",
+        data={
+            "grant_type": "authorization_code",
+            "code": code,
+            "code_verifier": verifier,
+            "client_id": client_id,
+            "redirect_uri": redirect_uri,
+        },
+    )
+    assert res.status_code == 200, res.text
+    tok = res.json()
+    assert tok["token_type"] == "Bearer"
+    access = tok["access_token"]
+    assert access.startswith("ship_pat_")
+
+    # The issued token works on the MCP edge.
+    mcp = await v1_client.post(
+        "/mcp",
+        headers={"Authorization": f"Bearer {access}"},
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "arguments": {},
+            "params": {"name": "list_workspaces", "arguments": {}},
+        },
+    )
+    assert mcp.status_code == 200
+    assert mcp.json()["result"]["isError"] is False
+
+
+@pytest.mark.asyncio
+async def test_pkce_mismatch_refused(db_session, v1_client, seed_workspace) -> None:
+    _, raw, workspace = seed_workspace
+    _, challenge = _pkce()
+    redirect_uri = "http://127.0.0.1:53682/callback"
+    client_id = await _register(v1_client, redirect_uri)
+    granted = await _grant(
+        v1_client,
+        raw,
+        client_id=client_id,
+        redirect_uri=redirect_uri,
+        challenge=challenge,
+        workspace_id=workspace.id,
+    )
+    code = _code_from_redirect(granted.json()["redirect_to"])
+
+    res = await v1_client.post(
+        "/oauth/token",
+        data={
+            "grant_type": "authorization_code",
+            "code": code,
+            "code_verifier": "the-wrong-verifier",
+            "client_id": client_id,
+            "redirect_uri": redirect_uri,
+        },
+    )
+    assert res.status_code == 400
+    assert res.json()["error"] == "invalid_grant"
+
+
+@pytest.mark.asyncio
+async def test_code_is_single_use(db_session, v1_client, seed_workspace) -> None:
+    _, raw, workspace = seed_workspace
+    verifier, challenge = _pkce()
+    redirect_uri = "http://127.0.0.1:53682/callback"
+    client_id = await _register(v1_client, redirect_uri)
+    granted = await _grant(
+        v1_client,
+        raw,
+        client_id=client_id,
+        redirect_uri=redirect_uri,
+        challenge=challenge,
+        workspace_id=workspace.id,
+    )
+    code = _code_from_redirect(granted.json()["redirect_to"])
+    payload = {
+        "grant_type": "authorization_code",
+        "code": code,
+        "code_verifier": verifier,
+        "client_id": client_id,
+        "redirect_uri": redirect_uri,
+    }
+    first = await v1_client.post("/oauth/token", data=payload)
+    assert first.status_code == 200
+    replay = await v1_client.post("/oauth/token", data=payload)
+    assert replay.status_code == 400
+    assert replay.json()["error"] == "invalid_grant"
+
+
+@pytest.mark.asyncio
+async def test_token_refuses_redirect_uri_mismatch(
+    db_session, v1_client, seed_workspace
+) -> None:
+    _, raw, workspace = seed_workspace
+    verifier, challenge = _pkce()
+    redirect_uri = "http://127.0.0.1:53682/callback"
+    client_id = await _register(v1_client, redirect_uri)
+    granted = await _grant(
+        v1_client,
+        raw,
+        client_id=client_id,
+        redirect_uri=redirect_uri,
+        challenge=challenge,
+        workspace_id=workspace.id,
+    )
+    code = _code_from_redirect(granted.json()["redirect_to"])
+    res = await v1_client.post(
+        "/oauth/token",
+        data={
+            "grant_type": "authorization_code",
+            "code": code,
+            "code_verifier": verifier,
+            "client_id": client_id,
+            "redirect_uri": "http://127.0.0.1:53682/EVIL",
+        },
+    )
+    assert res.status_code == 400
+    assert res.json()["error"] == "invalid_grant"
+
+
+@pytest.mark.asyncio
+async def test_grant_refuses_plain_pkce(db_session, v1_client, seed_workspace) -> None:
+    _, raw, workspace = seed_workspace
+    redirect_uri = "http://127.0.0.1:53682/callback"
+    client_id = await _register(v1_client, redirect_uri)
+    res = await v1_client.post(
+        "/oauth/authorize/grant",
+        headers={"Authorization": f"Bearer {raw}"},
+        json={
+            "client_id": client_id,
+            "redirect_uri": redirect_uri,
+            "code_challenge": "",
+            "code_challenge_method": "plain",
+            "state": "xyz",
+            "workspace_id": str(workspace.id),
+        },
+    )
+    assert res.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_grant_refuses_unregistered_redirect(
+    db_session, v1_client, seed_workspace
+) -> None:
+    _, raw, workspace = seed_workspace
+    _, challenge = _pkce()
+    client_id = await _register(v1_client, "http://127.0.0.1:53682/callback")
+    res = await _grant(
+        v1_client,
+        raw,
+        client_id=client_id,
+        redirect_uri="https://evil.example.com/cb",
+        challenge=challenge,
+        workspace_id=workspace.id,
+    )
+    assert res.status_code == 400
+    assert res.json()["detail"] == "invalid_redirect_uri"

--- a/apps/console/src/app/(authed)/oauth/authorize/page.tsx
+++ b/apps/console/src/app/(authed)/oauth/authorize/page.tsx
@@ -16,10 +16,7 @@ import { redirect } from "next/navigation";
 
 import { PageBody, PageHeader } from "@/components/app-shell";
 import { ApiHttpError, describeOAuthClient } from "@/lib/api/client";
-import {
-  getCachedSessionToken,
-  getCachedWorkspaces,
-} from "@/lib/api/session-cache.server";
+import { getCachedSessionToken } from "@/lib/api/session-cache.server";
 
 export const dynamic = "force-dynamic";
 
@@ -77,9 +74,6 @@ export default async function OAuthAuthorizePage({
     return <ConsentError reason="The redirect URL does not match this client's registration." />;
   }
 
-  const workspaces = await getCachedWorkspaces();
-  if (workspaces.length === 0) redirect("/onboarding?step=github");
-
   const clientName = client.client_name?.trim() || "An MCP client";
 
   return (
@@ -97,10 +91,11 @@ export default async function OAuthAuthorizePage({
             </h2>
             <p className="mt-2 text-sm text-white/70">
               It will act as <b className="text-white/85">you</b> through the
-              MCP edge — planning, tickets, reviews, and approvals — scoped to
-              the workspace you pick below. Hard-destructive actions still
-              require a typed confirm in the console. You can revoke this any
-              time in Settings → Agents &amp; access.
+              MCP edge — planning, tickets, reviews, and approvals — across{" "}
+              <b className="text-white/85">all your workspaces</b>, including
+              creating new ones. Hard-destructive actions still require a typed
+              confirm in the console. You can revoke this any time in Settings →
+              Agents &amp; access.
             </p>
 
             <form action="/api/oauth/grant" method="POST" className="mt-5 space-y-4">
@@ -114,35 +109,6 @@ export default async function OAuthAuthorizePage({
               />
               <input type="hidden" name="state" value={state} />
               <input type="hidden" name="scope" value={scope} />
-
-              <fieldset>
-                <legend className="mb-2 text-[10px] font-bold uppercase tracking-widest text-white/55">
-                  Grant access to workspace
-                </legend>
-                <div className="space-y-1.5">
-                  {workspaces.map((w, i) => (
-                    <label
-                      key={w.id}
-                      className="flex cursor-pointer items-center gap-2.5 rounded-lg border border-white/10 bg-white/[0.03] px-3 py-2 text-sm hover:border-aqua/30"
-                    >
-                      <input
-                        type="radio"
-                        name="workspace_id"
-                        value={w.id}
-                        defaultChecked={i === 0}
-                        required
-                        className="accent-aqua"
-                      />
-                      <span className="min-w-0 flex-1">
-                        <span className="block truncate text-white/90">{w.name}</span>
-                        <span className="block truncate text-[10px] uppercase tracking-wider text-white/40">
-                          {w.slug}
-                        </span>
-                      </span>
-                    </label>
-                  ))}
-                </div>
-              </fieldset>
 
               <div className="flex items-center gap-3 pt-1">
                 <button

--- a/apps/console/src/app/(authed)/oauth/authorize/page.tsx
+++ b/apps/console/src/app/(authed)/oauth/authorize/page.tsx
@@ -1,0 +1,238 @@
+/**
+ * `/oauth/authorize` — MCP OAuth consent screen (ELS-296).
+ *
+ * The human-facing half of Ship's OAuth broker. An MCP client (Claude
+ * Code / Desktop) sends the operator here after Dynamic Client
+ * Registration; the `(authed)` layout bounces them through the normal
+ * console login first if needed. They pick the workspace to grant and
+ * approve — the grant route mints a single-use PKCE-bound code and 302s
+ * the browser back to the client's loopback `redirect_uri`. Deny bounces
+ * back with `error=access_denied`.
+ *
+ * No token is ever pasted: add the server URL → log in → grant → done.
+ */
+
+import { redirect } from "next/navigation";
+
+import { PageBody, PageHeader } from "@/components/app-shell";
+import { ApiHttpError, describeOAuthClient } from "@/lib/api/client";
+import {
+  getCachedSessionToken,
+  getCachedWorkspaces,
+} from "@/lib/api/session-cache.server";
+
+export const dynamic = "force-dynamic";
+
+type SearchParams = Record<string, string | string[] | undefined>;
+
+function str(v: string | string[] | undefined): string {
+  return typeof v === "string" ? v : "";
+}
+
+export default async function OAuthAuthorizePage({
+  searchParams,
+}: {
+  searchParams?: Promise<SearchParams>;
+}) {
+  const params = ((await (searchParams ?? Promise.resolve({}))) ?? {}) as SearchParams;
+
+  const clientId = str(params.client_id);
+  const redirectUri = str(params.redirect_uri);
+  const codeChallenge = str(params.code_challenge);
+  const codeChallengeMethod = str(params.code_challenge_method) || "S256";
+  const state = str(params.state);
+  const scope = str(params.scope);
+  const responseType = str(params.response_type) || "code";
+
+  const token = await getCachedSessionToken();
+  if (!token) {
+    const here = `/oauth/authorize?${new URLSearchParams(
+      Object.entries(params).flatMap(([k, v]) =>
+        typeof v === "string" ? [[k, v]] : [],
+      ) as [string, string][],
+    ).toString()}`;
+    redirect(`/login?next=${encodeURIComponent(here)}&reason=session_expired`);
+  }
+
+  if (!clientId || !redirectUri || !codeChallenge || responseType !== "code") {
+    return <ConsentError reason="This authorization request is incomplete or unsupported." />;
+  }
+  if (codeChallengeMethod !== "S256") {
+    return <ConsentError reason="This client must use PKCE with S256." />;
+  }
+
+  let client: Awaited<ReturnType<typeof describeOAuthClient>>;
+  try {
+    client = await describeOAuthClient(clientId, token);
+  } catch (err) {
+    if (err instanceof ApiHttpError && err.status === 404) {
+      return <ConsentError reason="Unknown client — re-add the Ship MCP server in your agent." />;
+    }
+    return <ConsentError reason="Couldn't load the client right now. Try again in a moment." />;
+  }
+
+  // Defense-in-depth: the grant endpoint re-validates, but reject an
+  // off-list redirect here so we never render Approve for a bad URI.
+  if (!redirectUriAllowed(client.redirect_uris, redirectUri)) {
+    return <ConsentError reason="The redirect URL does not match this client's registration." />;
+  }
+
+  const workspaces = await getCachedWorkspaces();
+  if (workspaces.length === 0) redirect("/onboarding?step=github");
+
+  const clientName = client.client_name?.trim() || "An MCP client";
+
+  return (
+    <>
+      <PageHeader kicker="authorize" title="Connect your agent" />
+      <PageBody>
+        <div className="mx-auto w-full max-w-lg">
+          <section
+            data-testid="oauth-consent"
+            className="rounded-2xl border border-aqua/30 bg-aqua/[0.05] p-6"
+          >
+            <h2 className="text-lg font-semibold text-white">
+              <span className="text-aqua">{clientName}</span> wants to operate
+              Ship on your behalf
+            </h2>
+            <p className="mt-2 text-sm text-white/70">
+              It will act as <b className="text-white/85">you</b> through the
+              MCP edge — planning, tickets, reviews, and approvals — scoped to
+              the workspace you pick below. Hard-destructive actions still
+              require a typed confirm in the console. You can revoke this any
+              time in Settings → Agents &amp; access.
+            </p>
+
+            <form action="/api/oauth/grant" method="POST" className="mt-5 space-y-4">
+              <input type="hidden" name="client_id" value={clientId} />
+              <input type="hidden" name="redirect_uri" value={redirectUri} />
+              <input type="hidden" name="code_challenge" value={codeChallenge} />
+              <input
+                type="hidden"
+                name="code_challenge_method"
+                value={codeChallengeMethod}
+              />
+              <input type="hidden" name="state" value={state} />
+              <input type="hidden" name="scope" value={scope} />
+
+              <fieldset>
+                <legend className="mb-2 text-[10px] font-bold uppercase tracking-widest text-white/55">
+                  Grant access to workspace
+                </legend>
+                <div className="space-y-1.5">
+                  {workspaces.map((w, i) => (
+                    <label
+                      key={w.id}
+                      className="flex cursor-pointer items-center gap-2.5 rounded-lg border border-white/10 bg-white/[0.03] px-3 py-2 text-sm hover:border-aqua/30"
+                    >
+                      <input
+                        type="radio"
+                        name="workspace_id"
+                        value={w.id}
+                        defaultChecked={i === 0}
+                        required
+                        className="accent-aqua"
+                      />
+                      <span className="min-w-0 flex-1">
+                        <span className="block truncate text-white/90">{w.name}</span>
+                        <span className="block truncate text-[10px] uppercase tracking-wider text-white/40">
+                          {w.slug}
+                        </span>
+                      </span>
+                    </label>
+                  ))}
+                </div>
+              </fieldset>
+
+              <div className="flex items-center gap-3 pt-1">
+                <button
+                  type="submit"
+                  name="decision"
+                  value="approve"
+                  data-testid="oauth-approve"
+                  className="rounded-full bg-gradient-to-r from-coral via-lilac to-aqua px-5 py-2 text-sm font-bold text-ink shadow-glow transition hover:brightness-110"
+                >
+                  Approve &amp; connect
+                </button>
+                <button
+                  type="submit"
+                  name="decision"
+                  value="deny"
+                  data-testid="oauth-deny"
+                  className="rounded-full border border-white/15 px-4 py-2 text-sm font-semibold text-white/70 transition hover:text-white"
+                >
+                  Deny
+                </button>
+              </div>
+            </form>
+          </section>
+          <p className="mt-3 text-center text-[11px] text-white/40">
+            Requested by a client registered at{" "}
+            <code className="font-mono">{hostOf(redirectUri)}</code>
+          </p>
+        </div>
+      </PageBody>
+    </>
+  );
+}
+
+function ConsentError({ reason }: { reason: string }) {
+  return (
+    <>
+      <PageHeader kicker="authorize" title="Connect your agent" />
+      <PageBody>
+        <div className="mx-auto w-full max-w-lg">
+          <div
+            data-testid="oauth-consent-error"
+            className="rounded-2xl border border-coral/30 bg-coral/[0.06] p-6 text-sm text-coral/95"
+          >
+            {reason}
+          </div>
+        </div>
+      </PageBody>
+    </>
+  );
+}
+
+function hostOf(uri: string): string {
+  try {
+    return new URL(uri).host;
+  } catch {
+    return uri;
+  }
+}
+
+function isLoopback(uri: string): boolean {
+  try {
+    const h = new URL(uri).hostname.toLowerCase();
+    return h === "127.0.0.1" || h === "localhost" || h === "::1";
+  } catch {
+    return false;
+  }
+}
+
+/** Mirror of the backend's _redirect_uri_allowed: exact match, except
+ * loopback URIs match port-insensitively (RFC 8252 §7.3). */
+function redirectUriAllowed(registered: string[], requested: string): boolean {
+  if (registered.includes(requested)) return true;
+  if (!isLoopback(requested)) return false;
+  let req: URL;
+  try {
+    req = new URL(requested);
+  } catch {
+    return false;
+  }
+  return registered.some((reg) => {
+    if (!isLoopback(reg)) return false;
+    try {
+      const r = new URL(reg);
+      return (
+        r.protocol === req.protocol &&
+        r.hostname === req.hostname &&
+        r.pathname === req.pathname
+      );
+    } catch {
+      return false;
+    }
+  });
+}

--- a/apps/console/src/app/api/oauth/grant/route.ts
+++ b/apps/console/src/app/api/oauth/grant/route.ts
@@ -1,0 +1,102 @@
+/**
+ * POST /api/oauth/grant — the consent screen's Approve / Deny action.
+ *
+ * Approve: call the backend grant endpoint (under the operator's
+ * session) to mint a single-use PKCE-bound authorization code, then
+ * 302 the browser to the client's loopback `redirect_uri` with the
+ * code + state. Deny: 302 back with `error=access_denied`. Either way
+ * the operator never sees or pastes a token — the MCP client picks the
+ * code up on its loopback listener and exchanges it for the access
+ * token at the backend token endpoint.
+ */
+
+import { NextResponse } from "next/server";
+
+import {
+  ApiHttpError,
+  ApiUnavailableError,
+  isApiConfigured,
+  oauthAuthorizeGrant,
+} from "@/lib/api/client";
+import { getSessionToken } from "@/lib/api/session";
+import { resolveOrigin } from "@/lib/api/origin";
+
+function field(form: FormData, key: string): string {
+  const v = form.get(key);
+  return typeof v === "string" ? v.trim() : "";
+}
+
+/** Only bounce to same-shape client redirect URIs: http(s) with a code
+ * or error query. Guards against open-redirect via a forged form. */
+function safeRedirectTarget(uri: string): URL | null {
+  try {
+    const u = new URL(uri);
+    if (u.protocol !== "http:" && u.protocol !== "https:") return null;
+    return u;
+  } catch {
+    return null;
+  }
+}
+
+export async function POST(request: Request) {
+  const origin = resolveOrigin(request);
+  const form = await request.formData();
+  const decision = field(form, "decision");
+  const redirectUri = field(form, "redirect_uri");
+  const state = field(form, "state");
+
+  const target = safeRedirectTarget(redirectUri);
+  if (!target) {
+    // Can't safely bounce anywhere — surface the error in-console.
+    return backToConsent(origin, "invalid_redirect_uri");
+  }
+
+  if (decision === "deny") {
+    target.searchParams.set("error", "access_denied");
+    if (state) target.searchParams.set("state", state);
+    return NextResponse.redirect(target.toString(), 303);
+  }
+
+  if (!isApiConfigured()) return backToConsent(origin, "api_unavailable");
+  const token = (await getSessionToken()) ?? undefined;
+
+  try {
+    const { redirect_to } = await oauthAuthorizeGrant(
+      {
+        client_id: field(form, "client_id"),
+        redirect_uri: redirectUri,
+        code_challenge: field(form, "code_challenge"),
+        code_challenge_method: field(form, "code_challenge_method") || "S256",
+        state: state || null,
+        scope: field(form, "scope") || null,
+        workspace_id: field(form, "workspace_id"),
+      },
+      token,
+    );
+    return NextResponse.redirect(redirect_to, 303);
+  } catch (err) {
+    if (err instanceof ApiHttpError && err.status === 401) {
+      return NextResponse.redirect(
+        new URL("/login?reason=session_expired", origin),
+        303,
+      );
+    }
+    // Per OAuth, surface failures to the client via the redirect so the
+    // agent shows a real error rather than hanging on its listener.
+    const code =
+      err instanceof ApiUnavailableError
+        ? "temporarily_unavailable"
+        : err instanceof ApiHttpError && err.status === 403
+          ? "access_denied"
+          : "server_error";
+    target.searchParams.set("error", code);
+    if (state) target.searchParams.set("state", state);
+    return NextResponse.redirect(target.toString(), 303);
+  }
+}
+
+function backToConsent(origin: string, error: string) {
+  const url = new URL("/", origin);
+  url.searchParams.set("oauth_error", error);
+  return NextResponse.redirect(url, 303);
+}

--- a/apps/console/src/app/api/oauth/grant/route.ts
+++ b/apps/console/src/app/api/oauth/grant/route.ts
@@ -69,7 +69,6 @@ export async function POST(request: Request) {
         code_challenge_method: field(form, "code_challenge_method") || "S256",
         state: state || null,
         scope: field(form, "scope") || null,
-        workspace_id: field(form, "workspace_id"),
       },
       token,
     );

--- a/apps/console/src/components/connect-agent-card.tsx
+++ b/apps/console/src/components/connect-agent-card.tsx
@@ -18,7 +18,15 @@ import { useEffect, useState } from "react";
 
 const dismissKey = (wsId: string) => `ship.connect-agent.dismissed.${wsId}`;
 
-function claudeCodeCommand(endpoint: string, secret: string | null): string {
+/** OAuth path (recommended): no token in the command — the agent
+ * discovers Ship's authorization server, opens a login, and you approve
+ * a workspace in the browser. */
+function oauthCommand(endpoint: string): string {
+  return `claude mcp add ship ${endpoint} -t http`;
+}
+
+/** Token fallback (CI / headless): bearer a minted PAT directly. */
+function tokenCommand(endpoint: string, secret: string | null): string {
   const token = secret ?? "<your-token>";
   return `claude mcp add ship ${endpoint} -t http -H "Authorization: Bearer ${token}"`;
 }
@@ -113,7 +121,8 @@ export function ConnectAgentCard({
     );
   }
 
-  const command = claudeCodeCommand(mcpEndpoint, secret);
+  const oauthCmd = oauthCommand(mcpEndpoint);
+  const tokenCmd = tokenCommand(mcpEndpoint, secret);
 
   return (
     <section
@@ -150,22 +159,51 @@ export function ConnectAgentCard({
           </code>
         </Row>
 
-        <Row label="Agent token">
-          {secret ? (
-            <div>
+        {/* Primary: OAuth — no token to paste. The agent opens a Ship
+            login and you approve a workspace in the browser. */}
+        <Row label="Claude Code">
+          <div className="flex items-start gap-2">
+            <code className="min-w-0 flex-1 break-all rounded-lg border border-white/10 bg-ink/60 p-2 font-mono text-[11px] text-white/85">
+              {oauthCmd}
+            </code>
+            <button
+              type="button"
+              onClick={() => copy("oauth", oauthCmd)}
+              className="shrink-0 rounded-full border border-white/15 px-2.5 py-1 text-[10px] font-bold text-white/70 hover:text-white"
+            >
+              {copied === "oauth" ? "Copied ✓" : "Copy"}
+            </button>
+          </div>
+          <p className="mt-1 text-[10px] text-white/50">
+            On first use your agent opens a Ship login and asks you to approve
+            a workspace — no token to paste. Revoke any time in Settings →
+            Agents &amp; access.
+          </p>
+        </Row>
+
+        <Row label="Claude Desktop">
+          <p className="text-xs text-white/65">
+            Settings → Connectors → Add custom connector — URL{" "}
+            <code className="font-mono text-white/85">{mcpEndpoint}</code>. It
+            walks you through the same login + approve.
+          </p>
+        </Row>
+
+        {/* Fallback: a long-lived PAT for CI / headless agents that
+            can't do an interactive browser login. */}
+        <details className="rounded-lg border border-white/10 bg-white/[0.02] p-2.5">
+          <summary className="cursor-pointer text-[10px] font-bold uppercase tracking-widest text-white/55 hover:text-white">
+            Headless / CI? Use a token instead
+          </summary>
+          <div className="mt-3 space-y-2">
+            {secret ? (
               <code
                 data-testid="connect-agent-secret"
                 className="block break-all rounded-lg border border-aqua/30 bg-ink/60 p-2 font-mono text-xs text-aqua/95"
               >
                 {secret}
               </code>
-              <p className="mt-1 text-[10px] text-white/50">
-                Copy it now — the secret is never shown again. Revoke any
-                time in Settings → Agents &amp; access.
-              </p>
-            </div>
-          ) : (
-            <div className="flex flex-wrap items-center gap-2">
+            ) : (
               <button
                 type="button"
                 onClick={mint}
@@ -175,49 +213,26 @@ export function ConnectAgentCard({
               >
                 {minting ? "Minting…" : "Mint agent token"}
               </button>
-              <span className="text-[10px] text-white/45">
-                or use an existing key from Settings → Agents &amp; access
-              </span>
+            )}
+            <div className="flex items-start gap-2">
+              <code className="min-w-0 flex-1 break-all rounded-lg border border-white/10 bg-ink/60 p-2 font-mono text-[11px] text-white/85">
+                {tokenCmd}
+              </code>
+              <button
+                type="button"
+                onClick={() => copy("token", tokenCmd)}
+                className="shrink-0 rounded-full border border-white/15 px-2.5 py-1 text-[10px] font-bold text-white/70 hover:text-white"
+              >
+                {copied === "token" ? "Copied ✓" : "Copy"}
+              </button>
             </div>
-          )}
-        </Row>
-
-        <Row label="Claude Code">
-          <div className="flex items-start gap-2">
-            <code className="min-w-0 flex-1 break-all rounded-lg border border-white/10 bg-ink/60 p-2 font-mono text-[11px] text-white/85">
-              {command}
-            </code>
-            <button
-              type="button"
-              onClick={() => copy("code", command)}
-              className="shrink-0 rounded-full border border-white/15 px-2.5 py-1 text-[10px] font-bold text-white/70 hover:text-white"
-            >
-              {copied === "code" ? "Copied ✓" : "Copy"}
-            </button>
+            {secret && (
+              <p className="text-[10px] text-white/50">
+                Copy it now — the secret is never shown again.
+              </p>
+            )}
           </div>
-        </Row>
-
-        <Row label="Claude Desktop">
-          <p className="text-xs text-white/65">
-            Settings → Connectors → Add custom connector — URL{" "}
-            <code className="font-mono text-white/85">{mcpEndpoint}</code>, header{" "}
-            <code className="font-mono text-white/85">
-              Authorization: Bearer {secret ? "<minted token>" : "<your-token>"}
-            </code>
-            <button
-              type="button"
-              onClick={() =>
-                copy(
-                  "desktop",
-                  `Authorization: Bearer ${secret ?? "<your-token>"}`,
-                )
-              }
-              className="ml-2 rounded-full border border-white/15 px-2 py-0.5 text-[10px] font-bold text-white/70 hover:text-white"
-            >
-              {copied === "desktop" ? "Copied ✓" : "Copy header"}
-            </button>
-          </p>
-        </Row>
+        </details>
       </div>
 
       {error && <p className="mt-3 text-xs text-coral/95">{error}</p>}

--- a/apps/console/src/lib/api/client.ts
+++ b/apps/console/src/lib/api/client.ts
@@ -3366,7 +3366,6 @@ export function oauthAuthorizeGrant(
     code_challenge_method: string;
     state?: string | null;
     scope?: string | null;
-    workspace_id: string;
   },
   token?: string,
 ): Promise<{ redirect_to: string }> {

--- a/apps/console/src/lib/api/client.ts
+++ b/apps/console/src/lib/api/client.ts
@@ -3337,6 +3337,46 @@ export function mintToken(
   });
 }
 
+// --- MCP OAuth broker (ELS-296) ---------------------------------------------
+
+export type McpOAuthClientInfo = {
+  client_id: string;
+  client_name: string | null;
+  redirect_uris: string[];
+};
+
+/** Public metadata for the consent screen (session-authed). */
+export function describeOAuthClient(
+  clientId: string,
+  token?: string,
+): Promise<McpOAuthClientInfo> {
+  return apiFetch<McpOAuthClientInfo>(
+    `/oauth/clients/${encodeURIComponent(clientId)}`,
+    { token },
+  );
+}
+
+/** Operator approved consent → mint the single-use code; returns the
+ * redirect URL (``redirect_uri?code=…&state=…``) to bounce the browser to. */
+export function oauthAuthorizeGrant(
+  input: {
+    client_id: string;
+    redirect_uri: string;
+    code_challenge: string;
+    code_challenge_method: string;
+    state?: string | null;
+    scope?: string | null;
+    workspace_id: string;
+  },
+  token?: string,
+): Promise<{ redirect_to: string }> {
+  return apiFetch<{ redirect_to: string }>(`/oauth/authorize/grant`, {
+    method: "POST",
+    body: input,
+    token,
+  });
+}
+
 export function listTokens(token?: string): Promise<ApiTokenInfo[]> {
   return apiFetch<ApiTokenInfo[]>(`/v1/auth/tokens`, { token });
 }

--- a/apps/console/src/lib/console-mode.test.ts
+++ b/apps/console/src/lib/console-mode.test.ts
@@ -49,9 +49,10 @@ describe("isPathAllowed", () => {
       expect(isPathAllowed("full", p)).toBe(true);
     }
   });
-  it("residual allows hub + approve + Chat + Settings only", () => {
+  it("residual allows hub + approve + oauth + Chat + Settings only", () => {
     expect(isPathAllowed("residual", "/")).toBe(true);
     expect(isPathAllowed("residual", "/approve/123")).toBe(true);
+    expect(isPathAllowed("residual", "/oauth/authorize")).toBe(true);
     expect(isPathAllowed("residual", "/chat")).toBe(true);
     expect(isPathAllowed("residual", "/settings/general")).toBe(true);
     expect(isPathAllowed("residual", "/inbox")).toBe(false);
@@ -59,8 +60,9 @@ describe("isPathAllowed", () => {
     expect(isPathAllowed("residual", "/process")).toBe(false);
     expect(isPathAllowed("residual", "/memory")).toBe(false);
   });
-  it("off keeps the /approve confirm surface reachable (must-fix)", () => {
+  it("off keeps the /approve + /oauth surfaces reachable (must-fix)", () => {
     expect(isPathAllowed("off", "/approve/abc")).toBe(true);
+    expect(isPathAllowed("off", "/oauth/authorize")).toBe(true);
     expect(isPathAllowed("off", "/")).toBe(true);
     expect(isPathAllowed("off", "/inbox")).toBe(false);
     expect(isPathAllowed("off", "/chat")).toBe(false);

--- a/apps/console/src/lib/console-mode.ts
+++ b/apps/console/src/lib/console-mode.ts
@@ -40,8 +40,8 @@ export function envDefaultMode(): ConsoleMode {
  * link target for Telegram buttons and MCP web_url refusals) is
  * reachable in EVERY mode (must-fix: never orphan pending operator
  * approvals). */
-const RESIDUAL_PREFIXES = ["/", "/approve", "/chat", "/settings"] as const;
-const OFF_PREFIXES = ["/", "/approve"] as const;
+const RESIDUAL_PREFIXES = ["/", "/approve", "/oauth", "/chat", "/settings"] as const;
+const OFF_PREFIXES = ["/", "/approve", "/oauth"] as const;
 
 function matchesPrefix(pathname: string, prefix: string): boolean {
   if (prefix === "/") return pathname === "/";


### PR DESCRIPTION
Business operators can't easily paste a PAT; this makes Ship the OAuth
2.1 authorization server for the MCP edge so the operator just adds the
server URL, logs in, approves a workspace, and is done. No token to copy.

Ship brokers over Auth0 rather than delegating to it: it owns the
discovery + consent surface (per-workspace grant — the RBAC workstream),
doesn't depend on Auth0 Dynamic Client Registration, works under any
upstream IdP, and the issued access token is a short-lived
workspace-scoped ship_pat_ — so the existing _resolve_pat path validates
it unchanged, no second credential type.

Backend (machine-facing, app root):
- Discovery: /.well-known/oauth-protected-resource (+/mcp variant, RFC
  9728) and /.well-known/oauth-authorization-server (RFC 8414); the
  authorization_endpoint points at the console, token+registration at
  the API.
- /mcp now 401s with WWW-Authenticate: Bearer resource_metadata=... so
  the client bootstraps the flow instead of demanding a pasted token.
- POST /oauth/register — Dynamic Client Registration (RFC 7591), public
  PKCE clients (token_endpoint_auth_method=none).
- POST /oauth/authorize/grant — session-authed; validates client +
  redirect_uri (loopback port-insensitive per RFC 8252) + PKCE-S256 +
  workspace membership, mints a single-use code.
- POST /oauth/token — code+verifier → scoped ship_pat_ (90d). Refuses
  replay, wrong verifier, wrong redirect_uri, expired/consumed codes.
- migration 0090: mcp_oauth_clients + mcp_oauth_codes.

Console (human-facing):
- /oauth/authorize consent screen (the (authed) layout handles login):
  client name + workspace picker + Approve/Deny; grant route 302s back
  to the client's loopback redirect with code/state (or access_denied).
- /oauth + /approve reachable in every console.surface mode.
- Connect-your-agent card leads with the OAuth command (no header);
  the PAT path is now a Headless/CI fallback.

Tests: 10 backend (discovery, 401 hint, DCR, full PKCE flow → working
token on /mcp, replay/verifier/redirect refusals, membership + plain-PKCE
guards); console-mode allowlist + tsc/lint green. End-to-end smoked on
the local stack incl. the console consent page + grant redirect.

Follow-up: refresh-token grant if 90d re-consent friction shows up.
