### PR TITLE
feat(console): gradient-forward visual + connect-card guide + chat quick-actions (ELS-317/318/319)

### DIFF
--- a/apps/console/src/app/(authed)/chat/single-window-chat.tsx
+++ b/apps/console/src/app/(authed)/chat/single-window-chat.tsx
@@ -1544,7 +1544,10 @@ export function SingleWindowChat({
         <div ref={scrollerRef} className="flex-1 overflow-y-auto py-4">
           <ChoiceProvider onChoose={(label) => void send(label)}>
             {segments.length === 0 ? (
-              <EmptyHint hasArchivedChats={hasArchivedChats} />
+              <EmptyHint
+                hasArchivedChats={hasArchivedChats}
+                onPick={(p) => void send(p)}
+              />
             ) : (
               <div className="space-y-6">
                 {/* Single ordered timeline. Tool segments are NOT
@@ -1763,28 +1766,93 @@ export function SingleWindowChat({
   );
 }
 
-function EmptyHint({ hasArchivedChats }: { hasArchivedChats: boolean }) {
+/** Quick standard actions for the empty Navigator (ELS-319). Each fires
+ * as a ready-to-run first message via ``send`` — same one-click→send
+ * contract as ChoiceProvider. */
+const QUICK_ACTIONS: { title: string; sub: string; prompt: string }[] = [
+  {
+    title: "Plan a project",
+    sub: "Brief + auto-decompose into tickets",
+    prompt:
+      "Plan a new project: add CSV export to the billing page. Draft a short brief, then break it into tickets.",
+  },
+  {
+    title: "What's in flight",
+    sub: "Active runs, PRs, in-progress tickets",
+    prompt:
+      "What's in flight right now? Summarize active runs, open PRs, and tickets in progress.",
+  },
+  {
+    title: "Review a PR",
+    sub: "Run pr-review on a pull request",
+    prompt:
+      "Review PR #142 in elmundi/ship and tell me whether it's ready to merge.",
+  },
+  {
+    title: "Pending approvals",
+    sub: "What's waiting on your sign-off",
+    prompt:
+      "Show me everything waiting on my approval and walk me through each item.",
+  },
+  {
+    title: "Set up a repo",
+    sub: "Activate + open the seed PR",
+    prompt:
+      "Set up Ship in elmundi/ship — activate the repo and open the seed PR.",
+  },
+  {
+    title: "Workspace status",
+    sub: "Engine health and what's stalled",
+    prompt:
+      "Give me a status check on this workspace — engine health, anything stalled, and what needs my attention.",
+  },
+];
+
+function EmptyHint({
+  hasArchivedChats,
+  onPick,
+}: {
+  hasArchivedChats: boolean;
+  onPick: (prompt: string) => void;
+}) {
   return (
-    <div className="flex h-full items-center justify-center text-center text-[12px] text-white/35">
-      <div>
-        <p className="font-semibold text-white/60">Ask Ship anything about this workspace.</p>
-        <p className="mt-1 max-w-sm">
-          It can pull up Inbox items, walk you through a Play, kick off a
-          Run, or surface what your repos look like under the hood. Try
-          asking <em className="not-italic text-white/55">&ldquo;what&rsquo;s in my inbox?&rdquo;</em>{" "}
-          or <em className="not-italic text-white/55">&ldquo;list active automations&rdquo;</em>.
+    <div className="mx-auto flex h-full max-w-2xl flex-col justify-center px-4">
+      <div className="text-center">
+        <p className="font-display text-lg font-bold text-white">
+          Ask Ship anything about this workspace.
         </p>
-        {hasArchivedChats ? (
-          <p className="mt-3">
-            <Link
-              href="/chat/archived"
-              className="text-white/45 hover:text-white"
-            >
-              Looking for an older thread? View archived chats →
-            </Link>
-          </p>
-        ) : null}
+        <p className="mx-auto mt-1.5 max-w-md text-[12px] leading-relaxed text-white/45">
+          Drive planning, reviews, runs and approvals in plain language — or
+          start with one of these:
+        </p>
       </div>
+
+      <div className="mt-5 grid grid-cols-1 gap-2.5 sm:grid-cols-2 lg:grid-cols-3">
+        {QUICK_ACTIONS.map((a) => (
+          <button
+            key={a.title}
+            type="button"
+            onClick={() => onPick(a.prompt)}
+            className="quick-action group"
+            data-testid="chat-quick-action"
+          >
+            <div className="text-sm font-semibold text-white group-hover:text-aqua">
+              {a.title}
+            </div>
+            <div className="mt-0.5 text-[11px] leading-relaxed text-white/55">
+              {a.sub}
+            </div>
+          </button>
+        ))}
+      </div>
+
+      {hasArchivedChats ? (
+        <p className="mt-5 text-center text-[12px] text-white/35">
+          <Link href="/chat/archived" className="text-white/45 hover:text-white">
+            Looking for an older thread? View archived chats →
+          </Link>
+        </p>
+      ) : null}
     </div>
   );
 }

--- a/apps/console/src/app/globals.css
+++ b/apps/console/src/app/globals.css
@@ -7,24 +7,34 @@
   :root {
     --background: 222 47% 6%;
     --foreground: 204 100% 95%;
-    --card: 222 47% 8%;
+    /* Opaque cards sit one tier above ink so they read against the
+     * brand wash (ELS-317 gradient-forward visual). */
+    --card: 222 44% 9%;
     --card-foreground: 204 100% 95%;
-    --popover: 222 47% 8%;
+    --popover: 222 46% 8%;
     --popover-foreground: 204 100% 95%;
     --primary: 38 47% 61%;
     --primary-foreground: 222 47% 6%;
-    --secondary: 0 0% 100%;
+    /* Real dark-slate secondary fill (was pure white). */
+    --secondary: 222 30% 16%;
     --secondary-foreground: 204 100% 95%;
-    --muted: 222 20% 14%;
+    --muted: 222 24% 13%;
     --muted-foreground: 0 0% 70%;
     --accent: 38 47% 61%;
     --accent-foreground: 222 47% 6%;
-    --destructive: 0 84% 60%;
+    --destructive: 0 84% 62%;
     --destructive-foreground: 0 0% 98%;
+    /* Borders stay white — consumed as white/alpha (hairline-on-glass),
+     * NOT a solid grey. This is what makes the gradient look read. */
     --border: 0 0% 100%;
     --input: 0 0% 100%;
     --ring: 38 47% 61%;
     --radius: 1rem;
+    /* Ship surface vocabulary (ELS-317): elevation + signature glow,
+     * referenced by .surface-card / .surface-signature / .quick-action. */
+    --elev-1: 0 1px 0 rgba(255, 255, 255, 0.05) inset, 0 1px 2px rgba(0, 0, 0, 0.4);
+    --elev-2: 0 4px 24px rgba(0, 0, 0, 0.28), inset 0 1px 0 rgba(255, 255, 255, 0.06);
+    --glow-gold: 0 0 80px -20px rgba(207, 169, 107, 0.4);
     color-scheme: dark;
   }
 }
@@ -39,7 +49,10 @@ body {
    * dimmer alphas (0.18 / 0.12 / 0.10) which left the operator-side
    * feeling colder than the marketing surface. Same numbers as
    * apps/landing/src/app/globals.css so the two sit on a single
-   * brand palette. */
+   * brand palette. ``fixed`` anchors the wash so it doesn't scroll-
+   * detach on long hub pages (ELS-317). */
+  background-color: #0b1020;
+  background-attachment: fixed;
   background-image: radial-gradient(
       ellipse 120% 80% at 50% -20%,
       rgba(179, 136, 255, 0.35),
@@ -66,7 +79,7 @@ body {
  * ------------------------------------------------------------------ */
 
 .glass-panel {
-  @apply rounded-3xl border border-white/10 bg-white/[0.04] backdrop-blur-xl;
+  @apply rounded-2xl border border-white/10 bg-white/[0.04] backdrop-blur-xl;
   box-shadow: 0 4px 24px rgba(0, 0, 0, 0.25), inset 0 1px 0 rgba(255, 255, 255, 0.06);
 }
 
@@ -88,6 +101,52 @@ body {
 
 .btn-ghost {
   @apply inline-flex items-center justify-center gap-2 rounded-full border border-white/15 bg-transparent px-6 py-3 text-sm font-semibold text-white/70 transition hover:border-white/40 hover:bg-white/5 hover:text-white;
+}
+
+/* ------------------------------------------------------------------ *
+ * ELS-317 — gradient-forward surface tiers                           *
+ *                                                                    *
+ * Three tiers, every container is exactly one:                       *
+ *   Tier 0 — the page (body wash). No fill.                          *
+ *   Tier 1 — .surface-card: the default glass card everywhere.       *
+ *   Tier 2 — .surface-signature: hero / front-door only, MAX ONE per *
+ *            screen — glass + localized gold/lilac corner glow + a    *
+ *            1px top sheen. This is where the "rich" look lives.      *
+ * .quick-action is the Tier-1 prompt-starter tile (gold accent on    *
+ * hover, never a gradient fill — gradient is reserved for the one    *
+ * CTA pill per screen).                                              *
+ * ------------------------------------------------------------------ */
+
+.surface-card {
+  @apply rounded-2xl border border-white/10 bg-white/[0.04] backdrop-blur-xl;
+  box-shadow: var(--elev-2);
+}
+
+.surface-signature {
+  @apply relative overflow-hidden rounded-2xl border border-white/10 backdrop-blur-xl;
+  background:
+    radial-gradient(120% 140% at 0% 0%, rgba(207, 169, 107, 0.12), transparent 50%),
+    radial-gradient(120% 140% at 100% 0%, rgba(179, 136, 255, 0.1), transparent 55%),
+    rgba(255, 255, 255, 0.03);
+  box-shadow: var(--elev-2), var(--glow-gold);
+}
+
+.surface-signature::before {
+  content: "";
+  position: absolute;
+  inset: 0 0 auto 0;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.25), transparent);
+}
+
+.quick-action {
+  @apply rounded-2xl border border-white/10 bg-white/[0.04] p-4 text-left backdrop-blur-xl transition;
+  box-shadow: var(--elev-2);
+}
+
+.quick-action:hover {
+  @apply border-aqua/40;
+  box-shadow: var(--elev-2), inset 0 0 24px -8px rgba(207, 169, 107, 0.35);
 }
 
 /* --- Navigator / single-window chat ---------------------------------- */

--- a/apps/console/src/components/connect-agent-card.tsx
+++ b/apps/console/src/components/connect-agent-card.tsx
@@ -135,10 +135,7 @@ export function ConnectAgentCard({
   const tokenCmd = tokenCommand(mcpEndpoint, secret);
 
   return (
-    <Card
-      data-testid="connect-agent-card"
-      className="rounded-2xl border-aqua/30 bg-aqua/[0.05] shadow-none"
-    >
+    <Card data-testid="connect-agent-card" className="surface-signature">
       <CardHeader className="flex flex-row items-start justify-between gap-3 space-y-0 p-5 pb-0">
         <div>
           <Badge
@@ -148,9 +145,10 @@ export function ConnectAgentCard({
             Connect your agent
           </Badge>
           <p className="mt-2 max-w-xl text-sm text-white/70">
-            Ship is operated from the agent you already live in — attach it
-            over MCP and run planning, tickets, approvals, and reviews from
-            there. The console stays for settings and destructive confirms.
+            Ship runs from the agent you already work in. Connect once, then
+            drive planning, tickets, reviews, and approvals by just talking to
+            your agent. The console is only for settings and confirming risky
+            actions.
           </p>
         </div>
         {dismissed === false && (
@@ -167,18 +165,22 @@ export function ConnectAgentCard({
         )}
       </CardHeader>
 
-      <CardContent className="space-y-3 p-5 pt-4">
+      <CardContent className="space-y-4 p-5 pt-4">
         <Row label="MCP endpoint">
-          <code className="break-all font-mono text-xs text-white/85">
+          <code className="break-all font-mono text-xs text-aqua/90">
             {mcpEndpoint}
           </code>
         </Row>
 
         <Separator className="bg-white/10" />
 
-        {/* Primary: OAuth — no token to paste. The agent opens a Ship
-            login and you approve a workspace in the browser. */}
-        <Row label="Claude Code">
+        {/* Step 1 — Connect over OAuth. No token to paste. */}
+        <div className="space-y-2">
+          <StepLabel n="1" title="Connect" />
+          <p className="text-xs text-white/60">
+            Run this, then approve a workspace in the browser when your agent
+            opens the Ship login:
+          </p>
           <div className="flex items-start gap-2">
             <code className="min-w-0 flex-1 break-all rounded-lg border border-white/10 bg-ink/60 p-2 font-mono text-[11px] text-white/85">
               {oauthCmd}
@@ -192,20 +194,46 @@ export function ConnectAgentCard({
               {copied === "oauth" ? "Copied ✓" : "Copy"}
             </Button>
           </div>
-          <p className="mt-1 text-[10px] text-white/50">
-            On first use your agent opens a Ship login and asks you to approve
-            a workspace — no token to paste. Revoke any time in Settings →
-            Agents &amp; access.
+          <p className="text-[10px] text-white/45">
+            Claude Desktop: Settings → Connectors → Add custom connector, URL{" "}
+            <code className="font-mono text-white/75">{mcpEndpoint}</code>.
+            Revoke any time in Settings → Agents &amp; access.
           </p>
-        </Row>
+        </div>
 
-        <Row label="Claude Desktop">
-          <p className="text-xs text-white/65">
-            Settings → Connectors → Add custom connector — URL{" "}
-            <code className="font-mono text-white/85">{mcpEndpoint}</code>. It
-            walks you through the same login + approve.
+        {/* Step 2 — ready-to-paste operator prompts. */}
+        <div className="space-y-2">
+          <StepLabel n="2" title="Try these" />
+          <p className="text-xs text-white/60">
+            Paste any of these into your agent to drive Ship:
           </p>
-        </Row>
+          <ul className="space-y-1.5">
+            {EXAMPLE_PROMPTS.map((ex) => (
+              <li
+                key={ex.label}
+                className="flex items-start gap-2 rounded-lg border border-white/10 bg-ink/40 p-2"
+              >
+                <div className="min-w-0 flex-1">
+                  <div className="text-[11px] font-semibold text-white/85">
+                    {ex.label}
+                  </div>
+                  <div className="mt-0.5 text-[11px] leading-relaxed text-white/55">
+                    {ex.prompt}
+                  </div>
+                </div>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="xs"
+                  onClick={() => copy(ex.label, ex.prompt)}
+                  className="shrink-0 border-0 text-white/40 hover:text-aqua"
+                >
+                  {copied === ex.label ? "Copied ✓" : "Copy"}
+                </Button>
+              </li>
+            ))}
+          </ul>
+        </div>
 
         {/* Fallback: a long-lived PAT for CI / headless agents that
             can't do an interactive browser login. */}
@@ -224,11 +252,11 @@ export function ConnectAgentCard({
             ) : (
               <Button
                 type="button"
+                variant="default"
                 onClick={mint}
                 disabled={minting}
                 data-testid="connect-agent-mint"
                 size="sm"
-                className="bg-aqua/80 text-ink hover:bg-aqua"
               >
                 {minting ? "Minting…" : "Mint agent token"}
               </Button>
@@ -257,6 +285,53 @@ export function ConnectAgentCard({
 
       {error && <p className="px-5 pb-5 text-xs text-coral/95">{error}</p>}
     </Card>
+  );
+}
+
+/** Ready-to-paste operator prompts (ELS-318). Each exercises a real
+ * Ship MCP flow once the agent is attached. */
+const EXAMPLE_PROMPTS: { label: string; prompt: string }[] = [
+  {
+    label: "Plan a feature",
+    prompt:
+      "Plan a new project: add CSV export to the billing page. Write a short brief, then break it into tickets.",
+  },
+  {
+    label: "See what's in flight",
+    prompt:
+      "What's in flight right now? Show me active runs and any tickets in progress.",
+  },
+  {
+    label: "Start a ticket",
+    prompt: "Start ELS-142 — move it into In Progress and kick off the work.",
+  },
+  {
+    label: "Review a PR",
+    prompt:
+      "Review PR #142 in elmundi/ship and tell me if it's safe to merge.",
+  },
+  {
+    label: "Clear approvals",
+    prompt:
+      "Show me everything waiting on my approval, then walk me through each one.",
+  },
+  {
+    label: "Set up a repo",
+    prompt:
+      "Set up Ship in my repo elmundi/ship — activate it and open the seed PR.",
+  },
+];
+
+function StepLabel({ n, title }: { n: string; title: string }) {
+  return (
+    <div className="flex items-center gap-2">
+      <span className="flex h-5 w-5 items-center justify-center rounded-full border border-aqua/40 text-[10px] font-bold text-aqua">
+        {n}
+      </span>
+      <span className="text-[11px] font-bold uppercase tracking-widest text-white/70">
+        {title}
+      </span>
+    </div>
   );
 }
 


### PR DESCRIPTION
Expert-led redo after the flat **Direction C** restyle was rejected (the gradient look reads better). Keeps the brand wash; consolidates consistency; adds the two requested features.

**ELS-317 — gradient-forward theme** (`globals.css`)
- keep the radial brand wash + `background-attachment: fixed`
- **3 surface tiers**: `.surface-card` (default glass), `.surface-signature` (hero only — gold/lilac corner glow + 1px top sheen), `.quick-action` (prompt tile, gold accent on hover). Gradient reserved for the one CTA pill per screen.
- `--elev-1/-2` + `--glow-gold` tokens; `--card` 8→9%, `--secondary` white→dark slate; one radius family

**ELS-318 — connect-card → 'Start operating Ship' guide**
- promoted to `.surface-signature` (the front door)
- **Step 1 Connect (OAuth) → Step 2 'Try these'** with 6 ready-to-paste operator prompts grounded in real MCP flows; headless-token path kept as fallback; mint → brand CTA

**ELS-319 — Navigator quick-action cards**
- empty chat renders 6 quick-action tiles; click fires `send(prompt)` (same one-click→send contract as ChoiceProvider)

Reference look for founder review. ELS-310-313 stay Backlog (gated). Built by hand from two expert specs (design + recon/content).