### PR TITLE
fix(ELS-330): code_review gate resolves sibling-attached GitHub install

### DIFF
--- a/apps/backend/app/api/v1/routes/agent_runs.py
+++ b/apps/backend/app/api/v1/routes/agent_runs.py
@@ -1334,6 +1334,7 @@ async def _validate_code_review_to_auto_merge(
 
     from backend.app.db.models.integrations import (
         GitHubInstallation as _GHInstall,
+        WorkspaceRepo as _WorkspaceRepo,
     )
     from backend.app.integrations.github.app_auth import (
         fetch_installation_token as _fetch_install_token,
@@ -1347,6 +1348,29 @@ async def _validate_code_review_to_auto_merge(
             ).limit(1)
         )
     ).scalar_one_or_none()
+    if install_row is None:
+        # ELS-330: the install may be SIBLING-ATTACHED — this workspace
+        # activated the repo under ANOTHER workspace's install (migration
+        # 0076 multi-workspace-per-install), so no install row is owned
+        # here. Mirror repos.py::_resolve_installation: resolve through
+        # the workspace's activated repos' installation_id FK before
+        # declaring no_install. Without this the gate false-blocks every
+        # code_review→auto_merge in a workspace whose GitHub install lives
+        # in a sibling (e.g. Ship-on-Ship → elmundi's ElMundiUA install).
+        install_row = (
+            await session.execute(
+                _select(_GHInstall)
+                .join(
+                    _WorkspaceRepo,
+                    _WorkspaceRepo.installation_id == _GHInstall.id,
+                )
+                .where(
+                    _WorkspaceRepo.workspace_id == workspace_id,
+                    _GHInstall.suspended_at.is_(None),
+                )
+                .limit(1)
+            )
+        ).scalar_one_or_none()
     if install_row is None:
         return False, "no_install"
 

--- a/apps/backend/tests/test_phase4_code_review_validation.py
+++ b/apps/backend/tests/test_phase4_code_review_validation.py
@@ -94,6 +94,7 @@ def _run_with_mocked_gh(
     check_runs,
     pr_url: str | None = _PR_URL,
     require_approval: bool = True,
+    sibling_install: bool = False,
 ):
     """Drive the validator with mocked install row + httpx transport."""
     transport = httpx.MockTransport(_gh_handler(
@@ -106,9 +107,17 @@ def _run_with_mocked_gh(
             super().__init__(*args, transport=transport, **kwargs)
 
     session = AsyncMock()
-    scalar_one_or_none = MagicMock(return_value=_mock_install_row())
-    exec_result = MagicMock(scalar_one_or_none=scalar_one_or_none)
-    session.execute = AsyncMock(return_value=exec_result)
+    install_result = MagicMock(
+        scalar_one_or_none=MagicMock(return_value=_mock_install_row())
+    )
+    if sibling_install:
+        # ELS-330: the direct install lookup misses (no install owned by
+        # this workspace) → the gate falls back to the sibling-attached
+        # install on the second query.
+        miss = MagicMock(scalar_one_or_none=MagicMock(return_value=None))
+        session.execute = AsyncMock(side_effect=[miss, install_result])
+    else:
+        session.execute = AsyncMock(return_value=install_result)
 
     with patch(
         "backend.app.integrations.github.app_auth.fetch_installation_token",
@@ -235,7 +244,9 @@ def test_no_pr_url_resolves_open_pr_from_ticket() -> None:
     open_pr = MagicMock(scalar_one_or_none=MagicMock(return_value=_PR_URL))
     no_install = MagicMock(scalar_one_or_none=MagicMock(return_value=None))
     session = AsyncMock()
-    session.execute = AsyncMock(side_effect=[open_pr, no_install])
+    # 3 queries: resolve open PR (hit) → direct install (miss) → ELS-330
+    # sibling install (miss) → no_install.
+    session.execute = AsyncMock(side_effect=[open_pr, no_install, no_install])
 
     ok, reason = asyncio.new_event_loop().run_until_complete(
         _validate_code_review_to_auto_merge(
@@ -423,3 +434,18 @@ def test_ci_incomplete_blocks_even_on_high() -> None:
         require_approval=False,
     )
     assert ok is False and reason == "ci_incomplete"
+
+
+def test_sibling_attached_install_resolves_not_no_install() -> None:
+    # ELS-330: the workspace owns no GitHubInstallation row — its install
+    # is sibling-attached (repo activated under another workspace's install,
+    # migration 0076). The direct lookup misses; the gate must fall back to
+    # the sibling install and proceed to the review + CI checks, NOT freeze
+    # on no_install. With an APPROVED review + green CI it passes.
+    ok, reason = _run_with_mocked_gh(
+        reviews=[{"state": "APPROVED"}],
+        pr_detail={"head": {"sha": _HEAD_SHA}},
+        check_runs=[{"name": "test", "status": "completed", "conclusion": "success"}],
+        sibling_install=True,
+    )
+    assert (ok, reason) == (True, "ok")


### PR DESCRIPTION
## Problem (caught via the inbox, ELS-329, 2026-06-17)
The `code_review → auto_merge` gate looked up the GitHub install with a naive `GitHubInstallation.workspace_id == workspace_id` query and returned **`no_install`** when none was found. **Ship-on-Ship owns zero install rows** — its install is **sibling-attached** (migration 0076 multi-workspace-per-install): the `ElMundiUA/ship` WorkspaceRepo points at an `installation_id` whose GitHubInstallation row belongs to the sibling **elmundi** workspace (account ElMundiUA). So the gate froze **every** agent-pipeline `code_review → auto_merge` in the workspace. Surfaced on ELS-329 / PR #415 immediately after ELS-327 correctly got it past `no_pr_url`.

## Fix
When the direct install lookup misses, fall back to the sibling-attached install via `WorkspaceRepo.installation_id == GitHubInstallation.id` (mirrors `repos.py::_resolve_installation`) before returning `no_install`. Gate stays strict on APPROVED review + green CI.

## Tests
- `test_sibling_attached_install_resolves_not_no_install` — no direct install, sibling-attached one → gate passes the install check (not `no_install`).
- Updated the ELS-327 open-PR-resolve test for the extra sibling query.
- 24/24 green across phase4 + linear suites.

Closes ELS-330. Unblocks ELS-329 once deployed.