### PR TITLE
feat(mcp): dispatch_ticket — fire/recover a stuck ticket from the operator's agent (ELS-314)

### DIFF
--- a/apps/backend/app/api/v1/routes/mcp.py
+++ b/apps/backend/app/api/v1/routes/mcp.py
@@ -143,7 +143,16 @@ Typical flows:
 - "what's in flight" → `dashboard_get`, `ticket_list`, `runs_list`.
 - "do ticket X" → `ticket_update` with the target state — the status
   field is the engine's only transition signal; the FSM takes over
-  from there.
+  from there. Don't hand-walk a ticket through every stage yourself:
+  set the entry/target state and let the engine cascade. Wrong manual
+  states mostly no-op (the dispatcher routes off labels), but they can
+  desync the tracker — prefer one intent signal over micro-managing.
+- "ticket looks stuck / parked / I just moved it and nothing happened"
+  → `dispatch_ticket` (ticket_ref). It fires the ticket's current
+  stage immediately and recovers stalls the diff-poller missed — it
+  honours every gate (lock, cascade cap, dependency blocks), so it's
+  safe to use as your recovery button. Returns `fired` + the reason
+  (e.g. `blocked_by_dependency`, `no_routine`).
 - "review this PR" → `run_workflow` with workflow_name="pr-review".
 - "set Ship up on this repo" → `repo_setup_status` to see what's
   missing, then close gaps: `github_list_install_repos` +
@@ -479,6 +488,43 @@ _NATIVE_TOOLS: list[dict[str, Any]] = [
             "required": ["external_ids"],
         },
     },
+    {
+        "name": "dispatch_ticket",
+        "description": (
+            "Force-fire (or recover) a ticket's current SDLC stage — run "
+            "the agent the event path would, right now. Use it when a "
+            "ticket is stuck/parked (the diff-based poller missed it, or "
+            "you just moved it and don't want to wait for the next tick), "
+            "or to retry a stage after clearing what blocked it. Resolves "
+            "the stage from the ticket's labels unless you pass ``stage``. "
+            "Respects EVERY safety gate (shadow mode, cascade limit, ticket "
+            "lock, workspace dispatch cap, dependency blocks) — a trigger, "
+            "not a bypass. **Mutating; admin-only**; verify-before-mutate. "
+            "Returns whether a run fired and the reason "
+            "(``fired`` / ``no_routine`` / ``blocked_by_dependency`` / "
+            "``lock_held`` / ``cascade_blocked`` / ``shadow`` / …)."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "workspace_id": _WORKSPACE_ID_PROP,
+                "ticket_ref": {
+                    "type": "string",
+                    "description": "Tracker-native id, e.g. ELS-99.",
+                },
+                "stage": {
+                    "type": "string",
+                    "description": (
+                        "Optional FSM stage to dispatch (e.g. "
+                        "``dev_implementation``, ``decomposition``, "
+                        "``code_review``). Omit to resolve from the "
+                        "ticket's current labels."
+                    ),
+                },
+            },
+            "required": ["ticket_ref"],
+        },
+    },
 ]
 
 
