### PR TITLE
fix(test): strangler gate skips path-less router proxies

### DIFF
--- a/apps/backend/tests/test_strangler_regression_gate.py
+++ b/apps/backend/tests/test_strangler_regression_gate.py
@@ -13,7 +13,11 @@ from __future__ import annotations
 def _route_paths() -> set[str]:
     from backend.app.main import app
 
-    return {r.path for r in app.routes}
+    # Some FastAPI/Starlette versions leave a path-less ``_IncludedRouter``
+    # proxy in ``app.routes`` per ``include_router`` call (seen in CI once
+    # the MCP edge + OAuth broker routers were mounted). Those carry no
+    # path to gate on — skip anything without a ``.path``.
+    return {r.path for r in app.routes if hasattr(r, "path")}
 
 
 def test_deleted_render_routes_are_gone() -> None:


### PR DESCRIPTION
CI's FastAPI/Starlette leaves a path-less _IncludedRouter in app.routes
per include_router call; the gate's {r.path for r in app.routes} blew up
with AttributeError once the MCP edge + OAuth broker routers were both
mounted (passed locally — version skew). Guard with hasattr(r,'path');
the gate only cares about real route paths.
