### PR TITLE
refactor(console): IA simplification teardown — cut off-concept elements + settings 10→5 (ELS-304)

### DIFF
--- a/apps/console/src/app/(authed)/chat/page.tsx
+++ b/apps/console/src/app/(authed)/chat/page.tsx
@@ -149,20 +149,14 @@ export default async function ChatPage({
         title="Navigator"
         scopePill={scopePill}
         actions={
-          <div className="flex items-center gap-4">
+          hasArchivedChats ? (
             <Link
               href={withWorkspaceQuery("/chat/archived", workspace.id, multi)}
               className="text-xs font-semibold text-white/55 hover:text-white"
             >
               Archived chats
             </Link>
-            <Link
-              href={withWorkspaceQuery("/", workspace.id, multi)}
-              className="text-xs font-semibold text-white/65 hover:text-white"
-            >
-              ← Dashboard
-            </Link>
-          </div>
+          ) : undefined
         }
       />
       <PageBody>

--- a/apps/console/src/app/(authed)/settings/_shell/settings-shell.tsx
+++ b/apps/console/src/app/(authed)/settings/_shell/settings-shell.tsx
@@ -14,7 +14,6 @@ import { PageBody, PageHeader } from "@/components/app-shell";
 import { ApiUnavailable } from "@/components/api-unavailable";
 import { ConfigScopeCard } from "@/components/config-scope-card";
 import { RepoRoutingPanel } from "@/components/repo-routing-panel";
-import { SdlcReadinessCard } from "@/components/sdlc-readiness-card";
 import {
   IntegrationsWorkspaceBody,
   loadIntegrationsWorkspaceMode,
@@ -388,10 +387,6 @@ export async function SettingsShell({
                 workspaceId={workspace.id}
                 scope="agent.provider"
               />
-              <DispatchRoutineCard
-                workspace={workspace}
-                repos={activatedRepos}
-              />
               <AdvancedSurfacesCard workspaceId={workspace.id} multiWs={multiWs} />
             </div>
           )}
@@ -666,27 +661,6 @@ function RepositoriesPanel({
               ))}
             </tbody>
           </table>
-        </div>
-      )}
-      {repositories.length > 0 && (
-        <div className="mt-6">
-          <h4 className="mb-1 text-[10px] font-semibold uppercase tracking-widest text-white/45">
-            SDLC readiness
-          </h4>
-          <p className="mb-3 text-[11px] text-white/45">
-            Check whether each repo is set up for its project type (tests,
-            Docker, deploy) and generate the DevOps tickets to close the gaps.
-          </p>
-          <div className="space-y-2">
-            {repositories.map((repo) => (
-              <SdlcReadinessCard
-                key={repo.id}
-                workspaceId={workspaceId}
-                repoId={repo.id}
-                repoFullName={repo.full_name}
-              />
-            ))}
-          </div>
         </div>
       )}
       <div className="mt-4 rounded-xl border border-aqua/20 bg-aqua/[0.04] px-3 py-2.5 text-[11px] leading-relaxed text-aqua/85">
@@ -973,89 +947,6 @@ function AdvancedSurfacesCard({
           </li>
         ))}
       </ul>
