### PR TITLE
feat(process): per-stage execution backend + live Cursor model catalog

### DIFF
--- a/apps/backend/app/api/v1/routes/repos.py
+++ b/apps/backend/app/api/v1/routes/repos.py
@@ -1335,6 +1335,7 @@ async def wizard_seed(
         "cursor_agent": ("cursor",),
         "ship_cloud_agent": ("cursor-cloud",),
         "codex_cli": ("codex",),
+        "claude_code": ("claude-md",),
         "local_cli": ("claude-md",),
         "auto": ("claude-md",),
         "main": ("claude-md",),
@@ -2197,6 +2198,9 @@ _PROCESS_AGENT_PROFILES = frozenset(
         "cheaper",
         "cursor_agent",
         "codex_cli",
+        # Per-stage Claude Code backend — completes the concrete-CLI trio
+        # that overrides the workspace provider at runtime.
+        "claude_code",
         "ship_cloud_agent",
         "local_cli",
     }

--- a/apps/backend/app/core/config.py
+++ b/apps/backend/app/core/config.py
@@ -400,6 +400,13 @@ class Settings(BaseSettings):
     # ``services.deploy.model_catalog``). Repo GitHub-secret keys can't be
     # read back from GitHub, so the dropdown relies on this env key.
     mistral_api_key: str | None = Field(default=None, alias="MISTRAL_API_KEY")
+    # Platform-owned Cursor key, used ONLY to populate the per-stage model
+    # dropdown for Cursor stages (``services.deploy.model_catalog`` →
+    # api.cursor.com/v1/models). Cursor has no keyless catalogue (models.dev
+    # doesn't list it) and its API 401s without a key, so the picker needs
+    # this. Read-only listing only — execution keeps using the repo's own
+    # write-only GitHub CURSOR_API_KEY secret, never this one.
+    cursor_api_key: str | None = Field(default=None, alias="CURSOR_API_KEY")
     # Hard cap on tokens we let the agent spend per turn (prompt + completion
     # combined). Triggers a 429 from the SSE route when exceeded so a runaway
     # tool-loop doesn't silently nuke a tenant's monthly budget.

--- a/apps/backend/app/services/deploy/model_catalog.py
+++ b/apps/backend/app/services/deploy/model_catalog.py
@@ -65,6 +65,9 @@ PROVIDER_DEFAULT_MODEL: Final[dict[str, str]] = {
     "anthropic": "claude-sonnet-4-6",
     "gemini": "gemini-flash-latest",
     "mistral": "mistral-small-latest",
+    # Cursor's catch-all — always valid, incl. Free plans. The picker lists
+    # the live slugs (composer, claude-*, …) when the platform key is set.
+    "cursor": "auto",
 }
 
 # Curated fallback shown when the provider has no backend key configured
@@ -78,6 +81,10 @@ _FALLBACK_MODELS: Final[dict[str, tuple[str, ...]]] = {
     ),
     "gemini": ("gemini-pro-latest", "gemini-flash-latest", "gemini-2.5-pro"),
     "mistral": ("mistral-large-latest", "mistral-small-latest"),
+    # Cursor without a platform key: the always-valid slugs. ``composer``
+    # is the rolling alias for the latest Composer, so this stays useful
+    # without tracking version bumps.
+    "cursor": ("auto", "composer", "composer-latest"),
 }
 
 # OpenAI returns its whole catalogue (embeddings, audio, image…). We only
@@ -140,6 +147,8 @@ def _resolve_key(provider: str, settings: Settings) -> str | None:
         return (settings.deploy_planner_gemini_api_key or "").strip() or None
     if provider == "mistral":
         return (settings.mistral_api_key or "").strip() or None
+    if provider == "cursor":
+        return (settings.cursor_api_key or "").strip() or None
     return None
 
 
