### PR TITLE
fix(fsm): blocked ≠ needs:clarification + devops must commit (ELS-321, ELS-323)

### DIFF
--- a/apps/backend/app/api/v1/routes/agent_runs.py
+++ b/apps/backend/app/api/v1/routes/agent_runs.py
@@ -4742,24 +4742,16 @@ async def finish_agent_run(
             ref = _ticket_ref_from(resolved.kind, payload.ticket_ref)
             add_signal = getattr(resolved.gateway, "add_signal_label", None)
             if add_signal is not None:
+                # ELS-321: ``add_signal_label`` now self-heals a missing
+                # ``blocked`` label (list-or-create on the team), so the
+                # old "fall back to needs:clarification" path is gone — a
+                # hard block must NEVER masquerade as an operator-question
+                # clarification (it can't be answered → phantom freeze →
+                # manual label removal). On the rare residual failure we
+                # log and leave the ticket unfrozen rather than mislabel.
                 try:
                     await add_signal(ref, key="blocked")
                     actions.append("tracker:label:blocked")
-                except ValueError:
-                    # Legacy workspace whose Linear team was provisioned
-                    # before SIGNAL_LABELS gained ``blocked``. Fall back
-                    # to ``needs:clarification`` so the freeze still
-                    # takes effect (same OVERLAY_FREEZE_LABEL_PREFIXES
-                    # bucket). Operator re-runs the provisioner to
-                    # restore the canonical label.
-                    try:
-                        await add_signal(ref, key="needs_clarification")
-                        actions.append("tracker:label:needs_clarification:fallback")
-                    except Exception as exc:  # noqa: BLE001
-                        logger.warning(
-                            "blocked label fallback failed ws=%s ticket=%s: %s",
-                            workspace_id, payload.ticket_ref, exc,
-                        )
                 except Exception as exc:  # noqa: BLE001
                     logger.warning(
                         "blocked label add failed ws=%s ticket=%s: %s",

--- a/apps/backend/app/integrations/linear/tracker_adapter.py
+++ b/apps/backend/app/integrations/linear/tracker_adapter.py
@@ -648,10 +648,15 @@ class LinearTracker:
             raise ValueError(f"LinearTracker can't tag kind={ticket.kind}")
         label_id = self._signal_label_ids.get(key)
         if not label_id:
-            raise ValueError(
-                f"Signal label {key!r} is not provisioned for this team. "
-                "Re-run OAuth or call the provisioner."
-            )
+            # Self-heal (ELS-321): a team provisioned before this signal
+            # label existed (e.g. `blocked` on teams seeded pre-ELS-278)
+            # would otherwise raise — and the caller (agent_run.finish for
+            # outcome=blocked) then mislabels a hard-blocked ticket as
+            # `needs:clarification`, a phantom operator-question that can
+            # never be answered → permanent freeze + manual label removal.
+            # Provision the label on the fly (list-or-create) and cache it
+            # so `blocked` stays `blocked`.
+            label_id = await self._ensure_signal_label(key)
         await self._gql(
             """mutation ShipAddSignal($id: String!, $input: IssueUpdateInput!) {
               issueUpdate(id: $id, input: $input) { success }
@@ -661,6 +666,55 @@ class LinearTracker:
                 "input": {"addedLabelIds": [label_id]},
             },
         )
+
+    async def _ensure_signal_label(self, key: str) -> str:
+        """Resolve (and provision if missing) the Linear label id for a
+        signal ``key`` on this team, caching it on ``self``. (ELS-321)
+
+        Looks the label up by its canonical name first (idempotent —
+        re-provisioning a team that already has it is a no-op), creating
+        it only when absent. Raises ``ValueError`` only when the key is
+        unknown or the team id is missing — never silently borrows a
+        different signal label.
+        """
+        from backend.app.services.linear_provisioner import SIGNAL_LABELS
+
+        name = SIGNAL_LABELS.get(key)
+        if not name or not self._team_id:
+            raise ValueError(
+                f"Signal label {key!r} cannot be provisioned "
+                f"(unknown key or missing team id)."
+            )
+        found = await self._gql(
+            """query($f: IssueLabelFilter) {
+              issueLabels(filter: $f, first: 1) { nodes { id name } }
+            }""",
+            {"f": {"team": {"id": {"eq": self._team_id}}, "name": {"eq": name}}},
+        )
+        nodes = ((found.get("issueLabels") or {}).get("nodes")) or []
+        if nodes and nodes[0].get("id"):
+            label_id = nodes[0]["id"]
+        else:
+            created = await self._gql(
+                """mutation($input: IssueLabelCreateInput!) {
+                  issueLabelCreate(input: $input) {
+                    success
+                    issueLabel { id }
+                  }
+                }""",
+                {"input": {"name": name, "teamId": self._team_id}},
+            )
+            label_id = (
+                ((created.get("issueLabelCreate") or {}).get("issueLabel") or {})
+                .get("id")
+            )
+            if not label_id:
+                raise ValueError(
+                    f"failed to provision signal label {name!r} on team "
+                    f"{self._team_id}"
+                )
+        self._signal_label_ids[key] = label_id
+        return label_id
 
     async def transition(
         self,

--- a/apps/backend/app/resources/agent_roles/devops.md
+++ b/apps/backend/app/resources/agent_roles/devops.md
@@ -169,6 +169,19 @@ You ARE a code-changing role, so your sidecar MUST set `pr` when
 The runner appends a `Closes {{ISSUE}}` footer and the run-handle
 line to your `pr.body` automatically — don't write them yourself.
 
+**Before you set `pr`: actually write the files to disk.** The runner
+verifies the branch has commits vs `main` and rewrites your outcome to
+`blocked` ("branch has no commits") if it doesn't — so a `pr` with an
+empty branch is a hard fail, not a partial credit. This is the #1
+greenfield trap: do NOT describe a scaffold in your `comment` that you
+did not create. For a fresh/empty repo you MUST create every file
+(package layout, manifests, linter/formatter config, the CI workflow,
+README) in the working tree — the runner stages and commits whatever
+you wrote. Before finishing, confirm the files exist on disk (you
+created them this run). If there is genuinely nothing to write, your
+outcome is `blocked` with the reason — never `ready_next_step` with a
+`pr` that has no commits.
+
 End your `comment` with `[Ship SDLC:role-devops]`.
 
 ## Outcomes — pick exactly one

--- a/apps/backend/tests/test_blocked_freeze_label.py
+++ b/apps/backend/tests/test_blocked_freeze_label.py
@@ -140,9 +140,13 @@ def test_blocked_handler_adds_signal_label_in_source() -> None:
     body = src.read_text(encoding="utf-8")
     # The handler calls add_signal with key="blocked"
     assert 'await add_signal(ref, key="blocked")' in body
-    # Plus the fallback to needs_clarification for legacy workspaces
-    # whose Linear team was provisioned before SIGNAL_LABELS gained
-    # the "blocked" entry — both are in OVERLAY_FREEZE_LABEL_PREFIXES.
-    assert 'await add_signal(ref, key="needs_clarification")' in body
+    # ELS-321: a blocked outcome must NEVER masquerade as
+    # needs:clarification (a hard block is not an operator-question —
+    # it can't be answered, so the old fallback created a phantom
+    # clarification that froze the ticket until manual label removal).
+    # The fallback is removed; ``add_signal_label`` self-heals a missing
+    # ``blocked`` label instead. Pin that the fallback action string is
+    # gone so it can't silently come back.
+    assert "tracker:label:needs_clarification:fallback" not in body
     # And the dedicated inbox letter
     assert '"intake_reason": "agent_blocked"' in body  # flipped onto notify() (ELS-224)

--- a/apps/backend/tests/test_linear_signal_label_selfheal.py
+++ b/apps/backend/tests/test_linear_signal_label_selfheal.py
@@ -1,0 +1,95 @@
+"""ELS-321 — add_signal_label self-heals a missing signal label instead
+of raising (which made agent_run.finish mislabel a hard `blocked` as
+`needs:clarification` — a phantom clarification that froze the ticket
+until an operator hand-removed the label)."""
+
+from __future__ import annotations
+
+import pytest
+
+from backend.app.integrations.gateway.tracker import TicketRef
+from backend.app.integrations.linear.tracker_adapter import LinearTracker
+
+
+def _ref() -> TicketRef:
+    return TicketRef(kind="linear", workspace_hint=None, id="BUZ-11")
+
+
+def _tracker_without_blocked() -> tuple[LinearTracker, list[dict]]:
+    """Tracker whose team has `needs_clarification` but NOT `blocked`."""
+    t = LinearTracker(
+        "tok",
+        team_id="team-1",
+        signal_label_ids={"needs_clarification": "L-clar"},
+    )
+    calls: list[dict] = []
+
+    async def fake_gql(query: str, variables: dict):  # type: ignore[override]
+        calls.append({"query": query, "variables": variables})
+        if "issueLabels(" in query:
+            # Default: label does NOT exist on the team yet.
+            return {"issueLabels": {"nodes": []}}
+        if "issueLabelCreate" in query:
+            return {"issueLabelCreate": {"success": True, "issueLabel": {"id": "L-blocked"}}}
+        if "issueUpdate" in query:
+            return {"issueUpdate": {"success": True}}
+        return {}
+
+    t._gql = fake_gql  # type: ignore[assignment]
+    return t, calls
+
+
+@pytest.mark.asyncio
+async def test_add_signal_label_creates_missing_blocked_label() -> None:
+    t, calls = _tracker_without_blocked()
+
+    await t.add_signal_label(_ref(), key="blocked")
+
+    # It looked the label up, created it, cached the id, and applied it.
+    assert any("issueLabels(" in c["query"] for c in calls)
+    assert any("issueLabelCreate" in c["query"] for c in calls)
+    assert t._signal_label_ids["blocked"] == "L-blocked"
+    applied = [c for c in calls if "issueUpdate" in c["query"]]
+    assert applied, "expected the label to be applied via issueUpdate"
+    assert applied[0]["variables"]["input"]["addedLabelIds"] == ["L-blocked"]
+    # Never borrowed the clarification label.
+    assert t._signal_label_ids["needs_clarification"] == "L-clar"
+
+
+@pytest.mark.asyncio
+async def test_add_signal_label_reuses_existing_label_no_create() -> None:
+    t, calls = _tracker_without_blocked()
+
+    async def fake_gql(query: str, variables: dict):
+        calls.append({"query": query, "variables": variables})
+        if "issueLabels(" in query:
+            return {"issueLabels": {"nodes": [{"id": "L-existing", "name": "blocked"}]}}
+        if "issueUpdate" in query:
+            return {"issueUpdate": {"success": True}}
+        if "issueLabelCreate" in query:  # pragma: no cover - must not happen
+            raise AssertionError("should not create when label already exists")
+        return {}
+
+    t._gql = fake_gql  # type: ignore[assignment]
+
+    await t.add_signal_label(_ref(), key="blocked")
+
+    assert t._signal_label_ids["blocked"] == "L-existing"
+    assert not any("issueLabelCreate" in c["query"] for c in calls)
+
+
+@pytest.mark.asyncio
+async def test_add_signal_label_existing_key_skips_provisioning() -> None:
+    """A team that already has the label id cached never lists/creates."""
+    t = LinearTracker(
+        "tok", team_id="team-1", signal_label_ids={"blocked": "L-blocked"}
+    )
+    calls: list[dict] = []
+
+    async def fake_gql(query: str, variables: dict):
+        calls.append(query)
+        return {"issueUpdate": {"success": True}}
+
+    t._gql = fake_gql  # type: ignore[assignment]
+    await t.add_signal_label(_ref(), key="blocked")
+    assert not any("issueLabels(" in q or "issueLabelCreate" in q for q in calls)


### PR DESCRIPTION
Surfaced dogfooding Buzz (BUZ-11). **Chain:** devops agent declared a PR but committed nothing → `run.mjs` `verify_commits` rewrote `ready_next_step → blocked` → `agent_run.finish` tried `add_signal_label('blocked')` → Buzz's Linear team had no `blocked` label → ValueError → **fell back to `needs:clarification`**. A hard block became a phantom operator-question that can never be answered → permanent overlay-freeze → operator had to hand-remove the label.

**ELS-321** — `LinearTracker.add_signal_label` **self-heals**: missing signal label id → list-or-create on the team + cache, instead of raising. Dropped the `agent_run.finish` fallback that borrowed `needs:clarification` for a blocked outcome — a block must never look like a clarification (different overlay semantics; auto-resume on answer / on label removal already exists). Unit tests for create / reuse / already-cached.

**ELS-323** — devops role prompt: hard rule that the agent MUST write the scaffold files to disk before declaring `pr`; a `pr` with no commits is a hard `blocked`, not partial credit. Greenfield is the #1 trap.

**ELS-322** (picker skip-to-next-sibling when a pinned ticket is frozen) stays open — load-bearing dispatcher change; this PR removes the un-answerable phantom-clarification class that caused the manual toil, and auto-resume already exists for real clarifications/blocks.

Immediate Buzz mitigation already applied live (provisioned the `blocked` label on Buzz's team).