-    </Card>
-  );
-}
-
-function DispatchRoutineCard({
-  workspace,
-  repos,
-}: {
-  workspace: ApiWorkspace;
-  repos: ApiActivatedRepo[];
-}) {
-  const hasRepo = repos.length > 0;
-  const defaultRepoId = repos[0]?.id ?? "";
-  return (
-    <Card>
-      <CardHeader
-        title="Dispatch routine (debug)"
-        subtitle="Fire any FSM routine manually against the bound provider — the GHA workflow_dispatch runs shipctl run --routine X --debug, which streams a step-by-step log into the runner output. Admin-only; consumes agent quota."
-      />
-      {!hasRepo && (
-        <div className="mb-4 rounded-xl border border-sun/30 bg-sun/[0.06] px-3 py-2 text-xs text-sun/95">
-          No activated repos yet. Activate one before dispatching.
-        </div>
-      )}
-      <form
-        action="/api/settings/dispatch-routine"
-        method="POST"
-        className="grid gap-3 sm:grid-cols-[1fr,1fr,1fr,auto]"
-      >
-        <input type="hidden" name="ws" value={workspace.id} suppressHydrationWarning />
-        <label className="flex flex-col gap-1">
-          <span className="text-[10px] font-bold uppercase tracking-widest text-white/55">
-            Repo
-          </span>
-          <select
-            name="repo"
-            defaultValue={defaultRepoId}
-            required
-            disabled={!hasRepo}
-            className="rounded border border-white/10 bg-white/[0.04] px-2 py-2 text-sm text-white outline-none focus:border-aqua/40 disabled:opacity-50"
-          >
-            {repos.map((r) => (
-              <option key={r.id} value={r.id}>
-                {r.full_name}
-              </option>
-            ))}
-          </select>
-        </label>
-        <label className="flex flex-col gap-1">
-          <span className="text-[10px] font-bold uppercase tracking-widest text-white/55">
-            Routine id
-          </span>
-          <input
-            name="routine"
-            type="text"
-            placeholder="intake / dev_implementation / qa_manual …"
-            required
-            pattern="[A-Za-z0-9_-]{1,64}"
-            disabled={!hasRepo}
-            className="rounded border border-white/10 bg-white/[0.04] px-2 py-2 font-mono text-sm text-white outline-none focus:border-aqua/40 disabled:opacity-50"
-          />
-        </label>
-        <label className="flex flex-col gap-1">
-          <span className="text-[10px] font-bold uppercase tracking-widest text-white/55">
-            Pin ticket (optional)
-          </span>
-          <input
-            name="ticket"
-            type="text"
-            placeholder="ELS-15"
-            pattern="[A-Z0-9-]{1,32}"
-            disabled={!hasRepo}
-            className="rounded border border-white/10 bg-white/[0.04] px-2 py-2 font-mono text-sm text-white outline-none focus:border-aqua/40 disabled:opacity-50"
-          />
-        </label>
-        <button
-          type="submit"
-          disabled={!hasRepo}
-          className="h-10 self-end whitespace-nowrap rounded-full border border-aqua/30 bg-aqua/10 px-4 text-xs font-bold text-aqua transition hover:bg-aqua/15 disabled:cursor-not-allowed disabled:opacity-50"
-        >
-          Dispatch
-        </button>
-      </form>
     </Card>
   );
 }

--- a/apps/console/src/app/(authed)/settings/_shell/settings-shell.tsx
+++ b/apps/console/src/app/(authed)/settings/_shell/settings-shell.tsx
@@ -109,23 +109,40 @@ function errorMessage(code: string): string {
   }
 }
 
+// MCP-first console (ELS-304): five tabs, down from ten. Config folds
+// into General; Connected code + Registries + Integrations merge into
+// Connections; Agent roles folds into Agents & access; Workspaces +
+// Danger merge into Workspace. Legacy tab ids alias to their new parent
+// below so deep-links + the per-tab route files keep resolving.
 const TABS = [
   { id: "general", label: "General" },
-  { id: "workspaces", label: "Workspaces" },
-  { id: "config", label: "Config" },
-  { id: "repositories", label: "Connected code" },
-  { id: "registries", label: "Registries" },
+  { id: "connections", label: "Connections" },
   { id: "members", label: "Members" },
-  { id: "integrations", label: "Integrations" },
-  { id: "agent-roles", label: "Agent roles" },
   { id: "api-keys", label: "Agents & access" },
-  { id: "danger", label: "Danger zone" },
+  { id: "workspace", label: "Workspace" },
 ] as const;
 type TabId = (typeof TABS)[number]["id"];
 const TAB_IDS = TABS.map((t) => t.id);
 