@@ -278,6 +287,8 @@ async def _fetch_live(
         return await _fetch_anthropic(key, http)
     if provider == "gemini":
         return await _fetch_gemini(key, http)
+    if provider == "cursor":
+        return await _fetch_cursor(key, http)
     return []
 
 
@@ -329,6 +340,38 @@ async def _fetch_gemini(key: str, http: httpx.AsyncClient) -> list[str]:
         if model_id and _keep_chat_model(model_id):
             ids.append(model_id)
     return sorted(set(ids))
+
+
+async def _fetch_cursor(key: str, http: httpx.AsyncClient) -> list[str]:
+    """List Cursor models from ``GET api.cursor.com/v1/models``.
+
+    Response shape: ``{"items": [{"id", "displayName", "aliases": [...]}]}``.
+    The ``id`` is the slug ``cursor-agent --model`` accepts; the catch-all
+    entry comes back as ``id="default"`` but is invoked as ``auto`` (its
+    documented alias), so we surface it that way. Cursor returns a curated
+    ordering (Auto / Composer first, then models) — we preserve it rather
+    than sorting, and dedupe defensively.
+    """
+
+    resp = await http.get(
+        "https://api.cursor.com/v1/models",
+        headers={"Authorization": f"Bearer {key}"},
+    )
+    resp.raise_for_status()
+    items = resp.json().get("items", [])
+    ids: list[str] = []
+    seen: set[str] = set()
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        raw = str(item.get("id") or "").strip()
+        if not raw:
+            continue
+        model_id = "auto" if raw == "default" else raw
+        if model_id not in seen:
+            seen.add(model_id)
+            ids.append(model_id)
+    return ids
 
 
 __all__ = ["ModelListing", "PROVIDER_DEFAULT_MODEL", "list_planner_models"]

--- a/apps/backend/tests/test_v1_repo_config.py
+++ b/apps/backend/tests/test_v1_repo_config.py
@@ -22,6 +22,22 @@ import pytest
 import pytest_asyncio
 
 
+def test_validate_process_agent_profile_accepts_claude_code():
+    """claude_code joins the concrete-CLI trio as a valid per-stage backend."""
+    from fastapi import HTTPException
+
+    from backend.app.api.v1.routes.repos import _validate_process_agent_profile
+
+    # New value + the existing concrete CLIs and abstract profiles all pass.
+    for value in ("claude_code", "cursor_agent", "codex_cli", "main", None):
+        _validate_process_agent_profile(value, "process.states[0].specialist.agent_profile")
+
+    # Garbage still 422s.
+    with pytest.raises(HTTPException) as exc:
+        _validate_process_agent_profile("gpt_cli", "field")
+    assert exc.value.status_code == 422
+
+
 @pytest_asyncio.fixture
 async def seed_workspace_with_repo(db_session, seed_workspace):
     from backend.app.db.models.integrations import (

--- a/apps/console/src/app/(authed)/process/agent-profile-catalog.test.ts
+++ b/apps/console/src/app/(authed)/process/agent-profile-catalog.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { AGENT_PROFILE_OPTIONS } from "./agent-profile-catalog";
+
+describe("AGENT_PROFILE_OPTIONS", () => {
+  const ids = AGENT_PROFILE_OPTIONS.map((o) => o.id);
+
+  it("offers only the runtime-honoured backends", () => {
+    expect(ids).toEqual(["main", "cursor_agent", "codex_cli", "claude_code"]);
+  });
+
+  it("does not surface the legacy no-op profiles", () => {
+    for (const legacy of ["auto", "cheaper", "ship_cloud_agent", "local_cli"]) {
+      expect(ids).not.toContain(legacy);
+    }
+  });
+
+  it("keeps the workspace-default option first (used as the fallback)", () => {
+    expect(AGENT_PROFILE_OPTIONS[0]?.id).toBe("main");
+  });
+});

--- a/apps/console/src/app/(authed)/process/agent-profile-catalog.ts
+++ b/apps/console/src/app/(authed)/process/agent-profile-catalog.ts
@@ -4,40 +4,35 @@ export type AgentProfileOption = {
   description: string;
 };
 
+// The per-stage execution backend. Only options that the runtime
+// actually honours are offered:
+//   - "main" defers to the workspace-bound provider (the default).
+//   - cursor_agent / codex_cli / claude_code pin a concrete CLI for THIS
+//     stage, overriding the workspace provider at runtime.
+// The legacy profiles (auto / cheaper / ship_cloud_agent / local_cli) are
+// still accepted by the config schema for backwards-compat with existing
+// .ship/config.yml files, but are intentionally not surfaced here: they
+// never changed runtime routing and only confused operators. Configs that
+// still carry them resolve to the workspace provider at run time.
 export const AGENT_PROFILE_OPTIONS: AgentProfileOption[] = [
   {
-    id: "auto",
-    name: "Auto",
-    description: "Let Ship choose the backend from workspace policy and task needs.",
-  },
-  {
     id: "main",
-    name: "Main workspace agent",
-    description: "Use the default agent profile configured for this workspace.",
-  },
-  {
-    id: "cheaper",
-    name: "Cheaper profile",
-    description: "Prefer lower-cost execution for low-risk work.",
+    name: "Workspace default",
+    description: "Use the provider chosen for this workspace (Claude / Cursor / Codex).",
   },
   {
     id: "cursor_agent",
     name: "Cursor agent",
-    description: "Prefer repo-local coding work in Cursor.",
+    description: "Run this stage on the Cursor CLI, regardless of the workspace default.",
   },
   {
     id: "codex_cli",
     name: "Codex CLI",
-    description: "Prefer local CLI execution for code and docs tasks.",
+    description: "Run this stage on the OpenAI Codex CLI, regardless of the workspace default.",
   },
   {
-    id: "ship_cloud_agent",
-    name: "Ship cloud agent",
-    description: "Prefer managed cloud execution for background or scheduled work.",
-  },
-  {
-    id: "local_cli",
-    name: "Local CLI only",
-    description: "Keep execution on a local runner for sensitive repositories.",
+    id: "claude_code",
+    name: "Claude Code",
+    description: "Run this stage on the Claude Code CLI, regardless of the workspace default.",
   },
 ];

--- a/apps/console/src/app/(authed)/process/state-editor.test.tsx
+++ b/apps/console/src/app/(authed)/process/state-editor.test.tsx
@@ -106,9 +106,16 @@ describe("StateEditor model picker", () => {
     );
   });
 
-  it("uses a free-text field for Cursor (no catalogue) and patches the typed model", () => {
-    // Cursor has no models.dev catalogue, so no fetch — it's a free-text input
-    // (with suggestions) where Cursor-native models like Composer can be typed.
+  it("uses the live catalogue dropdown for Cursor and patches the picked model", async () => {
+    // Cursor now has a backend-served catalogue (platform key → cursor API),
+    // so it's a select fed by /api/deploy/planner-models?provider=cursor —
+    // not free-text. Picking an option patches specialist_model.
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ models: ["auto", "composer-2.5", "claude-opus-4-8"] }),
+    }));
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
     const onStateChange = vi.fn();
     render(
       <StateEditor
@@ -126,11 +133,15 @@ describe("StateEditor model picker", () => {
       />,
     );
 
-    const modelInput = screen.getByLabelText(/Model/i);
-    expect(modelInput).toHaveAttribute("list", "cursor-model-suggestions");
-    fireEvent.change(modelInput, { target: { value: "composer-1" } });
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    const [, init] = fetchMock.mock.calls[0] as unknown as [string, { body: string }];
+    expect(JSON.parse(init.body)).toMatchObject({ provider: "cursor" });
+
+    const modelControl = await screen.findByLabelText(/Model/i);
+    expect(modelControl).not.toHaveAttribute("list");
+    fireEvent.change(modelControl, { target: { value: "composer-2.5" } });
     expect(onStateChange).toHaveBeenCalledWith(
-      expect.objectContaining({ specialist_model: "composer-1" }),
+      expect.objectContaining({ specialist_model: "composer-2.5" }),
     );
   });
 
