### PR TITLE
fix(prompts): agent commits its own work; runner only pushes (ELS-323)

### DIFF
--- a/apps/backend/app/resources/agent_roles/system.md
+++ b/apps/backend/app/resources/agent_roles/system.md
@@ -71,9 +71,19 @@ start.
 **Do not call Ship's finish API directly.** Write your intended
 finish payload to `.ship/agent-finish.json` in the repo workdir and
 stop. The Ship runner (`run.mjs`) reads the sidecar after your
-session ends, owns the branch push + PR creation, and posts the
-finish call on your behalf — splicing the PR URL into your comment
-so the audit log captures it.
+session ends, **pushes the commits you made on your branch**, creates
+the PR from them, and posts the finish call on your behalf — splicing
+the PR URL into your comment so the audit log captures it.
+
+**You commit your own work — the runner does NOT.** The runner only
+pushes commits that already exist on your branch; it never stages or
+commits your working tree for you. So for any code-changing role you
+MUST `git add` + `git commit` your changes yourself before you write
+the sidecar and stop. A `pr` sidecar on a branch with **no commits
+vs the base** is rejected: the runner rewrites your outcome to
+`blocked` ("branch has no commits"). Writing files to the working
+tree but never committing them is the #1 failure on greenfield /
+scaffold work — your edits look done to you but vanish to the runner.
 
 Why: your session terminates **before** the runner has a chance to
 push your branch or run `gh pr create`. If you call `/finish`
@@ -121,6 +131,12 @@ leaves it `null`:
 The runner appends a `Closes <ticket>` footer + the run handle line
 to your body, so don't bother writing them yourself. Branch name is
 fixed by the runner; don't try to override it.
+
+Setting `pr` is a promise that **committed** work exists. Before you
+write the sidecar: make your edits, then `git add -A && git commit`
+with scoped, conventional messages. Verify with `git status` (clean)
+and `git log --oneline origin/<base>..HEAD` (≥1 commit). No commits →
+don't set `pr`; finish `blocked` with the reason instead.
 
 If your role doesn't change code (intake, BA, planners,
 project-section authors, qa_manual, reviewers, retro), set


### PR DESCRIPTION
Root cause of BUZ-11's repeated `branch has no commits → blocked`: `system.md`'s exit protocol said the runner *owns the branch push + PR creation* but **never told the agent to git-commit**. In the current edition `run.mjs` only **pushes** commits that already exist (`cursor.mjs`: 'let it make commits in place') — it does not stage/commit the working tree. A code-changing agent that wrote files + a sidecar but never committed left an empty branch → `verify_commits` rewrote `ready_next_step → blocked`. The agent literally narrated 'the Ship runner will push the branch' — it believed the runner committed.

**Fix** (shared `system.md` — covers developer, devops, every code-changing role):
- exit protocol now says the runner pushes **the commits you made**, and the agent commits its own work (runner never commits the tree)
- 'When to set `pr`' now requires `git add` + `git commit` before the sidecar + a `git status`/`git log` verify; no commits → don't set `pr`, finish `blocked`

Supersedes the devops.md-only hint from #407 — this is the all-roles fix. After deploy I'll re-run BUZ-11 (clean its stale `stage:planning` + `blocked` first) to confirm the scaffold now commits + opens a real PR.