### PR TITLE
fix(planning): decomposition auto-dispatches on start, no manual kick (ELS-320)

### DIFF
--- a/apps/backend/app/api/v1/routes/dashboard_priorities.py
+++ b/apps/backend/app/api/v1/routes/dashboard_priorities.py
@@ -771,10 +771,34 @@ async def start_decomposition(
     )
     await session.flush()
 
+    # Auto-start the decomposition routine inline (ELS-320) — the diff
+    # poller only fires on a net observed state change, so without this
+    # the anchor parks at stage:decomposition until a manual kick.
+    # Best-effort: the anchor is already transitioned; a dispatch hiccup
+    # falls back to the poller. Gates inside maybe_dispatch still apply.
+    anchor_ident = str(anchor.get("identifier") or "")
+    try:
+        from backend.app.services.dispatcher import maybe_dispatch
+
+        await maybe_dispatch(
+            session,
+            workspace_id=workspace_id,
+            ticket_ref=anchor_ident,
+            trigger_kind="decomposition_start",
+            fsm_stage="decomposition",
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "start_decomposition: inline dispatch failed workspace=%s anchor=%s err=%s",
+            workspace_id,
+            anchor_ident,
+            exc,
+        )
+
     return StartDecompositionOut(
         project_native_id=project_native_id,
         anchor_issue_id=str(anchor["id"]),
-        anchor_identifier=str(anchor.get("identifier") or ""),
+        anchor_identifier=anchor_ident,
     )
 
 

--- a/apps/backend/app/services/agent/tools.py
+++ b/apps/backend/app/services/agent/tools.py
@@ -5856,12 +5856,40 @@ class ToolBox:
         )
         await self._session.flush()
 
+        # Auto-start the decomposition routine inline instead of waiting
+        # for the diff-based poller to notice the new stage (ELS-320).
+        # The poller only fires on a NET observed state change, so the
+        # anchor used to park at stage:decomposition until a manual
+        # maybe_dispatch kick. Fire it here. Best-effort: the anchor is
+        # already transitioned, so a dispatch hiccup (shadow / cap / lock
+        # / transient) just falls back to the poller — never fail the
+        # handoff. All gates still apply inside maybe_dispatch.
+        dispatched = False
+        try:
+            from backend.app.services.dispatcher import maybe_dispatch
+
+            result = await maybe_dispatch(
+                self._session,
+                workspace_id=self._workspace_id,
+                ticket_ref=anchor_identifier,
+                trigger_kind="decomposition_start",
+                fsm_stage="decomposition",
+            )
+            dispatched = bool(getattr(result, "fired", False))
+        except Exception:  # noqa: BLE001
+            logger.exception(
+                "decomposition_start: inline dispatch failed ws=%s anchor=%s",
+                self._workspace_id,
+                anchor_identifier,
+            )
+
         return _json_result(
             {
                 "project_native_id": project_native_id,
                 "anchor_issue_id": anchor_id,
                 "anchor_identifier": anchor_identifier,
                 "process": "decomposition",
+                "dispatched": dispatched,
             }
         )
 

--- a/apps/backend/tests/test_navigator_mutating_tools.py
+++ b/apps/backend/tests/test_navigator_mutating_tools.py
@@ -323,6 +323,24 @@ async def test_start_decomposition_transitions_anchor_to_decomposition(
     )
     _patch_tracker(toolbox, monkeypatch, stub)
 
+    # ELS-320: start fires maybe_dispatch inline so decomposition runs
+    # without a manual kick. Capture the call instead of dispatching.
+    from types import SimpleNamespace
+
+    dispatch_calls: list[dict] = []
+
+    async def _fake_dispatch(
+        session, *, workspace_id, ticket_ref, trigger_kind, fsm_stage=None, **kw
+    ):
+        dispatch_calls.append(
+            {"ticket_ref": ticket_ref, "fsm_stage": fsm_stage, "trigger_kind": trigger_kind}
+        )
+        return SimpleNamespace(fired=True)
+
+    monkeypatch.setattr(
+        "backend.app.services.dispatcher.maybe_dispatch", _fake_dispatch
+    )
+
     raw = await toolbox._tool_decomposition_start(
         {"project_native_id": "proj-drafted"}
     )
@@ -330,12 +348,18 @@ async def test_start_decomposition_transitions_anchor_to_decomposition(
     assert payload["anchor_issue_id"] == "anchor-uuid"
     assert payload["anchor_identifier"] == "ELS-101"
     assert payload["process"] == "decomposition"
+    assert payload["dispatched"] is True
 
     # Anchor probed; transition fired with stage:decomposition (E16/ELS-123 single-stage entry; ELS-308).
     assert stub.anchor_calls == ["proj-drafted"]
     assert len(stub.transition_calls) == 1
     assert stub.transition_calls[0]["to_state"] == "decomposition"
     assert stub.transition_calls[0]["ref_id"] == "anchor-uuid"
+
+    # ELS-320: decomposition routine auto-dispatched inline, no kick.
+    assert len(dispatch_calls) == 1
+    assert dispatch_calls[0]["fsm_stage"] == "decomposition"
+    assert dispatch_calls[0]["ticket_ref"] == "ELS-101"
 
     audit = (
         await db_session.execute(


### PR DESCRIPTION
Fixes ELS-320 (closes the decomposition half of ELS-314).

**Problem.** `start_decomposition` transitions the anchor to `stage:decomposition` then relies on the diff-based poller to dispatch — but the poller only fires on a NET observed state change, so the anchor parks until a manual `maybe_dispatch` kick. Hit on ELS-305, ELS-309, BUZ-5, BUZ-6 — every decomposition needed a hand-kick.

**Fix.** Fire `maybe_dispatch(..., fsm_stage='decomposition')` **inline** right after the anchor transition, in BOTH start paths (MCP `decomposition_start` tool + HTTP route). Best-effort: anchor is already transitioned, so a dispatch hiccup (shadow/cap/lock/transient) falls back to the poller and never fails the handoff; all gates inside `maybe_dispatch` still apply. Removes poll latency too. Tool returns `dispatched: bool`.

**Test.** decomposition-start unit test stubs `maybe_dispatch`, asserts one call with `fsm_stage=decomposition` + `dispatched: true` (file CI-quarantined; verified locally).

**Verify live.** Next `start_decomposition` / `run_subagent kind=decomposition` produces `agent_run.dispatch routine=decomposition` immediately, no kick.