### PR TITLE
feat(mcp): sdlc_assess — proactive repo SDLC assessment over MCP (ELS-298)

### DIFF
--- a/apps/backend/app/api/v1/routes/mcp.py
+++ b/apps/backend/app/api/v1/routes/mcp.py
@@ -151,6 +151,10 @@ Typical flows:
   steps (agent secrets, the first GitHub/tracker OAuth) hand the
   operator the `fix_url`, wait, then re-run `repo_setup_status`. Once
   they merge the seed PR, Ship's bootstrap runs itself.
+- "what does this repo still need / set up deploy + tests" →
+  `sdlc_assess` to classify the repo and list its SDLC gaps +
+  recommended tickets. Proactively offer those to the operator; on a
+  yes, file them with `project_create` / `ticket_create`.
 - open questions / approvals → `inbox_list`, then `inbox_get` and
   `inbox_update`. Disposing an APPROVAL item requires passing
   `approval_echo` with the item's exact title — quote it to the
@@ -316,6 +320,36 @@ _NATIVE_TOOLS: list[dict[str, Any]] = [
                         "Pass false on an FSM-ready repo to bump the bundle "
                         "without touching the operator's tailored process."
                     ),
+                },
+            },
+            "required": ["repo_id"],
+        },
+    },
+    {
+        "name": "sdlc_assess",
+        "description": (
+            "Assess a repo's SDLC maturity and propose what to set up. "
+            "Harvests repo intel if needed (synchronous), classifies the "
+            "project type, and reports gaps vs the blueprint — missing "
+            "tests, CI, Docker, deploy, etc. — plus the required secrets "
+            "and an external checklist. Returns `recommended_tickets` "
+            "(title + what each scaffolds) so you can proactively offer to "
+            "wire deploy/tests in; propose them to the operator and, on "
+            "yes, file them. Pass refresh=true to re-harvest. This is the "
+            "'what does this repo still need?' tool — run it after a repo "
+            "is Ship-ready (see repo_setup_status / wizard_seed)."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "workspace_id": _WORKSPACE_ID_PROP,
+                "repo_id": {
+                    "type": "string",
+                    "description": "Activated-repo UUID.",
+                },
+                "refresh": {
+                    "type": "boolean",
+                    "description": "Re-harvest intel before assessing (default false).",
                 },
             },
             "required": ["repo_id"],
@@ -705,6 +739,77 @@ async def _call_native(
         ws_id = await _resolve_workspace_id(session, auth, arguments)
         return await _repo_setup_status(
             session, ws_id, repo_arg, settings=settings
+        )
+
+    if name == "sdlc_assess":
+        from backend.app.db.models.integrations import WorkspaceRepo
+        from backend.app.db.models.repo_intel import RepoIntelTriggeredBy
+        from backend.app.services.bootstrap_plan import _spec
+        from backend.app.services.repo_intel import (
+            get_current_intel,
+            harvest_repo_intel,
+        )
+        from backend.app.services.sdlc_readiness import build_readiness
+
+        refresh = bool(arguments.get("refresh"))
+        repo_id = _native_repo_id(arguments)
+        ws_id = await _resolve_workspace_id(session, auth, arguments)
+        repo = await session.get(WorkspaceRepo, repo_id)
+        if repo is None or repo.workspace_id != ws_id:
+            raise _McpToolError("repo not activated in this workspace")
+
+        # Harvest intel synchronously when missing or on refresh —
+        # best-effort: build_readiness degrades gracefully if it fails.
+        harvested = False
+        intel = await get_current_intel(session, repo_id)
+        if intel is None or refresh:
+            try:
+                await harvest_repo_intel(
+                    session=session,
+                    workspace_id=ws_id,
+                    repo_id=repo_id,
+                    triggered_by=RepoIntelTriggeredBy.MANUAL_REFRESH,
+                    settings=settings,
+                )
+                harvested = True
+            except Exception as exc:  # noqa: BLE001 — assess must not 500
+                logger.warning("sdlc_assess harvest failed for %s: %s", repo_id, exc)
+
+        result = await build_readiness(session=session, repo=repo)
+        if not result.has_blueprint or result.report is None:
+            return json.dumps(
+                {
+                    "repo_id": str(repo_id),
+                    "ready": False,
+                    "project_type": result.project_type,
+                    "detail": result.detail,
+                    "harvested": harvested,
+                }
+            )
+        rep = result.report
+        recommended = [
+            {"capability": c, "title": _spec(c)[0], "scaffold": _spec(c)[1]}
+            for c in rep.gaps
+        ]
+        return json.dumps(
+            {
+                "repo_id": str(repo_id),
+                "project_type": rep.project_type,
+                "delivery": rep.delivery,
+                "ready": rep.ready,
+                "gaps": list(rep.gaps),
+                "missing_required_secrets": list(rep.missing_required_secrets),
+                "external_checklist": list(rep.external_checklist),
+                "recommended_tickets": recommended,
+                "harvested": harvested,
+                "guidance": (
+                    "Propose recommended_tickets to the operator; on yes, "
+                    "file them (project_create / ticket_create). Missing "
+                    "secrets stay web-only — point them at the "
+                    "repo_setup_status fix_url. Don't create tickets "
+                    "unprompted."
+                ),
+            }
         )
 
     if name == "tracker_bind":

--- a/apps/backend/app/api/v1/routes/mcp.py
+++ b/apps/backend/app/api/v1/routes/mcp.py
@@ -153,8 +153,12 @@ Typical flows:
   they merge the seed PR, Ship's bootstrap runs itself.
 - "what does this repo still need / set up deploy + tests" →
   `sdlc_assess` to classify the repo and list its SDLC gaps +
-  recommended tickets. Proactively offer those to the operator; on a
-  yes, file them with `project_create` / `ticket_create`.
+  recommended tickets. Proactively offer the gaps to the operator; on
+  a yes, file them with `project_create` / `ticket_create`. If the repo
+  ALREADY has some setup (`existing_capabilities` / `integration_
+  decision` in the result), don't scaffold over it — ask the operator
+  how they want Ship to integrate (coexist / replace / adopt), present
+  the options, and act on their pick.
 - open questions / approvals → `inbox_list`, then `inbox_get` and
   `inbox_update`. Disposing an APPROVAL item requires passing
   `approval_echo` with the item's exact title — quote it to the
@@ -787,30 +791,66 @@ async def _call_native(
                 }
             )
         rep = result.report
+        # Gaps are clean adds. Satisfied capabilities mean the repo
+        # ALREADY has that setup (CI, tests, Docker, deploy…) — Ship must
+        # not scaffold over them blindly; surface them so the agent asks
+        # the operator how to integrate.
         recommended = [
             {"capability": c, "title": _spec(c)[0], "scaffold": _spec(c)[1]}
             for c in rep.gaps
         ]
-        return json.dumps(
-            {
-                "repo_id": str(repo_id),
-                "project_type": rep.project_type,
-                "delivery": rep.delivery,
-                "ready": rep.ready,
-                "gaps": list(rep.gaps),
-                "missing_required_secrets": list(rep.missing_required_secrets),
-                "external_checklist": list(rep.external_checklist),
-                "recommended_tickets": recommended,
-                "harvested": harvested,
-                "guidance": (
-                    "Propose recommended_tickets to the operator; on yes, "
-                    "file them (project_create / ticket_create). Missing "
-                    "secrets stay web-only — point them at the "
-                    "repo_setup_status fix_url. Don't create tickets "
-                    "unprompted."
+        existing = [
+            {"capability": c.capability, "matched_by": c.matched_by}
+            for c in rep.capabilities
+            if c.satisfied
+        ]
+        out: dict[str, Any] = {
+            "repo_id": str(repo_id),
+            "project_type": rep.project_type,
+            "delivery": rep.delivery,
+            "ready": rep.ready,
+            "gaps": list(rep.gaps),
+            "existing_capabilities": existing,
+            "missing_required_secrets": list(rep.missing_required_secrets),
+            "external_checklist": list(rep.external_checklist),
+            "recommended_tickets": recommended,
+            "harvested": harvested,
+            "guidance": (
+                "Gaps are clean adds — propose recommended_tickets to the "
+                "operator; on yes, file them (project_create / "
+                "ticket_create). Missing secrets stay web-only — point "
+                "them at the repo_setup_status fix_url. Don't create "
+                "tickets unprompted."
+            ),
+        }
+        if existing:
+            out["integration_decision"] = {
+                "why": (
+                    "This repo already has some of what Ship would set up "
+                    "(see existing_capabilities). Do NOT scaffold over it "
+                    "blindly — ASK the operator how they want Ship to "
+                    "integrate, present the options, and act on their pick."
                 ),
+                "options": [
+                    {
+                        "id": "coexist",
+                        "label": "Coexist — Ship wraps/uses the existing "
+                        "setup, adds only the missing gaps.",
+                    },
+                    {
+                        "id": "replace",
+                        "label": "Replace — swap the existing setup for "
+                        "Ship's blueprint (the old config is removed in the "
+                        "change).",
+                    },
+                    {
+                        "id": "adopt",
+                        "label": "Adopt — keep the existing setup as-is and "
+                        "register it with Ship, scaffolding nothing for it.",
+                    },
+                ],
             }
-        )
+        return json.dumps(out)
 
     if name == "tracker_bind":
         from backend.app.api.v1.routes.tracker_binding import (

--- a/apps/backend/tests/test_mcp_edge.py
+++ b/apps/backend/tests/test_mcp_edge.py
@@ -75,6 +75,7 @@ async def test_tools_list_projection_and_natives(
         "repo_setup_status",
         "tracker_bind",
         "wizard_seed",
+        "sdlc_assess",
     ):
         assert native in tools
     # workspace_id injected into projected tools.
@@ -159,6 +160,24 @@ async def test_wizard_seed_surfaces_precondition_error(
     result = res.json()["result"]
     assert result["isError"] is True
     assert "cannot seed yet" in result["content"][0]["text"]
+
+
+@pytest.mark.asyncio
+async def test_sdlc_assess_unknown_repo_errors(
+    db_session, v1_client, seed_workspace
+) -> None:
+    _, raw, _ = seed_workspace
+    res = await _post(
+        v1_client,
+        raw,
+        _rpc(
+            "tools/call",
+            {"name": "sdlc_assess", "arguments": {"repo_id": str(uuid.uuid4())}},
+        ),
+    )
+    result = res.json()["result"]
+    assert result["isError"] is True
+    assert "not activated" in result["content"][0]["text"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Part 2 of the connect-time intelligence: after a repo is Ship-ready the
agent can assess what it still needs and proactively offer to wire it up.

- sdlc_assess(workspace_id, repo_id, refresh?) native tool: harvests
  repo intel synchronously when missing/refresh (best-effort — the
  scheduled/worker harvest doesn't run in prod, so we run it inline),
  classifies the project type, runs build_readiness, and returns the
  gaps (tests/CI/Docker/deploy/…), missing required secrets, external
  checklist, and recommended_tickets (title + scaffold per gap, via
  bootstrap_plan._spec). Degrades cleanly to the 'no blueprint / harvest
  failed' detail. Read-only: it proposes, the operator confirms, the
  agent files via project_create/ticket_create (verify-before-mutate).
- SERVER_INSTRUCTIONS gains a 'what does this repo still need' flow.

Reuses services/sdlc_readiness.build_readiness + repo_intel.harvest_repo_
intel + bootstrap_plan._spec; no new endpoints. 18 edge tests green on
.venv (CI interpreter); unknown-repo path tested without GitHub.

Follow-up (ELS-300): list-installable-repos + repo_activate. A bootstrap_
devops action tool (generate the routed DevOps epic) can wrap
generate_bootstrap_plan when wanted.
