### PR TITLE
fix(repos): _resolve_installation falls back to sibling-attached install (ELS-303)

### DIFF
--- a/apps/backend/app/api/v1/routes/repos.py
+++ b/apps/backend/app/api/v1/routes/repos.py
@@ -146,6 +146,24 @@ async def _resolve_installation(
     )
     install = (await session.execute(stmt)).scalars().first()
     if install is None:
+        # Sibling-attached install (migration 0076 — multi-workspace per
+        # install): the workspace activated repos under ANOTHER
+        # workspace's install via the headless attach path, so no
+        # install row is owned by this workspace. Resolve it through the
+        # workspace's activated repos' installation_id FK. Additive —
+        # only runs when the direct lookup found nothing, so normal
+        # single-workspace installs are unaffected.
+        sibling_stmt = (
+            select(GitHubInstallation)
+            .join(
+                WorkspaceRepo,
+                WorkspaceRepo.installation_id == GitHubInstallation.id,
+            )
+            .where(WorkspaceRepo.workspace_id == workspace_id)
+            .where(GitHubInstallation.suspended_at.is_(None))
+        )
+        install = (await session.execute(sibling_stmt)).scalars().first()
+    if install is None:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail=(

--- a/apps/backend/tests/test_v1_repos.py
+++ b/apps/backend/tests/test_v1_repos.py
@@ -141,6 +141,66 @@ async def test_available_returns_live_set_with_activation_flag(
 
 
 @pytest.mark.asyncio
+async def test_available_resolves_sibling_attached_install(
+    v1_client,
+    db_session,
+    seed_workspace,
+    github_app_env,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Multi-workspace per install (migration 0076 / ELS-303): the
+    workspace owns NO install of its own but activated a repo under a
+    sibling workspace's install. _resolve_installation must fall back to
+    that install via the repo's installation_id instead of 409-ing."""
+    from backend.app.api.v1.routes import repos as repos_module
+    from backend.app.db.models.integrations import WorkspaceRepo
+    from backend.app.db.models.tenancy import Workspace
+
+    _, raw, workspace = seed_workspace
+    # The install belongs to a sibling workspace in the same org.
+    sibling = Workspace(
+        org_id=workspace.org_id,
+        slug=f"sib-{uuid.uuid4().hex[:6]}",
+        name="Sibling",
+    )
+    db_session.add(sibling)
+    await db_session.flush()
+    install = await _seed_installation(
+        db_session, sibling.id, installation_id=200
+    )
+    # Target workspace activated a repo under the sibling's install.
+    db_session.add(
+        WorkspaceRepo(
+            workspace_id=workspace.id,
+            installation_id=install.id,
+            provider="github",
+            external_id=2001,
+            full_name="acme/shared",
+            default_branch="main",
+            private=False,
+            html_url="https://github.com/acme/shared",
+            activated_at=datetime.now(timezone.utc),
+        )
+    )
+    await db_session.flush()
+
+    async def _stub(self) -> list:
+        return [_summary(external_id=2001, repo="shared")]
+
+    monkeypatch.setattr(
+        repos_module.GitHubCodeHost, "list_repo_summaries", _stub
+    )
+
+    response = await v1_client.get(
+        f"/v1/workspaces/{workspace.id}/repos/available",
+        headers={"Authorization": f"Bearer {raw}"},
+    )
+    assert response.status_code == 200, response.text
+    by_id = {r["external_id"]: r for r in response.json()}
+    assert by_id[2001]["activated"] is True
+
+
+@pytest.mark.asyncio
 async def test_activate_replaces_set_and_audit_logs(
     v1_client,
     db_session,


### PR DESCRIPTION
Under migration 0076 (multi-workspace per install) a workspace can
activate repos via the headless attach path under ANOTHER workspace's
GitHub App install — so it owns no install row of its own, and
_resolve_installation 409'd 'no active install'. That broke
list_available_repos, the console repo picker, and the new
github_list_install_repos / repo_activate MCP tools, even though
repo_setup_status (checking WorkspaceRepo.installation_id) reported the
repo wired. Caught live-testing repo_activate on Ship-on-Ship.

Fix: when the direct workspace-owned lookup finds nothing, resolve the
install via the workspace's activated repos' installation_id FK
(suspended_at IS NULL). Additive — only runs on the empty-direct path,
so single-workspace installs are unchanged. Fixes the console picker +
the MCP tools together. Test covers the sibling-attach resolution.
