### PR TITLE
feat(decomposition): child_tickets depends_on → Linear blocks (ELS-315)

### DIFF
--- a/apps/backend/app/api/v1/routes/agent_runs.py
+++ b/apps/backend/app/api/v1/routes/agent_runs.py
@@ -259,12 +259,23 @@ class ChildTicketCreate(BaseModel):
     ``project_id`` is derived server-side from the anchor ticket;
     the agent only declares title/body for each slice. Labels and
     priority are optional pass-throughs to the tracker adapter.
+
+    ``depends_on`` (ELS-315) lets the agent declare sequencing between
+    slices: a list of 0-based indices into the *same* ``child_tickets``
+    array naming the slices that must be **Done** before this one can
+    start. The server resolves each index to its freshly-created
+    identifier and writes a Linear ``blocks`` edge (blocker = the
+    depended-on slice, blocked = this one), which the dispatcher's
+    dependency gate then honours (``reason='blocked_by_dependency'``).
+    Out-of-range / self indices are dropped server-side. Leave empty
+    for independent slices.
     """
 
     title: str = Field(min_length=1, max_length=300)
     body: str = Field(min_length=1, max_length=32_000)
     labels: list[str] = Field(default_factory=list, max_length=20)
     priority: int | None = Field(default=None, ge=0, le=4)
+    depends_on: list[int] = Field(default_factory=list, max_length=20)
 
 
 class ProjectSectionPatch(BaseModel):
@@ -429,6 +440,60 @@ async def _try_ticket_snapshot(gateway: Any, ref: TicketRef) -> dict[str, Any] |
         return await fn(ref)
     except Exception:
         return None
+
+
+async def _wire_child_dependencies(
+    *,
+    gateway: Any,
+    children: list[ChildTicketCreate],
+    created_refs: list[Any],
+    actions: list[str],
+    workspace_id: Any,
+) -> None:
+    """Translate decomposition ``child_tickets[].depends_on`` into Linear
+    ``blocks`` edges so the dispatcher's dependency gate enforces the
+    sequencing the planner declared (ELS-315).
+
+    ``depends_on`` holds 0-based indices into ``children``; for each
+    ``children[i].depends_on = [j, …]`` we create ``blocks`` with
+    ``blocker = created_refs[j]`` and ``blocked = created_refs[i]`` (j
+    must be Done before i can start). Indices that are out of range,
+    self-referential, or point at a slice whose create failed are
+    dropped. Best-effort — a relation failure is logged + audited but
+    never raised; the children already exist.
+    """
+    relate = getattr(gateway, "relate_tickets", None)
+    if relate is None:
+        return
+    n = len(children)
+    for i, child in enumerate(children):
+        deps = getattr(child, "depends_on", None) or []
+        if created_refs[i] is None:
+            continue
+        for j in deps:
+            if not isinstance(j, int) or j < 0 or j >= n or j == i:
+                logger.warning(
+                    "agent_run.finish: dropping invalid depends_on idx=%r "
+                    "on child %d (n=%d) ws=%s",
+                    j, i, n, workspace_id,
+                )
+                continue
+            if created_refs[j] is None:
+                continue
+            try:
+                await relate(
+                    blocker=created_refs[j],
+                    blocked=created_refs[i],
+                    kind="blocks",
+                )
+                actions.append("tracker:child_dependency_linked")
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "agent_run.finish: relate_tickets failed "
+                    "blocker_idx=%d blocked_idx=%d ws=%s err=%s",
+                    j, i, workspace_id, exc,
+                )
+                actions.append("tracker:child_dependency_failed")
 
 
 def _ticket_ref_from(vendor_kind: str, raw: str) -> TicketRef:
@@ -4349,7 +4414,14 @@ async def finish_agent_run(
                 )
                 if project_id and create_fn is not None:
                     created_rows: list[tuple[str, str]] = []
-                    for child in payload.child_tickets:
+                    # Index-aligned with payload.child_tickets so
+                    # ``depends_on`` (0-based array indices) can resolve
+                    # to the freshly-created refs after the loop. None =
+                    # that slice's create failed (ELS-315).
+                    created_refs: list[Any] = [None] * len(
+                        payload.child_tickets
+                    )
+                    for idx, child in enumerate(payload.child_tickets):
                         try:
                             created = await create_fn(
                                 title=child.title,
@@ -4373,9 +4445,21 @@ async def finish_agent_run(
                             continue
                         identifier = created.display_id or str(created.ref.id)
                         created_rows.append((identifier, child.title))
+                        created_refs[idx] = created.ref
                         actions.append(
                             f"tracker:ticket_created:{identifier}"
                         )
+                    # Wire declared sequencing into Linear ``blocks`` edges
+                    # so the dispatcher's dependency gate enforces it
+                    # (ELS-315). Best-effort: a relation failure never
+                    # fails finish — the children already exist.
+                    await _wire_child_dependencies(
+                        gateway=resolved.gateway,
+                        children=payload.child_tickets,
+                        created_refs=created_refs,
+                        actions=actions,
+                        workspace_id=workspace_id,
+                    )
                     if created_rows and upsert is not None:
                         rendered = "\n".join(
                             f"- **{ident}** — {title}"

--- a/apps/backend/app/resources/agent_roles/decomposition.md
+++ b/apps/backend/app/resources/agent_roles/decomposition.md
@@ -104,11 +104,28 @@ ticket in the finish payload's top-level `child_tickets` array:
   acceptance criteria, test plans, or implementation notes —
   SDLC's planning bundle (intake + BA + tech + qa-arch in one run)
   refines those when the child enters its first stage.
+- **depends_on**: a list of 0-based indices into THIS `child_tickets`
+  array naming the slices that must ship (be **Done**) before this
+  one can start. Set it whenever your WBS ordering is real — e.g. a
+  phased migration / re-skin where "each ships as its own PR before
+  the next starts", a foundation slice every later slice builds on,
+  or a slice that needs a prior one's reviewed output. The server
+  turns each edge into a tracker `blocks` relation that the
+  dispatcher enforces, so the blocked slices won't dispatch until
+  their blocker is Done. **Don't** invent dependencies between
+  genuinely independent slices (that needlessly serialises work) —
+  but DO encode true sequencing instead of leaving it as prose, or
+  every child becomes eligible at once when the project is activated.
+  Typical phased epic: child 0 has `depends_on: []`, child 1 has
+  `[0]`, child 2 has `[1]`, … (a chain); a fan-out where slices 1-3
+  all build on the foundation slice 0 is `[0]` on each of 1, 2, 3.
 
 The server creates each child under the anchor's project, then
 auto-renders a `## Tasks` section listing the freshly-created
 identifiers — you don't ship a `project_sections` entry for Tasks,
-and you can't guess identifiers that don't exist yet.
+and you can't guess identifiers that don't exist yet. Likewise you
+reference dependencies by array index, never by identifier (they
+don't exist until the server creates them).
 
 ## Finish
 
@@ -126,7 +143,8 @@ Wire shape — all five phases land in one finish call:
     { "section": "Test architecture","body": "<your Phase 4 markdown>" }
   ],
   "child_tickets": [
-    { "title": "<WBS line>", "body": "<3-5 line scope>" },
+    { "title": "<WBS line 1>", "body": "<3-5 line scope>", "depends_on": [] },
+    { "title": "<WBS line 2>", "body": "<3-5 line scope>", "depends_on": [0] },
     ...
   ],
   "comment": "<one paragraph audit narration> [Ship decomposition:role-decomposition]",

--- a/apps/backend/tests/test_finish_project_sections_schema.py
+++ b/apps/backend/tests/test_finish_project_sections_schema.py
@@ -242,3 +242,108 @@ def test_child_ticket_priority_bounded() -> None:
         ChildTicketCreate(title="t", body="b", priority=-1)
     with pytest.raises(ValidationError):
         ChildTicketCreate(title="t", body="b", priority=5)
+
+
+# ---- ChildTicketCreate.depends_on → Linear blocks wiring (ELS-315) ----
+
+
+def test_child_ticket_depends_on_defaults_empty() -> None:
+    assert ChildTicketCreate(title="t", body="b").depends_on == []
+
+
+def test_child_ticket_depends_on_accepts_indices() -> None:
+    finish = FinishIn(
+        run_id="r1",
+        outcome="ready_next_step",
+        ticket_ref="PAC-9",
+        stage_next="planning_done",
+        process="decomposition",
+        child_tickets=[
+            {"title": "Foundation", "body": "b", "depends_on": []},
+            {"title": "Settings", "body": "b", "depends_on": [0]},
+            {"title": "Cleanup", "body": "b", "depends_on": [1]},
+        ],
+    )
+    assert [c.depends_on for c in finish.child_tickets] == [[], [0], [1]]
+
+
+class _RelStub:
+    """Records relate_tickets calls; create_ticket not exercised here."""
+
+    def __init__(self) -> None:
+        self.edges: list[tuple[object, object, str]] = []
+
+    async def relate_tickets(self, *, blocker, blocked, kind="blocks") -> None:
+        self.edges.append((blocker, blocked, kind))
+
+
+@pytest.mark.asyncio
+async def test_wire_child_dependencies_chain() -> None:
+    """A 0→1→2 chain produces two blocks edges with blocker=prior."""
+    from backend.app.api.v1.routes.agent_runs import _wire_child_dependencies
+
+    children = [
+        ChildTicketCreate(title="a", body="b", depends_on=[]),
+        ChildTicketCreate(title="b", body="b", depends_on=[0]),
+        ChildTicketCreate(title="c", body="b", depends_on=[1]),
+    ]
+    refs = ["REF0", "REF1", "REF2"]
+    gw = _RelStub()
+    actions: list[str] = []
+    await _wire_child_dependencies(
+        gateway=gw,
+        children=children,
+        created_refs=refs,
+        actions=actions,
+        workspace_id="ws",
+    )
+    assert gw.edges == [
+        ("REF0", "REF1", "blocks"),  # 0 blocks 1
+        ("REF1", "REF2", "blocks"),  # 1 blocks 2
+    ]
+    assert actions.count("tracker:child_dependency_linked") == 2
+
+
+@pytest.mark.asyncio
+async def test_wire_child_dependencies_drops_invalid_and_failed() -> None:
+    """Out-of-range / self idx are dropped; a dep on a slice whose
+    create failed (ref=None) is skipped silently."""
+    from backend.app.api.v1.routes.agent_runs import _wire_child_dependencies
+
+    children = [
+        ChildTicketCreate(title="a", body="b", depends_on=[5]),    # OOR
+        ChildTicketCreate(title="b", body="b", depends_on=[1]),    # self
+        ChildTicketCreate(title="c", body="b", depends_on=[0]),    # dep on failed
+    ]
+    refs = [None, "REF1", "REF2"]  # slice 0's create failed
+    gw = _RelStub()
+    actions: list[str] = []
+    await _wire_child_dependencies(
+        gateway=gw,
+        children=children,
+        created_refs=refs,
+        actions=actions,
+        workspace_id="ws",
+    )
+    # child 0 has no ref → skipped entirely; child 1 self-ref dropped;
+    # child 2 depends on failed slice 0 (ref None) → skipped. No edges.
+    assert gw.edges == []
+
+
+@pytest.mark.asyncio
+async def test_wire_child_dependencies_noop_without_adapter() -> None:
+    """A tracker without relate_tickets is a clean no-op."""
+    from backend.app.api.v1.routes.agent_runs import _wire_child_dependencies
+
+    class _Bare:
+        pass
+
+    actions: list[str] = []
+    await _wire_child_dependencies(
+        gateway=_Bare(),
+        children=[ChildTicketCreate(title="a", body="b", depends_on=[0])],
+        created_refs=["REF0"],
+        actions=actions,
+        workspace_id="ws",
+    )
+    assert actions == []


### PR DESCRIPTION
Fixes ELS-315.

**Why.** Decomposition (ELS-305→309-313) produced a strictly sequential 5-phase plan but encoded the ordering only as WBS prose — zero Linear `blocks` relations. Promoting the project to Active moved all 5 children to Todo and only a manual `blocks` chain kept 310-313 from dispatching in parallel (over-reach vs the founder-review-first gate). The planner must emit dependencies itself.

**Change.**
- `ChildTicketCreate` gains `depends_on: list[int]` — 0-based indices into the same `child_tickets` array naming slices that must be **Done** before this one starts.
- The finish handler tracks created refs index-aligned and `_wire_child_dependencies` writes `tracker.relate_tickets(blocker, blocked, 'blocks')` per edge. Best-effort: out-of-range / self / failed-create indices dropped; a relation failure never aborts child creation (children already exist).
- `decomposition.md` Phase 5 instructs setting `depends_on` for real WBS ordering (chain for phased migrations, fan-out on a foundation slice), NOT for independent slices; reference by index since identifiers don't exist yet.
- Unit tests: schema field + `_wire_child_dependencies` (chain, invalid/failed-idx drop, no-adapter no-op).

**Verified** live by hand first on ELS-309→313: the blocks chain produced `fired=True` for the head and `reason='blocked_by_dependency'` for the blocked child — this automates it. The adapter (`relate_tickets`) + gate (`get_ticket_blockers`) already existed; only the decomposition→finish wiring was missing. Refs ELS-314.