### PR TITLE
revert: console flat theme (#403/ELS-316 Direction C) — restore gradient look

### DIFF
--- a/apps/console/src/app/globals.css
+++ b/apps/console/src/app/globals.css
@@ -21,14 +21,10 @@
     --accent-foreground: 222 47% 6%;
     --destructive: 0 84% 60%;
     --destructive-foreground: 0 0% 98%;
-    /* Direction C (ELS-316): hairline borders instead of full-white —
-     * flat layered surfaces read as steps, not outlined boxes. */
-    --border: 220 18% 17%;
-    --input: 220 16% 22%;
+    --border: 0 0% 100%;
+    --input: 0 0% 100%;
     --ring: 38 47% 61%;
-    /* One radius scale (10px) — kills the 5-radius drift at the token
-     * level. Surfaces that want a softer corner use the signature panel. */
-    --radius: 0.625rem;
+    --radius: 1rem;
     color-scheme: dark;
   }
 }
@@ -39,15 +35,18 @@ html {
 
 body {
   @apply bg-ink text-mist antialiased;
-  /* Direction C (ELS-316): the console body is FLAT — no marketing
-   * radial wash. Brand tint is reserved for a single hero surface via
-   * ``.hero-tint`` so accents read as deliberate, not ambient. A faint
-   * top vignette keeps the dark from feeling like a void. */
+  /* Match the landing site exactly — the console used to render with
+   * dimmer alphas (0.18 / 0.12 / 0.10) which left the operator-side
+   * feeling colder than the marketing surface. Same numbers as
+   * apps/landing/src/app/globals.css so the two sit on a single
+   * brand palette. */
   background-image: radial-gradient(
-    ellipse 100% 60% at 50% -25%,
-    rgba(179, 136, 255, 0.06),
-    transparent 60%
-  );
+      ellipse 120% 80% at 50% -20%,
+      rgba(179, 136, 255, 0.35),
+      transparent 55%
+    ),
+    radial-gradient(ellipse 80% 50% at 100% 0%, rgba(207, 169, 107, 0.2), transparent 45%),
+    radial-gradient(ellipse 60% 40% at 0% 20%, rgba(255, 92, 108, 0.18), transparent 40%);
 }
 
 ::selection {
@@ -89,39 +88,6 @@ body {
 
 .btn-ghost {
   @apply inline-flex items-center justify-center gap-2 rounded-full border border-white/15 bg-transparent px-6 py-3 text-sm font-semibold text-white/70 transition hover:border-white/40 hover:bg-white/5 hover:text-white;
-}
-
-/* ------------------------------------------------------------------ *
- * Direction C (ELS-316) — Brand-forward Ship                         *
- *                                                                    *
- * ``.signature-panel`` is the ONE distinctive surface treatment      *
- * (reserved for the hero card on each page): a refined, FLAT panel —  *
- * hairline border, a soft inner top highlight and a faint aqua brand  *
- * tint, NOT translucent glass/backdrop-blur. Every other surface uses *
- * the plain shadcn ``card``. ``.hero-tint`` is a faint brand wash for *
- * a hero wrapper when a page wants the accent to breathe behind the   *
- * signature card. Keeping accents on these two means the rest reads   *
- * clean instead of uniformly tinted.                                 *
- * ------------------------------------------------------------------ */
-
-.signature-panel {
-  @apply relative rounded-xl border border-aqua/25 bg-card;
-  background-image: radial-gradient(
-    120% 140% at 0% 0%,
-    rgba(207, 169, 107, 0.08),
-    transparent 55%
-  );
-  box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.06),
-    0 10px 30px -16px rgba(0, 0, 0, 0.55);
-}
-
-.hero-tint {
-  background-image: radial-gradient(
-    90% 70% at 50% 0%,
-    rgba(207, 169, 107, 0.07),
-    transparent 60%
-  );
 }
 
 /* --- Navigator / single-window chat ---------------------------------- */

--- a/apps/console/src/components/connect-agent-card.tsx
+++ b/apps/console/src/components/connect-agent-card.tsx
@@ -20,6 +20,7 @@
 
 import { useEffect, useState } from "react";
 
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
@@ -136,16 +137,16 @@ export function ConnectAgentCard({
   return (
     <Card
       data-testid="connect-agent-card"
-      className="relative overflow-hidden rounded-xl border-aqua/25 bg-card shadow-[0_10px_30px_-16px_rgba(0,0,0,0.55)] ring-1 ring-inset ring-white/[0.05] [background-image:radial-gradient(120%_140%_at_0%_-10%,rgba(207,169,107,0.10),transparent_55%)]"
+      className="rounded-2xl border-aqua/30 bg-aqua/[0.05] shadow-none"
     >
       <CardHeader className="flex flex-row items-start justify-between gap-3 space-y-0 p-5 pb-0">
         <div>
-          <p className="font-mono text-[10px] font-bold uppercase tracking-[0.3em] text-aqua/80">
-            MCP edge
-          </p>
-          <h2 className="mt-1.5 font-display text-xl font-bold tracking-tight text-white">
+          <Badge
+            variant="outline"
+            className="border-aqua/40 bg-transparent text-[11px] font-bold uppercase tracking-widest text-aqua/90"
+          >
             Connect your agent
-          </h2>
+          </Badge>
           <p className="mt-2 max-w-xl text-sm text-white/70">
             Ship is operated from the agent you already live in — attach it
             over MCP and run planning, tickets, approvals, and reviews from


### PR DESCRIPTION
Founder feedback: the gradient look read better than the flat Direction-C restyle. Revert #403 to restore the gradient brand wash on prod while we redo the visual direction gradient-forward with design experts. The shadcn foundation (#402) stays; this only undoes the flat/hairline token + connect-card pilot changes.