### PR TITLE
feat(mcp): connected agent works by Ship's rules — get_policies tool + rules-of-engagement in instructions (ELS-297)

### DIFF
--- a/apps/backend/app/api/v1/routes/mcp.py
+++ b/apps/backend/app/api/v1/routes/mcp.py
@@ -114,7 +114,16 @@ mutation is attributed to them, so never fire a mutating tool the
 operator did not explicitly ask for in this conversation
 (verify-before-mutate). Suggest first; call after they confirm.
 
-Work by Ship's rules. Each workspace carries standing rules — its
+Track the work. Ship delivers THROUGH the tracker — the ticket is the
+source of truth, not the PR. Every unit of work gets a tracker ticket
+BEFORE you change code for it: `ticket_create` for a single feature/bug/
+task, or `project_create` (brief as body) + a decomposition subagent for
+anything larger. Move the ticket through its states with `ticket_update`
+as you go (the status field is the engine's only transition signal).
+Never reference a ticket id you didn't create. If the operator asks for
+code without a ticket, file the ticket first, then proceed.
+
+Work by Ship's rules. Each workspace also carries standing rules — its
 definition-of-done, conventions and methodology, the same ones Ship's
 own execution agents follow. BEFORE you act in a workspace (planning,
 tickets, reviews, comments) call `get_policies` for it and honour what

--- a/apps/backend/app/api/v1/routes/mcp.py
+++ b/apps/backend/app/api/v1/routes/mcp.py
@@ -114,6 +114,14 @@ mutation is attributed to them, so never fire a mutating tool the
 operator did not explicitly ask for in this conversation
 (verify-before-mutate). Suggest first; call after they confirm.
 
+Work by Ship's rules. Each workspace carries standing rules — its
+definition-of-done, conventions and methodology, the same ones Ship's
+own execution agents follow. BEFORE you act in a workspace (planning,
+tickets, reviews, comments) call `get_policies` for it and honour what
+it returns; treat those rules as binding on how you do the work, not
+optional advice. The non-negotiable ones are also enforced server-side
+(you'll get a refusal), but most are yours to uphold.
+
 Workspaces: every tool accepts an optional `workspace_id`. If the
 operator belongs to exactly one workspace it is inferred; otherwise
 call `list_workspaces` and ask which one they mean.
@@ -209,6 +217,21 @@ _NATIVE_TOOLS: list[dict[str, Any]] = [
             "(id, slug, name)."
         ),
         "inputSchema": {"type": "object", "properties": {}},
+    },
+    {
+        "name": "get_policies",
+        "description": (
+            "Load a workspace's standing rules — its definition-of-done, "
+            "conventions and methodology, the same prose policies Ship's "
+            "execution agents follow. Read this BEFORE acting in a "
+            "workspace and treat what it returns as binding on how you "
+            "plan, build and review there. Returns the rendered policy "
+            "preamble (empty when the workspace has set no rules)."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {"workspace_id": _WORKSPACE_ID_PROP},
+        },
     },
     {
         "name": "workspace_create",
@@ -383,6 +406,25 @@ async def _call_native(
         rows = await _member_workspaces(session, auth.user.id)
         return json.dumps(
             [{"id": str(w.id), "slug": w.slug, "name": w.name} for w in rows]
+        )
+
+    if name == "get_policies":
+        from backend.app.services.policies import render_policies_preamble
+
+        ws_id = await _resolve_workspace_id(session, auth, arguments)
+        preamble = await render_policies_preamble(session, ws_id)
+        return json.dumps(
+            {
+                "workspace_id": str(ws_id),
+                "policies": preamble or "",
+                "note": (
+                    "These are the workspace's standing rules — its "
+                    "definition of how Ship work gets done here. Follow "
+                    "them for every action you take in this workspace."
+                    if preamble
+                    else "This workspace has no standing rules set yet."
+                ),
+            }
         )
 
     if name == "workspace_create":

--- a/apps/backend/tests/test_mcp_edge.py
+++ b/apps/backend/tests/test_mcp_edge.py
@@ -71,12 +71,44 @@ async def test_tools_list_projection_and_natives(
         "workspace_create",
         "github_sibling_installs",
         "github_attach_install",
+        "get_policies",
     ):
         assert native in tools
     # workspace_id injected into projected tools.
     assert "workspace_id" in tools["dashboard_get"]["inputSchema"]["properties"]
     # approval_echo contract surfaced on inbox_update.
     assert "approval_echo" in tools["inbox_update"]["inputSchema"]["properties"]
+
+
+@pytest.mark.asyncio
+async def test_initialize_instructs_work_by_ship_rules(
+    db_session, v1_client, seed_workspace
+) -> None:
+    _, raw, _ = seed_workspace
+    res = await _post(v1_client, raw, _rpc("initialize", {}))
+    instructions = res.json()["result"]["instructions"]
+    assert "get_policies" in instructions
+    assert "Ship's rules" in instructions
+
+
+@pytest.mark.asyncio
+async def test_get_policies_returns_workspace_rules(
+    db_session, v1_client, seed_workspace
+) -> None:
+    _, raw, workspace = seed_workspace
+    res = await _post(
+        v1_client,
+        raw,
+        _rpc(
+            "tools/call",
+            {"name": "get_policies", "arguments": {"workspace_id": str(workspace.id)}},
+        ),
+    )
+    result = res.json()["result"]
+    assert result["isError"] is False
+    body = json.loads(result["content"][0]["text"])
+    assert body["workspace_id"] == str(workspace.id)
+    assert "policies" in body and "note" in body
 
 
 @pytest.mark.asyncio

--- a/apps/backend/tests/test_mcp_edge.py
+++ b/apps/backend/tests/test_mcp_edge.py
@@ -89,6 +89,10 @@ async def test_initialize_instructs_work_by_ship_rules(
     instructions = res.json()["result"]["instructions"]
     assert "get_policies" in instructions
     assert "Ship's rules" in instructions
+    # Ticket-discipline is set at connect, not left to the agent's habits:
+    # every unit of work gets a tracker ticket before code.
+    assert "ticket_create" in instructions
+    assert "BEFORE you change code" in instructions
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
The operator's attached agent is an edge, not a Ship execution agent, so
'work by Ship's rules' lands on two channels: hard rules stay server-side
gates (stakes, FSM — already there), and the soft methodology/DoD rides
the prompt. This wires the prompt half:

- get_policies(workspace_id) native MCP tool — returns the workspace's
  rendered standing-rules preamble (reuses render_policies_preamble, the
  same prose policies Ship's execution agents follow). User-scoped OAuth
  tokens span all workspaces, so it's per-workspace on demand rather than
  baked into initialize.
- SERVER_INSTRUCTIONS gains a 'Work by Ship's rules' clause: before
  acting in a workspace, call get_policies and treat what it returns as
  binding; the non-negotiable rules are also enforced server-side.

Tests: get_policies in tools/list + returns the workspace rules; initialize
carries the rules-of-engagement clause. (Part 1 of the connect-time
rules+assessment work; sdlc_assess + activation nudge follow.)
