### PR TITLE
fix(fsm): operator-merged PR → Done, not no_pr_url block (ELS-325)

### DIFF
--- a/apps/backend/app/api/v1/routes/agent_runs.py
+++ b/apps/backend/app/api/v1/routes/agent_runs.py
@@ -1188,6 +1188,35 @@ def _extract_pr_url(text: str | None) -> str | None:
     return match.group(0) if match else None
 
 
+async def _ticket_pr_already_merged(
+    session: AsyncSession, *, workspace_id: uuid.UUID, ticket_ref: str
+) -> bool:
+    """Has the ticket's PR already been merged out-of-band? (ELS-325)
+
+    The operator sometimes merges a PR by hand on github.com mid-chain.
+    The code_review/auto_merge gate then finds no OPEN PR to cite and
+    would wrongly block. We check the PR cache for a merged PR whose
+    conventional title carries this ticket (``infra(BUZ-11): …``); a
+    hit means the work shipped and the ticket should finish, not freeze.
+    """
+    from sqlalchemy import select as _select
+
+    from backend.app.db.models.pipelines import PullRequest
+
+    row = (
+        await session.execute(
+            _select(PullRequest.id)
+            .where(
+                PullRequest.workspace_id == workspace_id,
+                PullRequest.merged.is_(True),
+                PullRequest.title.ilike(f"%({ticket_ref})%"),
+            )
+            .limit(1)
+        )
+    ).first()
+    return row is not None
+
+
 async def _validate_code_review_to_auto_merge(
     session: AsyncSession,
     *,
@@ -1195,6 +1224,7 @@ async def _validate_code_review_to_auto_merge(
     pr_url: str | None,
     settings: Settings,
     require_approval: bool = True,
+    ticket_ref: str | None = None,
 ) -> tuple[bool, str]:
     """Verify the agent's ``code_review → auto_merge`` claim against
     GitHub.
@@ -1233,6 +1263,16 @@ async def _validate_code_review_to_auto_merge(
     failed merge), so a brittle gate is safer than a permissive one.
     """
     if not pr_url:
+        # ELS-325: no PR URL on the finish usually means the agent
+        # never opened one — but it ALSO happens when the operator
+        # merged the PR by hand mid-chain, leaving no open PR to cite.
+        # Distinguish: if the ticket's PR is already merged, signal
+        # ``already_merged`` so the caller finishes the ticket (→ Done)
+        # instead of freezing it as ``no_pr_url``.
+        if ticket_ref and await _ticket_pr_already_merged(
+            session, workspace_id=workspace_id, ticket_ref=ticket_ref
+        ):
+            return False, "already_merged"
         return False, "no_pr_url"
     pr_path_re = re.compile(
         r"^https://github\.com/([\w.-]+)/([\w.-]+)/pull/(\d+)$",
@@ -4192,9 +4232,39 @@ async def finish_agent_run(
             pr_url=pr_url,
             settings=settings,
             require_approval=autonomy_profile != "high",
+            ticket_ref=payload.ticket_ref,
         )
         actions.append(f"phase4:gate_profile:{autonomy_profile}")
-        if not gate_ok:
+        if not gate_ok and gate_reason == "already_merged":
+            # ELS-325: the PR was merged out-of-band (operator merged by
+            # hand). The work shipped — don't freeze. Skip auto_merge and
+            # finish the ticket at the terminal ``merged`` state (→ Done),
+            # the same place a normal auto-merge lands. Leaving
+            # ``outcome=ready_next_step`` lets the downstream transition
+            # move it; we just retarget stage_next.
+            logger.info(
+                "phase4 gate: %s PR already merged out-of-band ws=%s — "
+                "advancing to merged instead of blocking",
+                payload.ticket_ref, workspace_id,
+            )
+            session.add(
+                AuditLog(
+                    workspace_id=workspace_id,
+                    actor_user_id=auth.user.id,
+                    actor_token_id=auth.token.id if auth.token else None,
+                    action="transition.auto_merge_skipped_already_merged",
+                    target_kind="ticket",
+                    target_id=payload.ticket_ref,
+                    payload={
+                        "fsm_stage": payload.fsm_stage,
+                        "run_id": payload.run_id,
+                        "autonomy": autonomy_profile,
+                    },
+                )
+            )
+            payload.stage_next = "merged"
+            actions.append("phase4:already_merged:advance_done")
+        elif not gate_ok:
             logger.info(
                 "phase4 gate rejected code_review→auto_merge "
                 "ws=%s ticket=%s reason=%s pr_url=%s autonomy=%s",

--- a/apps/backend/tests/test_phase4_code_review_validation.py
+++ b/apps/backend/tests/test_phase4_code_review_validation.py
@@ -170,6 +170,50 @@ def test_no_pr_url_is_rejected() -> None:
     assert reason == "no_pr_url"
 
 
+def test_no_pr_url_with_already_merged_pr_signals_advance() -> None:
+    # ELS-325: operator merged the PR by hand mid-chain → no open PR to
+    # cite, but the ticket's PR IS merged. The gate must NOT block as
+    # ``no_pr_url`` — it returns ``already_merged`` so the caller
+    # finishes the ticket (→ Done) instead of freezing.
+    import asyncio
+
+    session = AsyncMock()
+    # _ticket_pr_already_merged → session.execute(...).first() truthy.
+    session.execute = AsyncMock(
+        return_value=MagicMock(first=MagicMock(return_value=("pr-id",)))
+    )
+    ok, reason = asyncio.new_event_loop().run_until_complete(
+        _validate_code_review_to_auto_merge(
+            session,
+            workspace_id=uuid.uuid4(),
+            pr_url=None,
+            settings=_build_settings(),
+            ticket_ref="ENG-7",
+        )
+    )
+    assert ok is False
+    assert reason == "already_merged"
+
+
+def test_no_pr_url_without_merged_pr_still_blocks() -> None:
+    import asyncio
+
+    session = AsyncMock()
+    session.execute = AsyncMock(
+        return_value=MagicMock(first=MagicMock(return_value=None))
+    )
+    ok, reason = asyncio.new_event_loop().run_until_complete(
+        _validate_code_review_to_auto_merge(
+            session,
+            workspace_id=uuid.uuid4(),
+            pr_url=None,
+            settings=_build_settings(),
+            ticket_ref="ENG-7",
+        )
+    )
+    assert (ok, reason) == (False, "no_pr_url")
+
+
 def test_invalid_pr_url_is_rejected() -> None:
     ok, reason = _run_with_mocked_gh(
         reviews=[], pr_detail={}, check_runs=[],


### PR DESCRIPTION
When the operator merges a ticket's PR by hand mid-chain, the `code_review→auto_merge` gate found no OPEN PR to cite and rewrote the finish to `blocked` (`reason=no_pr_url`) — the work shipped but the ticket falsely froze in Review (hit on **BUZ-11**: scaffold PR #3 merged manually → ticket stuck `blocked`).

**Fix.** `_validate_code_review_to_auto_merge` now takes `ticket_ref`; on the no-pr_url path it checks the PR cache for a **merged** PR carrying the ticket (conventional title `<type>(<TICKET>): …`) via `_ticket_pr_already_merged`. If merged → returns `already_merged`, and the finish handler retargets `stage_next='merged'` (→ Done) while keeping `outcome=ready_next_step` — the ticket finishes where a normal auto-merge lands, no freeze, no manual label removal. Genuine no-PR cases still block as `no_pr_url`.

**Tests** (collected, 26 passed): gate → `already_merged` when a merged PR exists + no pr_url; still `no_pr_url` when none; existing approval/CI/invalid-url cases unchanged.

BUZ-11 already unstuck by hand (→ Done); this prevents the recurrence for any operator-merged PR.