### PR TITLE
feat(process): per-stage model selection + agent-key management + tracker-bound fix

### DIFF
--- a/apps/backend/app/api/v1/routes/integrations.py
+++ b/apps/backend/app/api/v1/routes/integrations.py
@@ -123,6 +123,12 @@ def _validate_kind(kind: str) -> None:
 # {Linear,Notion}" CTA on receipt.
 _OAUTH_ONLY_KINDS: frozenset[str] = frozenset({"linear", "notion"})
 
+# Kinds whose credential is the installed GitHub App, not a per-integration
+# secret. There's nothing to probe, so a fresh row is healthy ("ok") the moment
+# it exists — leaving it "pending" (the secret-flow default) would strand gates
+# that require status==ok (e.g. the process-editor "Tracker bound" prereq).
+_APP_BACKED_KINDS: frozenset[str] = frozenset({"github"})
+
 
 @router.get("", response_model=list[IntegrationOut])
 async def list_integrations(
@@ -241,6 +247,14 @@ async def upsert_integration(
             row.status = "pending"
             row.last_health_at = None
             row.last_health_error = None
+    elif kind in _APP_BACKED_KINDS:
+        # GitHub Issues rides the installed GitHub App — no secret to probe, so
+        # it's healthy as soon as the row exists. Without this it stays
+        # "pending" forever and the process-editor "Tracker bound" prereq
+        # (which requires status==ok) never passes.
+        row.status = "ok"
+        row.last_health_at = datetime.now(timezone.utc)
+        row.last_health_error = None
     elif is_new:
         row.status = "pending"
 

--- a/apps/backend/tests/test_v1_integrations.py
+++ b/apps/backend/tests/test_v1_integrations.py
@@ -110,6 +110,31 @@ async def test_admin_can_upsert_integration_and_secret_stays_opaque(
 
 
 @pytest.mark.asyncio
+async def test_github_tracker_upsert_is_ok_without_secret(
+    v1_client, seed_workspace
+) -> None:
+    """GitHub Issues rides the installed GitHub App — there's no secret to
+    probe, so the row must land ``status=ok`` (not ``pending``). Regression for
+    the locked-editor bug: a github tracker stuck at ``pending`` left the
+    process-editor "Tracker bound" prereq (which requires ok) red forever.
+    """
+    _, raw, workspace = seed_workspace
+    headers = {"Authorization": f"Bearer {raw}"}
+
+    resp = await v1_client.put(
+        f"/v1/workspaces/{workspace.id}/integrations/github",
+        headers=headers,
+        json={"kind": "github", "config": {}, "secret": None},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["kind"] == "github"
+    assert body["has_secret"] is False
+    assert body["status"] == "ok"
+    assert body["last_health_at"] is not None
+
+
+@pytest.mark.asyncio
 async def test_upsert_returns_error_status_when_probe_fails(
     v1_client, monkeypatch: pytest.MonkeyPatch, seed_workspace
 ) -> None:

--- a/apps/console/src/app/(authed)/process/page.tsx
+++ b/apps/console/src/app/(authed)/process/page.tsx
@@ -328,6 +328,7 @@ function renderProcessPage({
           >
             <EditorContent
               workspaceId={workspace.id}
+              agentProvider={workspace.agent_provider}
               processId={resolvedProcessId}
               repoId={selectedRepo?.id}
               selectedTab={selectedTab}
@@ -500,6 +501,7 @@ function renderDownState(details?: string) {
  */
 async function EditorContent({
   workspaceId,
+  agentProvider,
   processId,
   repoId,
   selectedTab,
@@ -508,6 +510,7 @@ async function EditorContent({
   token,
 }: {
   workspaceId: string;
+  agentProvider?: string;
   processId: string;
   repoId: string | undefined;
   selectedTab: ProcessTab;
@@ -556,6 +559,7 @@ async function EditorContent({
         ) : (
           <ProcessEditorWorkspace
             workspaceId={workspaceId}
+            agentProvider={agentProvider}
             process={process}
             selectedStateId={selectedStateId}
             repoId={repoId}

--- a/apps/console/src/app/(authed)/process/process-config.test.ts
+++ b/apps/console/src/app/(authed)/process/process-config.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+
+import type { ApiProcess, ApiProcessState, ApiRepoConfig } from "@/lib/api/client";
+import { processConfigFromApiProcess, processFromRepoConfig } from "./process-config";
+
+type EditableState = ApiProcessState & { specialist_model?: string | null };
+
+function stateWith(extra: Partial<EditableState> = {}): ApiProcessState {
+  return {
+    id: "planning",
+    name: "Planning",
+    specialist_id: "intake",
+    specialist_name: "Intake",
+    instructions: "",
+    state: "planning",
+    layout: null,
+    triggers: [{ type: "manual", interval: null, event: null }],
+    exit_conditions: [],
+    block_conditions: [],
+    runtime: {
+      task_count: 0,
+      blocked_count: 0,
+      last_execution_time: null,
+      health: "ok",
+    },
+    ...extra,
+  } as ApiProcessState;
+}
+
+function processWith(states: ApiProcessState[]): ApiProcess {
+  return {
+    id: "development",
+    name: "Development",
+    primary: true,
+    state_count: states.length,
+    task_count: 0,
+    blocked_count: 0,
+    health: "ok",
+    description: "",
+    specialists: [],
+    states,
+    transitions: [],
+    tasks: [],
+    routines: [],
+    process_graph: { nodes: [], links: [] },
+    adapter_diagnostics: [],
+  } as unknown as ApiProcess;
+}
+
+describe("per-stage model round-trips through .ship/config.yml", () => {
+  it("serialises a chosen model under specialist.model", () => {
+    const proc = processWith([stateWith({ specialist_model: "claude-sonnet-4-6" })]);
+    const config = processConfigFromApiProcess(proc) as {
+      states: { specialist: { model?: string } }[];
+    };
+    expect(config.states[0].specialist.model).toBe("claude-sonnet-4-6");
+  });
+
+  it("omits model when unset so the provider default is used", () => {
+    const proc = processWith([stateWith()]);
+    const config = processConfigFromApiProcess(proc) as {
+      states: { specialist: { model?: string } }[];
+    };
+    expect(config.states[0].specialist.model).toBeUndefined();
+  });
+
+  it("parses specialist.model back from a saved config", () => {
+    const serialized = processConfigFromApiProcess(
+      processWith([stateWith({ specialist_model: "gpt-5-codex" })]),
+    );
+    const config = {
+      exists: true,
+      parsed: { process: serialized },
+    } as unknown as ApiRepoConfig;
+
+    const parsed = processFromRepoConfig(config, processWith([stateWith()]));
+    expect(parsed).not.toBeNull();
+    const state0 = parsed!.states[0] as EditableState;
+    expect(state0.specialist_model).toBe("gpt-5-codex");
+  });
+});

--- a/apps/console/src/app/(authed)/process/process-config.ts
+++ b/apps/console/src/app/(authed)/process/process-config.ts
@@ -44,6 +44,9 @@ function canonicalStateFromConfigRow(
 
 type ProcessStateWithAgentProfile = ApiProcessState & {
   specialist_agent_profile?: string | null;
+  // Concrete model id for this stage (e.g. "claude-sonnet-4-6"). null/empty
+  // means "use the provider's default model". Serialised as specialist.model.
+  specialist_model?: string | null;
 };
 
 export type ProcessConfigSource =
@@ -162,6 +165,7 @@ export function processConfigFromApiProcess(process: ApiProcess): Record<string,
         id: state.specialist_id,
         name: state.specialist_name,
         agent_profile: agentProfileFromState(state),
+        ...(modelFromState(state) ? { model: modelFromState(state) } : {}),
       },
       instructions: state.instructions,
       ...(state.layout ? { layout: state.layout } : {}),
@@ -245,6 +249,10 @@ function stateFromConfig(
       stringValue(row.agent_profile) ??
       agentProfileFromState(fallback) ??
       "main",
+    specialist_model:
+      stringValue(specialist?.model) ??
+      stringValue(row.model) ??
+      modelFromState(fallback),
     instructions:
       stringValue(row.instructions) ??
       stringValue(row.description) ??
@@ -402,6 +410,12 @@ function requiresHumanFromConfigRow(
 function agentProfileFromState(state: ApiProcessState | undefined): string {
   const extended = state as ProcessStateWithAgentProfile | undefined;
   return extended?.specialist_agent_profile || "main";
+}
+
+function modelFromState(state: ApiProcessState | undefined): string | null {
+  const extended = state as ProcessStateWithAgentProfile | undefined;
+  const value = extended?.specialist_model;
+  return value && value.trim() ? value : null;
 }
 
 function mergeProcessRoutines(

--- a/apps/console/src/app/(authed)/process/process-editor-workspace.tsx
+++ b/apps/console/src/app/(authed)/process/process-editor-workspace.tsx
@@ -19,6 +19,7 @@ import { StateEditor, type SpecialistOption } from "./state-editor";
 
 export function ProcessEditorWorkspace({
   workspaceId,
+  agentProvider,
   process,
   selectedStateId,
   repoId,
@@ -26,6 +27,7 @@ export function ProcessEditorWorkspace({
   tabs,
 }: {
   workspaceId: string;
+  agentProvider?: string;
   process: ApiProcess;
   selectedStateId?: string;
   repoId?: string;
@@ -227,6 +229,7 @@ export function ProcessEditorWorkspace({
       specialist_id: defaultSpecialist.id,
       specialist_name: defaultSpecialist.name,
       specialist_agent_profile: "main",
+      specialist_model: null,
       instructions: defaultSpecialist.role,
       state: lane,
       triggers: defaultSdlcStateTriggers(),
@@ -356,6 +359,8 @@ export function ProcessEditorWorkspace({
             <aside className="border-l-0 border-t border-white/[0.06] pt-6 xl:border-l xl:border-t-0 xl:pt-0 xl:pl-8">
               <StateEditor
                 processId={process.id}
+                workspaceId={workspaceId}
+                agentProvider={agentProvider}
                 repoId={repoId}
                 state={selectedState}
                 states={states}
@@ -492,6 +497,7 @@ function stateFingerprint(state: ApiProcessState) {
     specialist_id: state.specialist_id,
     specialist_name: state.specialist_name,
     specialist_agent_profile: agentProfileFromState(state),
+    specialist_model: modelFromState(state),
     instructions: state.instructions,
     layout: state.layout ?? null,
     triggers: state.triggers,
@@ -515,6 +521,12 @@ function agentProfileFromState(state: ApiProcessState) {
     (state as ApiProcessState & { specialist_agent_profile?: string | null })
       .specialist_agent_profile || "main"
   );
+}
+
+function modelFromState(state: ApiProcessState): string | null {
+  const value = (state as ApiProcessState & { specialist_model?: string | null })
+    .specialist_model;
+  return value && value.trim() ? value : null;
 }
 
 function transitionFingerprint(transitions: ApiProcess["transitions"]) {

--- a/apps/console/src/app/(authed)/process/state-editor.test.tsx
+++ b/apps/console/src/app/(authed)/process/state-editor.test.tsx
@@ -1,0 +1,169 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { ApiProcessState } from "@/lib/api/client";
+import { StateEditor } from "./state-editor";
+
+function stateWith(extra: Partial<ApiProcessState> = {}): ApiProcessState {
+  return {
+    id: "planning",
+    name: "Planning",
+    specialist_id: "intake",
+    specialist_name: "Intake",
+    instructions: "",
+    state: "planning",
+    layout: null,
+    triggers: [{ type: "manual", interval: null, event: null }],
+    exit_conditions: [],
+    block_conditions: [],
+    runtime: {
+      task_count: 0,
+      blocked_count: 0,
+      last_execution_time: null,
+      health: "ok",
+    },
+    ...extra,
+  } as ApiProcessState;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("StateEditor model picker", () => {
+  it("loads provider models and patches specialist_model on change", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ models: ["claude-sonnet-4-6", "claude-opus-4-8"] }),
+    }));
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    const onStateChange = vi.fn();
+    render(
+      <StateEditor
+        processId="development"
+        workspaceId="ws-1"
+        agentProvider="claude"
+        repoId="repo-1"
+        state={stateWith()}
+        states={[stateWith()]}
+        schedule={null}
+        transitions={[]}
+        specialistOptions={[{ id: "intake", name: "Intake", role: "Intake" }]}
+        config={null}
+        onStateChange={onStateChange}
+        onDeleteState={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    const [, init] = fetchMock.mock.calls[0] as unknown as [string, { body: string }];
+    expect(JSON.parse(init.body)).toMatchObject({ provider: "anthropic", repoId: "repo-1" });
+
+    const modelSelect = await screen.findByLabelText(/Model/i);
+    await waitFor(() =>
+      expect(
+        screen.getByRole("option", { name: "claude-opus-4-8" }),
+      ).toBeInTheDocument(),
+    );
+
+    fireEvent.change(modelSelect, { target: { value: "claude-opus-4-8" } });
+    expect(onStateChange).toHaveBeenCalledWith(
+      expect.objectContaining({ specialist_model: "claude-opus-4-8" }),
+    );
+  });
+
+  it("selecting the blank option clears the model (provider default)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ models: ["gpt-5-codex"] }),
+      })) as unknown as typeof fetch,
+    );
+
+    const onStateChange = vi.fn();
+    render(
+      <StateEditor
+        workspaceId="ws-1"
+        agentProvider="codex"
+        repoId="repo-1"
+        state={stateWith({ specialist_model: "gpt-5-codex" } as Partial<ApiProcessState>)}
+        states={[stateWith()]}
+        schedule={null}
+        transitions={[]}
+        specialistOptions={[{ id: "intake", name: "Intake", role: "Intake" }]}
+        config={null}
+        onStateChange={onStateChange}
+        onDeleteState={vi.fn()}
+      />,
+    );
+
+    const modelSelect = await screen.findByLabelText(/Model/i);
+    fireEvent.change(modelSelect, { target: { value: "" } });
+    expect(onStateChange).toHaveBeenCalledWith(
+      expect.objectContaining({ specialist_model: null }),
+    );
+  });
+
+  it("uses a free-text field for Cursor (no catalogue) and patches the typed model", () => {
+    // Cursor has no models.dev catalogue, so no fetch — it's a free-text input
+    // (with suggestions) where Cursor-native models like Composer can be typed.
+    const onStateChange = vi.fn();
+    render(
+      <StateEditor
+        workspaceId="ws-1"
+        agentProvider="cursor"
+        repoId="repo-1"
+        state={stateWith()}
+        states={[stateWith()]}
+        schedule={null}
+        transitions={[]}
+        specialistOptions={[{ id: "intake", name: "Intake", role: "Intake" }]}
+        config={null}
+        onStateChange={onStateChange}
+        onDeleteState={vi.fn()}
+      />,
+    );
+
+    const modelInput = screen.getByLabelText(/Model/i);
+    expect(modelInput).toHaveAttribute("list", "cursor-model-suggestions");
+    fireEvent.change(modelInput, { target: { value: "composer-1" } });
+    expect(onStateChange).toHaveBeenCalledWith(
+      expect.objectContaining({ specialist_model: "composer-1" }),
+    );
+  });
+
+  it("model picker follows the per-stage execution backend, not the workspace default", async () => {
+    // Workspace default is Cursor, but this stage runs Codex CLI — the picker
+    // must show OpenAI models (catalogue select), not Cursor free-text/composer.
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ models: ["gpt-5-codex"] }),
+    }));
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    render(
+      <StateEditor
+        workspaceId="ws-1"
+        agentProvider="cursor"
+        repoId="repo-1"
+        state={stateWith({ specialist_agent_profile: "codex_cli" } as Partial<ApiProcessState>)}
+        states={[stateWith()]}
+        schedule={null}
+        transitions={[]}
+        specialistOptions={[{ id: "intake", name: "Intake", role: "Intake" }]}
+        config={null}
+        onStateChange={vi.fn()}
+        onDeleteState={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    const [, init] = fetchMock.mock.calls[0] as unknown as [string, { body: string }];
+    expect(JSON.parse(init.body)).toMatchObject({ provider: "openai" });
+    // Catalogue select, not the Cursor free-text input (which has a datalist).
+    const modelControl = await screen.findByLabelText(/Model/i);
+    expect(modelControl).not.toHaveAttribute("list");
+  });
+});

--- a/apps/console/src/app/(authed)/process/state-editor.tsx
+++ b/apps/console/src/app/(authed)/process/state-editor.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { ReactNode } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 
 import { Card, CardHeader } from "@/components/ui";
 import type {
@@ -20,10 +20,47 @@ export type SpecialistOption = {
 
 type EditableProcessState = ApiProcessState & {
   specialist_agent_profile?: string | null;
+  specialist_model?: string | null;
 };
+
+// Workspace agent provider → models.dev catalogue provider for the live
+// /api/deploy/planner-models picker. Only providers that models.dev catalogues
+// belong here. Cursor is intentionally absent: it has no models.dev entry and
+// its own models (Composer, auto, …) aren't catalogued anywhere keyless, so it
+// falls through to the free-text path below.
+const CATALOG_PROVIDER: Record<string, string> = {
+  claude: "anthropic",
+  codex: "openai",
+};
+
+// Per-stage execution-backend profile → the agent provider that actually runs
+// the stage. cursor_agent / codex_cli pin a provider; the rest (auto / main /
+// cheaper / ship_cloud_agent / local_cli) defer to the workspace default
+// (agent_provider). This is what the Model picker keys off — so a stage set to
+// "Codex CLI" shows OpenAI models, not the workspace's Cursor/Composer.
+const PROFILE_PROVIDER: Record<string, string> = {
+  cursor_agent: "cursor",
+  codex_cli: "codex",
+};
+
+function providerForProfile(
+  profile: string,
+  workspaceProvider?: string,
+): string | undefined {
+  return PROFILE_PROVIDER[profile] ?? workspaceProvider;
+}
+
+// Cursor exposes no keyless model catalogue and its slugs vary by plan, so we
+// offer suggestions but keep the field free-text (whatever you type goes to
+// `cursor-agent --model`). ``auto`` is always valid (incl. Free plans);
+// ``composer`` is Cursor's rolling alias for the latest Composer (so operators
+// needn't track version bumps like composer-2 → composer-2.5).
+const CURSOR_MODEL_SUGGESTIONS = ["auto", "composer", "composer-latest"];
 
 export function StateEditor({
   processId,
+  workspaceId,
+  agentProvider,
   repoId,
   state,
   states,
@@ -37,6 +74,8 @@ export function StateEditor({
   embedded = false,
 }: {
   processId?: string;
+  workspaceId?: string;
+  agentProvider?: string;
   repoId?: string;
   state?: ApiProcessState;
   states: ApiProcessState[];
@@ -186,6 +225,16 @@ export function StateEditor({
           <AgentProfileSelector
             value={agentProfileFromState(selectedState)}
             onChange={(value) => patchState({ specialist_agent_profile: value })}
+          />
+          <ModelSelector
+            workspaceId={workspaceId}
+            repoId={repoId}
+            agentProvider={providerForProfile(
+              agentProfileFromState(selectedState),
+              agentProvider,
+            )}
+            value={modelFromState(selectedState)}
+            onChange={(value) => patchState({ specialist_model: value })}
           />
         </div>
       </details>
@@ -396,6 +445,152 @@ function AgentProfileSelector({
   );
 }
 
+function ModelSelector({
+  workspaceId,
+  repoId,
+  agentProvider,
+  value,
+  onChange,
+}: {
+  workspaceId?: string;
+  repoId?: string;
+  agentProvider?: string;
+  value: string | null;
+  onChange: (value: string | null) => void;
+}) {
+  // models.dev-catalogued providers get the live list; others (Cursor) get a
+  // free-text field — see CATALOG_PROVIDER / CURSOR_MODEL_SUGGESTIONS.
+  const catalogProvider = CATALOG_PROVIDER[agentProvider ?? ""] ?? null;
+  const label = (
+    <span className="mb-1 block text-[10px] font-bold uppercase tracking-widest text-white/45">
+      Model{" "}
+      <span className="font-normal normal-case tracking-normal text-white/30">
+        · {agentProvider ?? "provider"}
+      </span>
+    </span>
+  );
+
+  if (!catalogProvider) {
+    // Free-text: Cursor (and any uncatalogued provider). Whatever is typed is
+    // passed to the agent CLI's --model; empty → provider default. Cursor has
+    // no keyless model catalogue, so we link the operator to Cursor's own
+    // up-to-date list to copy a slug from rather than risk a stale dropdown.
+    return (
+      <div>
+        <label className="block">
+          {label}
+          <input
+            list="cursor-model-suggestions"
+            value={value ?? ""}
+            onChange={(event) => onChange(event.target.value.trim() || null)}
+            placeholder="Provider default (e.g. auto, composer)"
+            className="w-full rounded-md border border-white/10 bg-black/35 px-2 py-1.5 text-sm text-white outline-none transition placeholder:text-white/30 focus:border-aqua/40"
+          />
+        </label>
+        <datalist id="cursor-model-suggestions">
+          {CURSOR_MODEL_SUGGESTIONS.map((model) => (
+            <option key={model} value={model} />
+          ))}
+        </datalist>
+        <a
+          href="https://cursor.com/help/models-and-usage/available-models"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mt-1 inline-block text-[10px] text-white/40 transition hover:text-aqua hover:underline"
+        >
+          See Cursor&apos;s current models ↗
+        </a>
+      </div>
+    );
+  }
+
+  return (
+    <label className="block">
+      {label}
+      <CatalogModelSelect
+        workspaceId={workspaceId}
+        repoId={repoId}
+        provider={catalogProvider}
+        value={value}
+        onChange={onChange}
+      />
+    </label>
+  );
+}
+
+function CatalogModelSelect({
+  workspaceId,
+  repoId,
+  provider,
+  value,
+  onChange,
+}: {
+  workspaceId?: string;
+  repoId?: string;
+  provider: string;
+  value: string | null;
+  onChange: (value: string | null) => void;
+}) {
+  const [models, setModels] = useState<string[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!workspaceId || !repoId) return;
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    fetch("/api/deploy/planner-models", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ ws: workspaceId, repoId, provider }),
+    })
+      .then((res) =>
+        res.ok ? res.json() : Promise.reject(new Error(String(res.status))),
+      )
+      .then((data: { models?: string[] }) => {
+        if (!cancelled) setModels(Array.isArray(data.models) ? data.models : []);
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setModels([]);
+          setError("Couldn't load models — provider default will be used.");
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [workspaceId, repoId, provider]);
+
+  const current = value ?? "";
+  // Keep a previously-saved model selectable even if it's not in the live list.
+  const options = current && !models.includes(current) ? [current, ...models] : models;
+
+  return (
+    <>
+      <select
+        value={current}
+        onChange={(event) => onChange(event.target.value || null)}
+        disabled={!repoId}
+        className="w-full rounded-md border border-white/10 bg-black/35 px-2 py-1.5 text-sm text-white outline-none transition focus:border-aqua/40 disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        <option value="">{loading ? "Loading models…" : "Provider default"}</option>
+        {options.map((model) => (
+          <option key={model} value={model}>
+            {model}
+          </option>
+        ))}
+      </select>
+      {error ? (
+        <span className="mt-1 block text-[10px] text-coral/80">{error}</span>
+      ) : null}
+    </>
+  );
+}
+
 function EditorField({
   label,
   value,
@@ -422,4 +617,10 @@ function EditorField({
 function agentProfileFromState(state: ApiProcessState): string {
   const extended = state as EditableProcessState;
   return extended.specialist_agent_profile || "main";
+}
+
+function modelFromState(state: ApiProcessState): string | null {
+  const extended = state as EditableProcessState;
+  const value = extended.specialist_model;
+  return value && value.trim() ? value : null;
 }

--- a/apps/console/src/app/(authed)/settings/_shell/settings-shell.tsx
+++ b/apps/console/src/app/(authed)/settings/_shell/settings-shell.tsx
@@ -14,6 +14,7 @@ import { PageBody, PageHeader } from "@/components/app-shell";
 import { ApiUnavailable } from "@/components/api-unavailable";
 import { ConfigScopeCard } from "@/components/config-scope-card";
 import { RepoRoutingPanel } from "@/components/repo-routing-panel";
+import { AgentSecretsPanel } from "@/components/agent-secrets-panel";
 import {
   IntegrationsWorkspaceBody,
   loadIntegrationsWorkspaceMode,
@@ -466,6 +467,7 @@ export async function SettingsShell({
 
           {activeTab === "api-keys" && (
             <div className="space-y-6">
+              <AgentSecretsPanel workspaceId={workspace.id} repos={activatedRepos} />
               <TokensPanel
                 workspaceId={workspace.id}
                 tokens={tokens}

--- a/apps/console/src/components/agent-secrets-panel.test.tsx
+++ b/apps/console/src/components/agent-secrets-panel.test.tsx
@@ -1,0 +1,73 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { ApiAgentSecretStatus } from "@/lib/api/client";
+import type { ApiActivatedRepo } from "@/lib/api/types";
+import { AgentSecretsPanel } from "./agent-secrets-panel";
+
+const REPO = { id: "repo-1", full_name: "org/repo" } as ApiActivatedRepo;
+
+function secret(extra: Partial<ApiAgentSecretStatus>): ApiAgentSecretStatus {
+  return {
+    slug: "claude-md",
+    label: "Claude Code",
+    secret_name: "ANTHROPIC_API_KEY",
+    vendor_url: null,
+    description: null,
+    required: true,
+    present: false,
+    ...extra,
+  };
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("AgentSecretsPanel", () => {
+  it("shows a paste input for a PRESENT key (rotation) and saves drafts", async () => {
+    const agents = [
+      secret({ slug: "claude-md", label: "Claude Code", secret_name: "ANTHROPIC_API_KEY", present: true }),
+      secret({ slug: "cursor-cloud", label: "Cursor Cloud", secret_name: "CURSOR_API_KEY", present: false }),
+    ];
+    const calls: { url: string; init?: { method?: string; body?: string } }[] = [];
+    const fetchMock = vi.fn(async (url: string, init?: { method?: string; body?: string }) => {
+      calls.push({ url, init });
+      if (init?.method === "POST") {
+        return { ok: true, json: async () => ({ result: { pushed: ["claude-md"], failed: [] } }) };
+      }
+      return { ok: true, json: async () => ({ check: { repo_id: "repo-1", agents } }) };
+    });
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    render(<AgentSecretsPanel workspaceId="ws-1" repos={[REPO]} />);
+
+    // Status is fetched on mount for the (only) repo.
+    await waitFor(() => expect(screen.getByText("Claude Code")).toBeInTheDocument());
+    const getCall = calls.find((c) => c.init?.method !== "POST");
+    expect(getCall?.url).toContain("workspace_id=ws-1");
+    expect(getCall?.url).toContain("repo_id=repo-1");
+
+    // THE FIX: a present key still renders an input so it can be rotated.
+    const claudeInput = screen.getByPlaceholderText(
+      /ANTHROPIC_API_KEY — paste a new key to replace/,
+    );
+    expect(claudeInput).toBeInTheDocument();
+
+    fireEvent.change(claudeInput, { target: { value: "sk-ant-new" } });
+    fireEvent.click(screen.getByRole("button", { name: /Save keys/i }));
+
+    await waitFor(() =>
+      expect(calls.some((c) => c.init?.method === "POST")).toBe(true),
+    );
+    const post = calls.find((c) => c.init?.method === "POST");
+    expect(JSON.parse(post!.init!.body!)).toMatchObject({
+      workspace_id: "ws-1",
+      repo_id: "repo-1",
+      secrets: [{ slug: "claude-md", plaintext: "sk-ant-new" }],
+    });
+  });
+
+  it("prompts to activate a repo when there are none", () => {
+    render(<AgentSecretsPanel workspaceId="ws-1" repos={[]} />);
+    expect(screen.getByText(/Activate a repository first/i)).toBeInTheDocument();
+  });
+});

--- a/apps/console/src/components/agent-secrets-panel.tsx
+++ b/apps/console/src/components/agent-secrets-panel.tsx
@@ -1,0 +1,292 @@
+"use client";
+
+/**
+ * Agent provider keys — settings panel (Agents & access tab).
+ *
+ * Lets an operator add OR rotate the per-provider agent API keys (Claude /
+ * Cursor / Codex, plus optional LLM-fallback keys) for a chosen repository.
+ * Keys are GitHub Actions secrets stored per-repo, so the panel is scoped by a
+ * repo selector. Reuses the same BFF routes as the onboarding wizard
+ * (`/api/onboard/agent-secrets`), so there's one source of truth.
+ *
+ * Unlike the onboarding card, the paste input is shown even when a key is
+ * already `present` — rotation is a first-class settings use-case and the
+ * backend PUT overwrites idempotently.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+
+import { Card, CardHeader } from "@/components/ui";
+import type { ApiAgentSecretStatus } from "@/lib/api/client";
+import type { ApiActivatedRepo } from "@/lib/api/types";
+
+export function AgentSecretsPanel({
+  workspaceId,
+  repos,
+}: {
+  workspaceId: string;
+  repos: ApiActivatedRepo[];
+}) {
+  const [repoId, setRepoId] = useState<string>(repos[0]?.id ?? "");
+  const [agents, setAgents] = useState<ApiAgentSecretStatus[]>([]);
+  const [drafts, setDrafts] = useState<Record<string, string>>({});
+  const [failed, setFailed] = useState<Record<string, string>>({});
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [savedAt, setSavedAt] = useState<number | null>(null);
+
+  const refresh = useCallback(
+    async (rid: string) => {
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await fetch(
+          `/api/onboard/agent-secrets?workspace_id=${encodeURIComponent(
+            workspaceId,
+          )}&repo_id=${encodeURIComponent(rid)}`,
+        );
+        if (!res.ok) throw new Error(String(res.status));
+        const data = (await res.json()) as { check?: { agents?: ApiAgentSecretStatus[] } };
+        setAgents(data?.check?.agents ?? []);
+      } catch {
+        setAgents([]);
+        setError("Couldn't load agent secrets for this repository.");
+      } finally {
+        setLoading(false);
+      }
+    },
+    [workspaceId],
+  );
+
+  useEffect(() => {
+    if (repoId) refresh(repoId);
+  }, [repoId, refresh]);
+
+  if (repos.length === 0) {
+    return (
+      <Card>
+        <CardHeader
+          title="Agent provider keys"
+          subtitle="Activate a repository first — agent keys are stored as GitHub Actions secrets on each repo."
+        />
+      </Card>
+    );
+  }
+
+  async function save() {
+    if (!repoId) return;
+    const payload = Object.entries(drafts)
+      .filter(([, v]) => v.trim().length > 0)
+      .map(([slug, plaintext]) => ({ slug, plaintext: plaintext.trim() }));
+    if (payload.length === 0) return;
+    setSaving(true);
+    setError(null);
+    setFailed({});
+    try {
+      const res = await fetch("/api/onboard/agent-secrets", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ workspace_id: workspaceId, repo_id: repoId, secrets: payload }),
+      });
+      const data = (await res.json().catch(() => ({}))) as {
+        error?: string;
+        result?: { pushed?: string[]; failed?: { slug: string; error?: string; reason?: string }[] };
+      };
+      if (!res.ok) {
+        throw new Error(
+          data?.error === "github_app_missing"
+            ? "Ship's GitHub App lacks Secrets write access on this repo — reinstall/grant it, then retry."
+            : data?.error ?? `Save failed (${res.status}).`,
+        );
+      }
+      const result = data?.result;
+      const nextFailed: Record<string, string> = {};
+      for (const item of result?.failed ?? []) {
+        nextFailed[item.slug] = item.error ?? item.reason ?? "failed";
+      }
+      setFailed(nextFailed);
+      const pushed = new Set(result?.pushed ?? []);
+      setDrafts((d) => {
+        const next = { ...d };
+        for (const slug of pushed) delete next[slug];
+        return next;
+      });
+      setSavedAt(Date.now());
+      await refresh(repoId);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Couldn't save secrets.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  // Coding-agent keys drive which CLIs can run; llm-* are optional fallbacks.
+  // Hide an llm-* row whose secret_name a coding row already covers (dedupe).
+  const coding = agents.filter((a) => !a.slug.startsWith("llm-"));
+  const llm = agents.filter(
+    (a) =>
+      a.slug.startsWith("llm-") &&
+      !coding.some((c) => c.secret_name && c.secret_name === a.secret_name),
+  );
+  const hasDrafts = Object.values(drafts).some((v) => v.trim().length > 0);
+
+  return (
+    <Card>
+      <CardHeader
+        title="Agent provider keys"
+        subtitle="API keys for the coding agents Ship runs (Claude, Cursor, Codex). Stored as GitHub Actions secrets on the selected repo — set several so different process stages can use different backends. Add or paste a new value to rotate."
+      />
+      <div className="mt-4 space-y-4">
+        {repos.length > 1 ? (
+          <label className="block">
+            <span className="mb-1 block text-[10px] font-bold uppercase tracking-widest text-white/45">
+              Repository
+            </span>
+            <select
+              value={repoId}
+              onChange={(event) => {
+                setRepoId(event.target.value);
+                setDrafts({});
+                setFailed({});
+                setSavedAt(null);
+              }}
+              className="w-full rounded-md border border-white/10 bg-black/35 px-2 py-1.5 text-sm text-white outline-none transition focus:border-aqua/40 sm:max-w-md"
+            >
+              {repos.map((repo) => (
+                <option key={repo.id} value={repo.id}>
+                  {repo.full_name}
+                </option>
+              ))}
+            </select>
+          </label>
+        ) : null}
+
+        {error ? (
+          <div className="rounded-md border border-coral/25 bg-coral/[0.05] px-2 py-1.5 text-[12px] text-coral/90">
+            {error}
+          </div>
+        ) : null}
+
+        {loading ? (
+          <p className="text-sm text-white/45">Loading agent secrets…</p>
+        ) : (
+          <div className="space-y-2">
+            {coding.map((a) => (
+              <AgentSecretRow
+                key={a.slug}
+                secret={a}
+                draft={drafts[a.slug] ?? ""}
+                onDraft={(v) => setDrafts((d) => ({ ...d, [a.slug]: v }))}
+                failure={failed[a.slug]}
+              />
+            ))}
+          </div>
+        )}
+
+        {!loading && llm.length > 0 ? (
+          <details className="rounded-xl border border-white/10 bg-white/[0.02] p-3">
+            <summary className="cursor-pointer text-[10px] font-bold uppercase tracking-widest text-white/55">
+              Optional LLM fallback keys
+            </summary>
+            <div className="mt-3 space-y-2">
+              {llm.map((a) => (
+                <AgentSecretRow
+                  key={a.slug}
+                  secret={a}
+                  draft={drafts[a.slug] ?? ""}
+                  onDraft={(v) => setDrafts((d) => ({ ...d, [a.slug]: v }))}
+                  failure={failed[a.slug]}
+                />
+              ))}
+            </div>
+          </details>
+        ) : null}
+
+        <div className="flex items-center gap-3">
+          <button
+            type="button"
+            disabled={!hasDrafts || saving}
+            onClick={save}
+            className="rounded-md border border-aqua/30 bg-aqua/[0.08] px-3 py-1.5 text-[12px] font-semibold text-aqua transition hover:bg-aqua/[0.14] disabled:cursor-not-allowed disabled:border-white/10 disabled:bg-white/[0.03] disabled:text-white/30"
+          >
+            {saving ? "Saving…" : "Save keys"}
+          </button>
+          {savedAt && !hasDrafts ? (
+            <span className="text-[11px] text-white/45">Saved — secrets updated on the repo.</span>
+          ) : null}
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+function AgentSecretRow({
+  secret,
+  draft,
+  onDraft,
+  failure,
+}: {
+  secret: ApiAgentSecretStatus;
+  draft: string;
+  onDraft: (value: string) => void;
+  failure?: string;
+}) {
+  const pill = !secret.secret_name
+    ? { text: "no key needed", cls: "text-white/55" }
+    : secret.present
+      ? { text: "present", cls: "text-aqua" }
+      : secret.required
+        ? { text: "missing", cls: "text-coral" }
+        : { text: "optional", cls: "text-amber-200" };
+
+  return (
+    <div className="rounded-xl border border-white/10 bg-white/[0.03] p-3">
+      <div className="flex items-center justify-between gap-2">
+        <div className="text-sm font-semibold text-white">{secret.label}</div>
+        <span className={`text-[10px] font-bold uppercase tracking-widest ${pill.cls}`}>
+          {pill.text}
+        </span>
+      </div>
+      {secret.description ? (
+        <p className="mt-0.5 text-[12px] leading-relaxed text-white/45">{secret.description}</p>
+      ) : null}
+      <div className="mt-1.5 flex items-center gap-2">
+        {secret.secret_name ? (
+          <code className="rounded bg-black/40 px-1.5 py-0.5 font-mono text-[11px] text-white/60">
+            secrets.{secret.secret_name}
+          </code>
+        ) : null}
+        {secret.vendor_url ? (
+          <a
+            href={secret.vendor_url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-[11px] text-white/45 transition hover:text-aqua hover:underline"
+          >
+            Get key ↗
+          </a>
+        ) : null}
+      </div>
+      {/* Always render the input when a secret is expected — including when
+          already present — so operators can rotate a key (backend overwrites
+          idempotently). This is the fix vs the onboarding card, which hid it. */}
+      {secret.secret_name ? (
+        <input
+          type="password"
+          value={draft}
+          onChange={(event) => onDraft(event.target.value)}
+          placeholder={
+            secret.present
+              ? `${secret.secret_name} — paste a new key to replace`
+              : `${secret.secret_name} — paste plaintext key`
+          }
+          className="mt-2 w-full rounded-md border border-white/10 bg-black/25 px-2 py-1.5 text-sm text-white outline-none transition placeholder:text-white/30 focus:border-aqua/40"
+        />
+      ) : null}
+      {failure ? (
+        <span className="mt-1 block text-[10px] text-coral/80">Push failed: {failure}</span>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/cli/lib/agents/claude.mjs
+++ b/packages/cli/lib/agents/claude.mjs
@@ -65,6 +65,7 @@ export async function runClaudeAgent({
   workdir = process.cwd(),
   branchName,
   prompt,
+  model = null,
   env = {},
   onLog = (l) => process.stderr.write(`[claude] ${l}\n`),
 } = {}) {
@@ -84,10 +85,14 @@ export async function runClaudeAgent({
     "--output-format",
     "stream-json",
     "--verbose",
+    // Per-stage model override (claude --model <id>); omitted → CLI default.
+    ...(model ? ["--model", model] : []),
     prompt,
   ];
 
-  onLog(`launch claude branch=${branchName} cwd=${workdir} prompt=${prompt.length}b`);
+  onLog(
+    `launch claude branch=${branchName} cwd=${workdir} prompt=${prompt.length}b model=${model ?? "(default)"}`,
+  );
   const child = spawn("claude", args, {
     cwd: workdir,
     env: { ...process.env, ...env },

--- a/packages/cli/lib/agents/codex.mjs
+++ b/packages/cli/lib/agents/codex.mjs
@@ -34,6 +34,7 @@ export async function runCodexAgent({
   workdir = process.cwd(),
   branchName,
   prompt,
+  model = null,
   env = {},
   onLog = (l) => process.stderr.write(`[codex] ${l}\n`),
 } = {}) {
@@ -49,10 +50,14 @@ export async function runCodexAgent({
     "exec",
     "--full-auto",
     "--skip-git-repo-check",
+    // Per-stage model override (codex exec --model <id>); omitted → default.
+    ...(model ? ["--model", model] : []),
     prompt,
   ];
 
-  onLog(`launch codex exec branch=${branchName} cwd=${workdir} prompt=${prompt.length}b`);
+  onLog(
+    `launch codex exec branch=${branchName} cwd=${workdir} prompt=${prompt.length}b model=${model ?? "(default)"}`,
+  );
   const child = spawn("codex", args, {
     cwd: workdir,
     env: { ...process.env, ...env },

--- a/packages/cli/lib/agents/cursor.mjs
+++ b/packages/cli/lib/agents/cursor.mjs
@@ -33,6 +33,7 @@ export async function runCursorAgent({
   workdir = process.cwd(),
   branchName,
   prompt,
+  model = null,
   env = {},
   onLog = (l) => process.stderr.write(`[cursor] ${l}\n`),
 } = {}) {
@@ -56,7 +57,8 @@ export async function runCursorAgent({
   // Auto. Switch to Auto or upgrade plans to continue.") still
   // work. Operators on paid plans who want a specific model export
   // ``CURSOR_MODEL`` as a workflow secret and we pass it through.
-  const model = (process.env.CURSOR_MODEL || env.CURSOR_MODEL || "auto").trim();
+  // Precedence: per-stage model (from .ship/config.yml) → CURSOR_MODEL → auto.
+  const resolvedModel = (model || process.env.CURSOR_MODEL || env.CURSOR_MODEL || "auto").trim();
   const args = [
     "--print",
     "--force",
@@ -66,11 +68,13 @@ export async function runCursorAgent({
     "--output-format",
     "text",
     "--model",
-    model,
+    resolvedModel,
     prompt,
   ];
 
-  onLog(`launch cursor-agent branch=${branchName} cwd=${workdir} prompt=${prompt.length}b`);
+  onLog(
+    `launch cursor-agent branch=${branchName} cwd=${workdir} prompt=${prompt.length}b model=${resolvedModel}`,
+  );
   const child = spawn("cursor-agent", args, {
     cwd: workdir,
     env: { ...process.env, ...env },

--- a/packages/cli/lib/commands/run.mjs
+++ b/packages/cli/lib/commands/run.mjs
@@ -53,7 +53,7 @@ import fs from "node:fs";
 import path from "node:path";
 
 import { readConfig, findShipRoot } from "../config/io.mjs";
-import { resolveExecutable } from "../runtime/routines.mjs";
+import { resolveExecutable, stageModelFromStates } from "../runtime/routines.mjs";
 import { DEFAULT_PROVIDER, runAgent } from "../agents/index.mjs";
 import { fetchWithRetry } from "../retry.mjs";
 
@@ -236,6 +236,12 @@ async function _runCommandImpl(ctx, rest) {
   // default. Lets one role (``ba``) drive both ``ba_requirements`` for
   // SDLC and ``wbs`` for decomposition without per-process role clones.
   const fsmStage = resolved.executable?.fsm_stage || roleResolved.fsm_stage || null;
+  // Per-stage model: prefer a routine-level model, else the model the process
+  // editor stored on the matching ``process.states`` entry (configs often ship
+  // ``routines: {}``, so the model lives on the state). null → provider default.
+  const stageModel =
+    resolved.executable?.model ||
+    stageModelFromStates(config, { fsmStage, specialist: specialistSlug });
   const roleBody = roleResolved.prompt || "";
   const systemBody = systemResolved?.prompt || "";
 
@@ -379,11 +385,15 @@ async function _runCommandImpl(ctx, rest) {
         specialist: specialistSlug,
         specialist_source: roleResolved.source,
         fsm_stage: fsmStage,
+        // Resolved per-stage model (routine or matching process state) that
+        // would be passed to the agent CLI's --model; null = provider default.
+        // Lets a dry-run confirm the model without launching an agent.
+        model: stageModel || null,
         task,
         prompt,
       }, null, 2));
     } else {
-      console.error(`# ship: dry-run handle=${runHandle} specialist=${specialistSlug} (${roleResolved.source}) fsm_stage=${fsmStage || "(context-free)"}`);
+      console.error(`# ship: dry-run handle=${runHandle} specialist=${specialistSlug} (${roleResolved.source}) fsm_stage=${fsmStage || "(context-free)"} model=${stageModel || "(default)"}`);
       if (task) {
         console.error(`# ship: task ticket_ref=${task.ticket_ref} title=${JSON.stringify(task.title || "")}`);
       } else {
@@ -442,12 +452,18 @@ async function _runCommandImpl(ctx, rest) {
     provider,
     branch: branchName,
     prompt_len: prompt.length,
+    // Surfaces the resolved per-stage model in the run's structured events so
+    // operators can confirm which model actually ran. null = provider default.
+    model: stageModel || null,
   });
   try {
     runtime = await runAgent(provider, {
       workdir: process.cwd(),
       branchName,
       prompt,
+      // Per-stage model resolved above (routine or matching process state);
+      // null → the provider CLI's own default. Threaded to the CLI --model.
+      model: stageModel || null,
     });
   } catch (err) {
     emit(args, {

--- a/packages/cli/lib/runtime/routines.mjs
+++ b/packages/cli/lib/runtime/routines.mjs
@@ -64,6 +64,10 @@ export function routineToExecutable(id, routine) {
     idempotency: routine.idempotency || null,
     prompt: stringOrNull(routine.prompt) || stringOrNull(routine.instructions),
     agent_profile: stringOrNull(routine.agent_profile) || stringOrNull(routine.specialist?.agent_profile),
+    // Per-stage concrete model id (e.g. "claude-sonnet-4-6"). Read from the
+    // routine or its mirrored specialist record (the process-stage shape
+    // carries it under ``specialist.model``). null → provider default.
+    model: stringOrNull(routine.model) || stringOrNull(routine.specialist?.model),
     // Per-routine FSM stage override. When set, ``shipctl run`` uses
     // it instead of the role's default ``fsm_stage`` — that's how a
     // single role (e.g. ``ba``) serves both SDLC (``ba_requirements``)
@@ -79,6 +83,39 @@ export function routineToExecutable(id, routine) {
     // / retro / sweeps — fall through to ``0`` (effectively last).
     pipeline_priority: numberOrZero(routine.pipeline_priority),
   };
+}
+
+/**
+ * Resolve the per-stage model when it lives on ``process.states`` (the
+ * process editor writes the operator's pick there under
+ * ``specialist.model``) rather than on a routine. ``shipctl`` executes by
+ * routine/stage and configs commonly ship ``routines: {}``, so match the
+ * running stage to its state — by state ``id`` (== the canonical fsm_stage),
+ * then canonical ``state``, then specialist slug — and read the model.
+ * Returns null when unset (provider default).
+ */
+export function stageModelFromStates(config, { fsmStage, specialist } = {}) {
+  const states = config?.process?.states;
+  if (!Array.isArray(states)) return null;
+  const modelOf = (s) => {
+    const m = s?.specialist?.model;
+    return typeof m === "string" && m.trim() ? m.trim() : null;
+  };
+  // Identify the running stage precisely — by state id (== the canonical
+  // fsm_stage), else by canonical ``state``. When found, return ITS model
+  // (even if null): do NOT fall back to specialist, or a stage that merely
+  // shares a specialist (e.g. planning & validation both devops_platform)
+  // would leak another stage's model.
+  const stage = fsmStage
+    ? states.find((s) => s?.id === fsmStage) ||
+      states.find((s) => s?.state === fsmStage)
+    : null;
+  if (stage) return modelOf(stage);
+  // Stage couldn't be identified — best-effort by specialist slug.
+  const bySpec = specialist
+    ? states.find((s) => s?.specialist?.id === specialist && modelOf(s))
+    : null;
+  return bySpec ? modelOf(bySpec) : null;
 }
 
 /**
@@ -123,6 +160,7 @@ export function laneToExecutable(id, lane) {
     idempotency: lane.idempotency || null,
     prompt: null,
     agent_profile: null,
+    model: null,
   };
 }
 

--- a/packages/cli/tests/model-selection.test.mjs
+++ b/packages/cli/tests/model-selection.test.mjs
@@ -1,0 +1,78 @@
+// Per-stage model selection — the model chosen per stage in the process
+// editor is persisted to .ship/config.yml under ``specialist.model`` and must
+// surface on the runtime executable so ``shipctl run`` can pass it to the
+// agent CLI as ``--model``. These pin the config → executable boundary.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  resolveExecutable,
+  routineToExecutable,
+  stageModelFromStates,
+} from "../lib/runtime/routines.mjs";
+
+// Mirrors a real .ship/config.yml: model lives on process.states, routines are
+// empty, and two stages share the same specialist (devops_platform).
+const STATES_CONFIG = {
+  process: {
+    routines: {},
+    states: [
+      { id: "planning", state: "planning", specialist: { id: "devops_platform", model: "claude-4.5-haiku" } },
+      { id: "dev_implementation", state: "executing", specialist: { id: "developer" } },
+      { id: "validation", state: "executing", specialist: { id: "devops_platform" } },
+    ],
+  },
+};
+
+test("stageModelFromStates: planning stage resolves its per-stage model", () => {
+  assert.equal(
+    stageModelFromStates(STATES_CONFIG, { fsmStage: "planning", specialist: "devops_platform" }),
+    "claude-4.5-haiku",
+  );
+});
+
+test("stageModelFromStates: validation (same specialist) does NOT inherit planning's model", () => {
+  // Matched by state id, so the shared specialist must not leak the model.
+  assert.equal(
+    stageModelFromStates(STATES_CONFIG, { fsmStage: "validation", specialist: "devops_platform" }),
+    null,
+  );
+});
+
+test("stageModelFromStates: null when no states / no model", () => {
+  assert.equal(stageModelFromStates({}, { fsmStage: "planning" }), null);
+});
+
+test("routineToExecutable: reads model from routine.model", () => {
+  const ex = routineToExecutable("developer", {
+    specialist: "developer",
+    model: "claude-sonnet-4-6",
+  });
+  assert.equal(ex.model, "claude-sonnet-4-6");
+});
+
+test("routineToExecutable: reads model from the mirrored specialist record", () => {
+  const ex = routineToExecutable("developer", {
+    specialist: { id: "developer", name: "Developer", model: "gpt-5-codex" },
+  });
+  assert.equal(ex.model, "gpt-5-codex");
+  assert.equal(ex.specialist, "developer");
+});
+
+test("routineToExecutable: model is null when unset (provider default)", () => {
+  const ex = routineToExecutable("developer", { specialist: "developer" });
+  assert.equal(ex.model, null);
+});
+
+test("resolveExecutable: surfaces the per-stage model from the config map", () => {
+  const config = {
+    process: {
+      routines: {
+        developer: { specialist: { id: "developer", model: "claude-opus-4-8" } },
+      },
+    },
+  };
+  const resolved = resolveExecutable(config, "developer");
+  assert.equal(resolved.executable.model, "claude-opus-4-8");
+});


### PR DESCRIPTION
## What
- **Process editor — per-stage model picker.** Pick a concrete model per stage. Claude/Codex use the live models.dev catalogue; Cursor is free-text (no keyless catalogue exists) with `auto`/`composer` suggestions + a link to Cursor's model list. The picker follows the per-stage **Execution Backend**, not the workspace default. Persists as `specialist.model` in `.ship/config.yml` via the publish PR flow.
- **shipctl** resolves the per-stage model from `process.states` (matched by stage id; configs commonly ship `routines: {}`), passes it to the agent CLI `--model`, and logs it in the `launch_agent` event, raw CLI line, and `--dry-run` output.
- **Settings → Agents & access** — new panel to add/rotate agent provider API keys (Claude/Cursor/Codex + optional LLM fallbacks) per repo, reusing the existing agent-secrets push. Fixes the gap where a PRESENT key had no input to rotate.
- **Backend** — GitHub-App-backed trackers (`github`) land `status=ok` on install instead of stuck `pending`, so the process-editor "Tracker bound" prereq passes.

## Tests
vitest (config round-trip, ModelSelector catalog/cursor/per-stage, agent-secrets panel), CLI node:test (stage model resolution + shared-specialist disambiguation), pytest (github tracker ok). Verified locally via `shipctl --dry-run`: planning → `claude-4.5-haiku`, validation (same specialist) → default.

## Ship note
Runners install `@elmundi/ship-cli@latest`, so the runtime model change lands live after the CLI is published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)