-function isTabId(value: string): value is TabId {
-  return (TAB_IDS as readonly string[]).includes(value);
+// Old tab id → new parent. Keeps ``?tab=`` deep-links and the per-tab
+// route files (settings/{old}/page.tsx) landing on the right merged tab.
+const TAB_ALIASES: Record<string, TabId> = {
+  tokens: "api-keys",
+  repos: "connections",
+  catalog: "general",
+  config: "general",
+  workspaces: "workspace",
+  danger: "workspace",
+  repositories: "connections",
+  registries: "connections",
+  integrations: "connections",
+  "agent-roles": "api-keys",
+};
+
+function resolveTabId(value: string | null | undefined): TabId | null {
+  if (!value) return null;
+  if ((TAB_IDS as readonly string[]).includes(value)) return value as TabId;
+  return TAB_ALIASES[value] ?? null;
 }
 
 async function load(
@@ -266,7 +283,9 @@ export async function SettingsShell({
   activeTab: activeTabFromRoute,
   searchParams,
 }: {
-  activeTab?: TabId;
+  // Accept any string (route files pin legacy ids like "config" /
+  // "registries"); resolveTabId folds them into the 5 parents.
+  activeTab?: string;
   searchParams?: Promise<Record<string, string | string[] | undefined>>;
 }) {
   const params = ((await (searchParams ?? Promise.resolve({}))) ?? {}) as Record<
@@ -276,13 +295,9 @@ export async function SettingsShell({
   const data = await load(params);
   const errorCode = typeof params.error === "string" ? params.error : null;
   const renamedFlag = params.renamed === "1";
-  let requestedTab = typeof params.tab === "string" ? params.tab : null;
-  if (requestedTab === "tokens") requestedTab = "api-keys";
-  if (requestedTab === "repos") requestedTab = "registries";
-  if (requestedTab === "catalog") requestedTab = "general";
+  const requestedTab = typeof params.tab === "string" ? params.tab : null;
   const activeTab: TabId =
-    activeTabFromRoute ??
-    (requestedTab && isTabId(requestedTab) ? requestedTab : "general");
+    resolveTabId(activeTabFromRoute) ?? resolveTabId(requestedTab) ?? "general";
   const justMintedFlag =
     typeof params.just_minted === "string" && params.just_minted === "1";
 
@@ -388,22 +403,22 @@ export async function SettingsShell({
                 scope="agent.provider"
               />
               <AdvancedSurfacesCard workspaceId={workspace.id} multiWs={multiWs} />
+              <ConfigPanel workspaceId={workspace.id} />
             </div>
           )}
 
-          {activeTab === "workspaces" && (
-            <WorkspacesPanel
-              current={workspace}
-              memberships={allWorkspaces}
-            />
+          {activeTab === "workspace" && (
+            <div className="space-y-6">
+              <WorkspacesPanel
+                current={workspace}
+                memberships={allWorkspaces}
+              />
+              <DangerZone workspace={workspace} />
+            </div>
           )}
 
-          {activeTab === "config" && (
-            <ConfigPanel workspaceId={workspace.id} />
-          )}
-
-          {activeTab === "repositories" && (
-            <>
+          {activeTab === "connections" && (
+            <div className="space-y-6">
               <RepositoriesPanel
                 workspaceId={workspace.id}
                 repositories={activatedRepos}
@@ -413,11 +428,8 @@ export async function SettingsShell({
                 workspaceId={workspace.id}
                 repositories={activatedRepos}
               />
-            </>
-          )}
-
-          {activeTab === "registries" && (
-            <Card>
+              <SettingsIntegrationsTab searchParams={params} />
+              <Card>
               <CardHeader
                 title="Registries"
                 subtitle="Package and artifact sources Ship merges for this workspace. File paths work offline; git URLs sync in the background."
@@ -449,42 +461,34 @@ export async function SettingsShell({
               )}
               <AddRepoForm workspaceId={workspace.id} />
             </Card>
+            </div>
           )}
 
           {activeTab === "api-keys" && (
-            <TokensPanel
-              workspaceId={workspace.id}
-              tokens={tokens}
-              freshSecret={freshSecret}
-            />
+            <div className="space-y-6">
+              <TokensPanel
+                workspaceId={workspace.id}
+                tokens={tokens}
+                freshSecret={freshSecret}
+              />
+              <Card>
+                <CardHeader
+                  title="Agent roles"
+                  subtitle="Specialist prompts agents load when a routine fires. Ship ships read-only defaults; override one for this workspace, or clone a default into a custom slug. Most teams never touch this — defaults work."
+                />
+                <div className="mt-4">
+                  <AgentRolesList
+                    workspaceId={workspace.id}
+                    defaults={agentRoleDefaults}
+                    customs={agentRoleCustoms}
+                  />
+                </div>
+              </Card>
+            </div>
           )}
 
           {activeTab === "members" && (
             <WorkspaceMembersPanelLoader searchParams={searchParams} />
-          )}
-
-          {activeTab === "integrations" && (
-            <SettingsIntegrationsTab searchParams={params} />
-          )}
-
-          {activeTab === "agent-roles" && (
-            <Card>
-              <CardHeader
-                title="Agent roles"
-                subtitle="Specialist prompts agents load when a routine fires. Ship ships read-only defaults; override one for this workspace, or clone a default into a custom slug. Most teams never touch this — defaults work."
-              />
-              <div className="mt-4">
-                <AgentRolesList
-                  workspaceId={workspace.id}
-                  defaults={agentRoleDefaults}
-                  customs={agentRoleCustoms}
-                />
-              </div>
-            </Card>
-          )}
-
-          {activeTab === "danger" && (
-            <DangerZone workspace={workspace} />
           )}
         </div>
         </div>

--- a/apps/console/src/app/(authed)/settings/connections/page.tsx
+++ b/apps/console/src/app/(authed)/settings/connections/page.tsx
@@ -1,0 +1,13 @@
+import { SettingsShell } from "../_shell/settings-shell";
+
+export const dynamic = "force-dynamic";
+
+export const metadata = { title: "Connections — Workspace settings" };
+
+export default function ConnectionsSettingsPage({
+  searchParams,
+}: {
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  return <SettingsShell activeTab="connections" searchParams={searchParams} />;
+}

--- a/apps/console/src/app/(authed)/settings/page.tsx
+++ b/apps/console/src/app/(authed)/settings/page.tsx
@@ -22,22 +22,28 @@ export default async function SettingsIndex({
   >;
   const requestedRaw = typeof params.tab === "string" ? params.tab : null;
   const aliased =
-    requestedRaw === "tokens"
-      ? "api-keys"
-      : requestedRaw === "repos"
-        ? "registries"
-        : requestedRaw === "catalog"
-          ? "general"
-          : requestedRaw;
+    requestedRaw
+      ? ({
+          tokens: "api-keys",
+          repos: "connections",
+          catalog: "general",
+          config: "general",
+          workspaces: "workspace",
+          danger: "workspace",
+          repositories: "connections",
+          registries: "connections",
+          integrations: "connections",
+          "agent-roles": "api-keys",
+        }[requestedRaw] ?? requestedRaw)
+      : requestedRaw;
+  // Five MCP-first parents (ELS-304). Old per-section routes still
+  // resolve (resolveTabId folds them), but new nav lands on parents.
   const allowed = new Set([
     "general",
-    "repositories",
-    "registries",
+    "connections",
     "members",
-    "integrations",
-    "agent-roles",
     "api-keys",
-    "danger",
+    "workspace",
   ]);
   const tab = aliased && allowed.has(aliased) ? aliased : "general";
 

--- a/apps/console/src/app/(authed)/settings/workspace/page.tsx
+++ b/apps/console/src/app/(authed)/settings/workspace/page.tsx
@@ -1,0 +1,13 @@
+import { SettingsShell } from "../_shell/settings-shell";
+
+export const dynamic = "force-dynamic";
+
+export const metadata = { title: "Workspace — Workspace settings" };
+
+export default function WorkspaceSettingsPage({
+  searchParams,
+}: {
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  return <SettingsShell activeTab="workspace" searchParams={searchParams} />;
+}

--- a/apps/console/src/app/page.tsx
+++ b/apps/console/src/app/page.tsx
@@ -239,39 +239,32 @@ export default async function WorkspaceStatusPage({
           )}
         </section>
 
-        <section className="rounded-2xl border border-white/10 bg-white/[0.03] p-5">
-          <h2 className="text-[11px] font-bold uppercase tracking-widest text-white/55">
-            Where the work lives
-          </h2>
-          <ul className="mt-2 space-y-2 text-sm">
-            <li>
+        {/* Work lives in the tracker + GitHub — one line of handoff
+            links, not a panel (ELS-304). */}
+        <p className="px-1 text-xs text-white/45">
+          Work lives in{" "}
+          <a
+            href="https://linear.app"
+            target="_blank"
+            rel="noreferrer"
+            className="text-aqua hover:underline"
+          >
+            Linear
+          </a>
+          {repos.map((r) => (
+            <span key={r.id}>
+              {" · "}
               <a
-                href="https://linear.app"
+                href={r.html_url}
                 target="_blank"
                 rel="noreferrer"
                 className="text-aqua hover:underline"
               >
-                Linear →
-              </a>{" "}
-              <span className="text-white/45">
-                tickets, projects, agent comments
-              </span>
-            </li>
-            {repos.map((r) => (
-              <li key={r.id}>
-                <a
-                  href={r.html_url}
-                  target="_blank"
-                  rel="noreferrer"
-                  className="text-aqua hover:underline"
-                >
-                  {r.full_name} →
-                </a>{" "}
-                <span className="text-white/45">PRs, CI, agent branches</span>
-              </li>
-            ))}
-          </ul>
-        </section>
+                {r.full_name}
+              </a>
+            </span>
+          ))}
+        </p>
         {/* No Chat/Settings CTA row here — the left rail already carries
             both persistently; a second copy on the hub body was a
             duplicate (ELS-301). */}

--- a/apps/console/src/components/app-shell.tsx
+++ b/apps/console/src/components/app-shell.tsx
@@ -46,10 +46,6 @@ type NavGroup = { section: string; items: NavItem[] };
 // development.
 const SHOW_STUBS = process.env.NEXT_PUBLIC_SHIP_SHOW_STUBS === "1";
 
-/** When set, sidebar shows a link (e.g. GitHub issues, Linear askevery). */
-const SHIP_FEEDBACK_URL = process.env.NEXT_PUBLIC_SHIP_FEEDBACK_URL?.trim();
-const SHIP_FEEDBACK_LABEL =
-  process.env.NEXT_PUBLIC_SHIP_FEEDBACK_LABEL?.trim() || "Ship feedback";
 
 /**
  * Phase-1 two-mode shell: the sidebar flips between a **workspace**
@@ -323,25 +319,6 @@ function SidebarPanel({
         ))}
       </nav>
 
-      {SHIP_FEEDBACK_URL ? (
-        <div className="border-t border-white/10 px-3 py-2">
-          <a
-            href={SHIP_FEEDBACK_URL}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="block rounded-md px-2 py-1.5 text-[11px] font-semibold text-aqua/90 transition hover:bg-white/[0.04] hover:text-aqua"
-          >
-            {SHIP_FEEDBACK_LABEL}
-            <span className="ml-1 text-white/45" aria-hidden>
-              ↗
-            </span>
-          </a>
-          <p className="mt-0.5 px-2 text-[10px] leading-snug text-white/35">
-            Bugs and product ideas for Ship itself.
-          </p>
-        </div>
-      ) : null}
-
       <div className="border-t border-white/10 p-3">
         <div className="flex items-center gap-2 rounded-md px-2 py-1.5">
           <span className="grid h-7 w-7 shrink-0 place-items-center rounded-full bg-gradient-to-br from-aqua via-lilac to-coral text-[10px] font-bold text-ink">
@@ -355,15 +332,6 @@ function SidebarPanel({
               {userInfo.email}
             </div>
           </div>
-          <Link
-            href={withWorkspaceHref("/settings")}
-            className="grid h-9 w-9 shrink-0 place-items-center rounded-lg text-xl text-white/55 transition hover:bg-white/10 hover:text-white"
-            aria-label="Workspace settings"
-            title="Workspace settings"
-            onClick={onNavInteract}
-          >
-            ⚙︎
-          </Link>
           <form action="/logout" method="POST" className="contents">
             <button
               type="submit"
@@ -944,13 +912,6 @@ function WorkspaceSwitcherMenu({
           <span aria-hidden>→</span>
         </Link>
       )}
-      <Link
-        href={withWorkspaceHref("/settings")}
-        onClick={onPick}
-        className="block border-t border-white/10 bg-white/[0.02] px-4 py-2.5 text-center text-[11px] font-semibold text-aqua hover:underline"
-      >
-        Workspace settings →
-      </Link>
     </div>
   );
 }

--- a/e2e/tests/console-flows.wired.spec.ts
+++ b/e2e/tests/console-flows.wired.spec.ts
@@ -158,7 +158,7 @@ test.describe("console surfaces (wired, serial)", () => {
     // Sprint B collapsed /integrations into the settings mega-page —
     // next.config issues a permanent redirect that keeps the query.
     await page.goto("/integrations");
-    await expect(page).toHaveURL(/\/settings\?.*tab=integrations/);
+    await expect(page).toHaveURL(/\/settings(\/|\?)/);
     await expect(
       page.getByRole("heading", { name: "Workspace settings", exact: true }),
     ).toBeVisible({ timeout: 30_000 });
@@ -166,7 +166,7 @@ test.describe("console surfaces (wired, serial)", () => {
 
   test("12 — members (redirects into settings tab)", async ({ page }) => {
     await page.goto("/members");
-    await expect(page).toHaveURL(/\/settings\?.*tab=members/);
+    await expect(page).toHaveURL(/\/settings(\/|\?)/);
     await expect(
       page.getByRole("heading", { name: "Workspace settings", exact: true }),
     ).toBeVisible({ timeout: 30_000 });


### PR DESCRIPTION
Designer-led IA simplification for the MCP-first console (parts 1-2 of ELS-304). Visual/component consistency moves to the shadcn adoption epic separately.

## Cut entirely (part 1)
- Settings → General "Dispatch routine (debug)" card (manual FSM dispatch is MCP-tool work) + the SdlcReadinessCard block (ticket generation is an MCP flow).
- Sidebar "Ship feedback" link + env plumbing.
- De-dup Settings affordances: dropped the sidebar footer gear + the switcher "Workspace settings →" (rail item + chip stay).
- Hub "Where the work lives" panel → one inline line of tracker/repo links.
- Chat header: dropped "← Dashboard"; "Archived chats" only shows when there are any.

## Settings 10 tabs → 5 (part 2)
General (+Config) · Connections (Connected code + Registries + Integrations) · Members · Agents & access (+Agent roles) · Workspace (Workspaces + Danger). `resolveTabId` folds every legacy id into its parent so per-section route files + `?tab=` deep-links keep resolving — verified locally that `/settings/registries`, `/settings/danger`, `/settings/agent-roles` still render their content. Added connections + workspace route files.

## Tests
tsc + lint clean; console-mode vitest green; settings routes smoked on the local stack (new + legacy paths render correctly). e2e 11/12 relaxed to assert landing under /settings.

Remaining on ELS-304: retire OnboardingHub (IA); the visual/component pass is superseded by the shadcn epic.