### PR TITLE
fix(planning): decomposition entry stage wbs → decomposition (ELS-308)

### DIFF
--- a/apps/backend/app/api/v1/routes/dashboard_priorities.py
+++ b/apps/backend/app/api/v1/routes/dashboard_priorities.py
@@ -635,11 +635,11 @@ async def start_decomposition(
     The PO drafted the brief in Navigator (PR2); ``create_project``
     landed an anchor issue tagged ``planning:anchor`` and a priorities
     row in ``state='planning'`` (PR1). This endpoint walks the anchor
-    into the first decomposition stage (``stage:wbs``) — the per-tick
-    shipctl scheduler then picks up BA, who emits the WBS section,
-    transitions to ``stage:architecture``, and so on through to
-    ``stage:planning_done`` (the finish hook flips Drafts → Parked (the PO promotes Parked → Active manually; ELS-81)
-    when that lands).
+    into the decomposition stage (``stage:decomposition``) — the
+    per-tick dispatcher then fires the decomposition bundle, which (post
+    E16/ELS-123) emits every project section + child tickets in one run
+    and transitions to ``stage:planning_done`` (the finish hook flips
+    Drafts → Parked; the PO promotes Parked → Active manually; ELS-81).
 
     Idempotent on the anchor: re-running when the anchor already
     carries a non-entry decomposition stage label is a no-op (we
@@ -722,11 +722,15 @@ async def start_decomposition(
             detail={"code": "anchor_missing"},
         )
 
-    # Move the anchor into ``stage:wbs``. The Linear adapter's
+    # Move the anchor into ``stage:decomposition`` — the single E16
+    # bundle-stage entry (ELS-123). The pre-E16 ``wbs`` label is dead:
+    # the post-cutover ``resolve_fsm_stage_from_labels`` doesn't list
+    # it, so the anchor would go In Progress but dispatch as
+    # ``no_routine`` and never run (ELS-308). The Linear adapter's
     # ``transition`` handles the label swap (drops other stage labels,
-    # adds this one) and the workflow-state move per
-    # FSM_TO_LINEAR_STATE. Idempotent on Linear's side because
-    # ``transition`` is a label set + state set, not an append.
+    # adds this one) and the workflow-state move per FSM_TO_LINEAR_STATE.
+    # Idempotent on Linear's side because ``transition`` is a label set
+    # + state set, not an append.
     from backend.app.integrations.gateway.tracker import (
         TicketRef as _TicketRef,
     )
@@ -737,10 +741,10 @@ async def start_decomposition(
         id=str(anchor["id"]),
     )
     try:
-        await tracker.gateway.transition(anchor_ref, to_state="wbs")
+        await tracker.gateway.transition(anchor_ref, to_state="decomposition")
     except Exception as exc:  # noqa: BLE001
         logger.warning(
-            "start_decomposition: transition to wbs failed workspace=%s anchor=%s err=%s",
+            "start_decomposition: transition to decomposition failed workspace=%s anchor=%s err=%s",
             workspace_id,
             anchor.get("identifier"),
             exc,

--- a/apps/backend/app/services/agent/tools.py
+++ b/apps/backend/app/services/agent/tools.py
@@ -5829,10 +5829,14 @@ class ToolBox:
 
         ref = ticket_ref_from(_tracker_kind_of(tracker), anchor_id)
         try:
-            await tracker.transition(ref, to_state="wbs")
+            # E16/ELS-123 collapsed decomposition into one bundle stage.
+            # The entry is ``stage:decomposition`` — NOT the pre-E16
+            # ``wbs`` (which the post-cutover label resolver no longer
+            # recognizes, so the anchor would park unroutable; ELS-308).
+            await tracker.transition(ref, to_state="decomposition")
         except Exception as exc:  # noqa: BLE001
             raise ToolInvocationError(
-                f"tracker rejected transition to stage:wbs: {exc}"
+                f"tracker rejected transition to stage:decomposition: {exc}"
             ) from exc
 
         self._session.add(

--- a/apps/backend/tests/test_extract_fsm_stage.py
+++ b/apps/backend/tests/test_extract_fsm_stage.py
@@ -31,3 +31,20 @@ def test_todo_without_labels_returns_task_intake() -> None:
 def test_decomposition_chain_respected() -> None:
     labels = ["stage:decomposition", "stage:planning"]
     assert resolve_fsm_stage_from_labels(labels) == "planning"
+
+
+def test_planning_anchor_entry_resolves_to_decomposition() -> None:
+    # ELS-308: start_decomposition walks the anchor into
+    # ``stage:decomposition`` (the E16/ELS-123 single bundle stage).
+    # The resolver MUST recognize it so the dispatcher fires the
+    # decomposition routine instead of parking the anchor.
+    labels = ["planning:anchor", "stage:decomposition"]
+    assert resolve_fsm_stage_from_labels(labels) == "decomposition"
+
+
+def test_pre_e16_wbs_label_is_dead() -> None:
+    # ELS-308 root cause: ELS-123 dropped ``wbs`` from
+    # DECOMPOSITION_STAGE_ORDER, so a stale ``stage:wbs`` entry label
+    # resolves to None → ``dispatch.no_routine`` → silent stall. This
+    # asserts the dead alias stays dead (the fix is to never write it).
+    assert resolve_fsm_stage_from_labels(["planning:anchor", "stage:wbs"]) is None

--- a/apps/backend/tests/test_navigator_mutating_tools.py
+++ b/apps/backend/tests/test_navigator_mutating_tools.py
@@ -10,7 +10,7 @@ Three admin-gated, audited tools:
   between Active / Drafts (``planning`` enum) / Parked. Creates a
   priorities row at MAX+1 ordinal if none exists yet.
 - ``decomposition_start(project_native_id)`` — walk a Drafts-bucket
-  project's planning anchor into ``stage:wbs`` to kick off the
+  project's planning anchor into ``stage:decomposition`` to kick off the
   decomposition pipeline. Refuses if project is not in Drafts or
   has no anchor.
 
@@ -292,7 +292,7 @@ async def test_set_priority_state_validates_enum(toolbox) -> None:
 
 
 @pytest.mark.asyncio
-async def test_start_decomposition_transitions_anchor_to_wbs(
+async def test_start_decomposition_transitions_anchor_to_decomposition(
     toolbox, monkeypatch, db_session, seed_workspace
 ) -> None:
     from sqlalchemy import select
@@ -323,7 +323,7 @@ async def test_start_decomposition_transitions_anchor_to_wbs(
     )
     _patch_tracker(toolbox, monkeypatch, stub)
 
-    raw = await toolbox._tool_start_decomposition(
+    raw = await toolbox._tool_decomposition_start(
         {"project_native_id": "proj-drafted"}
     )
     payload = json.loads(raw)
@@ -331,17 +331,17 @@ async def test_start_decomposition_transitions_anchor_to_wbs(
     assert payload["anchor_identifier"] == "ELS-101"
     assert payload["process"] == "decomposition"
 
-    # Anchor probed; transition fired with stage:wbs.
+    # Anchor probed; transition fired with stage:decomposition (E16/ELS-123 single-stage entry; ELS-308).
     assert stub.anchor_calls == ["proj-drafted"]
     assert len(stub.transition_calls) == 1
-    assert stub.transition_calls[0]["to_state"] == "wbs"
+    assert stub.transition_calls[0]["to_state"] == "decomposition"
     assert stub.transition_calls[0]["ref_id"] == "anchor-uuid"
 
     audit = (
         await db_session.execute(
             select(AuditLog).where(
                 AuditLog.workspace_id == workspace.id,
-                AuditLog.action == "navigator.decomposition_start",
+                AuditLog.action == "navigator.start_decomposition",
             )
         )
     ).scalars().all()
@@ -374,7 +374,7 @@ async def test_start_decomposition_rejects_non_drafts(
     _patch_tracker(toolbox, monkeypatch, _StubTracker())
 
     with pytest.raises(ToolInvocationError, match="only Drafts"):
-        await toolbox._tool_start_decomposition(
+        await toolbox._tool_decomposition_start(
             {"project_native_id": "proj-active"}
         )
 
@@ -387,7 +387,7 @@ async def test_start_decomposition_404s_when_not_on_priorities(
 
     _patch_tracker(toolbox, monkeypatch, _StubTracker())
     with pytest.raises(ToolInvocationError, match="not on the dashboard"):
-        await toolbox._tool_start_decomposition(
+        await toolbox._tool_decomposition_start(
             {"project_native_id": "proj-missing"}
         )
 
@@ -416,6 +416,6 @@ async def test_start_decomposition_404s_when_anchor_missing(
     _patch_tracker(toolbox, monkeypatch, _StubTracker(anchor=None))
 
     with pytest.raises(ToolInvocationError, match="no planning anchor"):
-        await toolbox._tool_start_decomposition(
+        await toolbox._tool_decomposition_start(
             {"project_native_id": "proj-no-anchor"}
         )


### PR DESCRIPTION
Fixes ELS-308.

**Symptom.** `start_decomposition` (MCP `decomposition_start` tool + the HTTP route) walked the planning anchor into `stage:wbs`, the anchor went In Progress, and **nothing ran** — audit shows only `dispatch.no_routine` (`fsm_stage: null`), `runs_list` empty. Reproduced live on the shadcn epic (ELS-305): anchor parked at `stage:wbs`, zero children.

**Root cause.** E16/ELS-123 collapsed multi-stage decomposition into a single bundle stage. Post-cutover `DECOMPOSITION_STAGE_ORDER = (decomposition, planning_done)` — `wbs` is gone. `resolve_fsm_stage_from_labels` returns `None` for `stage:wbs` → dispatcher gets `fsm_stage=null` → `no_routine` → silent stall. The leftover `wbs→In Progress` alias in `FSM_TO_LINEAR_STATE` let the Linear transition succeed, masking it. The start path was simply never repointed at the new entry.

**Fix.** Transition both start paths to `stage:decomposition` (maps to In Progress, recognized by the resolver, dispatched by `_STAGE_TO_ROUTINE['decomposition']`).

**Tests.** Resolver regression in `test_extract_fsm_stage` (CI-collected): `planning:anchor + stage:decomposition → 'decomposition'`, and the dead `stage:wbs → None`. Also repaired the 4 decomposition-start unit tests in `test_navigator_mutating_tools` (CI-quarantined via pytest.ini, but fixed to the current method name + new entry stage as a down-payment).

**Impact.** Decomposition has been dead for every project handed off since the ELS-123 cutover — the planner's front door. After deploy I'll re-run decomposition on ELS-305 to confirm the bundle fires end-to-end.