### PR TITLE
feat(ELS-328): enforce 1:1 Linear team binding

### DIFF
--- a/apps/backend/app/api/v1/routes/linear_oauth.py
+++ b/apps/backend/app/api/v1/routes/linear_oauth.py
@@ -61,6 +61,56 @@ logger = logging.getLogger(__name__)
 router = APIRouter(tags=["linear-oauth"])
 
 
+async def _assert_team_unclaimed(
+    session: AsyncSession, *, workspace_id: uuid.UUID, team_id: str | None
+) -> None:
+    """ELS-328: a Linear team binds to at most one workspace.
+
+    The tracker is the dispatch-signal source. If two workspaces poll the
+    same Linear team they both dispatch the same ticket (shared ``ELS-###``
+    ref) and the repo resolves per-workspace → cross-tenant action (the
+    ship-landing / ``no_pr_url`` incident, 2026-06). Block a *second*
+    workspace from claiming a team that another workspace already has bound
+    AND actively polls (a ``ready`` native linear install). Re-binding the
+    same team inside the same workspace stays allowed (idempotent
+    reconnect / repick).
+    """
+    if not team_id:
+        return
+    clash = (
+        await session.execute(
+            select(Integration.workspace_id)
+            .join(
+                NativeIntegrationInstallation,
+                NativeIntegrationInstallation.workspace_id
+                == Integration.workspace_id,
+            )
+            .where(
+                Integration.kind == "linear",
+                Integration.config["team_id"].astext == team_id,
+                Integration.workspace_id != workspace_id,
+                NativeIntegrationInstallation.provider
+                == NativeIntegrationProvider.LINEAR,
+                NativeIntegrationInstallation.status == "ready",
+            )
+            .limit(1)
+        )
+    ).first()
+    if clash is not None:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "code": "linear_team_already_bound",
+                "message": (
+                    "This Linear team is already connected to another Ship "
+                    "workspace. A tracker team binds to one workspace only — "
+                    "disconnect it there first, or pick a different team."
+                ),
+                "team_id": team_id,
+            },
+        )
+
+
 class InstallStartResponse(BaseModel):
     install_url: str
     state: str
@@ -345,6 +395,9 @@ async def linear_install_callback(
             )
         elif len(teams) == 1:
             picked = teams[0]
+            await _assert_team_unclaimed(
+                session, workspace_id=workspace_id, team_id=picked["id"]
+            )
             result = await linear_provisioner.provision_team(
                 tracker=live, team_key=picked["key"], settings=settings
             )
@@ -997,6 +1050,9 @@ async def linear_team_repick(
             },
         )
 
+    await _assert_team_unclaimed(
+        session, workspace_id=workspace_id, team_id=target["id"]
+    )
     try:
         result = await linear_provisioner.provision_team(
             tracker=live, team_key=target["key"], settings=settings

--- a/apps/backend/tests/test_linear_team_one_to_one.py
+++ b/apps/backend/tests/test_linear_team_one_to_one.py
@@ -1,0 +1,63 @@
+"""ELS-328 — a Linear team binds to at most one workspace.
+
+The tracker is the dispatch-signal source: two workspaces on the same
+Linear team both dispatch the same ``ELS-###`` ticket and the repo
+resolves per-workspace → cross-tenant action (the ship-landing /
+``no_pr_url`` incident, 2026-06). ``_assert_team_unclaimed`` blocks a
+*second* workspace from claiming a team another workspace already binds
+and actively polls; re-binding inside the same workspace stays allowed
+(enforced by the ``workspace_id != current`` filter in the query).
+
+These tests pin the helper's branch logic against a mocked session,
+matching the mock-based style of test_phase4_code_review_validation.py.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from backend.app.api.v1.routes.linear_oauth import _assert_team_unclaimed
+
+
+def _session(first_result):
+    s = AsyncMock()
+    s.execute = AsyncMock(
+        return_value=MagicMock(first=MagicMock(return_value=first_result))
+    )
+    return s
+
+
+def test_blocks_when_team_claimed_by_other_workspace() -> None:
+    s = _session(("other-workspace-uuid",))
+    with pytest.raises(HTTPException) as ei:
+        asyncio.new_event_loop().run_until_complete(
+            _assert_team_unclaimed(
+                s, workspace_id=uuid.uuid4(), team_id="team-123"
+            )
+        )
+    assert ei.value.status_code == 409
+    assert ei.value.detail["code"] == "linear_team_already_bound"
+    assert ei.value.detail["team_id"] == "team-123"
+
+
+def test_allows_when_team_unclaimed() -> None:
+    s = _session(None)
+    # No raise — the team is free.
+    asyncio.new_event_loop().run_until_complete(
+        _assert_team_unclaimed(s, workspace_id=uuid.uuid4(), team_id="team-123")
+    )
+
+
+def test_noop_on_empty_team_id() -> None:
+    # An unset team_id (multi-team connect awaiting a repick) short-circuits
+    # before touching the DB — nothing to claim yet.
+    s = _session(("should-not-be-read",))
+    asyncio.new_event_loop().run_until_complete(
+        _assert_team_unclaimed(s, workspace_id=uuid.uuid4(), team_id=None)
+    )
+    s.execute.assert_not_called()


### PR DESCRIPTION
## Why
A tracker team is the **dispatch-signal source**, but schema uniqueness is per-workspace only — nothing stopped two workspaces from binding the same Linear team. It happened: the throwaway `ship-landing` workspace sat on the same `elship` team as `Ship on Ship` from 2026-06-10. Both pollers then saw + dispatched the same `ELS-###` ticket, repo resolved per-workspace → the recurring **`no_pr_url` / wrong-repo** cluster (ELS-309's reviewer ran against the wrong tenant's repo). Already mitigated by disabling ship-landing's linear install; this prevents recurrence.

GitHub *installs* are intentionally multi-workspace (Dev/Staging/Prod). **Trackers are not** — they're the source of record for what to act on.

## Change
`_assert_team_unclaimed()` — before a workspace binds a Linear team (auto-pick on single-team connect **and** the manual team repick), refuse with **HTTP 409 `linear_team_already_bound`** if another workspace already has that `team_id` bound AND an actively-polled (`status=ready`) native linear install. Re-binding the same team in the same workspace stays allowed (idempotent — `workspace_id != current` filter). Uses the same canonical `config.team_id` lookup the webhook + poller already rely on.

## Tests
`test_linear_team_one_to_one.py` — blocks on clash (409 + code), allows when free, no-ops on unset team_id. 19/19 green across the linear suite (no regressions).

Part of ELS-328. Follow-up in the same ticket: dispatcher tenant-fence (refuse a ticket whose resolved repo isn't the polling workspace's) as defence in depth; + a one-off prod collision audit (reported separately).