@@ -784,6 +830,71 @@ async def _call_native(
         ws_id = await _resolve_workspace_id(session, auth, arguments)
         return await _repo_setup_status(
             session, ws_id, repo_arg, settings=settings
+        )
+
+    if name == "dispatch_ticket":
+        from backend.app.integrations.gateway.tracker import TicketRef
+        from backend.app.services.dispatcher import maybe_dispatch
+        from backend.app.services.linear_provisioner import (
+            resolve_fsm_stage_from_labels,
+        )
+        from backend.app.services.tracker_resolver import resolve_for_workspace
+
+        ws_id = await _resolve_workspace_id(session, auth, arguments)
+        ticket_ref = str(arguments.get("ticket_ref") or "").strip()
+        if not ticket_ref:
+            raise _McpToolError("ticket_ref is required")
+        stage = arguments.get("stage")
+        if stage is not None and not isinstance(stage, str):
+            raise _McpToolError("stage must be a string")
+        stage = (stage or "").strip() or None
+        if stage is None:
+            # Recover a stuck/parked ticket without the caller knowing the
+            # FSM: resolve its stage from the current labels (ELS-314).
+            resolved = await resolve_for_workspace(
+                session=session, settings=settings, workspace_id=ws_id
+            )
+            if resolved is None:
+                raise _McpToolError("no tracker bound for this workspace")
+            labels: list[str] = []
+            ticket_state: str | None = None
+            snap_fn = getattr(resolved.gateway, "get_ticket_snapshot", None)
+            if snap_fn is not None:
+                try:
+                    snap = await snap_fn(
+                        TicketRef(
+                            kind=resolved.kind,
+                            workspace_hint=None,
+                            id=ticket_ref,
+                        )
+                    )
+                    labels = (snap or {}).get("labels") or []
+                    ticket_state = (snap or {}).get("state")
+                except Exception:  # noqa: BLE001 — degrade to explicit stage
+                    labels = []
+            stage = resolve_fsm_stage_from_labels(labels, state=ticket_state)
+            if not stage:
+                raise _McpToolError(
+                    "couldn't resolve the ticket's stage from its labels — "
+                    "pass `stage` explicitly (e.g. dev_implementation, "
+                    "decomposition, code_review)"
+                )
+        result = await maybe_dispatch(
+            session,
+            workspace_id=ws_id,
+            ticket_ref=ticket_ref,
+            trigger_kind="mcp_dispatch",
+            fsm_stage=stage,
+            settings=settings,
+        )
+        reason = getattr(result, "reason", None)
+        return json.dumps(
+            {
+                "ticket_ref": ticket_ref,
+                "fsm_stage": stage,
+                "fired": bool(getattr(result, "fired", False)),
+                "reason": str(reason) if reason is not None else None,
+            }
         )
 
     if name == "sdlc_assess":

--- a/apps/backend/tests/test_mcp_edge.py
+++ b/apps/backend/tests/test_mcp_edge.py
@@ -78,8 +78,13 @@ async def test_tools_list_projection_and_natives(
         "sdlc_assess",
         "github_list_install_repos",
         "repo_activate",
+        "dispatch_ticket",
     ):
         assert native in tools
+    # dispatch_ticket (ELS-314) exposes ticket_ref (required) + optional stage.
+    _dt = tools["dispatch_ticket"]["inputSchema"]
+    assert "ticket_ref" in _dt["properties"] and "stage" in _dt["properties"]
+    assert _dt.get("required") == ["ticket_ref"]
     # workspace_id injected into projected tools.
     assert "workspace_id" in tools["dashboard_get"]["inputSchema"]["properties"]
     # approval_echo contract surfaced on inbox_update.
@@ -195,6 +200,21 @@ async def test_repo_activate_requires_external_ids(
     result = res.json()["result"]
     assert result["isError"] is True
     assert "external_ids" in result["content"][0]["text"]
+
+
+@pytest.mark.asyncio
+async def test_dispatch_ticket_requires_ticket_ref(
+    db_session, v1_client, seed_workspace
+) -> None:
+    _, raw, _ = seed_workspace
+    res = await _post(
+        v1_client,
+        raw,
+        _rpc("tools/call", {"name": "dispatch_ticket", "arguments": {}}),
+    )
+    result = res.json()["result"]
+    assert result["isError"] is True
+    assert "ticket_ref" in result["content"][0]["text"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes the recovery half of **ELS-314**. Until now, when the diff-based poller missed a ticket (stuck anchor, just-moved state, post-clarify retry), the only fix was `kubectl exec maybe_dispatch` — cluster access a real operator doesn't have, breaking the MCP-edge promise. Hit repeatedly dogfooding Buzz.

**Adds** a native `dispatch_ticket` MCP tool: `ticket_ref` + optional `stage`. Stage omitted → resolves the ticket's stage from its labels (`resolve_fsm_stage_from_labels`) so a naive caller recovers a stall without knowing the FSM, then calls `dispatcher.maybe_dispatch` under the operator PAT. **Respects every gate** (shadow / cascade limit / ticket lock / workspace dispatch cap / dependency blocks) — a trigger, not a bypass. Returns `fired` + `reason`.

`SERVER_INSTRUCTIONS`: documents it as the recovery button + a 'don't hand-walk every state — set one intent signal, let the FSM cascade' guardrail for external agents that don't know our transition rules.

**Tests:** `dispatch_ticket` in tools/list (ticket_ref required, stage optional); tools/call without ticket_ref errors. (Verified empirically all session — this is the exec-path maybe_dispatch I ran ~6× to unstick ELS-305/309/BUZ-11, now a first-class MCP tool.)

This is the highest safety lever from the naive-external-agent risk review: stalls become self-recoverable from the agent.