@@ -163,6 +174,136 @@ describe("StateEditor model picker", () => {
     const [, init] = fetchMock.mock.calls[0] as unknown as [string, { body: string }];
     expect(JSON.parse(init.body)).toMatchObject({ provider: "openai" });
     // Catalogue select, not the Cursor free-text input (which has a datalist).
+    const modelControl = await screen.findByLabelText(/Model/i);
+    expect(modelControl).not.toHaveAttribute("list");
+  });
+
+  it("spells out the workspace provider on the 'Workspace default' backend option", () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: true, json: async () => ({ models: [] }) })) as unknown as typeof fetch,
+    );
+    render(
+      <StateEditor
+        workspaceId="ws-1"
+        agentProvider="cursor"
+        repoId="repo-1"
+        state={stateWith({ specialist_agent_profile: "main" } as Partial<ApiProcessState>)}
+        states={[stateWith()]}
+        schedule={null}
+        transitions={[]}
+        specialistOptions={[{ id: "intake", name: "Intake", role: "Intake" }]}
+        config={null}
+        onStateChange={vi.fn()}
+        onDeleteState={vi.fn()}
+      />,
+    );
+    const backend = screen.getByLabelText(/Execution backend/i);
+    expect(backend).toHaveTextContent("Workspace default · Cursor");
+  });
+
+  it("resets the model to provider default when the backend switches provider", async () => {
+    // Stage runs Cursor with composer-2.5 picked; switching the backend to
+    // Codex CLI (openai) must clear the now-invalid model, not keep composer.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: true, json: async () => ({ models: [] }) })) as unknown as typeof fetch,
+    );
+    const onStateChange = vi.fn();
+    render(
+      <StateEditor
+        workspaceId="ws-1"
+        agentProvider="cursor"
+        repoId="repo-1"
+        state={stateWith({
+          specialist_agent_profile: "cursor_agent",
+          specialist_model: "composer-2.5",
+        } as Partial<ApiProcessState>)}
+        states={[stateWith()]}
+        schedule={null}
+        transitions={[]}
+        specialistOptions={[{ id: "intake", name: "Intake", role: "Intake" }]}
+        config={null}
+        onStateChange={onStateChange}
+        onDeleteState={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText(/Execution backend/i), {
+      target: { value: "codex_cli" },
+    });
+    expect(onStateChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        specialist_agent_profile: "codex_cli",
+        specialist_model: null,
+      }),
+    );
+  });
+
+  it("keeps the model when the backend stays on the same provider", async () => {
+    // main → local_cli both resolve to the workspace provider — no reset.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: true, json: async () => ({ models: [] }) })) as unknown as typeof fetch,
+    );
+    const onStateChange = vi.fn();
+    render(
+      <StateEditor
+        workspaceId="ws-1"
+        agentProvider="claude"
+        repoId="repo-1"
+        state={stateWith({
+          specialist_agent_profile: "main",
+          specialist_model: "claude-opus-4-8",
+        } as Partial<ApiProcessState>)}
+        states={[stateWith()]}
+        schedule={null}
+        transitions={[]}
+        specialistOptions={[{ id: "intake", name: "Intake", role: "Intake" }]}
+        config={null}
+        onStateChange={onStateChange}
+        onDeleteState={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText(/Execution backend/i), {
+      target: { value: "claude_code" },
+    });
+    // claude_code and main both → anthropic here, so the model is preserved.
+    const call = onStateChange.mock.calls.at(-1)?.[0];
+    expect(call).toMatchObject({ specialist_agent_profile: "claude_code" });
+    expect(call).not.toHaveProperty("specialist_model", null);
+  });
+
+  it("Claude Code backend shows anthropic models even on a Cursor workspace", async () => {
+    // Workspace default is Cursor, but this stage pins Claude Code — the
+    // picker must query the anthropic catalogue, matching what the runtime
+    // now actually runs for the stage.
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ models: ["claude-opus-4-8"] }),
+    }));
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    render(
+      <StateEditor
+        workspaceId="ws-1"
+        agentProvider="cursor"
+        repoId="repo-1"
+        state={stateWith({ specialist_agent_profile: "claude_code" } as Partial<ApiProcessState>)}
+        states={[stateWith()]}
+        schedule={null}
+        transitions={[]}
+        specialistOptions={[{ id: "intake", name: "Intake", role: "Intake" }]}
+        config={null}
+        onStateChange={vi.fn()}
+        onDeleteState={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    const [, init] = fetchMock.mock.calls[0] as unknown as [string, { body: string }];
+    expect(JSON.parse(init.body)).toMatchObject({ provider: "anthropic" });
     const modelControl = await screen.findByLabelText(/Model/i);
     expect(modelControl).not.toHaveAttribute("list");
   });

