### PR TITLE
fix(ELS-327): code_review gate resolves the ticket's open PR, not just the finish payload

### DIFF
--- a/apps/backend/app/api/v1/routes/agent_runs.py
+++ b/apps/backend/app/api/v1/routes/agent_runs.py
@@ -1217,6 +1217,39 @@ async def _ticket_pr_already_merged(
     return row is not None
 
 
+async def _ticket_open_pr_url(
+    session: AsyncSession, *, workspace_id: uuid.UUID, ticket_ref: str
+) -> str | None:
+    """Resolve an OPEN PR for the ticket from the PR cache (ELS-327).
+
+    The code_review gate reads the PR URL from the agent's finish
+    ``comment``. When a finish omits the ``PR: <url>`` line — but the
+    work DID open a PR — the gate used to false-block on ``no_pr_url``
+    even though an open, CI-green PR exists (the recurring ELS-309 stall;
+    cluster of 265 / 194 / 295 / 309 since 2026-06-12). We look up the
+    newest open, non-merged PR whose conventional title carries this
+    ticket (``feat(ELS-309): …``) and return its ``html_url`` so the gate
+    can validate reviews + CI against it instead of freezing the chain.
+    """
+    from sqlalchemy import select as _select
+
+    from backend.app.db.models.pipelines import PullRequest
+
+    return (
+        await session.execute(
+            _select(PullRequest.html_url)
+            .where(
+                PullRequest.workspace_id == workspace_id,
+                PullRequest.merged.is_(False),
+                PullRequest.state.ilike("open"),
+                PullRequest.title.ilike(f"%({ticket_ref})%"),
+            )
+            .order_by(PullRequest.number.desc())
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+
+
 async def _validate_code_review_to_auto_merge(
     session: AsyncSession,
     *,
@@ -1263,17 +1296,27 @@ async def _validate_code_review_to_auto_merge(
     failed merge), so a brittle gate is safer than a permissive one.
     """
     if not pr_url:
-        # ELS-325: no PR URL on the finish usually means the agent
-        # never opened one — but it ALSO happens when the operator
-        # merged the PR by hand mid-chain, leaving no open PR to cite.
-        # Distinguish: if the ticket's PR is already merged, signal
-        # ``already_merged`` so the caller finishes the ticket (→ Done)
-        # instead of freezing it as ``no_pr_url``.
-        if ticket_ref and await _ticket_pr_already_merged(
-            session, workspace_id=workspace_id, ticket_ref=ticket_ref
-        ):
-            return False, "already_merged"
-        return False, "no_pr_url"
+        # The finish payload carried no ``PR: <url>`` line. Before
+        # freezing on ``no_pr_url``, try to recover the PR from the
+        # ticket itself:
+        #   - ELS-327: an OPEN PR (resolve it and validate that PR — the
+        #     recurring code_review stall where the gate read the PR from
+        #     the finish payload, not the ticket, and false-blocked
+        #     CI-green work like ELS-309 / PR #402);
+        #   - ELS-325: else a MERGED PR (operator merged out-of-band) →
+        #     ``already_merged`` so the caller finishes the ticket (→ Done).
+        if ticket_ref:
+            resolved_open = await _ticket_open_pr_url(
+                session, workspace_id=workspace_id, ticket_ref=ticket_ref
+            )
+            if resolved_open:
+                pr_url = resolved_open
+            elif await _ticket_pr_already_merged(
+                session, workspace_id=workspace_id, ticket_ref=ticket_ref
+            ):
+                return False, "already_merged"
+        if not pr_url:
+            return False, "no_pr_url"
     pr_path_re = re.compile(
         r"^https://github\.com/([\w.-]+)/([\w.-]+)/pull/(\d+)$",
         re.IGNORECASE,

--- a/apps/backend/tests/test_phase4_code_review_validation.py
+++ b/apps/backend/tests/test_phase4_code_review_validation.py
@@ -178,9 +178,13 @@ def test_no_pr_url_with_already_merged_pr_signals_advance() -> None:
     import asyncio
 
     session = AsyncMock()
-    # _ticket_pr_already_merged → session.execute(...).first() truthy.
+    # ELS-327: _ticket_open_pr_url runs first → scalar_one_or_none None
+    # (no OPEN PR). Then _ticket_pr_already_merged → first() truthy.
     session.execute = AsyncMock(
-        return_value=MagicMock(first=MagicMock(return_value=("pr-id",)))
+        return_value=MagicMock(
+            scalar_one_or_none=MagicMock(return_value=None),
+            first=MagicMock(return_value=("pr-id",)),
+        )
     )
     ok, reason = asyncio.new_event_loop().run_until_complete(
         _validate_code_review_to_auto_merge(
@@ -199,8 +203,12 @@ def test_no_pr_url_without_merged_pr_still_blocks() -> None:
     import asyncio
 
     session = AsyncMock()
+    # No OPEN PR (scalar_one_or_none None) and no MERGED PR (first None).
     session.execute = AsyncMock(
-        return_value=MagicMock(first=MagicMock(return_value=None))
+        return_value=MagicMock(
+            scalar_one_or_none=MagicMock(return_value=None),
+            first=MagicMock(return_value=None),
+        )
     )
     ok, reason = asyncio.new_event_loop().run_until_complete(
         _validate_code_review_to_auto_merge(
@@ -212,6 +220,34 @@ def test_no_pr_url_without_merged_pr_still_blocks() -> None:
         )
     )
     assert (ok, reason) == (False, "no_pr_url")
+
+
+def test_no_pr_url_resolves_open_pr_from_ticket() -> None:
+    # ELS-327: the finish carried no ``PR:`` line, but the ticket has an
+    # OPEN PR in the cache. The gate must resolve it and validate THAT
+    # PR rather than false-blocking on ``no_pr_url`` (the recurring
+    # ELS-309 code_review stall — PR #402 open + CI green). Here the open
+    # PR resolves to a valid URL and we let the install lookup miss,
+    # proving the gate got PAST PR resolution + URL parsing into the
+    # GitHub-backed checks instead of returning no_pr_url / already_merged.
+    import asyncio
+
+    open_pr = MagicMock(scalar_one_or_none=MagicMock(return_value=_PR_URL))
+    no_install = MagicMock(scalar_one_or_none=MagicMock(return_value=None))
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[open_pr, no_install])
+
+    ok, reason = asyncio.new_event_loop().run_until_complete(
+        _validate_code_review_to_auto_merge(
+            session,
+            workspace_id=uuid.uuid4(),
+            pr_url=None,
+            settings=_build_settings(),
+            ticket_ref="ELS-309",
+        )
+    )
+    assert ok is False
+    assert reason == "no_install"
 
 
 def test_invalid_pr_url_is_rejected() -> None:


### PR DESCRIPTION
## Problem (caught by the Ship-on-Ship daily digest, 2026-06-15)
The `code_review → auto_merge` gate (`_validate_code_review_to_auto_merge`) read the PR URL **only** from the agent's finish comment (`_extract_pr_url(payload.comment)`). When a finish omitted the `PR: <url>` line but an **open, CI-green** PR existed, it false-blocked with `no_pr_url` and froze the ticket.

Recurring `no_pr_url` cluster since 2026-06-12: **ELS-309, ELS-265, ELS-194, ELS-295**. ELS-309 passed planning → dev → QA → validation, then failed final code_review **3× in one day** with `no_pr_url` despite **PR #402 open + CI green**.

## Fix
When the finish payload carries no PR URL and a `ticket_ref` is set, resolve the ticket's **newest open, non-merged** PR from the PR cache (`_ticket_open_pr_url`, title contains `(TICKET-REF)`) and run the normal validation (≥1 APPROVED review + green CI) against it. Only fall through to `already_merged` (ELS-325) / `no_pr_url` when no open PR exists. The gate stays strict on review + CI — only *where it finds the PR* changed.

## Tests
- `test_no_pr_url_resolves_open_pr_from_ticket` — payload-less finish + open cached PR → gate gets past `no_pr_url` into the GitHub checks.
- Updated `already_merged` / `no_pr_url` tests for the extra open-PR lookup.
- 20/20 pass (`.venv/bin/python -m pytest apps/backend/tests/test_phase4_code_review_validation.py`).

Closes ELS-327. Unblocks ELS-309 once deployed.