### PR TITLE
fix(console): config-scope cards 404 — drop double /v1 (ELS-307)

### DIFF
--- a/apps/console/src/components/config-scope-card.tsx
+++ b/apps/console/src/components/config-scope-card.tsx
@@ -62,14 +62,17 @@ export function ConfigScopeCard({
     let cancelled = false;
     setStage("loading");
     setErrMsg(null);
+    // The /api/proxy/[...path] handler prepends `/v1/` itself, so the
+    // path here must NOT include `v1/` — otherwise the backend gets
+    // `/v1/v1/...` and 404s (ELS-307; latent since ELS-236).
     fetch(
-      `/api/proxy/v1/workspaces/${encodeURIComponent(workspaceId)}/config/${encodeURIComponent(scope)}`,
+      `/api/proxy/workspaces/${encodeURIComponent(workspaceId)}/config/${encodeURIComponent(scope)}`,
       { method: "GET", cache: "no-store" },
     )
       .then(async (res) => {
         if (!res.ok) {
-          const body = (await res.json().catch(() => ({}))) as { error?: string; message?: string };
-          throw new Error(body.message || body.error || `HTTP ${res.status}`);
+          const body = (await res.json().catch(() => ({}))) as { error?: string; message?: string; detail?: string };
+          throw new Error(body.message || body.error || body.detail || `HTTP ${res.status}`);
         }
         return (await res.json()) as ScopeDetail;
       })
@@ -95,7 +98,7 @@ export function ConfigScopeCard({
     setErrMsg(null);
     try {
       const res = await fetch(
-        `/api/proxy/v1/workspaces/${encodeURIComponent(workspaceId)}/config/${encodeURIComponent(scope)}`,
+        `/api/proxy/workspaces/${encodeURIComponent(workspaceId)}/config/${encodeURIComponent(scope)}`,
         {
           method: "PUT",
           headers: { "content-type": "application/json" },
@@ -103,8 +106,8 @@ export function ConfigScopeCard({
         },
       );
       if (!res.ok) {
-        const body = (await res.json().catch(() => ({}))) as { error?: string; message?: string };
-        throw new Error(body.message || body.error || `HTTP ${res.status}`);
+        const body = (await res.json().catch(() => ({}))) as { error?: string; message?: string; detail?: string };
+        throw new Error(body.message || body.error || body.detail || `HTTP ${res.status}`);
       }
       const result = (await res.json()) as PutResult;
       // Backend re-reads after write — keep the form synced with


### PR DESCRIPTION
Fixes ELS-307.

**Symptom.** Settings → General and → Workspace showed a stack of red `Couldn't load <scope>: HTTP 404` cards (agent.provider, agent.default_profile, catalog.sources, console.surface, autonomy.profile, local_executor.enabled, chat.comment_inbound).

**Cause.** `config-scope-card.tsx` called `/api/proxy/v1/workspaces/{ws}/config/{scope}`, but the `/api/proxy/[...path]` handler already prepends `/v1/` → backend got `/v1/v1/...` → 404. Canonical route is `GET /v1/workspaces/{ws}/config/{scope}`. Latent since ELS-236; the ELS-304 teardown only made the cards visible.

**Fix.** Drop the redundant `v1/` in both GET and PUT; read the proxy `{detail}` error body so failures surface a message instead of bare `HTTP 404`.