--- a/apps/console/src/app/(authed)/process/state-editor.tsx
+++ b/apps/console/src/app/(authed)/process/state-editor.tsx
@@ -23,24 +23,33 @@ type EditableProcessState = ApiProcessState & {
   specialist_model?: string | null;
 };
 
-// Workspace agent provider → models.dev catalogue provider for the live
-// /api/deploy/planner-models picker. Only providers that models.dev catalogues
-// belong here. Cursor is intentionally absent: it has no models.dev entry and
-// its own models (Composer, auto, …) aren't catalogued anywhere keyless, so it
-// falls through to the free-text path below.
+// Agent provider → the catalogue provider key sent to the live
+// /api/deploy/planner-models picker. anthropic/openai come from models.dev
+// (keyless); cursor is served by the backend via a platform Cursor key
+// (api.cursor.com/v1/models), with a curated auto/composer fallback when no
+// key is set. Any provider NOT listed here falls through to the free-text
+// path below.
 const CATALOG_PROVIDER: Record<string, string> = {
   claude: "anthropic",
   codex: "openai",
+  // Cursor now has a live catalogue too — the backend lists it via a
+  // platform Cursor key (api.cursor.com/v1/models). Falls back to a curated
+  // list (auto / composer) server-side when no key is configured, so the
+  // dropdown is always populated.
+  cursor: "cursor",
 };
 
 // Per-stage execution-backend profile → the agent provider that actually runs
-// the stage. cursor_agent / codex_cli pin a provider; the rest (auto / main /
-// cheaper / ship_cloud_agent / local_cli) defer to the workspace default
-// (agent_provider). This is what the Model picker keys off — so a stage set to
-// "Codex CLI" shows OpenAI models, not the workspace's Cursor/Composer.
+// the stage. cursor_agent / codex_cli / claude_code pin a provider; the rest
+// (main / auto / cheaper / ship_cloud_agent / local_cli) defer to the workspace
+// default (agent_provider). This mapping is shared by two consumers: the Model
+// picker (so a stage set to "Codex CLI" shows OpenAI models, not the
+// workspace's Cursor/Composer) AND — via the CLI's own copy in routines.mjs —
+// the runtime, which now honours the same override when launching the agent.
 const PROFILE_PROVIDER: Record<string, string> = {
   cursor_agent: "cursor",
   codex_cli: "codex",
+  claude_code: "claude",
 };
 
 function providerForProfile(
@@ -224,7 +233,25 @@ export function StateEditor({
           </div>
           <AgentProfileSelector
             value={agentProfileFromState(selectedState)}
-            onChange={(value) => patchState({ specialist_agent_profile: value })}
+            workspaceProvider={agentProvider}
+            onChange={(value) => {
+              // Switching the execution backend can change the provider
+              // (e.g. Cursor → Codex). A model picked for the old provider
+              // (composer-2.5) is invalid for the new one, so reset it to
+              // "Provider default" when the provider actually changes —
+              // otherwise the picker would keep showing a cross-provider
+              // model that the runtime can't run.
+              const prevProvider = providerForProfile(
+                agentProfileFromState(selectedState),
+                agentProvider,
+              );
+              const nextProvider = providerForProfile(value, agentProvider);
+              patchState(
+                nextProvider !== prevProvider
+                  ? { specialist_agent_profile: value, specialist_model: null }
+                  : { specialist_agent_profile: value },
+              );
+            }}
           />
           <ModelSelector
             workspaceId={workspaceId}
@@ -414,16 +441,32 @@ function sourceLabel(source: NonNullable<SpecialistOption["source"]>) {
   return "Custom";
 }
 
+// Workspace agent_provider → a human label for the "Workspace default"
+// option, so the operator sees which concrete CLI the default resolves to
+// (e.g. "Workspace default · Cursor") instead of having to remember it.
+const PROVIDER_LABEL: Record<string, string> = {
+  cursor: "Cursor",
+  codex: "Codex",
+  claude: "Claude",
+};
+
 function AgentProfileSelector({
   value,
   onChange,
+  workspaceProvider,
 }: {
   value: string;
   onChange: (value: string) => void;
+  workspaceProvider?: string;
 }) {
   const selectedOption =
     AGENT_PROFILE_OPTIONS.find((option) => option.id === value) ??
     AGENT_PROFILE_OPTIONS[0];
+  // Spell out the workspace default's concrete provider on the "main" option.
+  const labelFor = (option: (typeof AGENT_PROFILE_OPTIONS)[number]) =>
+    option.id === "main" && workspaceProvider
+      ? `${option.name} · ${PROVIDER_LABEL[workspaceProvider] ?? workspaceProvider}`
+      : option.name;
   return (
     <label className="block">
       <span className="mb-1 block text-[10px] font-bold uppercase tracking-widest text-white/45">
@@ -437,7 +480,7 @@ function AgentProfileSelector({
       >
         {AGENT_PROFILE_OPTIONS.map((option) => (
           <option key={option.id} value={option.id}>
-            {option.name}
+            {labelFor(option)}
           </option>
         ))}
       </select>
@@ -458,8 +501,9 @@ function ModelSelector({
   value: string | null;
   onChange: (value: string | null) => void;
 }) {
-  // models.dev-catalogued providers get the live list; others (Cursor) get a
-  // free-text field — see CATALOG_PROVIDER / CURSOR_MODEL_SUGGESTIONS.
+  // Catalogued providers (anthropic / openai / cursor) get the live dropdown;
+  // any uncatalogued provider falls back to a free-text field — see
+  // CATALOG_PROVIDER / CURSOR_MODEL_SUGGESTIONS.
   const catalogProvider = CATALOG_PROVIDER[agentProvider ?? ""] ?? null;
   const label = (
     <span className="mb-1 block text-[10px] font-bold uppercase tracking-widest text-white/45">

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -131,6 +131,9 @@ services:
       # Extra deploy-planner vendor — also powers the live model dropdown
       # in the New deployment modal (services.deploy.model_catalog).
       MISTRAL_API_KEY: ${MISTRAL_API_KEY:-}
+      # Platform Cursor key — read-only, only to populate the per-stage
+      # model dropdown for Cursor stages (Cursor has no keyless catalogue).
+      CURSOR_API_KEY: ${CURSOR_API_KEY:-}
       AGENT_VENDOR: ${AGENT_VENDOR:-openai}
       DEPLOY_PLANNER_GEMINI_API_KEY: ${DEPLOY_PLANNER_GEMINI_API_KEY:-}
       DEPLOY_PLANNER_GEMINI_MODEL: ${DEPLOY_PLANNER_GEMINI_MODEL:-gemini-2.5-flash}

--- a/packages/cli/lib/commands/run.mjs
+++ b/packages/cli/lib/commands/run.mjs
@@ -53,7 +53,12 @@ import fs from "node:fs";
 import path from "node:path";
 
 import { readConfig, findShipRoot } from "../config/io.mjs";
-import { resolveExecutable, stageModelFromStates } from "../runtime/routines.mjs";
+import {
+  resolveExecutable,
+  stageModelFromStates,
+  stageAgentProfileFromStates,
+  providerForAgentProfile,
+} from "../runtime/routines.mjs";
 import { DEFAULT_PROVIDER, runAgent } from "../agents/index.mjs";
 import { fetchWithRetry } from "../retry.mjs";
 
@@ -242,6 +247,15 @@ async function _runCommandImpl(ctx, rest) {
   const stageModel =
     resolved.executable?.model ||
     stageModelFromStates(config, { fsmStage, specialist: specialistSlug });
+  // Per-stage execution backend: a stage may pin a concrete CLI
+  // (cursor_agent / codex_cli / claude_code) that differs from the
+  // workspace-bound provider. Prefer a routine-level agent_profile, else
+  // the one the process editor stored on the matching state. Abstract
+  // profiles (main/auto/…) resolve to null → keep the workspace binding.
+  const stageAgentProfile =
+    resolved.executable?.agent_profile ||
+    stageAgentProfileFromStates(config, { fsmStage, specialist: specialistSlug });
+  const stageProviderOverride = providerForAgentProfile(stageAgentProfile);
   const roleBody = roleResolved.prompt || "";
   const systemBody = systemResolved?.prompt || "";
 
@@ -389,11 +403,15 @@ async function _runCommandImpl(ctx, rest) {
         // would be passed to the agent CLI's --model; null = provider default.
         // Lets a dry-run confirm the model without launching an agent.
         model: stageModel || null,
+        // Per-stage execution backend and the provider it forces (null =
+        // no override → the workspace-bound provider runs at launch time).
+        agent_profile: stageAgentProfile || null,
+        agent_profile_provider: stageProviderOverride || null,
         task,
         prompt,
       }, null, 2));
     } else {
-      console.error(`# ship: dry-run handle=${runHandle} specialist=${specialistSlug} (${roleResolved.source}) fsm_stage=${fsmStage || "(context-free)"} model=${stageModel || "(default)"}`);
+      console.error(`# ship: dry-run handle=${runHandle} specialist=${specialistSlug} (${roleResolved.source}) fsm_stage=${fsmStage || "(context-free)"} model=${stageModel || "(default)"} backend=${stageAgentProfile || "(workspace)"}${stageProviderOverride ? `→${stageProviderOverride}` : ""}`);
       if (task) {
         console.error(`# ship: task ticket_ref=${task.ticket_ref} title=${JSON.stringify(task.title || "")}`);
       } else {
@@ -406,19 +424,34 @@ async function _runCommandImpl(ctx, rest) {
   }
 
   // 4) Resolve the agent runtime. The workspace's bound provider
-  // (``GET /v1/workspaces/{ws}/agent-provider``) is the single source
+  // (``GET /v1/workspaces/{ws}/agent-provider``) is the default source
   // of truth — when it fails we fall straight back to the resolver's
   // built-in ``DEFAULT_PROVIDER`` (cursor) so an unreachable API
   // doesn't strand the runner. The legacy ``.ship/config.yml``
   // ``agent.default.provider`` / ``agent.overrides`` block was
   // dropped in PR-5 of the local-CLI swap.
+  //
+  // A per-stage execution backend (``specialist.agent_profile`` →
+  // cursor_agent / codex_cli / claude_code) overrides the workspace
+  // binding for THIS stage only, so one process can plan on Cursor while
+  // the rest stays on the workspace default. The runner already installs
+  // all three CLIs and exposes all three API keys, so the override just
+  // picks which adapter runs — the corresponding provider key must be
+  // present in repo secrets or the adapter throws its own auth error.
   const workspaceProvider = await fetchWorkspaceAgentProvider({
     apiBase,
     apiToken,
     workspaceId,
   });
-  const provider = workspaceProvider || DEFAULT_PROVIDER;
-  step("resolve_provider", workspaceProvider ? "ok" : "default", { provider });
+  const baseProvider = workspaceProvider || DEFAULT_PROVIDER;
+  const provider = stageProviderOverride || baseProvider;
+  step(
+    "resolve_provider",
+    stageProviderOverride ? "stage-override" : workspaceProvider ? "ok" : "default",
+    stageProviderOverride
+      ? { provider, workspace_provider: baseProvider, agent_profile: stageAgentProfile }
+      : { provider },
+  );
   const branchName = makeBranchName(runHandle, task?.ticket_ref);
   const baseBranch = (env.githubRef || "main").trim() || "main";
 

--- a/packages/cli/lib/config/schema.mjs
+++ b/packages/cli/lib/config/schema.mjs
@@ -55,6 +55,10 @@ export const PROCESS_AGENT_PROFILES = Object.freeze([
   "cheaper",
   "cursor_agent",
   "codex_cli",
+  // ``claude_code`` pins the Claude Code CLI as the per-stage backend,
+  // completing the concrete-CLI trio (cursor_agent / codex_cli /
+  // claude_code) that overrides the workspace provider at runtime.
+  "claude_code",
   "ship_cloud_agent",
   "local_cli",
 ]);

--- a/packages/cli/lib/runtime/routines.mjs
+++ b/packages/cli/lib/runtime/routines.mjs
@@ -119,6 +119,55 @@ export function stageModelFromStates(config, { fsmStage, specialist } = {}) {
 }
 
 /**
+ * Resolve the per-stage execution backend (``specialist.agent_profile``)
+ * the same way as {@link stageModelFromStates}: match the running stage
+ * to its ``process.states`` record by state ``id`` (== canonical
+ * fsm_stage), then canonical ``state``, then specialist slug. Returns
+ * null when unset — the caller then keeps the workspace-bound provider.
+ *
+ * Only concrete-CLI profiles matter to provider routing; ``main`` /
+ * ``auto`` / ``cheaper`` / ``local_cli`` / ``ship_cloud_agent`` deliberately
+ * return their literal value (or null) and are mapped to "no override" by
+ * the caller — this helper stays a pure config reader.
+ */
+export function stageAgentProfileFromStates(config, { fsmStage, specialist } = {}) {
+  const states = config?.process?.states;
+  if (!Array.isArray(states)) return null;
+  const profileOf = (s) => {
+    const p = s?.specialist?.agent_profile;
+    return typeof p === "string" && p.trim() ? p.trim() : null;
+  };
+  const stage = fsmStage
+    ? states.find((s) => s?.id === fsmStage) ||
+      states.find((s) => s?.state === fsmStage)
+    : null;
+  if (stage) return profileOf(stage);
+  const bySpec = specialist
+    ? states.find((s) => s?.specialist?.id === specialist && profileOf(s))
+    : null;
+  return bySpec ? profileOf(bySpec) : null;
+}
+
+/**
+ * Map a per-stage ``agent_profile`` to the agent runtime provider it
+ * pins, or null when it defers to the workspace-bound provider. Only the
+ * three concrete-CLI profiles override; the abstract ones
+ * (main/auto/cheaper/local_cli/ship_cloud_agent) intentionally return
+ * null so the workspace binding wins. Kept beside the resolver so the run
+ * command and tests share one source of truth.
+ */
+export const PROFILE_PROVIDER_OVERRIDE = Object.freeze({
+  cursor_agent: "cursor",
+  codex_cli: "codex",
+  claude_code: "claude",
+});
+
+export function providerForAgentProfile(agentProfile) {
+  if (!agentProfile) return null;
+  return PROFILE_PROVIDER_OVERRIDE[agentProfile] || null;
+}
+
+/**
  * Pull the agent-role slug out of a routine, preferring the new
  * ``specialist:`` key but falling back to the legacy ``pattern:`` and
  * stripping the historical ``role-`` prefix when present.

--- a/packages/cli/tests/backend-selection.test.mjs
+++ b/packages/cli/tests/backend-selection.test.mjs
@@ -1,0 +1,68 @@
+// Per-stage execution backend — the "Execution Backend" chosen per stage
+// in the process editor is persisted to .ship/config.yml under
+// ``specialist.agent_profile`` and, when it names a concrete CLI, must
+// override the workspace-bound provider for that stage at runtime. These
+// pin the config → provider-override boundary that ``shipctl run`` uses.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  stageAgentProfileFromStates,
+  providerForAgentProfile,
+} from "../lib/runtime/routines.mjs";
+
+// Mirrors a real .ship/config.yml: agent_profile lives on process.states,
+// routines are empty, and two stages share the same specialist.
+const STATES_CONFIG = {
+  process: {
+    routines: {},
+    states: [
+      { id: "planning", state: "planning", specialist: { id: "devops_platform", agent_profile: "cursor_agent" } },
+      { id: "dev_implementation", state: "executing", specialist: { id: "developer", agent_profile: "codex_cli" } },
+      { id: "validation", state: "executing", specialist: { id: "devops_platform" } },
+    ],
+  },
+};
+
+test("stageAgentProfileFromStates: planning resolves its per-stage backend", () => {
+  assert.equal(
+    stageAgentProfileFromStates(STATES_CONFIG, { fsmStage: "planning", specialist: "devops_platform" }),
+    "cursor_agent",
+  );
+});
+
+test("stageAgentProfileFromStates: validation (same specialist) does NOT inherit planning's backend", () => {
+  assert.equal(
+    stageAgentProfileFromStates(STATES_CONFIG, { fsmStage: "validation", specialist: "devops_platform" }),
+    null,
+  );
+});
+
+test("stageAgentProfileFromStates: null when no states", () => {
+  assert.equal(stageAgentProfileFromStates({}, { fsmStage: "planning" }), null);
+});
+
+test("providerForAgentProfile: concrete CLIs pin a provider", () => {
+  assert.equal(providerForAgentProfile("cursor_agent"), "cursor");
+  assert.equal(providerForAgentProfile("codex_cli"), "codex");
+  assert.equal(providerForAgentProfile("claude_code"), "claude");
+});
+
+test("providerForAgentProfile: abstract profiles defer to the workspace (null)", () => {
+  for (const p of ["main", "auto", "cheaper", "ship_cloud_agent", "local_cli"]) {
+    assert.equal(providerForAgentProfile(p), null, `${p} must not override`);
+  }
+  assert.equal(providerForAgentProfile(null), null);
+  assert.equal(providerForAgentProfile(undefined), null);
+});
+
+test("integration: planning overrides to cursor, validation keeps the workspace provider", () => {
+  const workspaceProvider = "claude";
+  // planning → cursor_agent → cursor (override wins)
+  const planning = stageAgentProfileFromStates(STATES_CONFIG, { fsmStage: "planning", specialist: "devops_platform" });
+  assert.equal(providerForAgentProfile(planning) || workspaceProvider, "cursor");
+  // validation → no profile → falls back to the workspace provider
+  const validation = stageAgentProfileFromStates(STATES_CONFIG, { fsmStage: "validation", specialist: "devops_platform" });
+  assert.equal(providerForAgentProfile(validation) || workspaceProvider, "claude");
+});


### PR DESCRIPTION
## What
Makes the per-stage **Execution Backend** real (scenario B) and adds a **live Cursor model catalog** for the picker.

Previously the Execution Backend dropdown was UI-only — the runtime always used the workspace-bound provider. Now a stage set to **Cursor / Codex / Claude Code** runs that CLI at runtime, while stages on **Workspace default** keep the workspace provider.

## Changes
**CLI**
- `routines.mjs`: `stageAgentProfileFromStates` + `providerForAgentProfile` (`cursor_agent→cursor`, `codex_cli→codex`, `claude_code→claude`; abstract profiles → workspace default).
- `run.mjs`: resolve per-stage provider override (`resolve_provider: stage-override`); dry-run surfaces `backend=…→provider`.
- `schema.mjs`: `claude_code` added to the agent_profile enum.

**Backend**
- `repos.py`: `claude_code` in the process agent_profile enum + seed map.
- `model_catalog.py` + `config.py`: Cursor catalog via a **platform `CURSOR_API_KEY`** (`api.cursor.com/v1/models`) — read-only, catalog-only, separate from execution secrets; curated `auto`/`composer` fallback when no key.

**Console**
- Execution Backend trimmed to runtime-honoured options (Workspace default / Cursor agent / Codex CLI / Claude Code); legacy profiles stay schema-valid for back-compat.
- Cursor gets the live dropdown; "Workspace default" spells out the concrete provider (e.g. `· Cursor`).
- Model resets to provider default when the backend switches provider (no more `composer` stuck on codex).

**Infra**: `docker-compose` passes `CURSOR_API_KEY` to the backend for the catalog.

## Tests
CLI **176/176** (new `backend-selection.test.mjs`), console process **27/27** (catalog/list/reset/label), backend `claude_code` enum unit test. Verified live on the local Docker stack: all three providers return `source=live` (cursor 31, anthropic 10, openai 73).

## Note on rollout
Per-stage **model** already works in prod (0.16.36). Per-stage **backend override** is new CLI code here — needs a version bump + `npm publish` to go live on runners (separate follow-up). Console + backend deploy on merge as usual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)